### PR TITLE
Rough first pass to display getTransactions

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -21,7 +21,7 @@ function getWalletServiceSuccess(walletService) {
     //setTimeout( () => {dispatch(getPingAttempt());}, 1000);
     //setTimeout( () => {dispatch(getNetworkAttempt());}, 1000);
     //setTimeout( () => {dispatch(getAccountNumberAttempt("default"));}, 1000);
-    //setTimeout( () => {dispatch(getTransactionsAttempt(2, 10, '', ''));}, 1000);
+    setTimeout( () => {dispatch(getTransactionsAttempt(0, 300000, '', ''));}, 1000);
 
     // Check here to see if wallet was just created from an existing
     // seed.  If it was created from a newly generated seed there is no
@@ -326,14 +326,22 @@ function accounts() {
 
 export const GETTRANSACTIONS_ATTEMPT = 'GETTRANSACTIONS_ATTEMPT';
 export const GETTRANSACTIONS_FAILED = 'GETTRANSACTIONS_FAILED';
-export const GETTRANSACTIONS_SUCCESS = 'GETTRANSACTIONS_SUCCESS';
+export const GETTRANSACTIONS_PROGRESS = 'GETTRANSACTIONS_PROGRESS';
+export const GETTRANSACTIONS_COMPLETE = 'GETTRANSACTIONS_COMPLETE';
 
 function getTransactionsError(error) {
   return { error, type: GETTRANSACTIONS_FAILED };
 }
 
-function getTransactionsSuccess(getTransactionsResponse) {
-  return { getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_SUCCESS };
+function getTransactionsProgress(getTransactionsResponse) {
+  return { getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_PROGRESS };
+}
+
+function getTransactionsComplete() {
+  return (dispatch) => {
+    dispatch({ type: GETTRANSACTIONS_COMPLETE });
+    setTimeout( () => {dispatch(getBalanceAttempt());}, 1000);
+  };
 }
 
 export function getTransactionsAttempt(startHeight, endHeight, startHash, endHash, ) {
@@ -359,11 +367,13 @@ function transactions() {
     const { walletService } = getState().grpc;
     const { getTransactionsRequest } = getState().grpc;
     getTransactions(walletService, getTransactionsRequest,
-        function(getTransactionsResponse, err) {
+        function(finished, getTransactionsResponse, err) {
           if (err) {
             dispatch(getTransactionsError(err + ' Please try again'));
+          } else if (finished) {
+            dispatch(getTransactionsComplete());
           } else {
-            dispatch(getTransactionsSuccess(getTransactionsResponse));
+            dispatch(getTransactionsProgress(getTransactionsResponse));
           }
         });
   };

--- a/app/components/History.js
+++ b/app/components/History.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router';
 import {Table, TableBody, TableHeader, TableHeaderColumn,
   TableRow, TableRowColumn} from 'material-ui/Table';
 import ErrorScreen from './ErrorScreen';
-import { reverseHash } from '../helpers/byteActions'
+import { reverseHash } from '../helpers/byteActions';
 class History extends Component{
   static propTypes = {
     walletService: PropTypes.object,
@@ -27,9 +27,9 @@ class History extends Component{
           </TableHeader>
           <TableBody displayRowCheckbox={false}>
             {transactions.map(function(tx, i) {
-            var parseDate = new Date(tx.transaction.mined_transactions.timestamp*1000);
-              var s = tx.transaction.mined_transactions.transactions[0].hash.toString('hex')
-              var reversed = reverseHash(s)
+              var parseDate = new Date(tx.transaction.mined_transactions.timestamp*1000);
+              var s = tx.transaction.mined_transactions.transactions[0].hash.toString('hex');
+              var reversed = reverseHash(s);
               return (
                 <TableRow key={i}>
                   <TableRowColumn>{tx.transaction.mined_transactions.height}</TableRowColumn>

--- a/app/components/History.js
+++ b/app/components/History.js
@@ -5,16 +5,15 @@ import { Link } from 'react-router';
 import {Table, TableBody, TableHeader, TableHeaderColumn,
   TableRow, TableRowColumn} from 'material-ui/Table';
 import ErrorScreen from './ErrorScreen';
+import TxRows from './TxRows';
 
 class History extends Component{
   static propTypes = {
-    walletService: PropTypes.object.isRequired,
+    walletService: PropTypes.object,
   };
 
   render() {
-    const { walletService } = this.props;
-
-    /* View that will be seen when user has a set Client */
+    const { walletService, transactions } = this.props;
     const historyView = (
       <div>
         <h1>History Page</h1>
@@ -27,26 +26,18 @@ class History extends Component{
             </TableRow>
           </TableHeader>
           <TableBody>
-            <TableRow>
-              <TableRowColumn>20:20:20 November 28th 2016</TableRowColumn>
-              <TableRowColumn>txid</TableRowColumn>
-              <TableRowColumn>200</TableRowColumn>
-            </TableRow>
-            <TableRow>
-              <TableRowColumn>20:20:20 November 28th 2016</TableRowColumn>
-              <TableRowColumn>txid</TableRowColumn>
-              <TableRowColumn>200</TableRowColumn>
-            </TableRow>
-            <TableRow>
-              <TableRowColumn>20:20:20 November 28th 2016</TableRowColumn>
-              <TableRowColumn>txid</TableRowColumn>
-              <TableRowColumn>200</TableRowColumn>
-            </TableRow>
+            {transactions.map(function(tx, i) {
+            var parseDate = new Date(tx.transaction.mined_transactions.timestamp*1000);
+              return (
+                <TableRow key={i}>
+                  <TableRowColumn>{tx.transaction.mined_transactions.height}</TableRowColumn>
+                  <TableRowColumn>{tx.transaction.mined_transactions.transactions[0].hash.toString('hex')}</TableRowColumn>
+                  <TableRowColumn><span>{parseDate.toString()}</span></TableRowColumn>
+                </TableRow>);
+            })}
           </TableBody>
         </Table>
       </div>);
-
-    /* Check to see that client is not undefined */
     if (walletService === null) {
       return (<ErrorScreen />);
     } else {

--- a/app/components/History.js
+++ b/app/components/History.js
@@ -5,7 +5,6 @@ import { Link } from 'react-router';
 import {Table, TableBody, TableHeader, TableHeaderColumn,
   TableRow, TableRowColumn} from 'material-ui/Table';
 import ErrorScreen from './ErrorScreen';
-import TxRows from './TxRows';
 
 class History extends Component{
   static propTypes = {
@@ -17,22 +16,22 @@ class History extends Component{
     const historyView = (
       <div>
         <h1>History Page</h1>
-        <Table striped bordered condensed hover>
-          <TableHeader>
+        <Table fixedHeader={true} striped bordered condensed hover showCheckboxes={false} >
+          <TableHeader displaySelectAll={false}>
             <TableRow>
+              <TableHeaderColumn>Block Number</TableHeaderColumn>
               <TableHeaderColumn>Date</TableHeaderColumn>
-              <TableHeaderColumn>TXID</TableHeaderColumn>
-              <TableHeaderColumn>Amount</TableHeaderColumn>
+              <TableHeaderColumn>Transaction Hash</TableHeaderColumn>
             </TableRow>
           </TableHeader>
-          <TableBody>
+          <TableBody displayRowCheckbox={false}>
             {transactions.map(function(tx, i) {
             var parseDate = new Date(tx.transaction.mined_transactions.timestamp*1000);
               return (
                 <TableRow key={i}>
                   <TableRowColumn>{tx.transaction.mined_transactions.height}</TableRowColumn>
-                  <TableRowColumn>{tx.transaction.mined_transactions.transactions[0].hash.toString('hex')}</TableRowColumn>
                   <TableRowColumn><span>{parseDate.toString()}</span></TableRowColumn>
+                  <TableRowColumn colSpan={3}>{tx.transaction.mined_transactions.transactions[0].hash.toString('hex')}</TableRowColumn>
                 </TableRow>);
             })}
           </TableBody>

--- a/app/components/History.js
+++ b/app/components/History.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router';
 import {Table, TableBody, TableHeader, TableHeaderColumn,
   TableRow, TableRowColumn} from 'material-ui/Table';
 import ErrorScreen from './ErrorScreen';
-
+import { reverseHash } from '../helpers/byteActions'
 class History extends Component{
   static propTypes = {
     walletService: PropTypes.object,
@@ -13,6 +13,7 @@ class History extends Component{
 
   render() {
     const { walletService, transactions } = this.props;
+
     const historyView = (
       <div>
         <h1>History Page</h1>
@@ -27,11 +28,13 @@ class History extends Component{
           <TableBody displayRowCheckbox={false}>
             {transactions.map(function(tx, i) {
             var parseDate = new Date(tx.transaction.mined_transactions.timestamp*1000);
+              var s = tx.transaction.mined_transactions.transactions[0].hash.toString('hex')
+              var reversed = reverseHash(s)
               return (
                 <TableRow key={i}>
                   <TableRowColumn>{tx.transaction.mined_transactions.height}</TableRowColumn>
                   <TableRowColumn><span>{parseDate.toString()}</span></TableRowColumn>
-                  <TableRowColumn colSpan={3}>{tx.transaction.mined_transactions.transactions[0].hash.toString('hex')}</TableRowColumn>
+                  <TableRowColumn colSpan={3}>{reversed}</TableRowColumn>
                 </TableRow>);
             })}
           </TableBody>

--- a/app/components/Send.js
+++ b/app/components/Send.js
@@ -8,7 +8,7 @@ import TextField from 'material-ui/TextField';
 import ConstructTxForm from '../containers/ConstructTxForm';
 import SignTxForm from '../containers/SignTxForm';
 import ShowError from './ShowError';
-import { reverseHash } from '../helpers/byteActions'
+import { reverseHash } from '../helpers/byteActions';
 
 const style = {
   margin: 12,

--- a/app/components/Send.js
+++ b/app/components/Send.js
@@ -8,6 +8,7 @@ import TextField from 'material-ui/TextField';
 import ConstructTxForm from '../containers/ConstructTxForm';
 import SignTxForm from '../containers/SignTxForm';
 import ShowError from './ShowError';
+import { reverseHash } from '../helpers/byteActions'
 
 const style = {
   margin: 12,
@@ -60,7 +61,7 @@ class Send extends Component{
     const publishTxView = (
       <div>
         <h1>Published Tx!</h1>
-        <p>{publishTransactionResponse !== null ? publishTransactionResponse.transaction_hash.toString('hex') : null}</p>
+        <p>{publishTransactionResponse !== null ? reverseHash(publishTransactionResponse.transaction_hash.toString('hex')) : null}</p>
       </div>);
 
     if (constructTxResponse === null) {

--- a/app/containers/HistoryPage.js
+++ b/app/containers/HistoryPage.js
@@ -5,6 +5,7 @@ import History from '../components/History';
 function mapStateToProps(state) {
   return {
     walletService: state.grpc.walletService,
+    transactions: state.grpc.transactions,
   };
 }
 

--- a/app/helpers/byteActions.js
+++ b/app/helpers/byteActions.js
@@ -1,7 +1,7 @@
 export function reverseHash(s) {
-  s = s.replace(/^(.(..)*)$/, "0$1"); // add a leading zero if needed
+  s = s.replace(/^(.(..)*)$/, '0$1'); // add a leading zero if needed
   var a = s.match(/../g);             // split number in groups of two
   a.reverse();                        // reverse the groups
-  var s2 = a.join(""); 
-  return s2
+  var s2 = a.join('');
+  return s2;
 }

--- a/app/helpers/byteActions.js
+++ b/app/helpers/byteActions.js
@@ -1,0 +1,7 @@
+export function reverseHash(s) {
+  s = s.replace(/^(.(..)*)$/, "0$1"); // add a leading zero if needed
+  var a = s.match(/../g);             // split number in groups of two
+  a.reverse();                        // reverse the groups
+  var s2 = a.join(""); 
+  return s2
+}

--- a/app/index.js
+++ b/app/index.js
@@ -22,7 +22,7 @@ if (cfg.network == 'testnet') {
 var initialState = {
   version: {
     // RequiredVersion
-    requiredVersion: '4.2.0',
+    requiredVersion: '4.2.1',
     versionInvalid: false,
     versionInvalidError: null,
     // VersionService

--- a/app/index.js
+++ b/app/index.js
@@ -78,6 +78,7 @@ var initialState = {
     getAccountsRequestAttempt: false,
     getAccountsResponse: null,
     // Transactions
+    transactions: Array(),
     getTransactionsRequest: null,
     getTransactionsError: null,
     getTransactionsRequestAttempt: false,

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -145,16 +145,18 @@ export function getAccounts(client, request, cb) {
 }
 
 export function getTransactions(client, request, cb) {
-  var request = {};
-  console.log(request);
   var getTx = client.getTransactions(request);
   getTx.on('data', function(response) {
-    console.log('getTransactions', response);
-    return cb(response);
+    return cb(false, response);
   });
-  getTx.on('end', function(response) {
-    console.log('getTransactions end', response);
-    return cb(response);
+  getTx.on('end', function() {
+    return cb(true);
+  });
+  getTx.on('status', function(status) {
+    console.log('Rescan status:', status);
+  });
+  getTx.on('error', function(err) {
+        return cb(false, null, err);
   });
 }
 

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -153,7 +153,7 @@ export function getTransactions(client, request, cb) {
     return cb(true);
   });
   getTx.on('status', function(status) {
-    console.log('Rescan status:', status);
+    console.log('GetTx status:', status);
   });
   getTx.on('error', function(err) {
         return cb(false, null, err);

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -156,7 +156,7 @@ export function getTransactions(client, request, cb) {
     console.log('GetTx status:', status);
   });
   getTx.on('error', function(err) {
-        return cb(false, null, err);
+    return cb(false, null, err);
   });
 }
 

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -162,8 +162,8 @@ export default function grpc(state = {}, action) {
   case GETTRANSACTIONS_PROGRESS:
     return {...state,
       transactions: [
-        ...state.transactions, 
-        { transaction: action.getTransactionsResponse } 
+        ...state.transactions,
+        { transaction: action.getTransactionsResponse }
       ],
     };
   case GETTRANSACTIONS_COMPLETE:
@@ -172,7 +172,7 @@ export default function grpc(state = {}, action) {
       getTransactionsRequestAttempt: false,
       getTransactionsResponse: null,
       getTransactionsRequest: null,
-    };  
+    };
   default:
     return state;
   }

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -7,7 +7,7 @@ import {
   GETSTAKEINFO_ATTEMPT, GETSTAKEINFO_FAILED, GETSTAKEINFO_SUCCESS,
   GETTICKETPRICE_ATTEMPT, GETTICKETPRICE_FAILED, GETTICKETPRICE_SUCCESS,
   GETACCOUNTS_ATTEMPT, GETACCOUNTS_FAILED, GETACCOUNTS_SUCCESS,
-  GETTRANSACTIONS_ATTEMPT, GETTRANSACTIONS_FAILED, GETTRANSACTIONS_SUCCESS
+  GETTRANSACTIONS_ATTEMPT, GETTRANSACTIONS_FAILED, GETTRANSACTIONS_PROGRESS, GETTRANSACTIONS_COMPLETE
 } from '../actions/ClientActions';
 
 export default function grpc(state = {}, action) {
@@ -159,12 +159,20 @@ export default function grpc(state = {}, action) {
       getTransactionsError: action.error,
       getTransactionsRequestAttempt: false,
     };
-  case GETTRANSACTIONS_SUCCESS:
+  case GETTRANSACTIONS_PROGRESS:
+    return {...state,
+      transactions: [
+        ...state.transactions, 
+        { transaction: action.getTransactionsResponse } 
+      ],
+    };
+  case GETTRANSACTIONS_COMPLETE:
     return {...state,
       getTransactionsError: '',
       getTransactionsRequestAttempt: false,
-      getTransactionsResponse: action.getTransactionsResponse,
-    };
+      getTransactionsResponse: null,
+      getTransactionsRequest: null,
+    };  
   default:
     return state;
   }


### PR DESCRIPTION
For now we can just display the block height, timestamp and txid of the transactions due to limitations with the current GetTransactions gRPC.  In the coming weeks we can add all the information we'd like dcrwallet to provide to remove any major smarts or logic in decrediton and have dcrwallet do most of the heavy lifting.

Closes #100 