### PR TITLE
print config path in error

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -5,7 +5,7 @@ import { getWalletServiceAttempt } from './ClientActions';
 import { getVersionServiceAttempt } from './VersionActions';
 import { getSeederAttempt } from './SeedServiceActions';
 import { getDcrdCert } from '../middleware/grpc/client';
-import { getCfg } from '../config.js';
+import { getCfg, getCfgPath } from '../config.js';
 import { WalletExistsRequest, CreateWalletRequest, OpenWalletRequest,
   CloseWalletRequest, StartConsensusRpcRequest, DiscoverAddressesRequest,
   SubscribeToBlockNotificationsRequest, FetchHeadersRequest } from '../middleware/walletrpc/api_pb';
@@ -253,7 +253,7 @@ function startRpcAction() {
     startConsensusRpc(loader, startRpcRequest,
         function(err) {
           if (err) {
-            dispatch(startRpcError(err + ' Please try again'));
+            dispatch(startRpcError(err + '.  You may need to edit ' + getCfgPath() + ' and try again'));
           } else {
             dispatch(startRpcSuccess());
           }

--- a/app/components/GetStarted.js
+++ b/app/components/GetStarted.js
@@ -84,7 +84,7 @@ class Home extends Component{
         <div>
           <ShowError error={walletOpenError} />
           <h3>Opening wallet</h3>
-          <h5>Please enter the information below to connect to you dcrwallet</h5>
+          <h5>Please enter the information below to connect to your dcrwallet</h5>
           <WalletOpenForm/>
       </div>);
     }

--- a/app/config.js
+++ b/app/config.js
@@ -43,3 +43,9 @@ export function getCfg() {
   };
   return(cfg);
 }
+
+export function getCfgPath() {
+  const Config = require('electron-config');
+  const config = new Config();
+  return config.path;
+}


### PR DESCRIPTION
This is a little refinement for #162.  If they have a bad RPC username/password, port, etc it's not really clear what they would need to do to fix it so inform the user of the path to the config so they can edit it.