### PR TITLE
Add logic for mined and unmined transactions

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -336,15 +336,30 @@ function getTransactionsError(error) {
 
 function getTransactionsProgress(getTransactionsResponse) {
   return (dispatch, getState) => {
-    const { mined } = getState().grpc;
+    const { mined, unmined } = getState().grpc;
     var found = false;
-    for (var i = 0; i < mined.length; i++) {
-      if ( mined[i].getHeight() == getTransactionsResponse.getMinedTransactions().getHeight() ) {
-        found = true;
+    if (getTransactionsResponse.getMinedTransactions() !== undefined) {
+      for (var i = 0; i < mined.length; i++) {
+        if ( mined[i].getHeight() == getTransactionsResponse.getMinedTransactions().getHeight() ) {
+          found = true;
+        }
+      }
+      if (!found) {
+        dispatch({getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_MINED_PROGRESS })
       }
     }
-    if (!found) {
-      dispatch({getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_MINED_PROGRESS })
+    if (getTransactionsResponse.getUnminedTransactionsList().length > 0) {
+      found = false;
+      for (var i = 0; i < getTransactionsResponse.getUnminedTransactionsList(); i++) {
+        for (var k = 0; k < unmined.length; k++) {
+          if ( unmined[k].getHash() == getTransactionsResponse.getUnminedTransactions()[i].getHash() ) {
+            found = true;
+          }
+        }
+        if (!found) {
+          dispatch({getTransactionsResponse: getTransactionsResponse.getUnminedTransactions()[i], type: GETTRANSACTIONS_UNMINED_PROGRESS })
+        }
+      }
     }
   };
 }

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -334,7 +334,20 @@ function getTransactionsError(error) {
 }
 
 function getTransactionsProgress(getTransactionsResponse) {
-  return { getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_PROGRESS };
+  return (dispatch, getState) => {
+    const { transactions } = getState().grpc;
+    var found = false;
+    for (var i = 0; i < transactions.length; i++) {
+      console.log(i, transactions[i].getMinedTransactions().getHeight(), getTransactionsResponse.getMinedTransactions().getHeight())
+      if ( transactions[i].getMinedTransactions().getHeight() == getTransactionsResponse.getMinedTransactions().getHeight() ) {
+        console.log('found!', getTransactionsResponse.getMinedTransactions().getHeight());
+        found = true;
+      }
+    }
+    if (!found) {
+      dispatch({getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_PROGRESS })
+    }
+  };
 }
 
 function getTransactionsComplete() {

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -326,7 +326,8 @@ function accounts() {
 
 export const GETTRANSACTIONS_ATTEMPT = 'GETTRANSACTIONS_ATTEMPT';
 export const GETTRANSACTIONS_FAILED = 'GETTRANSACTIONS_FAILED';
-export const GETTRANSACTIONS_PROGRESS = 'GETTRANSACTIONS_PROGRESS';
+export const GETTRANSACTIONS_MINED_PROGRESS = 'GETTRANSACTIONS_MINED_PROGRESS';
+export const GETTRANSACTIONS_UNMINED_PROGRESS = 'GETTRANSACTIONS_UNMINED_PROGRESS';
 export const GETTRANSACTIONS_COMPLETE = 'GETTRANSACTIONS_COMPLETE';
 
 function getTransactionsError(error) {
@@ -335,15 +336,15 @@ function getTransactionsError(error) {
 
 function getTransactionsProgress(getTransactionsResponse) {
   return (dispatch, getState) => {
-    const { transactions } = getState().grpc;
+    const { mined } = getState().grpc;
     var found = false;
-    for (var i = 0; i < transactions.length; i++) {
-      if ( transactions[i].getMinedTransactions().getHeight() == getTransactionsResponse.getMinedTransactions().getHeight() ) {
+    for (var i = 0; i < mined.length; i++) {
+      if ( mined[i].getHeight() == getTransactionsResponse.getMinedTransactions().getHeight() ) {
         found = true;
       }
     }
     if (!found) {
-      dispatch({getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_PROGRESS })
+      dispatch({getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_MINED_PROGRESS })
     }
   };
 }

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -345,19 +345,19 @@ function getTransactionsProgress(getTransactionsResponse) {
         }
       }
       if (!found) {
-        dispatch({getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_MINED_PROGRESS })
+        dispatch({getTransactionsResponse: getTransactionsResponse, type: GETTRANSACTIONS_MINED_PROGRESS });
       }
     }
     if (getTransactionsResponse.getUnminedTransactionsList().length > 0) {
       found = false;
-      for (var i = 0; i < getTransactionsResponse.getUnminedTransactionsList(); i++) {
+      for (i = 0; i < getTransactionsResponse.getUnminedTransactionsList(); i++) {
         for (var k = 0; k < unmined.length; k++) {
           if ( unmined[k].getHash() == getTransactionsResponse.getUnminedTransactions()[i].getHash() ) {
             found = true;
           }
         }
         if (!found) {
-          dispatch({getTransactionsResponse: getTransactionsResponse.getUnminedTransactions()[i], type: GETTRANSACTIONS_UNMINED_PROGRESS })
+          dispatch({unmined: getTransactionsResponse.getUnminedTransactions()[i], type: GETTRANSACTIONS_UNMINED_PROGRESS });
         }
       }
     }

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -338,9 +338,7 @@ function getTransactionsProgress(getTransactionsResponse) {
     const { transactions } = getState().grpc;
     var found = false;
     for (var i = 0; i < transactions.length; i++) {
-      console.log(i, transactions[i].getMinedTransactions().getHeight(), getTransactionsResponse.getMinedTransactions().getHeight())
       if ( transactions[i].getMinedTransactions().getHeight() == getTransactionsResponse.getMinedTransactions().getHeight() ) {
-        console.log('found!', getTransactionsResponse.getMinedTransactions().getHeight());
         found = true;
       }
     }

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -220,8 +220,7 @@ function startRpcError(error) {
 function startRpcSuccess() {
   return (dispatch) => {
     dispatch({response: {}, type: STARTRPC_SUCCESS});
-    dispatch(fetchHeadersAttempt());
-    //dispatch(discoverAddressAttempt(true));
+    dispatch(subscribeBlockAttempt());
   };
 }
 
@@ -269,9 +268,12 @@ function discoverAddressError(error) {
 }
 
 function discoverAddressSuccess() {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch({response: {}, type: DISCOVERADDRESS_SUCCESS});
-    dispatch(subscribeBlockAttempt());
+    const { subscribeBlockNtfnsResponse } = getState().walletLoader;
+    if ( subscribeBlockNtfnsResponse !== null ) {
+      dispatch(fetchHeadersAttempt());
+    }
   };
 }
 
@@ -309,9 +311,12 @@ function subscribeBlockError(error) {
 }
 
 function subscribeBlockSuccess() {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch({response: {}, type: SUBSCRIBEBLOCKNTFNS_SUCCESS});
-    dispatch(getWalletServiceAttempt());
+    const { discoverAddressResponse } = getState().walletLoader;
+    if ( discoverAddressResponse !== null ) {
+      dispatch(fetchHeadersAttempt());
+    }
   };
 }
 
@@ -362,6 +367,7 @@ function fetchHeadersProgress(response) {
 function fetchHeadersSuccess(response) {
   return (dispatch) => {
     dispatch({response: response, type: FETCHHEADERS_SUCCESS});
+    dispatch(getWalletServiceAttempt());
   };
 }
 

--- a/app/components/GetStarted.js
+++ b/app/components/GetStarted.js
@@ -306,9 +306,9 @@ class Home extends Component{
             </StepContent>
           </Step>
           <Step>
-            <StepLabel>Fetch Headers</StepLabel>
+            <StepLabel>Subscribe to Block Notifications</StepLabel>
             <StepContent>
-              {fetchHeaders}
+              {}
             </StepContent>
           </Step>
           <Step>
@@ -318,9 +318,9 @@ class Home extends Component{
             </StepContent>
           </Step>
           <Step>
-            <StepLabel>Subscribe to Block Notifications</StepLabel>
+            <StepLabel>Fetch Headers</StepLabel>
             <StepContent>
-              {}
+              {fetchHeaders}
             </StepContent>
           </Step>
           <Step>

--- a/app/components/History.js
+++ b/app/components/History.js
@@ -55,7 +55,7 @@ class History extends Component{
   };
 
   render() {
-    const { walletService, transactions, getBalanceResponse, getBalanceRequestAttempt } = this.props;
+    const { walletService, mined, unmined, getBalanceResponse, getBalanceRequestAttempt } = this.props;
 
     const historyView = (
       <div style={styles.content}>
@@ -65,7 +65,7 @@ class History extends Component{
               <Balance onClick={!getBalanceRequestAttempt ? () => this.handleBalanceClick() : null}
               amount={getBalanceResponse.getTotal()} /> }
         </div>
-        <TxHistory transactions={transactions}/>
+        <TxHistory mined={mined} unmined={unmined}/>
       </div>);
     if (walletService === null) {
       return (<ErrorScreen />);

--- a/app/components/TxHistory.js
+++ b/app/components/TxHistory.js
@@ -54,6 +54,9 @@ class TxHistory extends Component {
     return (
       <div>
       <div style={styles.historyContainer}>
+        {unmined.length > 0 ? 
+          <p> Unmined Transactions </p>
+        : <p></p> }
         {unmined.map(function(tx) {
             var parseDate = new Date(tx.getTimestamp()*1000);
             var diffDays = Math.round(Math.abs((parseDate.getTime() - today.getTime())/(oneDay)));
@@ -95,6 +98,9 @@ class TxHistory extends Component {
         })}
       </div>
       <div style={styles.historyContainer}>
+        {mined.length > 0 ? 
+          <p> Mined Transactions </p>
+        : <p></p> }
         {mined.map(function(txs) {
           var parseDate = new Date(txs.getTimestamp()*1000);
           var diffDays = Math.round(Math.abs((parseDate.getTime() - today.getTime())/(oneDay)));

--- a/app/components/TxHistory.js
+++ b/app/components/TxHistory.js
@@ -54,51 +54,51 @@ class TxHistory extends Component {
     return (
       <div>
       <div style={styles.historyContainer}>
-        {unmined.length > 0 ? 
+        {unmined.length > 0 ?
           <p> Unmined Transactions </p>
         : <p></p> }
         {unmined.map(function(tx) {
-            var parseDate = new Date(tx.getTimestamp()*1000);
-            var diffDays = Math.round(Math.abs((parseDate.getTime() - today.getTime())/(oneDay)));
-            var credits = tx.getCreditsList();
-            var debits = tx.getDebitsList();
-            if (debits.length == 0) {
-              var txAmount = 0;
-              for(var k = 0; k < credits.length; k++){
-                txAmount += credits[k].getAmount();
-              }
-              return (
-              <div style={styles.transactionRow} key={j}>
+          var parseDate = new Date(tx.getTimestamp()*1000);
+          var diffDays = Math.round(Math.abs((parseDate.getTime() - today.getTime())/(oneDay)));
+          var credits = tx.getCreditsList();
+          var debits = tx.getDebitsList();
+          if (debits.length == 0) {
+            var txAmount = 0;
+            for(var k = 0; k < credits.length; k++){
+              txAmount += credits[k].getAmount();
+            }
+            return (
+              <div style={styles.transactionRow} key={tx.getHash()}>
                 <Receive />
                 <span style={styles.txAmount}><Balance amount={txAmount} /></span>
                 <span style={styles.txDateSince}>{diffDays} Days Since
                   <LeftArrow />
                 </span>
               </div>);
-            } else {
-              var prevAmount = 0;
-              txAmount = 0;
-              var returnedAmount = 0;
-              for(k = 0; k < credits.length; k++){
-                returnedAmount += credits[k].getAmount();
-              }
-              for(k = 0; k < debits.length; k++){
-                prevAmount += debits[k].getPreviousAmount();
-              }
-              txAmount = prevAmount - returnedAmount;
-              return (
-                <div style={styles.transactionRow} key={j}>
+          } else {
+            var prevAmount = 0;
+            txAmount = 0;
+            var returnedAmount = 0;
+            for(k = 0; k < credits.length; k++){
+              returnedAmount += credits[k].getAmount();
+            }
+            for(k = 0; k < debits.length; k++){
+              prevAmount += debits[k].getPreviousAmount();
+            }
+            txAmount = prevAmount - returnedAmount;
+            return (
+                <div style={styles.transactionRow} key={tx.getHash()}>
                   <Sent />
                   <span style={styles.txAmount}>-<Balance amount={txAmount} /></span>
                   <span style={styles.txDateSince}>{diffDays} Days Since
                     <LeftArrow />
                   </span>
                 </div>);
-            }
+          }
         })}
       </div>
       <div style={styles.historyContainer}>
-        {mined.length > 0 ? 
+        {mined.length > 0 ?
           <p> Mined Transactions </p>
         : <p></p> }
         {mined.map(function(txs) {
@@ -107,7 +107,7 @@ class TxHistory extends Component {
           //var s = Buffer.from(tx.transaction.getMinedTransactions().getTransactionsList()[0].getHash()).toString('hex');
           //var reversed = reverseHash(s);
           var minedTxs = txs.getTransactionsList();
-          return (minedTxs.map(function(tx, j) {
+          return (minedTxs.map(function(tx) {
             var credits = tx.getCreditsList();
             var debits = tx.getDebitsList();
             if (debits.length == 0) {
@@ -116,7 +116,7 @@ class TxHistory extends Component {
                 txAmount += credits[k].getAmount();
               }
               return (
-              <div style={styles.transactionRow} key={j}>
+              <div style={styles.transactionRow} key={tx.getHash()}>
                 <Receive />
                 <span style={styles.txAmount}><Balance amount={txAmount} /></span>
                 <span style={styles.txDateSince}>{diffDays} Days Since
@@ -135,7 +135,7 @@ class TxHistory extends Component {
               }
               txAmount = prevAmount - returnedAmount;
               return (
-                <div style={styles.transactionRow} key={j}>
+                <div style={styles.transactionRow} key={tx.getHash()}>
                   <Sent />
                   <span style={styles.txAmount}>-<Balance amount={txAmount} /></span>
                   <span style={styles.txDateSince}>{diffDays} Days Since

--- a/app/components/TxHistory.js
+++ b/app/components/TxHistory.js
@@ -48,13 +48,13 @@ class TxHistory extends Component {
     var oneDay = 24*60*60*1000; // hours*minutes*seconds*milliseconds
     var today = new Date();
     transactions.sort(function(a, b) {
-      return b.transaction.getMinedTransactions().getTimestamp() - a.transaction.getMinedTransactions().getTimestamp();
+      return b.getMinedTransactions().getTimestamp() - a.getMinedTransactions().getTimestamp();
     });
     return (
       <div>
       <div style={styles.historyContainer}>
         {transactions.map(function(txs) {
-          var unminedTxs = txs.transaction.getUnminedTransactionsList();
+          var unminedTxs = txs.getUnminedTransactionsList();
           return (unminedTxs.map(function(tx, j) {
             var parseDate = new Date(tx.getTimestamp()*1000);
             var diffDays = Math.round(Math.abs((parseDate.getTime() - today.getTime())/(oneDay)));
@@ -98,11 +98,11 @@ class TxHistory extends Component {
       </div>
       <div style={styles.historyContainer}>
         {transactions.map(function(txs) {
-          var parseDate = new Date(txs.transaction.getMinedTransactions().getTimestamp()*1000);
+          var parseDate = new Date(txs.getMinedTransactions().getTimestamp()*1000);
           var diffDays = Math.round(Math.abs((parseDate.getTime() - today.getTime())/(oneDay)));
           //var s = Buffer.from(tx.transaction.getMinedTransactions().getTransactionsList()[0].getHash()).toString('hex');
           //var reversed = reverseHash(s);
-          var minedTxs = txs.transaction.getMinedTransactions().getTransactionsList();
+          var minedTxs = txs.getMinedTransactions().getTransactionsList();
           return (minedTxs.map(function(tx, j) {
             var credits = tx.getCreditsList();
             var debits = tx.getDebitsList();

--- a/app/components/TxHistory.js
+++ b/app/components/TxHistory.js
@@ -44,18 +44,17 @@ const styles = {
 
 class TxHistory extends Component {
   render() {
-    const transactions = this.props.transactions;
+    const mined = this.props.mined;
+    const unmined = this.props.unmined;
     var oneDay = 24*60*60*1000; // hours*minutes*seconds*milliseconds
     var today = new Date();
-    transactions.sort(function(a, b) {
-      return b.getMinedTransactions().getTimestamp() - a.getMinedTransactions().getTimestamp();
+    mined.sort(function(a, b) {
+      return b.getTimestamp() - a.getTimestamp();
     });
     return (
       <div>
       <div style={styles.historyContainer}>
-        {transactions.map(function(txs) {
-          var unminedTxs = txs.getUnminedTransactionsList();
-          return (unminedTxs.map(function(tx, j) {
+        {unmined.map(function(tx) {
             var parseDate = new Date(tx.getTimestamp()*1000);
             var diffDays = Math.round(Math.abs((parseDate.getTime() - today.getTime())/(oneDay)));
             var credits = tx.getCreditsList();
@@ -93,16 +92,15 @@ class TxHistory extends Component {
                   </span>
                 </div>);
             }
-          }));
         })}
       </div>
       <div style={styles.historyContainer}>
-        {transactions.map(function(txs) {
-          var parseDate = new Date(txs.getMinedTransactions().getTimestamp()*1000);
+        {mined.map(function(txs) {
+          var parseDate = new Date(txs.getTimestamp()*1000);
           var diffDays = Math.round(Math.abs((parseDate.getTime() - today.getTime())/(oneDay)));
           //var s = Buffer.from(tx.transaction.getMinedTransactions().getTransactionsList()[0].getHash()).toString('hex');
           //var reversed = reverseHash(s);
-          var minedTxs = txs.getMinedTransactions().getTransactionsList();
+          var minedTxs = txs.getTransactionsList();
           return (minedTxs.map(function(tx, j) {
             var credits = tx.getCreditsList();
             var debits = tx.getDebitsList();

--- a/app/containers/HistoryPage.js
+++ b/app/containers/HistoryPage.js
@@ -5,7 +5,8 @@ import History from '../components/History';
 function mapStateToProps(state) {
   return {
     walletService: state.grpc.walletService,
-    transactions: state.grpc.transactions,
+    mined: state.grpc.mined,
+    unmined: state.grpc.unmined,
     getBalanceResponse: state.grpc.getBalanceResponse,
     getBalanceRequestAttempt: state.grpc.getBalanceRequestAttempt,
   };

--- a/app/index.js
+++ b/app/index.js
@@ -89,7 +89,8 @@ var initialState = {
     getAccountsRequestAttempt: false,
     getAccountsResponse: null,
     // Transactions
-    transactions: Array(),
+    mined: Array(),
+    unmined: Array(),
     getTransactionsRequest: null,
     getTransactionsError: null,
     getTransactionsRequestAttempt: false,

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -46,7 +46,6 @@ export function getAccountNumber(client, request, cb) {
       console.error(err);
       return cb(null, err);
     } else {
-      console.log('accountnumber{"default"} ==', response);
       return cb(response);
     }
   });
@@ -58,7 +57,6 @@ export function getStakeInfo(client, request, cb) {
       console.error(err);
       return cb(null, err);
     } else {
-      console.log('current stakeInfo', response);
       return cb(response);
     }
   });
@@ -70,7 +68,6 @@ export function getPing(client, request, cb) {
       console.error(err);
       return cb(null, err);
     } else {
-      console.log('ping', response);
       return cb(response);
     }
   });
@@ -82,7 +79,6 @@ export function getNetwork(client, request, cb) {
       console.error(err);
       return cb(null, err);
     } else {
-      console.log('network', response);
       return cb(response);
     }
   });
@@ -95,7 +91,6 @@ export function getAccounts(client, request, cb) {
       console.error(err);
       return cb(null, err);
     } else {
-      console.log('accounts', response);
       return cb(response);
     }
   });
@@ -123,7 +118,6 @@ export function getTicketPrice(client, request, cb) {
       console.error('ticketPrice', err);
       return cb(null, err);
     } else {
-      console.log('ticketPrice', response);
       return cb(response);
     }
   });

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -7,7 +7,7 @@ import {
   GETSTAKEINFO_ATTEMPT, GETSTAKEINFO_FAILED, GETSTAKEINFO_SUCCESS,
   GETTICKETPRICE_ATTEMPT, GETTICKETPRICE_FAILED, GETTICKETPRICE_SUCCESS,
   GETACCOUNTS_ATTEMPT, GETACCOUNTS_FAILED, GETACCOUNTS_SUCCESS,
-  GETTRANSACTIONS_ATTEMPT, GETTRANSACTIONS_FAILED, GETTRANSACTIONS_PROGRESS, GETTRANSACTIONS_COMPLETE
+  GETTRANSACTIONS_ATTEMPT, GETTRANSACTIONS_FAILED, GETTRANSACTIONS_MINED_PROGRESS, GETTRANSACTIONS_UNMINED_PROGRESS, GETTRANSACTIONS_COMPLETE
 } from '../actions/ClientActions';
 
 export default function grpc(state = {}, action) {
@@ -159,11 +159,18 @@ export default function grpc(state = {}, action) {
       getTransactionsError: action.error,
       getTransactionsRequestAttempt: false,
     };
-  case GETTRANSACTIONS_PROGRESS:
+  case GETTRANSACTIONS_MINED_PROGRESS:
     return {...state,
-      transactions: [
-        ...state.transactions,
-        action.getTransactionsResponse
+      mined: [
+        ...state.mined,
+        action.getTransactionsResponse.getMinedTransactions(),
+      ],
+    };
+  case GETTRANSACTIONS_UNMINED_PROGRESS:
+    return {...state,
+      unmined: [
+        ...state.unmined,
+        unmined,
       ],
     };
   case GETTRANSACTIONS_COMPLETE:

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -170,7 +170,7 @@ export default function grpc(state = {}, action) {
     return {...state,
       unmined: [
         ...state.unmined,
-        unmined,
+        action.unmined,
       ],
     };
   case GETTRANSACTIONS_COMPLETE:

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -163,7 +163,7 @@ export default function grpc(state = {}, action) {
     return {...state,
       transactions: [
         ...state.transactions,
-        { transaction: action.getTransactionsResponse }
+        action.getTransactionsResponse
       ],
     };
   case GETTRANSACTIONS_COMPLETE:

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -169,7 +169,7 @@ export default function walletLoader(state = {}, action) {
       fetchHeadersRequestAttempt: false,
       fetchHeadersRequest: null,
       fetchHeadersResponse: action.response,
-      stepIndex: 5,
+      stepIndex: 7,
     };
   case SUBSCRIBEBLOCKNTFNS_ATTEMPT:
     return {...state,
@@ -188,7 +188,7 @@ export default function walletLoader(state = {}, action) {
       subscribeBlockNtfnsRequestAttempt: false,
       subscribeBlockNtfnsRequest: null,
       subscribeBlockNtfnsResponse: action.response,
-      stepIndex: 7,  // Onto final prep
+      stepIndex: 5,  // Onto final prep
     };
 
   default:


### PR DESCRIPTION
Previously, only mined transactions were handled from the getTransactions rpc and they were all appended to the transactions state array. Now unmined and mined are dealt with in a relatively smart way (checking if they already exist and don't add if so).  This should set up decrediton to allow for pagination in a coming PR as well