### PR TITLE
Update grpc bindings for updated FetchHeaders response

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -348,16 +348,12 @@ function fetchHeadersFailed(error) {
 
 function fetchHeadersProgress(response) {
   return (dispatch, getState) => {
-    const { curBlocks, neededBlocks } = getState().walletLoader;
-    var newCurBlock = curBlocks + response.getFetchedHeadersCount();
-    if (curBlocks == 0) {
-      newCurBlock += response.getFirstNewBlockHeight();
-    }
-    if ( newCurBlock > neededBlocks ||
-    response.getFirstNewBlockHeight() + response.getFetchedHeadersCount() > neededBlocks ) {
+    const { neededBlocks } = getState().walletLoader;
+    var mainChainTipBlockHeight = response.getMainChainTipBlockHeight();
+    if ( mainChainTipBlockHeight > neededBlocks ) {
       dispatch(fetchHeadersSuccess(response));
     } else {
-      dispatch({curBlocks: newCurBlock, type: FETCHHEADERS_PROGRESS});
+      dispatch({type: FETCHHEADERS_PROGRESS});
       setTimeout( () => {dispatch(fetchHeadersAction());}, 1000);
     }
   };

--- a/app/index.js
+++ b/app/index.js
@@ -33,7 +33,7 @@ if (cfg.network == 'testnet') {
 var initialState = {
   version: {
     // RequiredVersion
-    requiredVersion: '4.2.2',
+    requiredVersion: '4.3.0',
     versionInvalid: false,
     versionInvalidError: null,
     // VersionService

--- a/app/middleware/api.proto
+++ b/app/middleware/api.proto
@@ -277,7 +277,9 @@ message FundTransactionResponse {
 message ConstructTransactionRequest {
 	message OutputDestination {
 		string address = 1;
+
 		bytes script = 2;
+		uint32 script_version = 3;
 	}
 	message Output {
 		OutputDestination destination = 1;
@@ -435,6 +437,8 @@ message FetchHeadersResponse {
 	uint32 fetched_headers_count = 1;
 	bytes first_new_block_hash = 2;
 	int32 first_new_block_height = 3;
+	bytes main_chain_tip_block_hash = 4;
+	int32 main_chain_tip_block_height = 5;
 }
 
 message GenerateRandomSeedRequest {

--- a/app/middleware/regen.sh
+++ b/app/middleware/regen.sh
@@ -1,1 +1,5 @@
+#!/bin/sh
+
+# This script regenerates the static js bindings for the api.proto file
+# You will need protoc and grpc_node_plugin bins installed for this to run properly
 protoc --js_out=import_style=commonjs,binary:./walletrpc --grpc_out=./walletrpc --plugin=protoc-gen-grpc=$(which grpc_node_plugin) ./api.proto

--- a/app/middleware/regen.sh
+++ b/app/middleware/regen.sh
@@ -1,0 +1,1 @@
+protoc --js_out=import_style=commonjs,binary:./walletrpc --grpc_out=./walletrpc --plugin=protoc-gen-grpc=$(which grpc_node_plugin) ./api.proto

--- a/app/middleware/walletrpc/api_pb.js
+++ b/app/middleware/walletrpc/api_pb.js
@@ -8743,7 +8743,8 @@ proto.walletrpc.ConstructTransactionRequest.OutputDestination.prototype.toObject
 proto.walletrpc.ConstructTransactionRequest.OutputDestination.toObject = function(includeInstance, msg) {
   var f, obj = {
     address: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    script: msg.getScript_asB64()
+    script: msg.getScript_asB64(),
+    scriptVersion: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -8787,6 +8788,10 @@ proto.walletrpc.ConstructTransactionRequest.OutputDestination.deserializeBinaryF
     case 2:
       var value = /** @type {!Uint8Array} */ (reader.readBytes());
       msg.setScript(value);
+      break;
+    case 3:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setScriptVersion(value);
       break;
     default:
       reader.skipField();
@@ -8837,6 +8842,13 @@ proto.walletrpc.ConstructTransactionRequest.OutputDestination.prototype.serializ
   if (f.length > 0) {
     writer.writeBytes(
       2,
+      f
+    );
+  }
+  f = this.getScriptVersion();
+  if (f !== 0) {
+    writer.writeUint32(
+      3,
       f
     );
   }
@@ -8894,6 +8906,21 @@ proto.walletrpc.ConstructTransactionRequest.OutputDestination.prototype.getScrip
 /** @param {!(string|Uint8Array)} value */
 proto.walletrpc.ConstructTransactionRequest.OutputDestination.prototype.setScript = function(value) {
   jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional uint32 script_version = 3;
+ * @return {number}
+ */
+proto.walletrpc.ConstructTransactionRequest.OutputDestination.prototype.getScriptVersion = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+};
+
+
+/** @param {number} value */
+proto.walletrpc.ConstructTransactionRequest.OutputDestination.prototype.setScriptVersion = function(value) {
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -14986,7 +15013,9 @@ proto.walletrpc.FetchHeadersResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     fetchedHeadersCount: jspb.Message.getFieldWithDefault(msg, 1, 0),
     firstNewBlockHash: msg.getFirstNewBlockHash_asB64(),
-    firstNewBlockHeight: jspb.Message.getFieldWithDefault(msg, 3, 0)
+    firstNewBlockHeight: jspb.Message.getFieldWithDefault(msg, 3, 0),
+    mainChainTipBlockHash: msg.getMainChainTipBlockHash_asB64(),
+    mainChainTipBlockHeight: jspb.Message.getFieldWithDefault(msg, 5, 0)
   };
 
   if (includeInstance) {
@@ -15034,6 +15063,14 @@ proto.walletrpc.FetchHeadersResponse.deserializeBinaryFromReader = function(msg,
     case 3:
       var value = /** @type {number} */ (reader.readInt32());
       msg.setFirstNewBlockHeight(value);
+      break;
+    case 4:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setMainChainTipBlockHash(value);
+      break;
+    case 5:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setMainChainTipBlockHeight(value);
       break;
     default:
       reader.skipField();
@@ -15091,6 +15128,20 @@ proto.walletrpc.FetchHeadersResponse.prototype.serializeBinaryToWriter = functio
   if (f !== 0) {
     writer.writeInt32(
       3,
+      f
+    );
+  }
+  f = this.getMainChainTipBlockHash_asU8();
+  if (f.length > 0) {
+    writer.writeBytes(
+      4,
+      f
+    );
+  }
+  f = this.getMainChainTipBlockHeight();
+  if (f !== 0) {
+    writer.writeInt32(
+      5,
       f
     );
   }
@@ -15163,6 +15214,60 @@ proto.walletrpc.FetchHeadersResponse.prototype.getFirstNewBlockHeight = function
 /** @param {number} value */
 proto.walletrpc.FetchHeadersResponse.prototype.setFirstNewBlockHeight = function(value) {
   jspb.Message.setField(this, 3, value);
+};
+
+
+/**
+ * optional bytes main_chain_tip_block_hash = 4;
+ * @return {!(string|Uint8Array)}
+ */
+proto.walletrpc.FetchHeadersResponse.prototype.getMainChainTipBlockHash = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/**
+ * optional bytes main_chain_tip_block_hash = 4;
+ * This is a type-conversion wrapper around `getMainChainTipBlockHash()`
+ * @return {string}
+ */
+proto.walletrpc.FetchHeadersResponse.prototype.getMainChainTipBlockHash_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getMainChainTipBlockHash()));
+};
+
+
+/**
+ * optional bytes main_chain_tip_block_hash = 4;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getMainChainTipBlockHash()`
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.FetchHeadersResponse.prototype.getMainChainTipBlockHash_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getMainChainTipBlockHash()));
+};
+
+
+/** @param {!(string|Uint8Array)} value */
+proto.walletrpc.FetchHeadersResponse.prototype.setMainChainTipBlockHash = function(value) {
+  jspb.Message.setField(this, 4, value);
+};
+
+
+/**
+ * optional int32 main_chain_tip_block_height = 5;
+ * @return {number}
+ */
+proto.walletrpc.FetchHeadersResponse.prototype.getMainChainTipBlockHeight = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 5, 0));
+};
+
+
+/** @param {number} value */
+proto.walletrpc.FetchHeadersResponse.prototype.setMainChainTipBlockHeight = function(value) {
+  jspb.Message.setField(this, 5, value);
 };
 
 


### PR DESCRIPTION
With new FetchHeadersResponse fields we can now just compare MainChainTipBlockHeight with what we calculated to be "neededBlocks" 

Also added the regen.sh script to update *pb.js files when api.proto changes

Fixes #165