### PR TITLE
Use same cfg path in dev and production.

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -59,9 +59,6 @@ export function getCfgPath() {
 // that was available when using the standalone node but not there when using
 // electron in production mode.
 export function appDataDirectory() {
-  const path = require('path');
-  const os = require('os');
-
   if (os.platform() == 'win32') {
     return path.join(os.homedir(), 'AppData', 'Local', 'Decrediton');
   } else if (process.platform === 'darwin') {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -42,6 +42,8 @@ if (process.env.NODE_ENV === 'development') {
   require('module').globalPaths.push(p); // eslint-disable-line
 }
 
+// Always use reasonable path for save data.
+app.setPath('userData', appDataDirectory());
 var cfg = getCfg();
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
This fixes an issue where decrediton can get stuck reading the config
from both places leaving a weird, mixed config that does not work.

Remove some redundant package imports in config while there.

Closes #273 