### PR TITLE
Address more lint issues.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,9 @@ module.exports = {
         ],
         "no-trailing-spaces": [
 	    "error"
+	],
+        "no-console": [
+	    "off"
 	]
     }
 };

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -1,4 +1,4 @@
-import { getBalance, getAccountNumber, getNetwork, getPing, 
+import { getBalance, getAccountNumber, getNetwork, getPing,
   getStakeInfo, getTicketPrice, getAccounts, getTransactions } from '../middleware/grpc/client';
 
 export const GETBALANCE_ATTEMPT = 'GETBALANCE_ATTEMPT';
@@ -17,13 +17,13 @@ export function getBalanceAttempt(accountNumber, requiredConfs) {
   var request = {
     account_number: accountNumber,
     required_confirmations: requiredConfs
-  }
+  };
   return (dispatch) => {
     dispatch({
       request: request,
       type: GETBALANCE_ATTEMPT });
     dispatch(balance());
-  }
+  };
 }
 
 function balance() {
@@ -32,13 +32,13 @@ function balance() {
     const { getBalanceRequest } = getState().grpc;
     getBalance(client, getBalanceRequest,
         function(getBalanceResponse, err) {
-      if (err) {
-        dispatch(getBalanceError(err + " Please try again"));
-      } else {
-        dispatch(getBalanceSuccess(getBalanceResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getBalanceError(err + ' Please try again'));
+          } else {
+            dispatch(getBalanceSuccess(getBalanceResponse));
+          }
+        });
+  };
 }
 
 export const GETACCOUNTNUMBER_ATTEMPT = 'GETACCOUNTNUMBER_ATTEMPT';
@@ -56,13 +56,13 @@ function getAccountNumberSuccess(getAccountNumberResponse) {
 export function getAccountNumberAttempt(accountName) {
   var request = {
     account_name: accountName
-  }
+  };
   return (dispatch) => {
     dispatch({
       request: request,
       type: GETACCOUNTNUMBER_ATTEMPT });
     dispatch(accountNumber());
-  }
+  };
 }
 
 function accountNumber() {
@@ -71,13 +71,13 @@ function accountNumber() {
     const { getAccountNumberRequest } = getState().grpc;
     getAccountNumber(client, getAccountNumberRequest,
         function(getAccountNumberResponse, err) {
-      if (err) {
-        dispatch(getAccountNumberError(err + " Please try again"));
-      } else {
-        dispatch(getAccountNumberSuccess(getAccountNumberResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getAccountNumberError(err + ' Please try again'));
+          } else {
+            dispatch(getAccountNumberSuccess(getAccountNumberResponse));
+          }
+        });
+  };
 }
 
 export const GETNETWORK_ATTEMPT = 'GETNETWORK_ATTEMPT';
@@ -93,13 +93,13 @@ function getNetworkSuccess(getNetworkResponse) {
 }
 
 export function getNetworkAttempt() {
-  var request = {}
+  var request = {};
   return (dispatch) => {
     dispatch({
       request: request,
       type: GETNETWORK_ATTEMPT });
     dispatch(network());
-  }
+  };
 }
 
 function network() {
@@ -108,13 +108,13 @@ function network() {
     const { getNetworkRequest } = getState().grpc;
     getNetwork(client, getNetworkRequest,
         function(getNetworkResponse, err) {
-      if (err) {
-        dispatch(getNetworkError(err + " Please try again"));
-      } else {
-        dispatch(getNetworkSuccess(getNetworkResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getNetworkError(err + ' Please try again'));
+          } else {
+            dispatch(getNetworkSuccess(getNetworkResponse));
+          }
+        });
+  };
 }
 
 export const GETPING_ATTEMPT = 'GETPING_ATTEMPT';
@@ -131,13 +131,13 @@ function getPingSuccess(getPingResponse) {
 
 export function getPingAttempt() {
   var request = {
-  }
+  };
   return (dispatch) => {
     dispatch({
       request: request,
       type: GETPING_ATTEMPT });
     dispatch(ping());
-  }
+  };
 }
 
 function ping() {
@@ -146,13 +146,13 @@ function ping() {
     const { getPingRequest } = getState().grpc;
     getPing(client, getPingRequest,
         function(getPingResponse, err) {
-      if (err) {
-        dispatch(getPingError(err + " Please try again"));
-      } else {
-        dispatch(getPingSuccess(getPingResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getPingError(err + ' Please try again'));
+          } else {
+            dispatch(getPingSuccess(getPingResponse));
+          }
+        });
+  };
 }
 
 export const GETSTAKEINFO_ATTEMPT = 'GETSTAKEINFO_ATTEMPT';
@@ -169,13 +169,13 @@ function getStakeInfoSuccess(getStakeInfoResponse) {
 
 export function getStakeInfoAttempt() {
   var request = {
-  }
+  };
   return (dispatch) => {
     dispatch({
       request: request,
       type: GETSTAKEINFO_ATTEMPT });
     dispatch(stakeInfo());
-  }
+  };
 }
 
 function stakeInfo() {
@@ -184,13 +184,13 @@ function stakeInfo() {
     const { getStakeInfoRequest } = getState().grpc;
     getStakeInfo(client, getStakeInfoRequest,
         function(getStakeInfoResponse, err) {
-      if (err) {
-        dispatch(getStakeInfoError(err + " Please try again"));
-      } else {
-        dispatch(getStakeInfoSuccess(getStakeInfoResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getStakeInfoError(err + ' Please try again'));
+          } else {
+            dispatch(getStakeInfoSuccess(getStakeInfoResponse));
+          }
+        });
+  };
 }
 
 export const GETTICKETPRICE_ATTEMPT = 'GETTICKETPRICE_ATTEMPT';
@@ -207,13 +207,13 @@ function getTicketPriceSuccess(getTicketPriceResponse) {
 
 export function getTicketPriceAttempt() {
   var request = {
-  }
+  };
   return (dispatch) => {
     dispatch({
       request: request,
       type: GETTICKETPRICE_ATTEMPT });
     dispatch(ticketPrice());
-  }
+  };
 }
 
 function ticketPrice() {
@@ -222,13 +222,13 @@ function ticketPrice() {
     const { getTicketPriceRequest } = getState().grpc;
     getTicketPrice(client, getTicketPriceRequest,
         function(getTicketPriceResponse, err) {
-      if (err) {
-        dispatch(getTicketPriceError(err + " Please try again"));
-      } else {
-        dispatch(getTicketPriceSuccess(getTicketPriceResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getTicketPriceError(err + ' Please try again'));
+          } else {
+            dispatch(getTicketPriceSuccess(getTicketPriceResponse));
+          }
+        });
+  };
 }
 
 export const GETACCOUNTS_ATTEMPT = 'GETACCOUNTS_ATTEMPT';
@@ -245,13 +245,13 @@ function getAccountsSuccess(getAccountsResponse) {
 
 export function getAccountsAttempt() {
   var request = {
-  }
+  };
   return (dispatch) => {
     dispatch({
       request: request,
       type: GETACCOUNTS_ATTEMPT });
     dispatch(accounts());
-  }
+  };
 }
 
 function accounts() {
@@ -260,13 +260,13 @@ function accounts() {
     const { getAccountsRequest } = getState().grpc;
     getAccounts(client, getAccountsRequest,
         function(getAccountsResponse, err) {
-      if (err) {
-        dispatch(getAccountsError(err + " Please try again"));
-      } else {
-        dispatch(getAccountsSuccess(getAccountsResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getAccountsError(err + ' Please try again'));
+          } else {
+            dispatch(getAccountsSuccess(getAccountsResponse));
+          }
+        });
+  };
 }
 
 export const GETTRANSACTIONS_ATTEMPT = 'GETTRANSACTIONS_ATTEMPT';
@@ -296,7 +296,7 @@ export function getTransactionsAttempt(startHeight, endHeight, startHash, endHas
       request: request,
       type: GETTRANSACTIONS_ATTEMPT });
     dispatch(transactions());
-  }
+  };
 }
 
 function transactions() {
@@ -305,11 +305,11 @@ function transactions() {
     const { getTransactionsRequest } = getState().grpc;
     getTransactions(client, getTransactionsRequest,
         function(getTransactionsResponse, err) {
-      if (err) {
-        dispatch(getTransactionsError(err + " Please try again"));
-      } else {
-        dispatch(getTransactionsSuccess(getTransactionsResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getTransactionsError(err + ' Please try again'));
+          } else {
+            dispatch(getTransactionsSuccess(getTransactionsResponse));
+          }
+        });
+  };
 }

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1,6 +1,6 @@
 import { getNextAddress, renameAccount, getNextAccount,
   rescan, importPrivateKey, importScript, changePassphrase,
-getFundingTransaction, signTransction, publishTransaction, 
+getFundingTransaction, signTransction, publishTransaction,
 purchaseTickets } from '../middleware/grpc/control';
 
 export const GETNEXTADDRESS_ATTEMPT = 'GETNEXTADDRESS_ATTEMPT';
@@ -19,13 +19,13 @@ export function getNextAddressAttempt(accountNum) {
   var request = {
     account: accountNum,
     kind: 0,
-  }
+  };
   return (dispatch) => {
     dispatch({
       request: request,
       type: GETNEXTADDRESS_ATTEMPT });
     dispatch(getNextAddressAction());
-  }
+  };
 }
 
 function getNextAddressAction() {
@@ -34,13 +34,13 @@ function getNextAddressAction() {
     const { getNextAddressRequest } = getState().control;
     getNextAddress(client, getNextAddressRequest,
         function(getNextAddressResponse, err) {
-      if (err) {
-        dispatch(getNextAddressError(err + " Please try again"));
-      } else {
-        dispatch(getNextAddressSuccess(getNextAddressResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getNextAddressError(err + ' Please try again'));
+          } else {
+            dispatch(getNextAddressSuccess(getNextAddressResponse));
+          }
+        });
+  };
 }
 
 export const RENAMEACCOUNT_ATTEMPT = 'RENAMEACCOUNT_ATTEMPT';
@@ -65,7 +65,7 @@ export function renameAccountAttempt(accountNumber, newName) {
       request: request,
       type: RENAMEACCOUNT_ATTEMPT });
     dispatch(renameAccountAction());
-  }
+  };
 }
 
 function renameAccountAction() {
@@ -74,13 +74,13 @@ function renameAccountAction() {
     const { renameAccountRequest } = getState().control;
     renameAccount(client, renameAccountRequest,
         function(renameAccountResponse, err) {
-      if (err) {
-        dispatch(renameAccountError(err + " Please try again"));
-      } else {
-        dispatch(renameAccountSuccess(renameAccountResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(renameAccountError(err + ' Please try again'));
+          } else {
+            dispatch(renameAccountSuccess(renameAccountResponse));
+          }
+        });
+  };
 }
 
 export const RESCAN_ATTEMPT = 'RESCAN_ATTEMPT';
@@ -104,7 +104,7 @@ export function rescanAttempt(beginHeight) {
       request: request,
       type: RESCAN_ATTEMPT });
     dispatch(rescanAction());
-  }
+  };
 }
 
 function rescanAction() {
@@ -113,13 +113,13 @@ function rescanAction() {
     const { rescanRequest } = getState().control;
     rescan(client, rescanRequest,
         function(rescanResponse, err) {
-      if (err) {
-        dispatch(rescanError(err + " Please try again"));
-      } else {
-        dispatch(rescanSuccess(rescanResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(rescanError(err + ' Please try again'));
+          } else {
+            dispatch(rescanSuccess(rescanResponse));
+          }
+        });
+  };
 }
 
 export const GETNEXTACCOUNT_ATTEMPT = 'GETNEXTACCOUNT_ATTEMPT';
@@ -144,7 +144,7 @@ export function getNextAccountAttempt(passphrase, accountName) {
       request: request,
       type: GETNEXTACCOUNT_ATTEMPT });
     dispatch(getNextAccountAction());
-  }
+  };
 }
 
 function getNextAccountAction() {
@@ -153,13 +153,13 @@ function getNextAccountAction() {
     const { getNextAccountRequest } = getState().control;
     getNextAccount(client, getNextAccountRequest,
         function(getNextAccountResponse, err) {
-      if (err) {
-        dispatch(getNextAccountError(err + " Please try again"));
-      } else {
-        dispatch(getNextAccountSuccess(getNextAccountResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(getNextAccountError(err + ' Please try again'));
+          } else {
+            dispatch(getNextAccountSuccess(getNextAccountResponse));
+          }
+        });
+  };
 }
 
 export const IMPORTPRIVKEY_ATTEMPT = 'IMPORTPRIVKEY_ATTEMPT';
@@ -188,7 +188,7 @@ export function importPrivateKeyAttempt(passphrase, accountNum, wif, rescan, sca
       request: request,
       type: IMPORTPRIVKEY_ATTEMPT });
     dispatch(importPrivateKeyAction());
-  }
+  };
 }
 
 function importPrivateKeyAction() {
@@ -197,13 +197,13 @@ function importPrivateKeyAction() {
     const { importPrivateKeyRequest } = getState().control;
     importPrivateKey(client, importPrivateKeyRequest,
         function(importPrivateKeyResponse, err) {
-      if (err) {
-        dispatch(importPrivateKeyError(err + " Please try again"));
-      } else {
-        dispatch(importPrivateKeySuccess(importPrivateKeyResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(importPrivateKeyError(err + ' Please try again'));
+          } else {
+            dispatch(importPrivateKeySuccess(importPrivateKeyResponse));
+          }
+        });
+  };
 }
 
 export const IMPORTSCRIPT_ATTEMPT = 'IMPORTSCRIPT_ATTEMPT';
@@ -230,7 +230,7 @@ export function importScriptAttempt(passphrase, script, rescan, scanFrom) {
       request: request,
       type: IMPORTSCRIPT_ATTEMPT });
     dispatch(importScriptAction());
-  }
+  };
 }
 
 function importScriptAction() {
@@ -239,13 +239,13 @@ function importScriptAction() {
     const { importScriptRequest } = getState().control;
     importScript(client, importScriptRequest,
         function(importScriptResponse, err) {
-      if (err) {
-        dispatch(importScriptError(err + " Please try again"));
-      } else {
-        dispatch(importScriptSuccess(importScriptResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(importScriptError(err + ' Please try again'));
+          } else {
+            dispatch(importScriptSuccess(importScriptResponse));
+          }
+        });
+  };
 }
 
 export const CHANGEPASSPHRASE_ATTEMPT = 'CHANGEPASSPHRASE_ATTEMPT';
@@ -270,7 +270,7 @@ export function changePassphraseAttempt(oldPass, newPass) {
       request: request,
       type: CHANGEPASSPHRASE_ATTEMPT });
     dispatch(changePassphraseAction());
-  }
+  };
 }
 
 function changePassphraseAction() {
@@ -279,13 +279,13 @@ function changePassphraseAction() {
     const { changePassphraseRequest } = getState().control;
     changePassphrase(client, changePassphraseRequest,
         function(changePassphraseResponse, err) {
-      if (err) {
-        dispatch(changePassphraseError(err + " Please try again"));
-      } else {
-        dispatch(changePassphraseSuccess(changePassphraseResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(changePassphraseError(err + ' Please try again'));
+          } else {
+            dispatch(changePassphraseSuccess(changePassphraseResponse));
+          }
+        });
+  };
 }
 
 export const FUNDTX_ATTEMPT = 'FUNDTX_ATTEMPT';
@@ -311,7 +311,7 @@ export function fundTransactionAttempt(accountNum, targetAmount, requiredConf) {
       request: request,
       type: FUNDTX_ATTEMPT });
     dispatch(fundTransactionAction());
-  }
+  };
 }
 
 function fundTransactionAction() {
@@ -320,13 +320,13 @@ function fundTransactionAction() {
     const { fundTransactionRequest } = getState().control;
     fundTransaction(client, fundTransactionRequest,
         function(fundTransactionResponse, err) {
-      if (err) {
-        dispatch(fundTransactionError(err + " Please try again"));
-      } else {
-        dispatch(fundTransactionSuccess(fundTransactionResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(fundTransactionError(err + ' Please try again'));
+          } else {
+            dispatch(fundTransactionSuccess(fundTransactionResponse));
+          }
+        });
+  };
 }
 
 export const SIGNTX_ATTEMPT = 'SIGNTX_ATTEMPT';
@@ -351,7 +351,7 @@ export function signTransactionAttempt(passphrase, rawTx) {
       request: request,
       type: SIGNTX_ATTEMPT });
     dispatch(signTransactionAction());
-  }
+  };
 }
 
 function signTransactionAction() {
@@ -360,13 +360,13 @@ function signTransactionAction() {
     const { signTransactionRequest } = getState().control;
     signTransaction(client, signTransactionRequest,
         function(signTransactionResponse, err) {
-      if (err) {
-        dispatch(signTransactionError(err + " Please try again"));
-      } else {
-        dispatch(signTransactionSuccess(signTransactionResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(signTransactionError(err + ' Please try again'));
+          } else {
+            dispatch(signTransactionSuccess(signTransactionResponse));
+          }
+        });
+  };
 }
 
 export const PUBLISHTX_ATTEMPT = 'PUBLISHTX_ATTEMPT';
@@ -390,7 +390,7 @@ export function publishTransactionAttempt(txId) {
       request: request,
       type: PUBLISHTX_ATTEMPT });
     dispatch(publishTransactionAction());
-  }
+  };
 }
 
 function publishTransactionAction() {
@@ -399,13 +399,13 @@ function publishTransactionAction() {
     const { publishTransactionRequest } = getState().control;
     publishTransaction(client, publishTransactionRequest,
         function(publishTransactionResponse, err) {
-      if (err) {
-        dispatch(publishTransactionError(err + " Please try again"));
-      } else {
-        dispatch(publishTransactionSuccess(publishTransactionResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(publishTransactionError(err + ' Please try again'));
+          } else {
+            dispatch(publishTransactionSuccess(publishTransactionResponse));
+          }
+        });
+  };
 }
 
 export const PURCHASETICKET_ATTEMPT = 'PURCHASETICKET_ATTEMPT';
@@ -440,7 +440,7 @@ ticketAddress, numTickets, poolAddress, poolFees, expiry, txFee, ticketFee) {
       request: request,
       type: PURCHASETICKET_ATTEMPT });
     dispatch(purchaseTicketAction());
-  }
+  };
 }
 
 function purchaseTicketAction() {
@@ -449,11 +449,11 @@ function purchaseTicketAction() {
     const { purchaseTicketRequest } = getState().control;
     purchaseTicket(client, purchaseTicketRequest,
         function(purchaseTicketResponse, err) {
-      if (err) {
-        dispatch(purchaseTicketError(err + " Please try again"));
-      } else {
-        dispatch(purchaseTicketSuccess(purchaseTicketResponse));
-      }
-    })
-  }
+          if (err) {
+            dispatch(purchaseTicketError(err + ' Please try again'));
+          } else {
+            dispatch(purchaseTicketSuccess(purchaseTicketResponse));
+          }
+        });
+  };
 }

--- a/app/actions/LoginActions.js
+++ b/app/actions/LoginActions.js
@@ -13,20 +13,20 @@ function loginSuccess(client) {
   return (dispatch) => {
     dispatch({ client, type: LOGIN_SUCCESS });
     dispatch(getNextAddressAttempt(0));
-  }
+  };
 }
 
 export function loginRequest() {
   return (dispatch, getState) => {
     const { getLoaderRequest } = getState().walletLoader;
     dispatch({
-      address: getLoaderRequest.address, 
-      port: getLoaderRequest.port, 
-      passphrase: '', 
-      type: LOGIN_ATTEMPT })
+      address: getLoaderRequest.address,
+      port: getLoaderRequest.port,
+      passphrase: '',
+      type: LOGIN_ATTEMPT });
     dispatch(login());
-    
-  }
+
+  };
 }
 
 function login() {
@@ -34,10 +34,10 @@ function login() {
     const { address, port } = getState().login;
     client(address, port, function(client, err) {
       if (err) {
-        dispatch(loginError(err + " Please try again"));
+        dispatch(loginError(err + ' Please try again'));
       } else {
         dispatch(loginSuccess(client));
       }
-    })
-  }
+    });
+  };
 }

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -14,19 +14,19 @@ function transactionNtfnsData(response) {
 }
 
 export function transactionNftnsStart() {
-  var request = {}
+  var request = {};
   return (dispatch) => {
     dispatch({request: request, type: TRANSACTIONNFTNS_START });
     dispatch(startTransactionNtfns());
-  }
+  };
 }
 
 export function transactionNftnsEnd() {
-  var request = {}
+  var request = {};
   return (dispatch) => {
     dispatch({request: request, type: TRANSACTIONNFTNS_END });
     //
-  }
+  };
 }
 
 function startTransactionNtfns() {
@@ -35,11 +35,11 @@ function startTransactionNtfns() {
     const { transactionNftnsRequest } = getState().notifications;
     transactionNtfs(client, transactionNftnsRequest,
       function(data) {
-        console.log("Transaction received:", data);
+        console.log('Transaction received:', data);
         dispatch(startTransactionNtfns(data));
       }
-    )
-  }
+    );
+  };
 }
 
 export const SPENTNESSNFTNS_START = 'SPENTNESSNFTNS_START';
@@ -56,19 +56,19 @@ function spentnessNtfnsData(response) {
 }
 
 export function spentnessNftnsStart() {
-  var request = {}
+  var request = {};
   return (dispatch) => {
     dispatch({request: request, type: SPENTNESSNFTNS_START });
     dispatch(startSpentnessNtfns());
-  }
+  };
 }
 
 export function spentnessNftnsEnd() {
-  var request = {}
+  var request = {};
   return (dispatch) => {
     dispatch({request: request, type: SPENTNESSNFTNS_END });
     //
-  }
+  };
 }
 
 function startSpentnessNtfns() {
@@ -77,11 +77,11 @@ function startSpentnessNtfns() {
     const { spentnessNftnsRequest } = getState().notifications;
     spentnessNtfs(client, spentnessNftnsRequest,
       function(data) {
-        console.log("Spentness received:", data);
+        console.log('Spentness received:', data);
         dispatch(startSpentnessNtfns(data));
       }
-    )
-  }
+    );
+  };
 }
 
 export const ACCOUNTNFTNS_START = 'ACCOUNTNFTNS_START';
@@ -102,19 +102,19 @@ export function accountNftnsStart(accountNum) {
     account: accountNum,
     no_notify_unspent: false,
     no_notify_spent: false,
-  }
+  };
   return (dispatch) => {
     dispatch({request: request, type: ACCOUNTNFTNS_START });
     dispatch(startAccountNtfns());
-  }
+  };
 }
 
 export function accountNftnsEnd() {
-  var request = {}
+  var request = {};
   return (dispatch) => {
     dispatch({request: request, type: ACCOUNTNFTNS_END });
     //
-  }
+  };
 }
 
 function startAccountNtfns() {
@@ -123,9 +123,9 @@ function startAccountNtfns() {
     const { accountNftnsRequest } = getState().notifications;
     accountNtfs(client, accountNftnsRequest,
       function(data) {
-        console.log("Account received:", data);
+        console.log('Account received:', data);
         dispatch(startAccountNtfns(data));
       }
-    )
-  }
+    );
+  };
 }

--- a/app/actions/SeedServiceActions.js
+++ b/app/actions/SeedServiceActions.js
@@ -26,11 +26,11 @@ export function seederRequest() {
   return (dispatch, getState) => {
     const { getLoaderRequest } = getState().walletLoader;
     dispatch({
-      request: 
+      request:
       { address: getLoaderRequest.address, port: getLoaderRequest.port },
       type: SEEDER_ATTEMPT });
     dispatch(getSeeder());
-  }
+  };
 }
 
 function getSeeder() {
@@ -38,13 +38,13 @@ function getSeeder() {
     const { getSeederRequest } = getState().seedService;
     seeder(getSeederRequest, function(seeder, err) {
       if (err) {
-        dispatch(seederError(err + " Please try again"));
+        dispatch(seederError(err + ' Please try again'));
         //throw err
       } else {
         dispatch(seederSuccess(seeder));
       }
-    })
-  }
+    });
+  };
 }
 
 export const GENERATERANDOMSEED_ATTEMPT = 'GENERATERANDOMSEED_ATTEMPT';
@@ -59,28 +59,28 @@ function generateRandomSeedSuccess(response) {
   return (dispatch) => {
     dispatch({ response: response, type: GENERATERANDOMSEED_SUCCESS });
     dispatch(decodeSeedAttempt(response.seed_mnemonic));
-  }
+  };
 }
 
 export function generateRandomSeedAttempt() {
   return (dispatch) => {
     dispatch({request: {seed_length:0}, type: GENERATERANDOMSEED_ATTEMPT });
     dispatch(generateRandomSeedAction());
-  }
+  };
 }
 
 function generateRandomSeedAction() {
   return (dispatch, getState) => {
     const { seeder, generateRandomSeedRequest } = getState().seedService;
-    generateRandomSeed(seeder, generateRandomSeedRequest, 
+    generateRandomSeed(seeder, generateRandomSeedRequest,
         function(response, err) {
-      if (err) {
-        dispatch(generateRandomSeedError(err + " Please try again"));
-      } else {
-        dispatch(generateRandomSeedSuccess(response));
-      }
-    })
-  }
+          if (err) {
+            dispatch(generateRandomSeedError(err + ' Please try again'));
+          } else {
+            dispatch(generateRandomSeedSuccess(response));
+          }
+        });
+  };
 }
 
 export const DECODESEED_ATTEMPT = 'DECODESEED_ATTEMPT';
@@ -94,7 +94,7 @@ function decodeSeedError(error) {
 function decodeSeedSuccess(response) {
   return (dispatch) => {
     dispatch({response: response, type: DECODESEED_SUCCESS });
-  }
+  };
 }
 
 export function decodeSeedAttempt(mnemonic) {
@@ -102,19 +102,19 @@ export function decodeSeedAttempt(mnemonic) {
     console.log(mnemonic);
     dispatch({request: {user_input:mnemonic}, type: DECODESEED_ATTEMPT });
     dispatch(decodeSeedAction());
-  }
+  };
 }
 
 function decodeSeedAction() {
   return (dispatch, getState) => {
     const { seeder, decodeSeedRequest } = getState().seedService;
-    decodeSeed(seeder, decodeSeedRequest, 
+    decodeSeed(seeder, decodeSeedRequest,
         function(response, err) {
-      if (err) {
-        dispatch(decodeSeedError(err + " Please try again"));
-      } else {
-        dispatch(decodeSeedSuccess(response));
-      }
-    })
-  }
+          if (err) {
+            dispatch(decodeSeedError(err + ' Please try again'));
+          } else {
+            dispatch(decodeSeedSuccess(response));
+          }
+        });
+  };
 }

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -1,4 +1,4 @@
-import { loader, createWallet, walletExists, openWallet, 
+import { loader, createWallet, walletExists, openWallet,
   closeWallet, discoverAddresses, subscribeBlockNtfns,
   startConsensusRpc, fetchHeaders} from '../middleware/grpc/loader';
 import { loginRequest } from './LoginActions';
@@ -30,11 +30,11 @@ export function loaderRequest(address, port) {
   var request = {
     address: address,
     port: port,
-  }
+  };
   return (dispatch) => {
     dispatch({request: request, type: LOADER_ATTEMPT });
     setTimeout(dispatch(getLoader()), 3000);
-  }
+  };
 }
 
 function getLoader() {
@@ -42,13 +42,13 @@ function getLoader() {
     const { getLoaderRequest } = getState().walletLoader;
     loader(getLoaderRequest, function(loader, err) {
       if (err) {
-        dispatch(loaderError(err + " Please try again"));
+        dispatch(loaderError(err + ' Please try again'));
         //throw err
       } else {
         dispatch(loaderSuccess(loader));
       }
-    })
-  }
+    });
+  };
 }
 
 export const WALLETEXIST_ATTEMPT = 'WALLETEXIST_ATTEMPT';
@@ -62,7 +62,7 @@ function walletExistError(error) {
 function walletExistSuccess(response) {
   return (dispatch) => {
     dispatch({response: response, type: WALLETEXIST_SUCCESS });
-  }
+  };
 }
 
 export function walletExistRequest() {
@@ -70,21 +70,21 @@ export function walletExistRequest() {
   return (dispatch) => {
     dispatch({request: {}, type: WALLETEXIST_ATTEMPT });
     setTimeout(dispatch(checkWalletExist()), 3000);
-  }
+  };
 }
 
 function checkWalletExist() {
   return (dispatch, getState) => {
     const { loader, walletExistRequest } = getState().walletLoader;
-    walletExists(loader, walletExistRequest, 
+    walletExists(loader, walletExistRequest,
         function(response, err) {
-      if (err) {
-        dispatch(walletExistError(err + " Please try again"));
-      } else {
-        dispatch(walletExistSuccess(response));
-      }
-    })
-  }
+          if (err) {
+            dispatch(walletExistError(err + ' Please try again'));
+          } else {
+            dispatch(walletExistSuccess(response));
+          }
+        });
+  };
 }
 
 export const CREATEWALLET_ATTEMPT = 'CREATEWALLET_ATTEMPT';
@@ -100,7 +100,7 @@ function createWalletSuccess() {
     dispatch({response: {}, type: CREATEWALLET_SUCCESS });
     dispatch(startRpcRequest());
     dispatch(loginRequest());
-  }
+  };
 }
 
 export function createWalletRequest(pubPass, privPass, seed) {
@@ -109,28 +109,28 @@ export function createWalletRequest(pubPass, privPass, seed) {
     private_passphrase: Buffer.from(privPass),
     seed: Buffer.from(seed),
   };
-  return (dispatch) => { 
+  return (dispatch) => {
     dispatch({
       request: request,
       pubPass: pubPass,
       privPass: privPass,
       type: CREATEWALLET_ATTEMPT });
     setTimeout(dispatch(createNewWallet()), 3000);
-  }
+  };
 }
 
 function createNewWallet() {
   return (dispatch, getState) => {
     const { loader, walletCreateRequest } = getState().walletLoader;
-    createWallet(loader, walletCreateRequest, 
+    createWallet(loader, walletCreateRequest,
         function(err) {
-      if (err) {
-        dispatch(createWalletError(err + " Please try again"));
-      } else {
-        dispatch(createWalletSuccess());
-      }
-    })
-  }
+          if (err) {
+            dispatch(createWalletError(err + ' Please try again'));
+          } else {
+            dispatch(createWalletSuccess());
+          }
+        });
+  };
 }
 
 export const OPENWALLET_ATTEMPT = 'OPENWALLET_ATTEMPT';
@@ -152,30 +152,30 @@ function openWalletSuccess() {
 export function openWalletRequest(pubPass, privPass) {
   var request = {
     public_passphrase: Buffer.from(pubPass),
-  }
+  };
   return (dispatch) => {
     dispatch({
-      request: request, 
+      request: request,
       pubPass: pubPass,
       privPass: privPass,
       type: OPENWALLET_ATTEMPT});
 
     setTimeout(dispatch(openWalletAction()), 3000);
-  }
+  };
 }
 
 function openWalletAction() {
   return (dispatch, getState) => {
     const { loader, walletOpenRequest } = getState().walletLoader;
-    openWallet(loader, walletOpenRequest, 
+    openWallet(loader, walletOpenRequest,
         function(err) {
-      if (err) {
-        dispatch(openWalletError(pubPass + err + " Please try again"));
-      } else {
-        dispatch(openWalletSuccess());
-      }
-    })
-  }
+          if (err) {
+            dispatch(openWalletError(pubPass + err + ' Please try again'));
+          } else {
+            dispatch(openWalletSuccess());
+          }
+        });
+  };
 }
 
 export const CLOSEWALLET_ATTEMPT = 'CLOSEWALLET_ATTEMPT';
@@ -196,7 +196,7 @@ export function closeWalletRequest() {
   return (dispatch) => {
     dispatch({request: {}, type: CLOSEWALLET_ATTEMPT});
     dispatch(closeWalletAction());
-  }
+  };
 }
 
 function closeWalletAction() {
@@ -204,13 +204,13 @@ function closeWalletAction() {
     const { loader, walletCloseRequest } = getState().walletLoader;
     closeWallet(loader, walletCloseRequest,
         function(err) {
-      if (err) {
-        dispatch(closeWalletError(err + " Please try again"));
-      } else {
-        dispatch(closeWalletSuccess());
-      }
-    })
-  }
+          if (err) {
+            dispatch(closeWalletError(err + ' Please try again'));
+          } else {
+            dispatch(closeWalletSuccess());
+          }
+        });
+  };
 }
 
 export const STARTRPC_ATTEMPT = 'STARTRPC_ATTEMPT';
@@ -230,14 +230,14 @@ function startRpcSuccess() {
 
 export function startRpcRequest() {
   var cfg = getCfg();
-  var rpcport = "";
-  if (cfg.network == "testnet") {
+  var rpcport = '';
+  if (cfg.network == 'testnet') {
     rpcport = cfg.daemon_port_testnet;
   } else {
     rpcport = cfg.daemon_port;
   }
   var request = {
-    network_address: "127.0.0.1:" + rpcport,
+    network_address: '127.0.0.1:' + rpcport,
     username: cfg.rpc_user,
     password: Buffer.from(cfg.rpc_pass),
     certificate: getDcrdCert(),
@@ -245,7 +245,7 @@ export function startRpcRequest() {
   return (dispatch) => {
     dispatch({request: request, type: STARTRPC_ATTEMPT});
     dispatch(startRpcAction());
-  }
+  };
 }
 
 function startRpcAction() {
@@ -253,13 +253,13 @@ function startRpcAction() {
     const { loader, startRpcRequest } = getState().walletLoader;
     startConsensusRpc(loader, startRpcRequest,
         function(err) {
-      if (err) {
-        dispatch(startRpcError(err + " Please try again"));
-      } else {
-        dispatch(startRpcSuccess());
-      }
-    })
-  }
+          if (err) {
+            dispatch(startRpcError(err + ' Please try again'));
+          } else {
+            dispatch(startRpcSuccess());
+          }
+        });
+  };
 }
 
 export const DISCOVERADDRESS_ATTEMPT = 'DISCOVERADDRESS_ATTEMPT';
@@ -280,14 +280,14 @@ function discoverAddressSuccess() {
 export function discoverAddressAttempt(discoverAccts) {
 
   return (dispatch, getState) => {
-    const { privatePassphrase } = getState().walletLoader
+    const { privatePassphrase } = getState().walletLoader;
     var request = {
       discover_accounts: discoverAccts,
       private_passphrase: Buffer.from(privatePassphrase),
-    }
+    };
     dispatch({request: request, type: DISCOVERADDRESS_ATTEMPT});
     dispatch(discoverAddressAction());
-  }
+  };
 }
 
 function discoverAddressAction() {
@@ -296,13 +296,13 @@ function discoverAddressAction() {
     const { discoverAddressRequest } = getState().walletLoader;
     discoverAddresses(loader, discoverAddressRequest,
         function(err) {
-      if (err) {
-        dispatch(discoverAddressError(err + " Please try again"));
-      } else {
-        dispatch(discoverAddressSuccess());
-      }
-    })
-  }
+          if (err) {
+            dispatch(discoverAddressError(err + ' Please try again'));
+          } else {
+            dispatch(discoverAddressSuccess());
+          }
+        });
+  };
 }
 
 export const SUBSCRIBEBLOCKNTFNS_ATTEMPT = 'SUBSCRIBEBLOCKNTFNS_ATTEMPT';
@@ -323,7 +323,7 @@ export function subscribeBlockAttempt() {
   return (dispatch) => {
     dispatch({request: {}, type: SUBSCRIBEBLOCKNTFNS_ATTEMPT});
     dispatch(subscribeBlockAction());
-  }
+  };
 }
 
 function subscribeBlockAction() {
@@ -331,13 +331,13 @@ function subscribeBlockAction() {
     const { loader, subscribeBlockNtfnsRequest } = getState().walletLoader;
     subscribeBlockNtfns(loader, subscribeBlockNtfnsRequest,
         function(err) {
-      if (err) {
-        dispatch(subscribeBlockError(err + " Please try again"));
-      } else {
-        dispatch(subscribeBlockSuccess());
-      }
-    })
-  }
+          if (err) {
+            dispatch(subscribeBlockError(err + ' Please try again'));
+          } else {
+            dispatch(subscribeBlockSuccess());
+          }
+        });
+  };
 }
 
 export const FETCHHEADERS_ATTEMPT = 'FETCHHEADER_ATTEMPT';
@@ -360,7 +360,7 @@ export function fetchHeadersAttempt() {
   return (dispatch) => {
     dispatch({request: {}, type: FETCHHEADERS_ATTEMPT});
     dispatch(fetchHeadersAction());
-  }
+  };
 }
 
 function fetchHeadersAction() {
@@ -368,11 +368,11 @@ function fetchHeadersAction() {
     const { loader, fetchHeadersRequest } = getState().walletLoader;
     fetchHeaders(loader, fetchHeadersRequest,
         function(err) {
-      if (err) {
-        dispatch(fetchHeadersFailed(err + " Please try again"));
-      } else {
-        dispatch(fetchHeadersSuccess());
-      }
-    })
-  }
+          if (err) {
+            dispatch(fetchHeadersFailed(err + ' Please try again'));
+          } else {
+            dispatch(fetchHeadersSuccess());
+          }
+        });
+  };
 }

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -26,9 +26,9 @@ class Header extends Component {
     this.state = {open:false};
   }
   handleToggle = () => this.setState({open: !this.state.open});
-  
+
   render() {
-    const page = "HOME";
+    const page = 'HOME';
     return (
       <div>
         <AppBar onLeftIconButtonTouchTap={this.handleToggle} title="Decrediton" />

--- a/app/components/History.js
+++ b/app/components/History.js
@@ -10,12 +10,12 @@ class History extends Component{
     client: PropTypes.object.isRequired,
     isLoggedIn: PropTypes.bool.isRequired
   };
-  
+
   render() {
     const { client, isLoggedIn } = this.props;
 
     /* View that will be seen when user has a set Client */
-    const historyView = (      
+    const historyView = (
       <div>
         <h1>History Page</h1>
         <Table striped bordered condensed hover>
@@ -49,7 +49,7 @@ class History extends Component{
     /* Check to see that client is not undefined */
     if (isLoggedIn) {
       if (client === undefined) {
-        <p>Error occurred, should have client available</p>
+        <p>Error occurred, should have client available</p>;
       } else {
         return(historyView);
       }
@@ -61,6 +61,6 @@ class History extends Component{
       );
     }
   }
-};
+}
 
 export default History;

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -11,18 +11,18 @@ import LinearProgress from 'material-ui/LinearProgress';
 
 const styles = {
   mainArea: {
-    backgroundColor:"#2971ff"
+    backgroundColor:'#2971ff'
   },
   sideBar: {
-    backgroundColor:"#2ed8a3"
+    backgroundColor:'#2ed8a3'
   },
   error: {
-    color:"red"
+    color:'red'
   },
   buttons: {
     margin: 12
   }
-}
+};
 
 class Home extends Component{
   constructor(props) {
@@ -42,7 +42,7 @@ class Home extends Component{
     getStakeInfoRequestAttempt: PropTypes.bool.isRequired,
 
     getLoaderRequestAttempt: PropTypes.bool.isRequired,
-    walletCreateRequestAttempt: PropTypes.bool.isRequired,    
+    walletCreateRequestAttempt: PropTypes.bool.isRequired,
     walletExistRequestAttempt: PropTypes.bool.isRequired,
     walletOpenRequestAttempt: PropTypes.bool.isRequired,
   }
@@ -58,7 +58,7 @@ class Home extends Component{
     const { getBalanceRequestAttempt, getBalanceResponse } = this.props;
     const { getStakeInfoRequestAttempt, getStakeInfoResponse } = this.props;
 
-    const { loader, getLoaderRequestAttempt, getLoaderError, loaderRequest } = this.props; 
+    const { loader, getLoaderRequestAttempt, getLoaderError, loaderRequest } = this.props;
     const { walletCreateResponse, walletCreateRequestAttempt, walletCreateError } = this.props;
     const { walletOpenResponse, walletOpenRequestAttempt, walletOpenError } = this.props;
     const { walletExistResponse, walletExistRequestAttempt, walletExistError } = this.props;
@@ -66,7 +66,7 @@ class Home extends Component{
     const { startRpcResponse, startRpcRequestAttempt, startRpcError } = this.props;
 
     /*  View that will be seen on fresh starts */
-    const getStarted = (      
+    const getStarted = (
       <div>
         <p>{error}</p>
         <h3>Welcome to Decrediton</h3>
@@ -88,63 +88,63 @@ class Home extends Component{
       </div>);
 
     /* View that will be seen when user has a set Client */
-    const homeView = (      
+    const homeView = (
       <div >
         <h1>Home Page</h1>
         <h3>Current balance: {getBalanceResponse === null ? 'Please refresh' : getBalanceResponse.total }</h3>
-        <RaisedButton                   
+        <RaisedButton
           style={styles.buttons}
           disabled={getBalanceRequestAttempt}
           onClick={!getBalanceRequestAttempt ? () => this.handleBalanceClick() : null}
           label={getBalanceRequestAttempt ? 'Getting Balance...' : 'Get Balance'}/>
         <h3>StakeInfo: {getStakeInfoResponse === null ? 'Please refresh' : getStakeInfoResponse.pool_size}</h3>
-        <RaisedButton 
+        <RaisedButton
           style={styles.buttons}
           disabled={getStakeInfoRequestAttempt}
           onClick={!getStakeInfoRequestAttempt? () => this.props.getStakeInfoAttempt() : null}
           label={getStakeInfoRequestAttempt ? 'Getting Stake Info...' : 'Get Stake Info'}/>
       </div>);
 
-    const getStartedCreateWallet = (    
+    const getStartedCreateWallet = (
       <div>
         <CreateWalletForm />
       </div>);
 
-    const getStartedWalletCreating = (      
+    const getStartedWalletCreating = (
       <div >
         <h3> Creating wallet </h3>
         <LinearProgress mode="indeterminate" />
       </div>);
-    
-    const getStartedWalletLoader = (      
+
+    const getStartedWalletLoader = (
       <div >
         <p>{error}</p>
         <RaisedButton type="submit"
           style={styles.buttons}
           primary={true}
-          onClick={() => {loaderRequest(address, port)}}
+          onClick={() => {loaderRequest(address, port);}}
           label='Get Started'/>
       </div>);
 
-    const getStartedGettingLoader = (      
+    const getStartedGettingLoader = (
       <div >
         <h3>Getting wallet loader service</h3>
         <LinearProgress mode="indeterminate" />
       </div>);
-      
-    const getStartedWalletExistRequest = (      
+
+    const getStartedWalletExistRequest = (
       <div >
         <h3>Checking if wallet exists</h3>
         <LinearProgress mode="indeterminate" />
       </div>);
 
-    const getStartedWalletExist = (      
+    const getStartedWalletExist = (
       <div>
         <p>{error}</p>
         <h3>Check if wallet exists</h3>
       </div>);
 
-    const getStartedWalletOpen = (      
+    const getStartedWalletOpen = (
       <div>
         <p >{error}</p>
         <h3>Opening wallet</h3>
@@ -152,7 +152,7 @@ class Home extends Component{
         <WalletOpenForm />
       </div>);
 
-    const getStartedOpeningWallet = (      
+    const getStartedOpeningWallet = (
       <div>
         <h3>Opening wallet</h3>
         <LinearProgress mode="indeterminate" />
@@ -184,17 +184,17 @@ class Home extends Component{
     }
     // Step 2b creating wallet
     if (walletCreateRequestAttempt) {
-      return(getStartedWalletCreating)
+      return(getStartedWalletCreating);
     }
     // Step 2 wallet exist action complete, though
     // wallet does not exist
-    
+
     if (walletExistResponse !== null && !walletExistResponse.exists) {
-      return(getStartedCreateWallet)
+      return(getStartedCreateWallet);
     }
     // Step 2 action
     if (walletExistRequestAttempt) {
-      return(getStartedWalletExistRequest)
+      return(getStartedWalletExistRequest);
     }
     // Step 1 complete/ Step 2 start
     if (loader !== null) {
@@ -208,6 +208,6 @@ class Home extends Component{
     // Step 1 start
     return (getStartedWalletLoader);
   }
-};
+}
 
 export default Home;

--- a/app/components/Receive.js
+++ b/app/components/Receive.js
@@ -15,7 +15,7 @@ class Receive extends Component{
     getNextAddressResponse: PropTypes.object,
     getNextAddressRequestAttempt: PropTypes.bool.isRequired,
   };
-  
+
   render() {
     const { client, isLoggedIn } = this.props;
     const { getNextAddressResponse, getNextAddressAttempt, getNextAddressRequestAttempt } = this.props;
@@ -25,7 +25,7 @@ class Receive extends Component{
       <div>
         <h1>Receive Page</h1>
         <h3>Current address: {getNextAddressResponse === null ? 'Please refresh' : getNextAddressResponse.address }</h3>
-        <RaisedButton 
+        <RaisedButton
           style={style}
           disabled={getNextAddressRequestAttempt}
           onClick={!getNextAddressRequestAttempt? () => this.props.getNextAddressAttempt(0) : null}
@@ -35,7 +35,7 @@ class Receive extends Component{
     /* Check to see that client is not undefined */
     if (isLoggedIn) {
       if (client === undefined) {
-        <p>Error occurred, should have client available</p>
+        <p>Error occurred, should have client available</p>;
       } else {
         return(receiveView);
       }
@@ -47,6 +47,6 @@ class Receive extends Component{
       );
     }
   }
-};
+}
 
 export default Receive;

--- a/app/components/Send.js
+++ b/app/components/Send.js
@@ -13,12 +13,12 @@ class Send extends Component{
     client: PropTypes.object,
     isLoggedIn: PropTypes.bool.isRequired
   };
-  
+
   render() {
     const { client, isLoggedIn } = this.props;
 
     /* View that will be seen when user has a set Client */
-    const sendView = (      
+    const sendView = (
       <div>
         <h1>Send Page</h1>
       </div>);
@@ -26,7 +26,7 @@ class Send extends Component{
     /* Check to see that client is not undefined */
     if (isLoggedIn) {
       if (client === undefined) {
-        <p>Error occurred, should have client available</p>
+        <p>Error occurred, should have client available</p>;
       } else {
         return(sendView);
       }
@@ -38,6 +38,6 @@ class Send extends Component{
       );
     }
   }
-};
+}
 
 export default Send;

--- a/app/config.js
+++ b/app/config.js
@@ -4,31 +4,31 @@ export function getCfg() {
   // If value is missing (or no config file) write the defaults.
   if (!config.has('network')) {
     config.set('network', 'testnet');
-  };
+  }
   if (!config.has('wallet_port_testnet')) {
     config.set('wallet_port_testnet', '19112');
-  };
+  }
   if (!config.has('wallet_port')) {
     config.set('wallet_port', '9112');
-  };
+  }
   if (!config.has('cert_path')) {
     config.set('cert_path','');
-  };
+  }
   if (!config.has('daemon_port')) {
     config.set('daemon_port','9109');
-  };
-    if (!config.has('daemon_port_testnet')) {
+  }
+  if (!config.has('daemon_port_testnet')) {
     config.set('daemon_port_testnet','19109');
-  };
+  }
   if (!config.has('daemon_cert_path')) {
     config.set('daemon_cert_path','');
-  };
+  }
   if (!config.has('rpc_user')) {
     config.set('rpc_user','USER');
-  };
+  }
   if (!config.has('rpc_pass')) {
     config.set('rpc_pass','PASSWORD');
-  };
+  }
 
   var cfg = {
     'network' :config.get('network'),
@@ -42,4 +42,4 @@ export function getCfg() {
     'rpc_pass': config.get('rpc_pass')
   };
   return(cfg);
-};
+}

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component, PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import Header from '../components/Header';
@@ -6,7 +6,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 // For Customization Options, edit  or use
 // './src/material_ui_raw_theme_file.jsx' as a template.
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import theme from '../materialUITheme'
+import theme from '../materialUITheme';
 import darkBaseTheme from 'material-ui/styles/baseThemes/darkBaseTheme';
 
 export default class App extends Component {

--- a/app/containers/CreateWalletForm.js
+++ b/app/containers/CreateWalletForm.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { createNewWallet, createWalletRequest } from '../actions/WalletLoaderActions'
+import React from 'react';
+import { connect } from 'react-redux';
+import { createNewWallet, createWalletRequest } from '../actions/WalletLoaderActions';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 
@@ -16,40 +16,40 @@ let CreateWalletForm = ({ dispatch }) => {
   return (
     <div>
       <form onSubmit={e => {
-        e.preventDefault()
+        e.preventDefault();
         if (pubpass == '' || privpass == '' || seed == '') {
-          return
+          return;
         }
-        dispatch(createWalletRequest(pubpass, privpass, seed))
-        pubpass = ''
-        privpass = ''
-        seed = ''
+        dispatch(createWalletRequest(pubpass, privpass, seed));
+        pubpass = '';
+        privpass = '';
+        seed = '';
       }}>
         <TextField
           id="pubpass"
           hintText="Public Password"
           floatingLabelText="Public Password"
-          onBlur={(e) =>{pubpass = e.target.value}}
+          onBlur={(e) =>{pubpass = e.target.value;}}
         /><br />
         <TextField
           id="privpass"
           hintText="Private Password"
           floatingLabelText="Private Password"
-          onBlur={(e) =>{privpass = e.target.value}}
+          onBlur={(e) =>{privpass = e.target.value;}}
         /><br />
         <TextField
           id="seed"
           hintText="Seed"
           floatingLabelText="Seed"
-          onBlur={(e) =>{seed = e.target.value}}
+          onBlur={(e) =>{seed = e.target.value;}}
         /><br />
         <RaisedButton type="submit"
-         style={style} 
+         style={style}
          label='Create Wallet'/>
       </form>
     </div>
-  )
-}
-CreateWalletForm = connect()(CreateWalletForm)
+  );
+};
+CreateWalletForm = connect()(CreateWalletForm);
 
-export default CreateWalletForm
+export default CreateWalletForm;

--- a/app/containers/HomePage.js
+++ b/app/containers/HomePage.js
@@ -34,7 +34,7 @@ function mapStateToProps(state) {
     walletOpenRequestAttempt: state.walletLoader.walletOpenRequestAttempt,
     walletOpenResponse: state.walletLoader.walletOpenResponse,
 
-  
+
   };
 }
 

--- a/app/containers/LoaderForm.js
+++ b/app/containers/LoaderForm.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { getLoader, loaderRequest } from '../actions/WalletLoaderActions'
+import React from 'react';
+import { connect } from 'react-redux';
+import { getLoader, loaderRequest } from '../actions/WalletLoaderActions';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 
@@ -15,33 +15,33 @@ let LoaderForm = ({ dispatch }) => {
   return (
     <div>
       <form onSubmit={e => {
-        e.preventDefault()
+        e.preventDefault();
         if (address == '' || port == '') {
-          return
+          return;
         }
-        dispatch(loaderRequest(address, port))
-        address = ''
-        port = ''
+        dispatch(loaderRequest(address, port));
+        address = '';
+        port = '';
       }}>
         <TextField
           id="address"
           hintText="Address"
           floatingLabelText="Address"
-          onBlur={(e) =>{address = e.target.value}}
+          onBlur={(e) =>{address = e.target.value;}}
         /><br />
         <TextField
           id="port"
           hintText="Port"
           floatingLabelText="Port"
-          onBlur={(e) =>{port = e.target.value}}
+          onBlur={(e) =>{port = e.target.value;}}
         /><br />
         <RaisedButton type="submit"
-         style={style} 
+         style={style}
          label='Get Loader'/>
       </form>
     </div>
-  )
-}
-LoaderForm = connect()(LoaderForm)
+  );
+};
+LoaderForm = connect()(LoaderForm);
 
-export default LoaderForm
+export default LoaderForm;

--- a/app/containers/LoginForm.js
+++ b/app/containers/LoginForm.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { login, loginRequest } from '../actions/LoginActions'
+import React from 'react';
+import { connect } from 'react-redux';
+import { login, loginRequest } from '../actions/LoginActions';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 
@@ -16,39 +16,39 @@ let LoginForm = ({ dispatch }) => {
   return (
     <div>
       <form onSubmit={e => {
-        e.preventDefault()
+        e.preventDefault();
         if (address == '' || port == '' || passphrase == '') {
-          return
+          return;
         }
-        dispatch(loginRequest(address, port, passphrase))
-        address = ''
-        port = ''
+        dispatch(loginRequest(address, port, passphrase));
+        address = '';
+        port = '';
       }}>
         <TextField
           id="address"
           hintText="Address"
           floatingLabelText="Address"
-          onBlur={(e) =>{address = e.target.value}}
+          onBlur={(e) =>{address = e.target.value;}}
         /><br />
         <TextField
           id="port"
           hintText="Port"
           floatingLabelText="Port"
-          onBlur={(e) =>{port = e.target.value}}
+          onBlur={(e) =>{port = e.target.value;}}
         /><br />
         <TextField
           id="passphase"
           hintText="Passphrase"
           floatingLabelText="Passphrase"
-          onBlur={(e) =>{passphrase = e.target.value}}
+          onBlur={(e) =>{passphrase = e.target.value;}}
         /><br />
         <RaisedButton type="submit"
-         style={style} 
+         style={style}
          label='Login'/>
       </form>
     </div>
-  )
-}
-LoginForm = connect()(LoginForm)
+  );
+};
+LoginForm = connect()(LoginForm);
 
-export default LoginForm
+export default LoginForm;

--- a/app/containers/WalletExistForm.js
+++ b/app/containers/WalletExistForm.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { checkWalletExist, walletExistRequest } from '../actions/WalletLoaderActions'
+import React from 'react';
+import { connect } from 'react-redux';
+import { checkWalletExist, walletExistRequest } from '../actions/WalletLoaderActions';
 import RaisedButton from 'material-ui/RaisedButton';
 
 const style = {
@@ -11,16 +11,16 @@ let WalletExistForm = ({ dispatch }) => {
   return (
     <div>
       <form onSubmit={e => {
-        e.preventDefault()
-        dispatch(walletExistRequest())
+        e.preventDefault();
+        dispatch(walletExistRequest());
       }}>
         <RaisedButton type="submit"
-         style={style} 
+         style={style}
          label='Check wallet exists'/>
       </form>
     </div>
-  )
-}
-WalletExistForm = connect()(WalletExistForm)
+  );
+};
+WalletExistForm = connect()(WalletExistForm);
 
-export default WalletExistForm
+export default WalletExistForm;

--- a/app/containers/WalletOpenForm.js
+++ b/app/containers/WalletOpenForm.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { openWalletAction, openWalletRequest } from '../actions/WalletLoaderActions'
+import React from 'react';
+import { connect } from 'react-redux';
+import { openWalletAction, openWalletRequest } from '../actions/WalletLoaderActions';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 
@@ -15,34 +15,34 @@ let LoaderForm = ({ dispatch }) => {
   return (
     <div>
       <form onSubmit={e => {
-        e.preventDefault()
+        e.preventDefault();
         if (pubpass == '' || privpass == '') {
           console.log(pubpass, privpass);
-          return
+          return;
         }
-        dispatch(openWalletRequest(pubpass, privpass))
-        pubpass = ''
-        privpass = ''
+        dispatch(openWalletRequest(pubpass, privpass));
+        pubpass = '';
+        privpass = '';
       }}>
         <TextField
           id="pubpass"
           hintText="Public Password"
           floatingLabelText="Public Password"
-          onBlur={(e) =>{pubpass = e.target.value}}
+          onBlur={(e) =>{pubpass = e.target.value;}}
         /><br />
         <TextField
           id="privpass"
           hintText="Private Password"
           floatingLabelText="Private Password"
-          onBlur={(e) =>{privpass = e.target.value}}
+          onBlur={(e) =>{privpass = e.target.value;}}
         /><br />
         <RaisedButton type="submit"
-         style={style} 
+         style={style}
          label='Open Wallet'/>
       </form>
     </div>
-  )
-}
-LoaderForm = connect()(LoaderForm)
+  );
+};
+LoaderForm = connect()(LoaderForm);
 
-export default LoaderForm
+export default LoaderForm;

--- a/app/index.js
+++ b/app/index.js
@@ -4,15 +4,15 @@ import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router, hashHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
-import injectTapEventPlugin from "react-tap-event-plugin";
+import injectTapEventPlugin from 'react-tap-event-plugin';
 import routes from './routes';
 import configureStore from './store/configureStore';
 import { getCfg } from './config.js';
 
 var cfg = getCfg();
 
-var grpcport = "";
-if (cfg.network == "testnet") {
+var grpcport = '';
+if (cfg.network == 'testnet') {
   grpcport = cfg.wallet_port_testnet;
 } else {
   grpcport = cfg.wallet_port;
@@ -20,12 +20,12 @@ if (cfg.network == "testnet") {
 
 var initialState = {
   login: {
-    address: "127.0.0.1",
+    address: '127.0.0.1',
     port: grpcport,
-    passphrase: "",
+    passphrase: '',
     isLoggedIn: false,
     isLoggingIn: false,
-    error: "",
+    error: '',
   },
   grpc: {
     // Balance
@@ -70,14 +70,14 @@ var initialState = {
     getTransactionsResponse: null,
   },
   walletLoader: {
-    // XXX Wallet Passphrases 
-    // We are storing these in state for dev ease, 
-    // but will construct an alternate system 
+    // XXX Wallet Passphrases
+    // We are storing these in state for dev ease,
+    // but will construct an alternate system
     // to properly/securely/safely store passphrases.
-    privatePassphrase: "",
-    publicPassphrase: "",
+    privatePassphrase: '',
+    publicPassphrase: '',
     // Loader
-    getLoaderRequestAttempt: false,   
+    getLoaderRequestAttempt: false,
     getLoaderRequest: null,
     loader: null,
     getLoaderError: null,
@@ -90,7 +90,7 @@ var initialState = {
     walletExistRequestAttempt: false,
     walletExistRequest: null,
     walletExistResponse: null,
-    walletExistError: null,    
+    walletExistError: null,
     // WalletOpen
     walletOpenRequestAttempt: false,
     walletOpenRequest: null,

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -35,17 +35,17 @@ function appDataDirectory() {
 }
 
 function GRPCWalletPort() {
-  if (cfg.network == "mainnet") {
-    return cfg.wallet_port
+  if (cfg.network == 'mainnet') {
+    return cfg.wallet_port;
   }
-  return cfg.wallet_port_testnet
+  return cfg.wallet_port_testnet;
 }
 
 function RPCDaemonPort() {
-  if (cfg.network == "mainnet") {
-    return cfg.daemon_port
+  if (cfg.network == 'mainnet') {
+    return cfg.daemon_port;
   }
-  return cfg.daemon_port_testnet
+  return cfg.daemon_port_testnet;
 }
 
 const installExtensions = async () => {
@@ -72,8 +72,8 @@ const launchDCRD = () => {
   // The spawn() below opens a pipe on fd 3
   args.push('--piperx=3');
 
-  if (cfg.network == "testnet") {
-     args.push('--testnet');
+  if (cfg.network == 'testnet') {
+    args.push('--testnet');
   }
 
   args.push('--rpclisten=127.0.0.1:' + RPCDaemonPort());
@@ -98,7 +98,7 @@ const launchDCRD = () => {
   });
 
   dcrd.unref();
-}
+};
 
 const launchDCRWallet = () => {
   var spawn = require('child_process').spawn;
@@ -113,8 +113,8 @@ const launchDCRWallet = () => {
 
   args.push('--appdata=' + appDataDirectory());
   args.push('--experimentalrpclisten=127.0.0.1:' + GRPCWalletPort());
-  if (cfg.network == "testnet") {
-     args.push('--testnet');
+  if (cfg.network == 'testnet') {
+    args.push('--testnet');
   }
   console.log(`Starting dcrwallet with ${args}`);
   var dcrwallet = spawn('dcrwallet', args, { detached: true, stdio: [ 'ignore', 'pipe', 'pipe', 'ignore', 'pipe'  ] });

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -1,7 +1,6 @@
 process.env['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA';
 
 import fs from 'fs';
-import url from 'url';
 import path from 'path';
 
 import os from 'os';
@@ -9,220 +8,217 @@ import grpc from 'grpc';
 
 import { getCfg } from '../../config.js';
 
-//import Buffer from 'buffer';
-var Buffer = require('buffer/').Buffer;
-
 export function getCert() {
-    var cfg = getCfg();
-    if (cfg.cert_path != '') {
-      return(cfg.cert_path)
-    }
-    var certPath = '';
-    if (os.platform() == 'win32') {
-        certPath = path.join(process.env.LOCALAPPDATA, 'Decrediton', 'rpc.cert');
-    } else if (os.platform() == 'darwin') {
-        certPath = path.join(process.env.HOME, 'Library', 'Application Support',
+  var cfg = getCfg();
+  if (cfg.cert_path != '') {
+    return(cfg.cert_path);
+  }
+  var certPath = '';
+  if (os.platform() == 'win32') {
+    certPath = path.join(process.env.LOCALAPPDATA, 'Decrediton', 'rpc.cert');
+  } else if (os.platform() == 'darwin') {
+    certPath = path.join(process.env.HOME, 'Library', 'Application Support',
             'Decrediton', 'rpc.cert');
-    } else {
-        var certPath = path.join(process.env.HOME, '.decrediton', 'rpc.cert');
-    }
+  } else {
+    certPath = path.join(process.env.HOME, '.decrediton', 'rpc.cert');
+  }
 
-    var cert = fs.readFileSync(certPath);
-    return(cert)
+  var cert = fs.readFileSync(certPath);
+  return(cert);
 }
 
 export function getDcrdCert() {
-    var cfg = getCfg();
-    if (cfg.daemon_cert_path != '') {
-      return(cfg.daemon_cert_path)
-    }
-    var certPath = '';
-    if (os.platform() == 'win32') {
-        certPath = path.join(process.env.LOCALAPPDATA, 'Decrediton', 'rpc.cert');
-    } else if (os.platform() == 'darwin') {
-        certPath = path.join(process.env.HOME, 'Library', 'Application Support',
+  var cfg = getCfg();
+  if (cfg.daemon_cert_path != '') {
+    return(cfg.daemon_cert_path);
+  }
+  var certPath = '';
+  if (os.platform() == 'win32') {
+    certPath = path.join(process.env.LOCALAPPDATA, 'Decrediton', 'rpc.cert');
+  } else if (os.platform() == 'darwin') {
+    certPath = path.join(process.env.HOME, 'Library', 'Application Support',
             'Decrediton', 'rpc.cert');
-    } else {
-        var certPath = path.join(process.env.HOME, '.dcrd', 'rpc.cert');
-    }
+  } else {
+    certPath = path.join(process.env.HOME, '.dcrd', 'rpc.cert');
+  }
 
-    var cert = fs.readFileSync(certPath);
-    return(cert)
+  var cert = fs.readFileSync(certPath);
+  return(cert);
 }
 
 export function client(address, port, cb) {
-    var protoDescriptor = grpc.load('./app/api.proto');
-    var walletrpc = protoDescriptor.walletrpc;
+  var protoDescriptor = grpc.load('./app/api.proto');
+  var walletrpc = protoDescriptor.walletrpc;
 
-    var cert = getCert();
-    var creds = grpc.credentials.createSsl(cert);
-    var client = new walletrpc.WalletService(address + ':' + port, creds);
+  var cert = getCert();
+  var creds = grpc.credentials.createSsl(cert);
+  var client = new walletrpc.WalletService(address + ':' + port, creds);
 
-    var deadline = new Date();
-    var deadlineInSeconds = 2;
-    deadline.setSeconds(deadline.getSeconds()+deadlineInSeconds);
-    grpc.waitForClientReady(client, deadline, function(err) {
-        if (err) {
-            return cb(null, err);
-        } else {
-            return cb(client);
-        }
-    });
+  var deadline = new Date();
+  var deadlineInSeconds = 2;
+  deadline.setSeconds(deadline.getSeconds()+deadlineInSeconds);
+  grpc.waitForClientReady(client, deadline, function(err) {
+    if (err) {
+      return cb(null, err);
+    } else {
+      return cb(client);
+    }
+  });
 }
 
 export function getBalance(client, request, cb) {
-    if (client === undefined) {
-        return cb(null, new Error("Client not available to getBalance"));
-    }
+  if (client === undefined) {
+    return cb(null, new Error('Client not available to getBalance'));
+  }
 
-    client.balance(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(null, err);
-        } else {
-            return cb(response);
-        }
-    });
+  client.balance(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(null, err);
+    } else {
+      return cb(response);
+    }
+  });
 }
 
 export function getAccountNumber(client, request, cb) {
-    client.accountNumber(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(null, err);
-        } else {
-            console.log('accountnumber{"default"} ==', response);
-            return cb(response);
-        }
-    });
+  client.accountNumber(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(null, err);
+    } else {
+      console.log('accountnumber{"default"} ==', response);
+      return cb(response);
+    }
+  });
 }
 
 export function getStakeInfo(client, request, cb) {
-    client.stakeInfo(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(null, err);
-        } else {
-            console.log('current stakeInfo', response);
-            return cb(response);
-        }
-    });
+  client.stakeInfo(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(null, err);
+    } else {
+      console.log('current stakeInfo', response);
+      return cb(response);
+    }
+  });
 }
 
 export function getPing(client, request, cb) {
-    client.ping(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(null, err);
-        } else {
-            console.log('ping', response);
-            return cb(response);
-        }
-    });
+  client.ping(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(null, err);
+    } else {
+      console.log('ping', response);
+      return cb(response);
+    }
+  });
 }
 
 export function getNetwork(client, request, cb) {
-    client.network(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(null, err);
-        } else {
-            console.log('network', response);
-            return cb(response);
-        }
-    });
+  client.network(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(null, err);
+    } else {
+      console.log('network', response);
+      return cb(response);
+    }
+  });
 }
 
 export function getAccounts(client, request, cb) {
     // Accounts
-    var request = {};
+  var request = {};
 
-    client.accounts(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(null, err);           
-        } else {
-            console.log('accounts', response);
-            return cb(response);
-        }
-    });
+  client.accounts(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(null, err);
+    } else {
+      console.log('accounts', response);
+      return cb(response);
+    }
+  });
 }
 
 export function getTransactions(client, request, cb) {
-    client.getTransactions(request, function(err, response, cb) {
-        if (err) {
-            console.error("getTransactions", err);
-            return cb(null, err);
-        } else {
-            console.log('getTransactions', response.mined_transactions.length);
-            return cb(response);
-        }
-    });
+  client.getTransactions(request, function(err, response, cb) {
+    if (err) {
+      console.error('getTransactions', err);
+      return cb(null, err);
+    } else {
+      console.log('getTransactions', response.mined_transactions.length);
+      return cb(response);
+    }
+  });
 }
 
 export function getTicketPrice(client, request, cb) {
-    client.ticketPrice(request, function(err, response) {
-        if (err) {
-            console.error("ticketPrice", err);
-            return cb(null, err);
-        } else {
-            console.log('ticketPrice', response);
-            return cb(response);
-        }
-    });
+  client.ticketPrice(request, function(err, response) {
+    if (err) {
+      console.error('ticketPrice', err);
+      return cb(null, err);
+    } else {
+      console.log('ticketPrice', response);
+      return cb(response);
+    }
+  });
 }
 
 export function transactionNtfs(client, request, cb) {
     // Register Notification Streams from Wallet
-    var transactionNtfns = client.transactionNotifications(request);
-    transactionNtfns.on('data', function(response) {
-        return cb(response);
-    });
-    transactionNtfns.on('end', function() {
-        console.log("Transaction notifications done")
+  var transactionNtfns = client.transactionNotifications(request);
+  transactionNtfns.on('data', function(response) {
+    return cb(response);
+  });
+  transactionNtfns.on('end', function() {
+    console.log('Transaction notifications done');
         // The server has finished sending
-    });
-    transactionNtfns.on('status', function(status) {
-        console.log("Transaction notifications status:", status)
-    });
+  });
+  transactionNtfns.on('status', function(status) {
+    console.log('Transaction notifications status:', status);
+  });
 }
 
 export function spentnessNtfs(client, request, cb) {
-    var spentnessNtfns = client.spentnessNotifications(request);
-    spentnessNtfns.on('data', function(response) {
-        return cb(response);
-    });
-    spentnessNtfns.on('end', function() {
-        console.log("Spentness notifications done")
+  var spentnessNtfns = client.spentnessNotifications(request);
+  spentnessNtfns.on('data', function(response) {
+    return cb(response);
+  });
+  spentnessNtfns.on('end', function() {
+    console.log('Spentness notifications done');
         // The server has finished sending
-    });
-    spentnessNtfns.on('status', function(status) {
-        console.log("Spentness notifications status:", status)
-    });
+  });
+  spentnessNtfns.on('status', function(status) {
+    console.log('Spentness notifications status:', status);
+  });
 }
 
 export function accountNtfs(client, request, cb) {
-    var accountNtfns = client.accountNotifications(request);
-    accountNtfns.on('data', function(response) {
-        return cb(response);
-    });
-    accountNtfns.on('end', function() {
-        console.log("Account notifications done")
+  var accountNtfns = client.accountNotifications(request);
+  accountNtfns.on('data', function(response) {
+    return cb(response);
+  });
+  accountNtfns.on('end', function() {
+    console.log('Account notifications done');
         // The server has finished sending
-    });
-    accountNtfns.on('status', function(status) {
-        console.log("Account notifications status:", status)
-    });
+  });
+  accountNtfns.on('status', function(status) {
+    console.log('Account notifications status:', status);
+  });
 }
 
 /*
-random seed for dev: 
-upshot paperweight billiard replica tactics hazardous 
-retouch undaunted bluebird Norwegian ribcage enchanting 
-brackish conformist hamlet bravado button undaunted 
-Dupont voyager sentence dictator keyboard unify 
-transit specialist regain insurgent spellbind consulting 
-keyboard autopsy sawdust 
+random seed for dev:
+upshot paperweight billiard replica tactics hazardous
+retouch undaunted bluebird Norwegian ribcage enchanting
+brackish conformist hamlet bravado button undaunted
+Dupont voyager sentence dictator keyboard unify
+transit specialist regain insurgent spellbind consulting
+keyboard autopsy sawdust
 
 Hex: f4a51fc3de6da8ea249bac512735711b2dea52f7b9487aede7d5a47eca387a10
 */

--- a/app/middleware/grpc/control.js
+++ b/app/middleware/grpc/control.js
@@ -2,162 +2,162 @@
 
 export function getNextAddress(client, request, cb) {
     // NextAddress
-    client.nextAddress(request, function(err, response) {
-        if (err) {
-            console.error("nextAddress", err);
-            return cb(null, err);
-        } else {
-            console.log('nextAddress', response);
-            return cb(response);
-        }
-    });
+  client.nextAddress(request, function(err, response) {
+    if (err) {
+      console.error('nextAddress', err);
+      return cb(null, err);
+    } else {
+      console.log('nextAddress', response);
+      return cb(response);
+    }
+  });
 }
 
 
 export function renameAccount(client, request, cb) {
     // RenameAccount
 
-    client.renameAccount(request, function(err, response) {
-        if (err) {
-            console.error("renameAccount", err);
-            return cb(null, err);
-        } else {
-            console.log('renameAccount', response);
-            return cb(response);
-        }
-    });
+  client.renameAccount(request, function(err, response) {
+    if (err) {
+      console.error('renameAccount', err);
+      return cb(null, err);
+    } else {
+      console.log('renameAccount', response);
+      return cb(response);
+    }
+  });
 }
 
 
 export function rescan(client, request, cb) {
     // Rescan
 
-    var rescanCall = client.rescan(request);
-    recanCall.on('data', function(response) {
-        console.log("Rescanned thru", response.rescanned_through);
-    });
-    rescanCall.on('end', function() {
-        console.log("Rescan done")
+  var rescanCall = client.rescan(request);
+  rescanCall.on('data', function(response) {
+    console.log('Rescanned thru', response.rescanned_through);
+  });
+  rescanCall.on('end', function() {
+    console.log('Rescan done');
             // The server has finished sending
-    });
-    rescanCall.on('status', function(status) {
-        console.log("Rescan status:", status)
-    });
+  });
+  rescanCall.on('status', function(status) {
+    console.log('Rescan status:', status);
+  });
 }
 
 export function getNextAccount(client, request, cb) {
     // NextAccount
 
-    client.nextAccount(request, function(err, response) {
-        if (err) {
-            console.error("nextAccount", err);
-            return cb(null, err);
-        } else {
-            console.log('nextAccount', response);
-            return cb(response);
-        }
-    });
+  client.nextAccount(request, function(err, response) {
+    if (err) {
+      console.error('nextAccount', err);
+      return cb(null, err);
+    } else {
+      console.log('nextAccount', response);
+      return cb(response);
+    }
+  });
 }
 
 export function importPrivateKey(client, request, cb) {
     // ImportPrivateKey
 
-    client.importPrivateKey(request, function(err, response) {
-        if (err) {
-            console.error("importPrivateKey", err);
-            return cb(null, err);
-        } else {
-            console.log('importePrivateKey', response);
-            return cb(response);
-        }
-    });
+  client.importPrivateKey(request, function(err, response) {
+    if (err) {
+      console.error('importPrivateKey', err);
+      return cb(null, err);
+    } else {
+      console.log('importePrivateKey', response);
+      return cb(response);
+    }
+  });
 }
 
 export function importScript(client, request, cb) {
     // ImportScript
 
-    client.importScript(request, function(err, response) {
-        if (err) {
-            console.error("importScript", err);
-            return cb(null, err);
-        } else {
-            console.log('importScript', response);
-            return cb(response);
-        }
-    });
+  client.importScript(request, function(err, response) {
+    if (err) {
+      console.error('importScript', err);
+      return cb(null, err);
+    } else {
+      console.log('importScript', response);
+      return cb(response);
+    }
+  });
 }
 
 export function changePassphrase(client, request, cb) {
-    // ChangePassphrase 
+    // ChangePassphrase
 
-   client.changePassphrase(request, function(err, response) {
-        if (err) {
-            console.error("changePassphrase", err);
-            return cb(null, err);
-        } else {
-            console.log('changePassphrase', response);
-            return cb(response);
-        }
-    });
+  client.changePassphrase(request, function(err, response) {
+    if (err) {
+      console.error('changePassphrase', err);
+      return cb(null, err);
+    } else {
+      console.log('changePassphrase', response);
+      return cb(response);
+    }
+  });
 }
 
 
-// TODO add unsigned tx contruction which will then be 
+// TODO add unsigned tx contruction which will then be
 // sent to sign/publishTransaction
 //
 
 export function getFundTransaction(client, request, cb) {
     // FundTransaction
 
-    client.fundTransaction(request, function(err, response) {
-        if (err) {
-            console.error("fundTransaction", err);
-            return cb(null, err);
-        } else {
-            console.log('fundTransaction', response);
-            return cb(response);
-        }
-    });
+  client.fundTransaction(request, function(err, response) {
+    if (err) {
+      console.error('fundTransaction', err);
+      return cb(null, err);
+    } else {
+      console.log('fundTransaction', response);
+      return cb(response);
+    }
+  });
 }
 
 export function signTransction(client, request, cb) {
     // SignTransaction
 
-    client.signTransaction(request, function(err, response) {
-        if (err) {
-            console.error("signTransaction", err);
-            return cb(null, err);
-        } else {
-            console.log("signTransaction", response);
-            return cb(response);
-        }
-    });
+  client.signTransaction(request, function(err, response) {
+    if (err) {
+      console.error('signTransaction', err);
+      return cb(null, err);
+    } else {
+      console.log('signTransaction', response);
+      return cb(response);
+    }
+  });
 }
 
 export function publishTransaction(client, request, cb) {
     // PublishTransaction
 
-    client.publishTransaction(request, function(err, response) {
-        if (err) {
-            console.error("publishTransaction", err);
-            return cb(null, err);
-        } else {
-            console.log("publishTransaction", response);
-            return cb(response);
-        }
-    });
+  client.publishTransaction(request, function(err, response) {
+    if (err) {
+      console.error('publishTransaction', err);
+      return cb(null, err);
+    } else {
+      console.log('publishTransaction', response);
+      return cb(response);
+    }
+  });
 }
 
 export function purchaseTickets(client, request, cb) {
     // PurchaseTickets
 
-    client.purchaseTickets(request, function(err, response) {
-        if (err) {
-            console.error("purchaseTickets", err);
-            return cb(null, err);
-        } else {
-            console.log('purchaseTickets', response);
-            return cb(response);
-        }
-    });
+  client.purchaseTickets(request, function(err, response) {
+    if (err) {
+      console.error('purchaseTickets', err);
+      return cb(null, err);
+    } else {
+      console.log('purchaseTickets', response);
+      return cb(response);
+    }
+  });
 }

--- a/app/middleware/grpc/loader.js
+++ b/app/middleware/grpc/loader.js
@@ -1,127 +1,121 @@
 process.env['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA';
 
-import fs from 'fs';
-import url from 'url';
-import path from 'path';
 import { getCert } from './client';
-import os from 'os';
 import grpc from 'grpc';
 
-var Buffer = require('buffer/').Buffer;
-
 export function loader(request, cb) {
-    var protoDescriptor = grpc.load('./app/api.proto');
-    var walletrpc = protoDescriptor.walletrpc;
+  var protoDescriptor = grpc.load('./app/api.proto');
+  var walletrpc = protoDescriptor.walletrpc;
 
-    var cert = getCert();
-    var creds = grpc.credentials.createSsl(cert);
-    var loader = new walletrpc.WalletLoaderService(request.address + ':' + request.port, creds);
+  var cert = getCert();
+  var creds = grpc.credentials.createSsl(cert);
+  var loader = new walletrpc.WalletLoaderService(request.address + ':' + request.port, creds);
 
-    var deadline = new Date();
-    var deadlineInSeconds = 2;
-    deadline.setSeconds(deadline.getSeconds()+deadlineInSeconds);
-    grpc.waitForClientReady(loader, deadline, function(err) {
-        if (err) {
-            return cb(null, err);
-        } else { 
-            return cb(loader);
-        }
-    });
+  var deadline = new Date();
+  var deadlineInSeconds = 2;
+  deadline.setSeconds(deadline.getSeconds()+deadlineInSeconds);
+  grpc.waitForClientReady(loader, deadline, function(err) {
+    if (err) {
+      return cb(null, err);
+    } else {
+      return cb(loader);
+    }
+  });
 }
 
 export function walletExists(loader, request, cb) {
-    loader.walletExists(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(null, err);
-        } else {
-            return cb(response);
-        }
-    });
+  loader.walletExists(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(null, err);
+    } else {
+      return cb(response);
+    }
+  });
 }
 
 export function createWallet(loader, request, cb) {
-    loader.createWallet(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(err);
-        } else {
-            console.log('created wallet');
-            return cb();
-        }
-    });
+  loader.createWallet(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(err);
+    } else {
+      console.log('created wallet');
+      return cb();
+    }
+  });
 }
 
 export function openWallet(loader, request, cb) {
-    loader.openWallet(request, function(err, response) {
-        if (err) {
-            if (err.message.includes("wallet already loaded")) {
-                return cb(response, null);
-            } else {
-                console.error(err.message);
-                return cb(null, err);
-            }
-        } else {
-            return cb();
-        }
-    });
+  loader.openWallet(request, function(err, response) {
+    if (err) {
+      if (err.message.includes('wallet already loaded')) {
+        return cb(response, null);
+      } else {
+        console.error(err.message);
+        return cb(null, err);
+      }
+    } else {
+      return cb();
+    }
+  });
 }
 
 export function closeWallet(loader,request, cb) {
-    loader.closeWallet(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(null, err);
-        } else {
-            return cb(response, null);
-        }
-    });
+  loader.closeWallet(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(null, err);
+    } else {
+      return cb(response, null);
+    }
+  });
 }
 
 export function startConsensusRpc(loader, request, cb) {
-    loader.startConsensusRpc(request, function(err, response) {
-        if (err) {
-            if (err.message.includes("RPC client already created")) {
-                return cb();
-            } else {
-                console.error(err);
-                return cb(err);
-            }
-        } else {
-            return cb();
-        }
-    });
+  loader.startConsensusRpc(request, function(err, response) {
+    if (err) {
+      if (err.message.includes('RPC client already created')) {
+        return cb();
+      } else {
+        console.error(err);
+        return cb(err);
+      }
+    } else {
+      return cb();
+    }
+  });
 }
 
 export function discoverAddresses(loader, request, cb) {
-    loader.discoverAddresses(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(err);
-        } else {
-            return cb();
-        }
-    });
+  loader.discoverAddresses(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(err);
+    } else {
+      return cb();
+    }
+  });
 }
 
 export function subscribeBlockNtfns(loader, request, cb) {
-    loader.subscribeToBlockNotifications(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(err);
-        } else {
-            return cb();
-        }
-    });
+  loader.subscribeToBlockNotifications(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(err);
+    } else {
+      return cb();
+    }
+  });
 }
 
 export function fetchHeaders(loader, request, cb) {
-    loader.fetchHeaders(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(err);
-        } else {
-            return cb();
-        }
-    });
+  loader.fetchHeaders(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(err);
+    } else {
+      return cb();
+    }
+  });
 }

--- a/app/middleware/grpc/seeder.js
+++ b/app/middleware/grpc/seeder.js
@@ -1,55 +1,49 @@
 process.env['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA';
 
-import fs from 'fs';
-import url from 'url';
-import path from 'path';
 import { getCert } from './client';
-import os from 'os';
 import grpc from 'grpc';
 
-var Buffer = require('buffer/').Buffer;
-
 export function seeder(request, cb) {
-    var protoDescriptor = grpc.load('./app/api.proto');
-    var walletrpc = protoDescriptor.walletrpc;
+  var protoDescriptor = grpc.load('./app/api.proto');
+  var walletrpc = protoDescriptor.walletrpc;
 
-    var cert = getCert();
-    var creds = grpc.credentials.createSsl(cert);
-    var seeder = new walletrpc.SeedService(request.address + ':' + request.port, creds);
+  var cert = getCert();
+  var creds = grpc.credentials.createSsl(cert);
+  var seeder = new walletrpc.SeedService(request.address + ':' + request.port, creds);
 
-    var deadline = new Date();
-    var deadlineInSeconds = 2;
-    deadline.setSeconds(deadline.getSeconds()+deadlineInSeconds);
-    grpc.waitForClientReady(seeder, deadline, function(err) {
-        if (err) {
-            return cb(null, err);
-        } else { 
-            return cb(seeder);
-        }
-    });
+  var deadline = new Date();
+  var deadlineInSeconds = 2;
+  deadline.setSeconds(deadline.getSeconds()+deadlineInSeconds);
+  grpc.waitForClientReady(seeder, deadline, function(err) {
+    if (err) {
+      return cb(null, err);
+    } else {
+      return cb(seeder);
+    }
+  });
 }
 
 export function generateRandomSeed(seeder, request, cb) {
-    seeder.generateRandomSeed(request, function(err, response) {
-        if (err) {
-            console.error(err);
-            return cb(null, err);
-        } else {
-            console.log(response);
-            return cb(response);
-        }
-    });
+  seeder.generateRandomSeed(request, function(err, response) {
+    if (err) {
+      console.error(err);
+      return cb(null, err);
+    } else {
+      console.log(response);
+      return cb(response);
+    }
+  });
 }
 
 export function decodeSeed(seeder, request, cb) {
-    seeder.decodeSeed(request, function(err, response) {
-        if (err) {
-            return cb(null, err);
-        } else {
-            console.log(response.decoded_seed.toString('hex'))
-            return cb(response);
-        }
-    });
+  seeder.decodeSeed(request, function(err, response) {
+    if (err) {
+      return cb(null, err);
+    } else {
+      console.log(response.decoded_seed.toString('hex'));
+      return cb(response);
+    }
+  });
 }
 /*
 bject {seed_bytes: Buffer[32], seed_hex: "59b335d2a7cd7d0a133106d1f779c987e65c842d6b5664925cc1a4b779a8442c", seed_mnemonic: "endow pocketful chopper sensation repay sandalwood…ssor jawbone paramount crumpled Chicago snowslide"}

--- a/app/routes.js
+++ b/app/routes.js
@@ -3,9 +3,9 @@ import React from 'react';
 import { Route, IndexRoute } from 'react-router';
 import App from './containers/App';
 import HomePage from './containers/HomePage';
-import HistoryPage from './containers/HistoryPage'
-import SendPage from './containers/SendPage'
-import ReceivePage from './containers/ReceivePage'
+import HistoryPage from './containers/HistoryPage';
+import SendPage from './containers/SendPage';
+import ReceivePage from './containers/ReceivePage';
 
 export default (
   <Route path="/" component={App}>


### PR DESCRIPTION
Allow console statements in .eslintrc.  We can always remove this
later on.

This includes many automatic fixes, a corrected variable name caught
by the linter, and removing unneeded requires from various files.

Closes #73