### PR TITLE
Handle dcrd or dcrwallet startup errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "electron-debug": "^1.0.1",
     "eslint-formatter-pretty": "^1.1.0",
     "eslint-plugin-react": "^6.9.0",
+    "is-running": "^2.1.0",
     "material-ui": "^0.16.2",
     "radium": "^0.18.1",
     "react": "^15.3.2",


### PR DESCRIPTION
If either process fails to start (in production mode only of course)
let the user know then stop (since there is no way to continue from
there).

Only shutdown processes that are currently running.

Closes #108