### PR TITLE
prevent infinite loop

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -351,10 +351,17 @@ function fetchHeadersProgress(response) {
   return (dispatch, getState) => {
     const { curBlocks, neededBlocks } = getState().walletLoader;
     var newCurBlock = curBlocks + response.getFetchedHeadersCount();
+    console.log("curBlocks " + curBlocks);
+
     if (curBlocks == 0) {
       newCurBlock += response.getFirstNewBlockHeight();
     }
-    if ( newCurBlock > neededBlocks ||
+    console.log("getFetchedHeadersCount " + response.getFetchedHeadersCount());
+    console.log("neededBlocks " + neededBlocks);
+    console.log("newCurBlock1 " + newCurBlock);
+    console.log("newCurBlock2 " + newCurBlock);
+    console.log("getFirstNewBlockHeight " + response.getFirstNewBlockHeight());
+    if ( response.getFetchedHeadersCount() == 0 || newCurBlock > neededBlocks ||
     response.getFirstNewBlockHeight() + response.getFetchedHeadersCount() > neededBlocks ) {
       dispatch(fetchHeadersSuccess(response));
     } else {

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -351,16 +351,16 @@ function fetchHeadersProgress(response) {
   return (dispatch, getState) => {
     const { curBlocks, neededBlocks } = getState().walletLoader;
     var newCurBlock = curBlocks + response.getFetchedHeadersCount();
-    console.log("curBlocks " + curBlocks);
+    console.log('curBlocks ' + curBlocks);
 
     if (curBlocks == 0) {
       newCurBlock += response.getFirstNewBlockHeight();
     }
-    console.log("getFetchedHeadersCount " + response.getFetchedHeadersCount());
-    console.log("neededBlocks " + neededBlocks);
-    console.log("newCurBlock1 " + newCurBlock);
-    console.log("newCurBlock2 " + newCurBlock);
-    console.log("getFirstNewBlockHeight " + response.getFirstNewBlockHeight());
+    console.log('getFetchedHeadersCount ' + response.getFetchedHeadersCount());
+    console.log('neededBlocks ' + neededBlocks);
+    console.log('newCurBlock1 ' + newCurBlock);
+    console.log('newCurBlock2 ' + newCurBlock);
+    console.log('getFirstNewBlockHeight ' + response.getFirstNewBlockHeight());
     if ( response.getFetchedHeadersCount() == 0 || newCurBlock > neededBlocks ||
     response.getFirstNewBlockHeight() + response.getFetchedHeadersCount() > neededBlocks ) {
       dispatch(fetchHeadersSuccess(response));


### PR DESCRIPTION
This is a workaround/debug for #165.  Not sure if this is correct since I didn't dig deep enough yet to understand what is going on.

The debug output I get is:

curBlocks 0
getFetchedHeadersCount 0
neededBlocks 241203.04985583338
newCurBlock1 0
newCurBlock2 0
getFirstNewBlockHeight 0

Without this it will just keep fetching 0 headers seemingly forever.

Closes #165.