### PR TITLE
Give user some feedback for daemon syncing

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -32,8 +32,8 @@ function getWalletServiceSuccess(walletService) {
     setTimeout( () => {dispatch(transactionNftnsStart());}, 1000);
     const { fetchHeadersResponse, walletCreateExisting } = getState().walletLoader;
     if ( walletCreateExisting && fetchHeadersResponse !== null ) {
-      if (fetchHeadersResponse.fetched_headers_count > 0) {
-        setTimeout(() => {dispatch(rescanAttempt(fetchHeadersResponse.first_new_block_height));}, 1000);
+      if (fetchHeadersResponse.getFetchedHeadersCount() > 0) {
+        setTimeout(() => {dispatch(rescanAttempt(fetchHeadersResponse.getFirstNewBlockHeight()));}, 1000);
       }
     }
     setTimeout(() => {hashHistory.push('/home');}, 1000);

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -354,7 +354,7 @@ function fetchHeadersProgress(response) {
     if (curBlocks == 0) {
       newCurBlock += response.getFirstNewBlockHeight();
     }
-    if ( newCurBlock > neededBlocks || 
+    if ( newCurBlock > neededBlocks ||
     response.getFirstNewBlockHeight() + response.getFetchedHeadersCount() > neededBlocks ) {
       dispatch(fetchHeadersSuccess());
     } else {

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -221,6 +221,7 @@ function startRpcError(error) {
 function startRpcSuccess() {
   return (dispatch) => {
     dispatch({response: {}, type: STARTRPC_SUCCESS});
+    dispatch(fetchHeadersAttempt());
     //dispatch(discoverAddressAttempt(true));
   };
 }
@@ -271,7 +272,7 @@ function discoverAddressError(error) {
 function discoverAddressSuccess() {
   return (dispatch) => {
     dispatch({response: {}, type: DISCOVERADDRESS_SUCCESS});
-    dispatch(fetchHeadersAttempt());
+    dispatch(subscribeBlockAttempt());
   };
 }
 
@@ -340,15 +341,33 @@ function subscribeBlockAction() {
 export const FETCHHEADERS_ATTEMPT = 'FETCHHEADER_ATTEMPT';
 export const FETCHHEADERS_FAILED = 'FETCHHEADERS_FAILED';
 export const FETCHHEADERS_SUCCESS = 'FETCHHEADERS_SUCCESS';
+export const FETCHHEADERS_PROGRESS = 'FETCHHEADERS_PROGRESS';
 
 function fetchHeadersFailed(error) {
   return { error, type: FETCHHEADERS_FAILED };
 }
 
+function fetchHeadersProgress(response) {
+  return (dispatch, getState) => {
+    const { curBlocks, neededBlocks } = getState().walletLoader;
+    var newCurBlock = curBlocks + response.getFetchedHeadersCount();
+    if (curBlocks == 0) {
+      newCurBlock += response.getFirstNewBlockHeight();
+    }
+    if ( newCurBlock > neededBlocks  || response.getFirstNewBlockHeight() + response.getFetchedHeadersCount() < neededBlocks ) {
+      dispatch({curBlocks: newCurBlock, type: FETCHHEADERS_PROGRESS});
+      console.log(newCurBlock, neededBlocks, curBlocks);
+      console.log(response.getFirstNewBlockHeight(),response.getFetchedHeadersCount());
+      setTimeout( () => {dispatch(fetchHeadersAction());}, 1000);
+    } else {
+      dispatch(fetchHeadersSuccess());
+    }
+  };
+}
+
 function fetchHeadersSuccess(response) {
   return (dispatch) => {
     dispatch({response: response, type: FETCHHEADERS_SUCCESS});
-    dispatch(subscribeBlockAttempt());
   };
 }
 
@@ -368,7 +387,7 @@ function fetchHeadersAction() {
           if (err) {
             dispatch(fetchHeadersFailed(err + ' Please try again'));
           } else {
-            dispatch(fetchHeadersSuccess(response));
+            dispatch(fetchHeadersProgress(response));
           }
         });
   };

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -356,7 +356,7 @@ function fetchHeadersProgress(response) {
     }
     if ( newCurBlock > neededBlocks ||
     response.getFirstNewBlockHeight() + response.getFetchedHeadersCount() > neededBlocks ) {
-      dispatch(fetchHeadersSuccess());
+      dispatch(fetchHeadersSuccess(response));
     } else {
       dispatch({curBlocks: newCurBlock, type: FETCHHEADERS_PROGRESS});
       setTimeout( () => {dispatch(fetchHeadersAction());}, 1000);

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -354,13 +354,12 @@ function fetchHeadersProgress(response) {
     if (curBlocks == 0) {
       newCurBlock += response.getFirstNewBlockHeight();
     }
-    if ( newCurBlock > neededBlocks  || response.getFirstNewBlockHeight() + response.getFetchedHeadersCount() < neededBlocks ) {
-      dispatch({curBlocks: newCurBlock, type: FETCHHEADERS_PROGRESS});
-      console.log(newCurBlock, neededBlocks, curBlocks);
-      console.log(response.getFirstNewBlockHeight(),response.getFetchedHeadersCount());
-      setTimeout( () => {dispatch(fetchHeadersAction());}, 1000);
-    } else {
+    if ( newCurBlock > neededBlocks || 
+    response.getFirstNewBlockHeight() + response.getFetchedHeadersCount() > neededBlocks ) {
       dispatch(fetchHeadersSuccess());
+    } else {
+      dispatch({curBlocks: newCurBlock, type: FETCHHEADERS_PROGRESS});
+      setTimeout( () => {dispatch(fetchHeadersAction());}, 1000);
     }
   };
 }

--- a/app/components/Balance.js
+++ b/app/components/Balance.js
@@ -18,7 +18,7 @@ class Balance extends React.Component {
   render() {
     var totalDcr = 0;
     var numberFormatPart = ['0','0'];
-    if (typeof this.props.amount !== 'undefined') {
+    if (typeof this.props.amount !== 'undefined' && this.props.amount !== 0) {
       totalDcr = parseInt(this.props.amount) / 100000000;
       numberFormatPart = totalDcr.toString().split('.');
     }

--- a/app/components/GetStarted.js
+++ b/app/components/GetStarted.js
@@ -4,6 +4,7 @@ import WalletOpenForm from '../containers/WalletOpenForm';
 import CreateWalletForm from '../containers/CreateWalletForm';
 import DiscoverAddressForm from '../containers/DiscoverAddressForm';
 import CircularProgress from 'material-ui/CircularProgress';
+import LinearProgress from 'material-ui/LinearProgress';
 import Dialog from 'material-ui/Dialog';
 import ShowError from './ShowError';
 import {
@@ -52,6 +53,7 @@ class Home extends Component{
   }
 
   render() {
+    const { curBlocks, neededBlocks } = this.props;
     const { stepIndex } = this.props;
     const { disclaimerOK } = this.props;
     const { versionInvalid, versionInvalidError } = this.props;
@@ -129,11 +131,19 @@ class Home extends Component{
     }
     const getStartedDiscoverAddress = (discoveringAddresses);
 
+    var ibdBlockProgress;
+    ibdBlockProgress = (curBlocks / neededBlocks) * 100;
+    ibdBlockProgress = ibdBlockProgress.toFixed(2);
+
     var fetchingHeaders;
     if (fetchHeadersRequestAttempt) {
       fetchingHeaders = (
         <div>
-          <CircularProgress size={80} thickness={6}/>
+          <LinearProgress mode="determinate"
+            min={0}
+            max={neededBlocks}
+            value={curBlocks} />
+          <p>{ibdBlockProgress}%</p>
         </div>
       );
     } else {

--- a/app/components/GetStarted.js
+++ b/app/components/GetStarted.js
@@ -248,15 +248,15 @@ class Home extends Component{
             </StepContent>
           </Step>
           <Step>
-            <StepLabel>Discover Addresses</StepLabel>
-            <StepContent>
-              {getStartedDiscoverAddress}
-            </StepContent>
-          </Step>
-          <Step>
             <StepLabel>Fetch Headers</StepLabel>
             <StepContent>
               {fetchHeaders}
+            </StepContent>
+          </Step>
+          <Step>
+            <StepLabel>Discover Addresses</StepLabel>
+            <StepContent>
+              {getStartedDiscoverAddress}
             </StepContent>
           </Step>
           <Step>

--- a/app/containers/GetStartedPage.js
+++ b/app/containers/GetStartedPage.js
@@ -44,6 +44,8 @@ function mapStateToProps(state) {
     discoverAddressError: state.walletLoader.discoverAddressError,
     discoverAddressResponse: state.walletLoader.discoverAddressResponse,
     // Step 5
+    curBlocks: state.walletLoader.curBlocks,
+    neededBlocks: state.walletLoader.neededBlocks,
     fetchHeadersRequestAttempt: state.walletLoader.fetchHeadersRequestAttempt,
     fetchHeadersError: state.walletLoader.fetchHeadersError,
     fetchHeadersResponse: state.walletLoader.fetchHeadersResponse,

--- a/app/index.js
+++ b/app/index.js
@@ -13,16 +13,18 @@ var cfg = getCfg();
 
 var grpcport = '';
 var neededBlocks = 0;
+var today = new Date();
+var startDate = new Date();
+var totalDays = 0.0;
+
 if (cfg.network == 'testnet') {
   grpcport = cfg.wallet_port_testnet;
-  var today = new Date();
-  var startDate = new Date("01/27/2016");
-  var totalDays = (today.getTime() - startDate.getTime()) / 1000 / 60 / 60 / 24;
+  startDate = new Date('01/27/2016');
+  totalDays = (today.getTime() - startDate.getTime()) / 1000 / 60 / 60 / 24;
   neededBlocks = totalDays * 720 * (0.95);
 } else {
-  var today = new Date();
-  var startDate = new Date("02/08/2016");
-  var totalDays = (today.getTime() - startDate.getTime()) / 1000 / 60 / 60 / 24;
+  startDate = new Date('02/08/2016');
+  totalDays = (today.getTime() - startDate.getTime()) / 1000 / 60 / 60 / 24;
   neededBlocks = totalDays * 288 * (0.95);
   grpcport = cfg.wallet_port;
 }

--- a/app/index.js
+++ b/app/index.js
@@ -12,9 +12,18 @@ import { getCfg } from './config.js';
 var cfg = getCfg();
 
 var grpcport = '';
+var neededBlocks = 0;
 if (cfg.network == 'testnet') {
   grpcport = cfg.wallet_port_testnet;
+  var today = new Date();
+  var startDate = new Date("01/27/2016");
+  var totalDays = (today.getTime() - startDate.getTime()) / 1000 / 60 / 60 / 24;
+  neededBlocks = totalDays * 720 * (0.95);
 } else {
+  var today = new Date();
+  var startDate = new Date("02/08/2016");
+  var totalDays = (today.getTime() - startDate.getTime()) / 1000 / 60 / 60 / 24;
+  neededBlocks = totalDays * 288 * (0.95);
   grpcport = cfg.wallet_port;
 }
 
@@ -85,6 +94,8 @@ var initialState = {
     getTransactionsResponse: null,
   },
   walletLoader: {
+    neededBlocks: neededBlocks,
+    curBlocks: 0,
     disclaimerOK: false,
     stepIndex: 0,
     // Loader

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -162,7 +162,7 @@ export default function walletLoader(state = {}, action) {
   case FETCHHEADERS_PROGRESS:
     return {...state,
       curBlocks: action.curBlocks,
-    }
+    };
   case FETCHHEADERS_SUCCESS:
     return {...state,
       fetchHeadersError: null,

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -6,7 +6,7 @@ import { CLOSEWALLET_ATTEMPT, CLOSEWALLET_FAILED, CLOSEWALLET_SUCCESS } from '..
 import { STARTRPC_ATTEMPT, STARTRPC_FAILED, STARTRPC_SUCCESS } from '../actions/WalletLoaderActions';
 import { DISCOVERADDRESS_ATTEMPT, DISCOVERADDRESS_FAILED, DISCOVERADDRESS_SUCCESS } from '../actions/WalletLoaderActions';
 import { SUBSCRIBEBLOCKNTFNS_ATTEMPT, SUBSCRIBEBLOCKNTFNS_FAILED, SUBSCRIBEBLOCKNTFNS_SUCCESS } from '../actions/WalletLoaderActions';
-import { FETCHHEADERS_ATTEMPT, FETCHHEADERS_FAILED, FETCHHEADERS_SUCCESS } from '../actions/WalletLoaderActions';
+import { FETCHHEADERS_ATTEMPT, FETCHHEADERS_FAILED, FETCHHEADERS_PROGRESS, FETCHHEADERS_SUCCESS } from '../actions/WalletLoaderActions';
 import { DISCLAIMER_OK } from '../actions/WalletLoaderActions';
 
 export default function walletLoader(state = {}, action) {
@@ -146,7 +146,7 @@ export default function walletLoader(state = {}, action) {
       discoverAddressRequestAttempt: false,
       discoverAddressRequest: null,
       discoverAddressResponse: action.response,
-      stepIndex: 5,
+      stepIndex: 6,
     };
   case FETCHHEADERS_ATTEMPT:
     return {...state,
@@ -159,13 +159,17 @@ export default function walletLoader(state = {}, action) {
       fetchHeadersRequestAttempt: false,
       fetchHeadersRequest: null,
     };
+  case FETCHHEADERS_PROGRESS:
+    return {...state,
+      curBlocks: action.curBlocks,
+    }
   case FETCHHEADERS_SUCCESS:
     return {...state,
       fetchHeadersError: null,
       fetchHeadersRequestAttempt: false,
       fetchHeadersRequest: null,
       fetchHeadersResponse: action.response,
-      stepIndex: 6,
+      stepIndex: 5,
     };
   case SUBSCRIBEBLOCKNTFNS_ATTEMPT:
     return {...state,


### PR DESCRIPTION
Due to various constraints on paths of communication, we currently can't easily determine what the progress on a daemon/wallet block syncness is.

To give users some sort of feedback, we've decided to calculate a rough block height that a daemon "should be at" given the current date.  So, for example, on testnet:  It's been roughly 350 days since the chain started.  With block time set in the dcrd params we can roughly expect 720 blocks mined each day on testnet.  Then we multiple by 95% to accomodate for a bit of variance.  So the current "neededBlocks" value is 239864 which is just under our current height of ~242000.

Obviously this is not ideal, but should be a good replacement in the meantime until we have another option.
Fixes #109 