### PR TITLE
Rig to remove public password on wallet creation for now

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -70,6 +70,7 @@ function walletExistError(error) {
 function walletExistSuccess(response) {
   return (dispatch) => {
     dispatch({response: response, type: WALLETEXIST_SUCCESS });
+    dispatch(openWalletAttempt('public'));
   };
 }
 
@@ -119,7 +120,7 @@ export function createWalletRequest(pubPass, privPass, seed, existing) {
 
 function createNewWallet(pubPass, privPass, seed) {
   var request = new CreateWalletRequest();
-  request.setPublicPassphrase(new Uint8Array(Buffer.from(pubPass)));
+  //request.setPublicPassphrase(new Uint8Array(Buffer.from(pubPass)));
   request.setPrivatePassphrase(new Uint8Array(Buffer.from(privPass)));
   request.setSeed(seed);
   return (dispatch, getState) => {

--- a/app/components/CreateWalletForm.js
+++ b/app/components/CreateWalletForm.js
@@ -37,22 +37,6 @@ class CreateWalletForm extends React.Component {
           onInvalidSubmit={this.notifyFormError.bind(this)}>
           <FormsyText
             type="password"
-            id="pubpass"
-            name="pubpass"
-            hintText="Public Password"
-            floatingLabelText="Public Password"
-          /><br />
-          <FormsyText
-            type="password"
-            id="pubpassVerify"
-            name="pubpassVerify"
-            hintText="Verify Public Password"
-            floatingLabelText="Verify Public Password"
-            validations="equalsField:pubpass"
-            validationError={passwordError}
-          /><br />
-          <FormsyText
-            type="password"
             id="privpass"
             name="privpass"
             hintText="Private Password"
@@ -142,7 +126,8 @@ class CreateWalletForm extends React.Component {
     var selectedSeedType = form_elements['seedtype'].value;
 
     var privpass = document.getElementById('privpassVerify').value;
-    var pubpass = document.getElementById('pubpassVerify').value;
+    // Commenting out pubpass temporarily
+    var pubpass = '';//document.getElementById('pubpassVerify').value;
     var seed = document.getElementById('seed').value;
 
     switch(selectedSeedType) {


### PR DESCRIPTION
Due to user confusion, we'll just be removing the public passphrase on wallet creation which has dcrwallet use the default 'public' passphrase instead.  Now on wallet open it will attempt to use that public passphrase first and if that fails it will ask the user for a proper password