### PR TITLE
Fix display when balance is zero.

### DIFF
--- a/app/components/Balance.js
+++ b/app/components/Balance.js
@@ -16,8 +16,12 @@ var styles = {
 
 class Balance extends React.Component {
   render() {
-    var totalDcr = parseInt(this.props.amount) / 100000000;
-    var numberFormatPart = totalDcr.toString().split('.');
+    var totalDcr = 0;
+    var numberFormatPart = ['0','0'];
+    if (typeof this.props.amounts !== 'undefined') {
+      totalDcr = parseInt(this.props.amount) / 100000000;
+      numberFormatPart = totalDcr.toString().split('.');
+    }
     return (
       <span
       style={styles.base}


### PR DESCRIPTION
If balance is zero (as with a fresh wallet), the display formatting is
broken due to an uninitialized value causing the home screen to not
load properly.

Closes #152