### PR TITLE
Use single directory for saved items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dcrd --testnet -u USER -P PASSWORD --rpclisten=127.0.0.1:19109 --rpccert=$HOME/.
 ```
 
 ```bash
-dcrwallet --testnet --experimentalrpclisten=127.0.0.1:19112 --noinitialload --tlscurve=P-256 --onetimetlskey --appdata=~/.decrediton
+dcrwallet --testnet --experimentalrpclisten=127.0.0.1:19112 --noinitialload --tlscurve=P-256 --onetimetlskey --appdata=~/.config/decrediton
 ```
 
 On macOS you should use:

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -49,11 +49,13 @@ function appDataDirectory() {
   const path = require('path');
   const os = require('os');
 
-  if (process.platform === 'darwin') {
+  if (os.platform() == 'win32') {
+    return path.join(process.env.LOCALAPPDATA, 'Decrediton');
+  } else if (process.platform === 'darwin') {
     return path.join(os.homedir(), 'Library','Application Support','decrediton');
+  } else {
+    return path.join(os.homedir(),'.config','decrediton');
   }
-
-  return path.join(os.homedir(),'.decrediton');
 }
 
 function GRPCWalletPort() {

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -22,7 +22,7 @@ export function getCert() {
     certPath = path.join(process.env.HOME, 'Library', 'Application Support',
             'decrediton', 'rpc.cert');
   } else {
-    certPath = path.join(process.env.HOME, '.decrediton', 'rpc.cert');
+    certPath = path.join(process.env.HOME, '.config', 'decrediton', 'rpc.cert');
   }
 
   try {


### PR DESCRIPTION
Previously, on linux, some things went in ~/.config/decrediton, others
wnet in ~/.decrediton.  Switch to always using ~/.config/decrediton/.

macOS was already using a single directory.

Correct wallet data location on windows.

Closes #61