### PR TITLE
Simplify grpc build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,8 @@ cd code
 git clone https://github.com/decred/decrediton.git
 git clone https://github.com/grpc/grpc
 cd grpc
-git remote add murg https://github.com/murgatroid99/grpc.git
-git fetch --all
-git checkout node_electron_build
 git submodule update --init
 npm install
-npm run electron-build -- --target=1.4.6
 cd ../decrediton
 npm install
 ```


### PR DESCRIPTION
Since electron support went into grpc we no longer need
to use a special branch or build instructions.

Until there is a new GRPC release local building is still necessary.

Closes #170