### PR TITLE
Fixed for Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ Start decrediton
 npm run dev
 ```
 
+### Windows
+
+On windows you will need some extra steps to build grpc.  This assumes
+you are using msys2 with various development tools (copilers, make,
+ect) all installed.
+
+Install node from the official package https://nodejs.org/en/download/
+and add it to your msys2 path.
+
+Install openssl from the following site:
+https://slproweb.com/products/Win32OpenSSL.html
+
+From an admin shell:
+
+```bash
+npm install --global --production windows-build-tools
+```
+
+Then build grpc as described above.
+
 ## Building the package
 
 To build a packaged version of decrediton (including a dmg on OSX and

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -4,8 +4,7 @@ import { loader, createWallet, walletExists, openWallet,
 import { getWalletServiceAttempt } from './ClientActions';
 import { getVersionServiceAttempt } from './VersionActions';
 import { getSeederAttempt } from './SeedServiceActions';
-import { getDcrdCert } from '../middleware/grpc/client';
-import { getCfg, getCfgPath } from '../config.js';
+import { getCfg, getCfgPath, getDcrdCert } from '../config.js';
 import { WalletExistsRequest, CreateWalletRequest, OpenWalletRequest,
   CloseWalletRequest, StartConsensusRpcRequest, DiscoverAddressesRequest,
   SubscribeToBlockNotificationsRequest, FetchHeadersRequest } from '../middleware/walletrpc/api_pb';

--- a/app/config.js
+++ b/app/config.js
@@ -1,3 +1,7 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
 export function getCfg() {
   const Config = require('electron-config');
   const config = new Config();
@@ -48,4 +52,67 @@ export function getCfgPath() {
   const Config = require('electron-config');
   const config = new Config();
   return config.path;
+}
+
+export function appDataDirectory() {
+  const path = require('path');
+  const os = require('os');
+
+  if (os.platform() == 'win32') {
+    return path.join(os.homedir(), 'AppData', 'Local', 'Decrediton');
+  } else if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library','Application Support','decrediton');
+  } else {
+    return path.join(os.homedir(),'.config','decrediton');
+  }
+}
+
+export function getCert() {
+  var cert = '';
+  var cfg = getCfg();
+  if (cfg.cert_path != '') {
+    return(cfg.cert_path);
+  }
+  var certPath = '';
+  if (os.platform() == 'win32') {
+    certPath = path.join(os.homedir(), 'AppData', 'Local', 'Decrediton', 'rpc.cert');
+  } else if (os.platform() == 'darwin') {
+    certPath = path.join(process.env.HOME, 'Library', 'Application Support',
+            'decrediton', 'rpc.cert');
+  } else {
+    certPath = path.join(process.env.HOME, '.config', 'decrediton', 'rpc.cert');
+  }
+
+  try {
+    cert = fs.readFileSync(certPath);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.log(certPath + ' does not exist');
+    } else if (err.code === 'EACCES') {
+      console.log(certPath + ' permission denied');
+    } else {
+      console.error(certPath + ' ' + err);
+    }
+  }
+
+  return(cert);
+}
+
+export function getDcrdCert() {
+  var cfg = getCfg();
+  if (cfg.daemon_cert_path != '') {
+    return(cfg.daemon_cert_path);
+  }
+  var certPath = '';
+  if (os.platform() == 'win32') {
+    certPath = path.join(os.homedir(), 'AppData', 'Local', 'Dcrd', 'rpc.cert');
+  } else if (os.platform() == 'darwin') {
+    certPath = path.join(process.env.HOME, 'Library', 'Application Support',
+            'Dcrd', 'rpc.cert');
+  } else {
+    certPath = path.join(process.env.HOME, '.dcrd', 'rpc.cert');
+  }
+
+  var cert = fs.readFileSync(certPath);
+  return(cert);
 }

--- a/app/config.js
+++ b/app/config.js
@@ -54,6 +54,10 @@ export function getCfgPath() {
   return config.path;
 }
 
+// In all the functions below the Windows path is constructed based on
+// os.homedir() rather than using process.env.LOCALAPPDATA because in my tests
+// that was available when using the standalone node but not there when using
+// electron in production mode.
 export function appDataDirectory() {
   const path = require('path');
   const os = require('os');

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -1,63 +1,9 @@
 process.env['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA';
 
-import fs from 'fs';
-import path from 'path';
-
-import os from 'os';
 import grpc from 'grpc';
 
-import { getCfg } from '../../config.js';
+import { getCert } from '../../config.js';
 var services = require('../walletrpc/api_grpc_pb.js');
-
-export function getCert() {
-  var cert = '';
-  var cfg = getCfg();
-  if (cfg.cert_path != '') {
-    return(cfg.cert_path);
-  }
-  var certPath = '';
-  if (os.platform() == 'win32') {
-    certPath = path.join(process.env.LOCALAPPDATA, 'Decrediton', 'rpc.cert');
-  } else if (os.platform() == 'darwin') {
-    certPath = path.join(process.env.HOME, 'Library', 'Application Support',
-            'decrediton', 'rpc.cert');
-  } else {
-    certPath = path.join(process.env.HOME, '.config', 'decrediton', 'rpc.cert');
-  }
-
-  try {
-    cert = fs.readFileSync(certPath);
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      console.log(certPath + ' does not exist');
-    } else if (err.code === 'EACCES') {
-      console.log(certPath + ' permission denied');
-    } else {
-      console.error(certPath + ' ' + err);
-    }
-  }
-
-  return(cert);
-}
-
-export function getDcrdCert() {
-  var cfg = getCfg();
-  if (cfg.daemon_cert_path != '') {
-    return(cfg.daemon_cert_path);
-  }
-  var certPath = '';
-  if (os.platform() == 'win32') {
-    certPath = path.join(process.env.LOCALAPPDATA, 'Dcrd', 'rpc.cert');
-  } else if (os.platform() == 'darwin') {
-    certPath = path.join(process.env.HOME, 'Library', 'Application Support',
-            'Dcrd', 'rpc.cert');
-  } else {
-    certPath = path.join(process.env.HOME, '.dcrd', 'rpc.cert');
-  }
-
-  var cert = fs.readFileSync(certPath);
-  return(cert);
-}
 
 export function getWalletService(address, port, cb) {
   var cert = getCert();

--- a/app/middleware/grpc/loader.js
+++ b/app/middleware/grpc/loader.js
@@ -1,6 +1,6 @@
 process.env['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA';
 
-import { getCert } from './client';
+import { getCert } from '../../config.js';
 import grpc from 'grpc';
 var services = require('../walletrpc/api_grpc_pb.js');
 

--- a/app/middleware/grpc/seeder.js
+++ b/app/middleware/grpc/seeder.js
@@ -1,6 +1,6 @@
 process.env['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA';
 
-import { getCert } from './client';
+import { getCert } from '../../config.js';
 import grpc from 'grpc';
 var services = require('../walletrpc/api_grpc_pb.js');
 export function seeder(request, cb) {

--- a/app/middleware/grpc/version.js
+++ b/app/middleware/grpc/version.js
@@ -1,4 +1,4 @@
-import { getCert } from './client';
+import { getCert } from '../../config.js';
 import grpc from 'grpc';
 var services = require('../walletrpc/api_grpc_pb.js');
 export function getVersionService(address, port, cb) {


### PR DESCRIPTION
Need to construct the path for Windows rather than using env variables
the way were we doing it before.

Move all functions that need path and config info to a single file,
config.js.

Detached should be false, esp for windows.

Don't use fd 4 that doesn't seem to work on win with wallet.

Closes #122