### PR TITLE
Use DCR as units on Send page instead of atoms.

### DIFF
--- a/app/components/Send.js
+++ b/app/components/Send.js
@@ -50,10 +50,10 @@ class Send extends Component{
         <p> raw tx <br/>
           {constructTxResponse !== null ? constructTxResponse.getUnsignedTransaction() : null}}
         </p>
-        <p> total previous output amount <br/>
+      <p> total previous output amount (atoms) <br/>
           {constructTxResponse != null ? constructTxResponse.getTotalPreviousOutputAmount() : null}
         </p>
-        <p> total output amount <br/>
+      <p> total output amount (atoms) <br/>
           {constructTxResponse !== null ? constructTxResponse.getTotalOutputAmount() : null}
         </p>
         <p> estimated signed size <br/>

--- a/app/containers/ConstructTxForm.js
+++ b/app/containers/ConstructTxForm.js
@@ -44,8 +44,8 @@ class ConstructTxForm extends React.Component {
                     onBlur={(e) =>{this.updateOutputDestination(output.key, e.target.value);}}/>
                   <TextField
                     key={'amount'+output.key}
-                    hintText="Amount"
-                    floatingLabelText="Amount"
+                    hintText="Amount (DCR)"
+                    floatingLabelText="Amount (DCR)"
                     onBlur={(e) =>{this.updateOutputAmount(output.key, e.target.value);}}/>
                   {this.state.outputs.length - 1 > parseInt(output.key) || this.state.outputs.length  === 1 ?
                     <div></div>:
@@ -100,8 +100,11 @@ class ConstructTxForm extends React.Component {
     this.setState({ outputs: updateOutputs });
   }
   updateOutputAmount(outputKey, amount) {
+    // For now just convert from atoms to dcr.  We can add option to switch
+    // later (and that need to impact more than just this function.
+    var units = 100000000;
     var updateOutputs = this.state.outputs;
-    updateOutputs[outputKey].amount = amount;
+    updateOutputs[outputKey].amount = amount * units;
     this.setState({ outputs: updateOutputs });
   }
     /*


### PR DESCRIPTION
Display units in send summary.

Closes #189