### PR TITLE
Do not use pipe for dcrd.

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -90,8 +90,11 @@ const launchDCRD = () => {
     dcrdExe = dcrdExe + '.exe';
   }
 
-  // The spawn() below opens a pipe on fd 3
-  args.push('--piperx=3');
+  if (os.platform() != 'win32') {
+    // The spawn() below opens a pipe on fd 4
+    // The spawn() below opens a pipe on fd 3
+    args.push('--piperx=3');
+  }
 
   if (cfg.network == 'testnet') {
     args.push('--testnet');


### PR DESCRIPTION
On win7 we had to avoid the fd 4 pipe for wallet.
win10 appears to need the same thing for dcrd (fd 3).