### PR TITLE
Integrate Stakepools' API

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -1,7 +1,6 @@
 import { getWalletService } from '../middleware/grpc/client';
 import { getNextAddressAttempt, loadActiveDataFiltersAttempt, rescanAttempt } from './ControlActions';
 import { transactionNftnsStart } from './NotificationActions';
-import { getStakePoolInfoAttempt } from './StakePoolActions';
 export const GETWALLETSERVICE_ATTEMPT = 'GETWALLETSERVICE_ATTEMPT';
 export const GETWALLETSERVICE_FAILED = 'GETWALLETSERVICE_FAILED';
 export const GETWALLETSERVICE_SUCCESS = 'GETWALLETSERVICE_SUCCESS';
@@ -23,7 +22,6 @@ function getWalletServiceSuccess(walletService) {
     setTimeout( () => {dispatch(getAccountsAttempt());}, 1000);
     setTimeout( () => {dispatch(getPingAttempt());}, 1000);
     setTimeout( () => {dispatch(getNetworkAttempt());}, 1000);
-    setTimeout( () => {dispatch(getStakePoolInfoAttempt());}, 1000);
     //setTimeout( () => {dispatch(getAccountNumberAttempt("default"));}, 1000);
     setTimeout( () => {dispatch(getTransactionInfoAttempt());}, 1000);
     //setTimeout( () => {dispatch(getMinedPaginatedTransactions(false))}, 1500);

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -1,6 +1,7 @@
 import { getWalletService } from '../middleware/grpc/client';
 import { getNextAddressAttempt, loadActiveDataFiltersAttempt, rescanAttempt } from './ControlActions';
 import { transactionNftnsStart } from './NotificationActions';
+import { getStakePoolInfoAttempt } from './StakePoolActions';
 export const GETWALLETSERVICE_ATTEMPT = 'GETWALLETSERVICE_ATTEMPT';
 export const GETWALLETSERVICE_FAILED = 'GETWALLETSERVICE_FAILED';
 export const GETWALLETSERVICE_SUCCESS = 'GETWALLETSERVICE_SUCCESS';
@@ -22,6 +23,7 @@ function getWalletServiceSuccess(walletService) {
     setTimeout( () => {dispatch(getAccountsAttempt());}, 1000);
     setTimeout( () => {dispatch(getPingAttempt());}, 1000);
     setTimeout( () => {dispatch(getNetworkAttempt());}, 1000);
+    setTimeout( () => {dispatch(getStakePoolInfoAttempt());}, 1000);
     //setTimeout( () => {dispatch(getAccountNumberAttempt("default"));}, 1000);
     setTimeout( () => {dispatch(getTransactionInfoAttempt());}, 1000);
     //setTimeout( () => {dispatch(getMinedPaginatedTransactions(false))}, 1500);

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -40,6 +40,7 @@ function updateSavedConfig(newPoolInfo, poolHost, apiKey, accountNum) {
   return (dispatch) => {
     var config = getCfg();
     var stakePoolConfigs = config.get('stakepools');
+    var successMessage = "You have successfully configured ";
     for (var i = 0; i < stakePoolConfigs.length; i++) {
       if (stakePoolConfigs[i].Host == poolHost) {
         stakePoolConfigs[i].ApiKey = apiKey;
@@ -48,11 +49,12 @@ function updateSavedConfig(newPoolInfo, poolHost, apiKey, accountNum) {
         stakePoolConfigs[i].Script = newPoolInfo.Script;
         stakePoolConfigs[i].TicketAddress = newPoolInfo.TicketAddress;
         stakePoolConfigs[i].VotingAccount = accountNum;
+        successMessage += poolHost;
         break;
       }
     }
     config.set('stakepools', stakePoolConfigs);
-    dispatch({ currentStakePoolConfig: stakePoolConfigs, type: UPDATESTAKEPOOLCONFIG_SUCCESS });
+    dispatch({ successMessage: successMessage, currentStakePoolConfig: stakePoolConfigs, type: UPDATESTAKEPOOLCONFIG_SUCCESS });
   };
 }
 

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -57,9 +57,8 @@ function getStakePoolInfoAction() {
 }
 
 export const SETSTAKEPOOLAPIKEY = "SETSTAKEPOOLAPIKEY"
-export function setStakePoolInformation(poolHost, apikey, accountNum) {
+export function setStakePoolInformation(poolHost, apiKey, accountNum) {
   return (dispatch, getState) => {
-    var purchaseInfo = requestPurchaseInfo(poolHost, apikey);
     getPurchaseInfo(
       poolHost, 
       apiKey,
@@ -69,7 +68,12 @@ export function setStakePoolInformation(poolHost, apikey, accountNum) {
           return;
         } else {
           // parse response data for no err
-          console.log(response);
+          if (response.data.message == 'success') {
+            console.log(response.data.data);
+          } else if (response.data.message == 'error') {
+            console.error(response.data.data)
+          }
+          
         }
       });
       /*

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -38,6 +38,19 @@ function getStakePoolInfoSuccess(response) {
   };
 }
 
+export const SETSTAKEPOOLAPIKEY = "SETSTAKEPOOLAPIKEY"
+export function setStakePoolApiKey(poolHost, apikey) {
+  return (dispatch, getState) => {
+    const { stakePoolConfig } = getState().stakepool;
+    var updatedStakePoolConfig = stakePoolConfig;
+    for (var i = 0; i < updatedStakePoolConfig.length; i++) {
+      if (poolHost == updatedStakePoolConfig[i].Host) {
+        updatedStakePoolConfig[i].ApiKey = apikey
+      }
+    }
+    dispatch({ updatedStakePoolConfig: updatedStakePoolConfig, type: SETSTAKEPOOLAPIKEY });
+  };
+}
 export function getStakePoolInfoAttempt() {
   return (dispatch, getState) => {
     dispatch({ type: GETSTAKEPOOLINFO_ATTEMPT });

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -4,6 +4,8 @@ export const GETSTAKEPOOLINFO_ATTEMPT = 'GETSTAKEPOOLINFO_ATTEMPT';
 export const GETSTAKEPOOLINFO_FAILED = 'GETSTAKEPOOLINFO_FAILED';
 export const GETSTAKEPOOLINFO_SUCCESS = 'GETSTAKEPOOLINFO_SUCCESS';
 
+import { NextAddressRequest } from '../middleware/walletrpc/api_pb';
+
 function getStakePoolInfoError(error) {
   return { error, type: GETSTAKEPOOLINFO_FAILED };
 }
@@ -76,7 +78,7 @@ export function setStakePoolInformation(poolHost, apiKey, accountNum) {
             dispatch({ stakePoolData: response.data.data, type: SETSTAKEPOOLAPIKEY });
           } else if (response.data.status == 'error') {
             if (response.data.message == 'purchaseinfo error - no address submitted') {
-              setStakePoolAddress(poolHost, apiKey, accountNum)
+              dispatch(setStakePoolAddressAction(poolHost, apiKey, accountNum));
               console.log("setting need address to true");
               return (true);
             } else {
@@ -92,10 +94,11 @@ export function setStakePoolInformation(poolHost, apiKey, accountNum) {
   }
 }
 
-function setStakePoolAddress(poolHost, apiKey, accountNum) {
+function setStakePoolAddressAction(poolHost, apiKey, accountNum) {
+  return (dispatch, getState) => {
   console.log("getting new address pubkey");
   const { walletService } = getState().grpc;
-      // get new address for requested VotingAccount
+  // get new address for requested VotingAccount
   var request = new NextAddressRequest();
   request.setAccount(accountNum);
   request.setKind(0);
@@ -105,7 +108,7 @@ function setStakePoolAddress(poolHost, apiKey, accountNum) {
       if (err) {
         // handle some err here some way
       } else {
-        addressPubKey = getNextAddressResponse.GetPublicKey();
+        addressPubKey = getNextAddressResponse.getPublicKey();
         setStakePoolAddress(
           poolHost, 
           apiKey, 
@@ -114,7 +117,7 @@ function setStakePoolAddress(poolHost, apiKey, accountNum) {
             if (response.data.status == 'success') {
               console.log(response.data.message);
               console.log(response.data.data);
-              setStakePoolInformation(poolHost, apiKey, accountNum)
+              dispatch(setStakePoolInformation(poolHost, apiKey, accountNum));
             } else if (response.data.status == 'error') {
               console.error(response.data.message);
             } else {
@@ -125,4 +128,5 @@ function setStakePoolAddress(poolHost, apiKey, accountNum) {
       }
     }
   );
+  }
 }

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -1,4 +1,5 @@
 import { stakePoolInfo, getPurchaseInfo, setStakePoolAddress } from '../middleware/stakepoolapi';
+import { getNextAddress } from './ControlActions';
 export const GETSTAKEPOOLINFO_ATTEMPT = 'GETSTAKEPOOLINFO_ATTEMPT';
 export const GETSTAKEPOOLINFO_FAILED = 'GETSTAKEPOOLINFO_FAILED';
 export const GETSTAKEPOOLINFO_SUCCESS = 'GETSTAKEPOOLINFO_SUCCESS';
@@ -37,26 +38,62 @@ function getStakePoolInfoSuccess(response) {
     dispatch({ stakePoolConfig: foundStakePoolConfigs, type: GETSTAKEPOOLINFO_SUCCESS });
   };
 }
-
-export const SETSTAKEPOOLAPIKEY = "SETSTAKEPOOLAPIKEY"
-export function setStakePoolApiKey(poolHost, apikey) {
-  return (dispatch, getState) => {
-    const { stakePoolConfig } = getState().stakepool;
-    var updatedStakePoolConfig = stakePoolConfig;
-    for (var i = 0; i < updatedStakePoolConfig.length; i++) {
-      if (poolHost == updatedStakePoolConfig[i].Host) {
-        updatedStakePoolConfig[i].ApiKey = apikey
-      }
-    }
-    dispatch({ updatedStakePoolConfig: updatedStakePoolConfig, type: SETSTAKEPOOLAPIKEY });
-  };
-}
 export function getStakePoolInfoAttempt() {
   return (dispatch, getState) => {
     dispatch({ type: GETSTAKEPOOLINFO_ATTEMPT });
     dispatch(getStakePoolInfoAction());
   };
 }
+function getStakePoolInfoAction() {
+  return (dispatch) => {
+    stakePoolInfo(function(response, err) {
+      if (err) {
+        dispatch(getStakePoolInfoError(err + ' Please try again'));
+      } else {
+        dispatch(getStakePoolInfoSuccess(response));
+      }
+    });
+  };
+}
+
+export const SETSTAKEPOOLAPIKEY = "SETSTAKEPOOLAPIKEY"
+export function setStakePoolInformation(poolHost, apikey, accountNum) {
+  return (dispatch, getState) => {
+    var purchaseInfo = requestPurchaseInfo(poolHost, apikey);
+    getPurchaseInfo(
+      poolHost, 
+      apiKey,
+      function(response, err) {
+        if (err) {
+          console.error(err);
+          return;
+        } else {
+          // parse response data for no err
+          console.log(response);
+        }
+      });
+      /*
+    const { walletService } = getState().grpc;
+    // get new address for requested VotingAccount
+    var request = new NextAddressRequest();
+    request.setAccount(accountNum);
+    request.setKind(0);
+    var addressPubKey = null;
+    walletService.nextAddress(request,
+      function(err, getNextAddressResponse) {
+        if (err) {
+          // handle some err here some way
+        } else {
+          addressPubKey = getNextAddressResponse.GetPublicKey();
+        }
+      });
+    
+
+    dispatch({ updatedStakePoolConfig: updatedStakePoolConfig, type: SETSTAKEPOOLAPIKEY });
+    */
+  };
+}
+
 function setStakePoolAddressAttempt(poolConfig) {
   return (dispatch, getState) => {
     const { getNextAddress } = getState().control
@@ -73,36 +110,4 @@ function setStakePoolAddressAttempt(poolConfig) {
         }
     });
   }
-}
-
-function requestPurchaseInfo(poolHost) {
-  return (dispatch, getState) => {
-    const { stakePoolConfig } = getState().stakepool 
-    for (var i = 0; i < stakePoolConfig; i++) {
-      if (stakePoolConfig[i].ApiKey != "") {
-        getPurchaseInfo(
-          stakePoolConfig[i].Host, 
-          stakePoolConfig[i].ApiKey,
-          function(response, err) {
-          if (err) {
-            console.error(err);
-          } else {
-            // parse response data for no err
-            console.log(response);
-          }
-        });
-      }
-    }
-  }
-}
-function getStakePoolInfoAction() {
-  return (dispatch) => {
-    stakePoolInfo(function(response, err) {
-      if (err) {
-        dispatch(getStakePoolInfoError(err + ' Please try again'));
-      } else {
-        dispatch(getStakePoolInfoSuccess(response));
-      }
-    });
-  };
 }

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -1,4 +1,4 @@
-import { stakePoolInfo, apiClientRequest } from '../middleware/stakepoolapi';
+import { stakePoolInfo, getPurchaseInfo, setStakePoolAddress } from '../middleware/stakepoolapi';
 export const GETSTAKEPOOLINFO_ATTEMPT = 'GETSTAKEPOOLINFO_ATTEMPT';
 export const GETSTAKEPOOLINFO_FAILED = 'GETSTAKEPOOLINFO_FAILED';
 export const GETSTAKEPOOLINFO_SUCCESS = 'GETSTAKEPOOLINFO_SUCCESS';
@@ -18,17 +18,7 @@ function getStakePoolInfoSuccess(response) {
         usablePools.push(response.data[stakePoolNames[i]]);
       }
     }
-    apiClientRequest(
-      "https://teststakepool.decred.org/api/v1/", 
-      "getpurchaseinfo", 
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0ODc5NzM3ODQsImlzcyI6Imh0dHBzOi8vdGVzdHN0YWtlcG9vbC5kZWNyZWQub3JnIiwibG9nZ2VkSW5BcyI6MTR9.HdJuTqDJPbVWPPzetOfQ7jK7PgadPeXWZulqgzZN-4U",
-      function(response, err) {
-        if (err) {
-          dispatch(console.log(err));
-        } else {
-          dispatch(console.log(response));
-        }
-      })
+    dispatch(setStakePoolAddressAttempt());
     dispatch({ data: usablePools, type: GETSTAKEPOOLINFO_SUCCESS });
   };
 }
@@ -39,7 +29,37 @@ export function getStakePoolInfoAttempt() {
     dispatch(getStakePoolInfoAction());
   };
 }
+function setStakePoolAddressAttempt() {
+  return (dispatch) => {
+    setStakePoolAddress(
+      "https://teststakepool.decred.org/api/v1/", 
+      "apiToken",
+      "pKAddress",
+      function(response, err) {
+        if (err) {
+          console.error(err);
+        } else {
+          console.log(response);
+          dispatch(requestPurchaseInfo());
+        }
+      });
+  }
+}
 
+function requestPurchaseInfo() {
+  return (dispatch) => {
+    getPurchaseInfo(
+      "https://teststakepool.decred.org/api/v1/", 
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0ODc5NzM3ODQsImlzcyI6Imh0dHBzOi8vdGVzdHN0YWtlcG9vbC5kZWNyZWQub3JnIiwibG9nZ2VkSW5BcyI6MTR9.HdJuTqDJPbVWPPzetOfQ7jK7PgadPeXWZulqgzZN-4U",
+      function(response, err) {
+        if (err) {
+          console.error(err);
+        } else {
+          console.log(response);
+        }
+      });
+  }
+}
 function getStakePoolInfoAction() {
   return (dispatch) => {
     stakePoolInfo(function(response, err) {

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -1,20 +1,18 @@
-import { stakePoolInfo, getPurchaseInfo, setStakePoolAddress } from '../middleware/stakepoolapi';
-import { getNextAddress } from './ControlActions';
+import { getPurchaseInfo, setStakePoolAddress } from '../middleware/stakepoolapi';
 import { NextAddressRequest } from '../middleware/walletrpc/api_pb';
 import { getCfg } from '../config.js';
 
-export const UPDATESTAKEPOOLCONFIG_ATTEMPT = "UPDATESTAKEPOOLCONFIG_ATTEMPT"
-export const UPDATESTAKEPOOLCONFIG_FAILED = "UPDATESTAKEPOOLCONFIG_FAILED"
-export const UPDATESTAKEPOOLCONFIG_SUCCESS = "UPDATESTAKEPOOLCONFIG_SUCCESS"
+export const UPDATESTAKEPOOLCONFIG_ATTEMPT = 'UPDATESTAKEPOOLCONFIG_ATTEMPT';
+export const UPDATESTAKEPOOLCONFIG_FAILED = 'UPDATESTAKEPOOLCONFIG_FAILED';
+export const UPDATESTAKEPOOLCONFIG_SUCCESS = 'UPDATESTAKEPOOLCONFIG_SUCCESS';
 
 export function setStakePoolInformation(poolHost, apiKey, accountNum, internal) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     if (!internal) {
       dispatch({ type: UPDATESTAKEPOOLCONFIG_ATTEMPT });
     }
-    var needAddress = false;
     getPurchaseInfo(
-      poolHost, 
+      poolHost,
       apiKey,
       function(response, err) {
         if (err) {
@@ -23,30 +21,25 @@ export function setStakePoolInformation(poolHost, apiKey, accountNum, internal) 
         } else {
           // parse response data for no err
           if (response.data.status == 'success') {
-            console.log(response.data.message);
-            console.log(response.data.data);
             dispatch(updateSavedConfig(response.data.data, poolHost, apiKey, accountNum));
           } else if (response.data.status == 'error') {
             if (response.data.message == 'purchaseinfo error - no address submitted') {
               dispatch(setStakePoolAddressAction(poolHost, apiKey, accountNum));
-              console.log("setting need address to true");
               return (true);
             } else {
-              console.error(response.data.message);
               dispatch({ error: response.data.message, type: UPDATESTAKEPOOLCONFIG_FAILED });
             }
           }
         }
       }
     );
-  }
+  };
 }
 
 function updateSavedConfig(newPoolInfo, poolHost, apiKey, accountNum) {
   return (dispatch) => {
     var config = getCfg();
     var stakePoolConfigs = config.get('stakepools');
-    console.log(stakePoolConfigs)
     for (var i = 0; i < stakePoolConfigs.length; i++) {
       if (stakePoolConfigs[i].Host == poolHost) {
         stakePoolConfigs[i].ApiKey = apiKey;
@@ -55,50 +48,46 @@ function updateSavedConfig(newPoolInfo, poolHost, apiKey, accountNum) {
         stakePoolConfigs[i].Script = newPoolInfo.Script;
         stakePoolConfigs[i].TicketAddress = newPoolInfo.TicketAddress;
         stakePoolConfigs[i].VotingAccount = accountNum;
-        console.log(stakePoolConfigs[i])
         break;
-      };
+      }
     }
-    console.log(stakePoolConfigs)
-    config.set('stakepools', stakePoolConfigs)
+    config.set('stakepools', stakePoolConfigs);
     dispatch({ currentStakePoolConfig: stakePoolConfigs, type: UPDATESTAKEPOOLCONFIG_SUCCESS });
-  }
+  };
 }
-        
+
 function setStakePoolAddressAction(poolHost, apiKey, accountNum) {
   return (dispatch, getState) => {
-  console.log("getting new address pubkey");
-  const { walletService } = getState().grpc;
+    const { walletService } = getState().grpc;
   // get new address for requested VotingAccount
-  var request = new NextAddressRequest();
-  request.setAccount(accountNum);
-  request.setKind(0);
-  var addressPubKey = null;
-  walletService.nextAddress(request,
+    var request = new NextAddressRequest();
+    request.setAccount(accountNum);
+    request.setKind(0);
+    var addressPubKey = null;
+    walletService.nextAddress(request,
     function(err, getNextAddressResponse) {
       if (err) {
         // handle some err here some way
       } else {
         addressPubKey = getNextAddressResponse.getPublicKey();
         setStakePoolAddress(
-          poolHost, 
-          apiKey, 
-          addressPubKey, 
+          poolHost,
+          apiKey,
+          addressPubKey,
           function(response, err) {
-            if (response.data.status == 'success') {
-              console.log(response.data.message);
-              console.log(response.data.data);
+            if (err) {
+              dispatch({ error: err, type: UPDATESTAKEPOOLCONFIG_FAILED });
+            } else if (response.data.status == 'success') {
               dispatch(setStakePoolInformation(poolHost, apiKey, accountNum, true));
             } else if (response.data.status == 'error') {
-              console.error(response.data.message);
               dispatch({ error: response.data.message, type: UPDATESTAKEPOOLCONFIG_FAILED });
             } else {
-              console.error("shouldn't be here set address:", response);
+              console.error('shouldn\'t be here set address:', response);
             }
           }
         );
       }
     }
   );
-  }
+  };
 }

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -1,0 +1,35 @@
+import { getVersionService } from '../middleware/grpc/client';
+import { stakePoolInfo } from '../middleware/stakepoolapi';
+export const GETSTAKEPOOLINFO_ATTEMPT = 'GETSTAKEPOOLINFO_ATTEMPT';
+export const GETSTAKEPOOLINFO_FAILED = 'GETSTAKEPOOLINFO_FAILED';
+export const GETSTAKEPOOLINFO_SUCCESS = 'GETSTAKEPOOLINFO_SUCCESS';
+
+function getStakePoolInfoError(error) {
+  return { error, type: GETSTAKEPOOLINFO_FAILED };
+}
+
+function getStakePoolInfoSuccess(versionService) {
+  return (dispatch) => {
+    dispatch({ versionService, type: GETSTAKEPOOLINFO_SUCCESS });
+  };
+}
+
+export function getStakePoolInfoAttempt() {
+  return (dispatch) => {
+    dispatch({ type: GETSTAKEPOOLINFO_ATTEMPT });
+    dispatch((getStakePoolInfoAction));
+  };
+}
+
+function getStakePoolInfoAction() {
+  return (dispatch, getState) => {
+    const { address, port } = getState().grpc;
+    stakePoolInfo(function(response, err) {
+      if (err) {
+        dispatch(getVersionServiceError(err + ' Please try again'));
+      } else {
+        dispatch(getVersionServiceSuccess(versionService));
+      }
+    });
+  };
+}

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -19,7 +19,7 @@ function getStakePoolInfoSuccess(response) {
       }
     }
 
-    dispatch({ data: usablePools. , type: GETSTAKEPOOLINFO_SUCCESS });
+    dispatch({ data: usablePools, type: GETSTAKEPOOLINFO_SUCCESS });
   };
 }
 

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -68,25 +68,31 @@ function setStakePoolAddressAttempt(poolConfig) {
         if (err) {
           console.error(err);
         } else {
+          // parse response data for no err
           console.log(response);
-          dispatch(requestPurchaseInfo());
         }
     });
   }
 }
 
-function requestPurchaseInfo() {
-  return (dispatch) => {
-    getPurchaseInfo(
-      "https://teststakepool.decred.org/api/v1/", 
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0ODc5NzM3ODQsImlzcyI6Imh0dHBzOi8vdGVzdHN0YWtlcG9vbC5kZWNyZWQub3JnIiwibG9nZ2VkSW5BcyI6MTR9.HdJuTqDJPbVWPPzetOfQ7jK7PgadPeXWZulqgzZN-4U",
-      function(response, err) {
-        if (err) {
-          console.error(err);
-        } else {
-          console.log(response);
-        }
-      });
+function requestPurchaseInfo(poolHost) {
+  return (dispatch, getState) => {
+    const { stakePoolConfig } = getState().stakepool 
+    for (var i = 0; i < stakePoolConfig; i++) {
+      if (stakePoolConfig[i].ApiKey != "") {
+        getPurchaseInfo(
+          stakePoolConfig[i].Host, 
+          stakePoolConfig[i].ApiKey,
+          function(response, err) {
+          if (err) {
+            console.error(err);
+          } else {
+            // parse response data for no err
+            console.log(response);
+          }
+        });
+      }
+    }
   }
 }
 function getStakePoolInfoAction() {

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -40,7 +40,7 @@ function updateSavedConfig(newPoolInfo, poolHost, apiKey, accountNum) {
   return (dispatch) => {
     var config = getCfg();
     var stakePoolConfigs = config.get('stakepools');
-    var successMessage = "You have successfully configured ";
+    var successMessage = 'You have successfully configured ';
     for (var i = 0; i < stakePoolConfigs.length; i++) {
       if (stakePoolConfigs[i].Host == poolHost) {
         stakePoolConfigs[i].ApiKey = apiKey;

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -1,4 +1,4 @@
-import { stakePoolInfo } from '../middleware/stakepoolapi';
+import { stakePoolInfo, apiClientRequest } from '../middleware/stakepoolapi';
 export const GETSTAKEPOOLINFO_ATTEMPT = 'GETSTAKEPOOLINFO_ATTEMPT';
 export const GETSTAKEPOOLINFO_FAILED = 'GETSTAKEPOOLINFO_FAILED';
 export const GETSTAKEPOOLINFO_SUCCESS = 'GETSTAKEPOOLINFO_SUCCESS';
@@ -18,7 +18,17 @@ function getStakePoolInfoSuccess(response) {
         usablePools.push(response.data[stakePoolNames[i]]);
       }
     }
-
+    apiClientRequest(
+      "https://teststakepool.decred.org/api/v1/", 
+      "getpurchaseinfo", 
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0ODc5NzM3ODQsImlzcyI6Imh0dHBzOi8vdGVzdHN0YWtlcG9vbC5kZWNyZWQub3JnIiwibG9nZ2VkSW5BcyI6MTR9.HdJuTqDJPbVWPPzetOfQ7jK7PgadPeXWZulqgzZN-4U",
+      function(response, err) {
+        if (err) {
+          dispatch(console.log(err));
+        } else {
+          dispatch(console.log(response));
+        }
+      })
     dispatch({ data: usablePools, type: GETSTAKEPOOLINFO_SUCCESS });
   };
 }

--- a/app/components/MenuLink.js
+++ b/app/components/MenuLink.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router';
 var styles = {
   linkColor: {
     display: 'block',
-    height: '53px',
+    height: '52px',
     backgroundImage: `url(${leftLinkColor})`,
     backgroundPosition: '0px 50%',
     backgroundSize: '0px',

--- a/app/components/SideBar.js
+++ b/app/components/SideBar.js
@@ -275,6 +275,7 @@ class SideBar extends Component {
           <MenuLink to="/send">Send</MenuLink>
           <MenuLink to="/receive">Receive</MenuLink>
           <MenuLink to="/history">History</MenuLink>
+          <MenuLink to="/stakepool">Stakepool Setup</MenuLink>
           <MenuLink to="/settings">Settings</MenuLink>
           <div style={styles.sidebarHelp}>
             <div style={styles.sidebarHelpTitle}>Help links</div>

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -89,6 +89,13 @@ const styles = {
     textAlign: 'right',
     textTransform: 'capitalize',
   },
+  contentNestStakePool: {
+    borderTop: '1px solid',
+    height: '185px',
+    position: 'relative',
+    borderBottom: '1px solid',
+    float: 'left',
+  },
   contentNestStakePoolSettings: {
     width: '100%',
     height: '20px',
@@ -555,7 +562,7 @@ class StakePool extends Component{
               <div style={styles.contentNestPrefixSend}>Api Key:</div>
               <div style={styles.contentNestAddressHashBlock}>
                 <div style={styles.inputForm}>
-                  <input
+                  <textarea
                     type="text"
                     style={styles.contentNestAddressAmountSum}
                     placeholder="API Key"
@@ -577,7 +584,7 @@ class StakePool extends Component{
             {currentStakePoolConfig.map((stakePool,i) => {
               if (stakePool.ApiKey && stakePool.Network == network) {
                 return(       
-                <div key={stakePool.Host}>
+                <div key={stakePool.Host} style={styles.contentNestStakePool}>
                   <div style={styles.contentNestStakePoolSettings}>
                     <div style={styles.contentNestPrefixStakePoolSettings}>URL:</div>
                     <div style={styles.contentNestContentStakePoolSettings}>
@@ -592,9 +599,7 @@ class StakePool extends Component{
                   </div>
                   <div style={styles.contentNestStakePoolSettings}>
                     <div style={styles.contentNestPrefixStakePoolSettings}>Script:</div>
-                    <div style={styles.contentNestContentStakePoolSettings}>
-                      {stakePool.Script}
-                    </div>
+                    <textarea disabled value={stakePool.Script} style={styles.contentNestContentStakePoolSettings}/>
                   </div>
                   <div style={styles.contentNestStakePoolSettings}>
                     <div style={styles.contentNestPrefixStakePoolSettings}>Pool Fees:</div>

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -47,7 +47,21 @@ class StakePool extends Component{
   static propTypes = {
     walletService: PropTypes.object,
   };
+  constructor(props) {
+    super(props);
 
+    this.state = {
+      stakePoolHost: '',
+      apiKey: '',
+      account: 0,
+    };
+  }
+  submitSignPublishTx() {
+    if (this.state.stakePoolHost == '' || this.state.apiKey == '') {
+      return;
+    }
+    this.props.signTransactionAttempt(this.state.privpass, this.props.constructTxResponse.getUnsignedTransaction());
+  }
   render() {
     const { walletService } = this.props;
     const { stakePoolInfoConfig } = this.props;

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -46,33 +46,38 @@ const styles = {
 class StakePool extends Component{
   static propTypes = {
     walletService: PropTypes.object,
-    getNextAddressResponse: PropTypes.object,
-    getNextAddressRequestAttempt: PropTypes.bool.isRequired,
   };
 
   render() {
     const { walletService } = this.props;
-    const { getNextAddressResponse, getNextAddressRequestAttempt } = this.props;
-    const { stakePoolInfoData } = this.props;
+    const { stakePoolInfoConfig } = this.props;
+    var selectStakePool = (
+      <div style={styles.selectStakePoolArea}>
+        <select
+          defaultValue={0}
+          style={styles.selectStakePool}
+          >
+          {stakePoolInfoConfig !== null ?
+            stakePoolInfoConfig.map((stakePool) => {
+              return (
+                <option style={styles.selectStakePoolNFirst} key={stakePool.Host} value={stakePool.Host}>
+                  {stakePool.Host}
+                </option>
+              );
+             }):
+            null
+          }
+        </select>
+      </div>);
     const copayReceive = (
       <div style={styles.view}>
         <Header
           headerTitleOverview="Stake pool settings"
-          headerMetaOverview={
-            getNextAddressResponse !== null ?
-              <div style={{fontSize:'33px'}}>{getNextAddressResponse.getAddress()}</div> :
-              <div></div>
-          }
+          headerMetaOverview={<div></div>}
         />
         <div style={styles.content}>
           <div style={styles.center}>
-            <Button
-              size="large"
-              block={false}
-              onClick={!getNextAddressRequestAttempt? () => this.props.getNextAddressAttempt(0) : null}
-              >
-              Generate new address
-            </Button>
+            {selectStakePool}
           </div>
         </div>
 			</div>

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -562,7 +562,7 @@ class StakePool extends Component{
               <div style={styles.contentNestPrefixSend}>Api Key:</div>
               <div style={styles.contentNestAddressHashBlock}>
                 <div style={styles.inputForm}>
-                  <textarea
+                  <input
                     type="text"
                     style={styles.contentNestAddressAmountSum}
                     placeholder="API Key"

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -425,7 +425,7 @@ class StakePool extends Component{
   render() {
     const { walletService } = this.props;
     const { getAccountsResponse } = this.props;
-    const { currentStakePoolConfig } = this.props;
+    const { currentStakePoolConfig, currentStakePoolConfigRequest, currentStakePoolConfigError } = this.props;
     const { getNetworkResponse } = this.props;
 
     var selectStakePool = (
@@ -436,7 +436,7 @@ class StakePool extends Component{
           >
           {currentStakePoolConfig !== null && getNetworkResponse !== null ?
             currentStakePoolConfig.map((stakePool) => {
-              if (stakePool.ApiKey == '' && stakePool.Network == getNetworkResponse.networkStr)
+              if (!stakePool.ApiKey && stakePool.Network == getNetworkResponse.networkStr)
               return (
                 <option style={styles.selectStakePoolNFirst} key={stakePool.Host} value={stakePool.Host}>
                   {stakePool.Host}
@@ -467,9 +467,14 @@ class StakePool extends Component{
           }
         </select>
       </div>);  
-    const copayReceive = (
+    const stakePool = (
       <div style={styles.view}>
         <Header
+          headerTop={
+            currentStakePoolConfigError !== null ?
+            <div key="updateStakePoolError" style={styles.viewNotificationError}>{currentStakePoolConfigError}</div> :
+            <div key="updateStakePoolError" ></div>
+          }
           headerTitleOverview="Stake pool settings"
           headerMetaOverview={<div></div>}
         />
@@ -495,7 +500,7 @@ class StakePool extends Component{
       return(
         <div style={styles.body}>
           <SideBar />
-          {copayReceive}
+          {stakePool}
         </div>);
     }
   }

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -411,7 +411,7 @@ class StakePool extends Component{
       //return;
     }
     //setStakePoolInformation(this.state.stakePoolHost, this.props.apiKey, this.props.account);
-    this.props.setStakePoolInformation("https://teststakepool.decred.org", this.props.apiKey, 0);
+    this.props.setStakePoolInformation("https://teststakepool.decred.org", this.state.apiKey, 0);
   }
   updateApiKey(apiKey) {
     this.setState({apiKey: apiKey});
@@ -424,16 +424,19 @@ class StakePool extends Component{
   }
   render() {
     const { walletService } = this.props;
-    const { stakePoolInfoConfig } = this.props;
     const { getAccountsResponse } = this.props;
+    const { currentStakePoolConfig } = this.props;
+    const { getNetworkResponse } = this.props;
+
     var selectStakePool = (
       <div style={styles.selectStakePoolArea}>
         <select
           defaultValue={0}
           style={styles.selectStakePool}
           >
-          {stakePoolInfoConfig !== null ?
-            stakePoolInfoConfig.map((stakePool) => {
+          {currentStakePoolConfig !== null ?
+            currentStakePoolConfig.map((stakePool) => {
+              if (stakePool.ApiKey == '' && stakePool.Network == getNetworkResponse.networkStr)
               return (
                 <option style={styles.selectStakePoolNFirst} key={stakePool.Host} value={stakePool.Host}>
                   {stakePool.Host}

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component, PropTypes } from 'react';
+import CircularProgress from 'material-ui/CircularProgress';
 import ErrorScreen from '../ErrorScreen';
 import SideBar from '../SideBar';
 import Header from '../Header';
@@ -583,9 +584,11 @@ class StakePool extends Component{
           headerTitleOverview="Stake pool settings"
           headerMetaOverview={<div></div>}
         />
-        {!activeStakePoolConfig || this.state.addAnotherStakePool && !currentStakePoolConfigRequest ?
+        {(!activeStakePoolConfig || this.state.addAnotherStakePool) && !currentStakePoolConfigRequest ?
           stakePoolConfigInput :
-          configuredStakePoolInformation
+          currentStakePoolConfigRequest ?
+            <CircularProgress style={styles.loading} size={125} thickness={6}/> :
+            configuredStakePoolInformation
         }
       </div>
     );

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -1,0 +1,92 @@
+// @flow
+import React, { Component, PropTypes } from 'react';
+import ErrorScreen from '../ErrorScreen';
+import Button from '../ButtonTanel';
+import SideBar from '../SideBar';
+import Header from '../Header';
+import qr from 'qr-image';
+
+const styles = {
+  body: {
+    position: 'fixed',
+    left: '0px',
+    top: '50%',
+    right: '0px',
+    display: 'block',
+    overflow: 'hidden',
+    width: '1178px',
+    height: '770px',
+    marginTop: '-385px',
+    marginRight: 'auto',
+    marginLeft: 'auto',
+    backgroundColor: '#FFF',
+  },
+  view: {
+    width: '880px',
+    height: '100%',
+    float: 'right',
+    backgroundColor: '#f3f6f6',
+  },
+  content: {
+    overflow: 'auto',
+    height: '556px',
+    padding: '54px 60px 54px 80px',
+  },
+  img: {
+    width: '250px',
+    paddingLeft: '244px',
+  },
+  center: {
+    textAlign: 'center',
+    justifyContent: 'center',
+    alignItems: 'center',
+  }
+};
+
+class StakePool extends Component{
+  static propTypes = {
+    walletService: PropTypes.object,
+    getNextAddressResponse: PropTypes.object,
+    getNextAddressRequestAttempt: PropTypes.bool.isRequired,
+  };
+
+  render() {
+    const { walletService } = this.props;
+    const { getNextAddressResponse, getNextAddressRequestAttempt } = this.props;
+
+    const copayReceive = (
+      <div style={styles.view}>
+        <Header
+          headerTitleOverview="Stake pool settings"
+          headerMetaOverview={
+            getNextAddressResponse !== null ?
+              <div style={{fontSize:'33px'}}>{getNextAddressResponse.getAddress()}</div> :
+              <div></div>
+          }
+        />
+        <div style={styles.content}>
+          <div style={styles.center}>
+            <Button
+              size="large"
+              block={false}
+              onClick={!getNextAddressRequestAttempt? () => this.props.getNextAddressAttempt(0) : null}
+              >
+              Generate new address
+            </Button>
+          </div>
+        </div>
+			</div>
+    );
+    if (walletService === null) {
+      return (<ErrorScreen />);
+    } else {
+      return(
+        <div style={styles.body}>
+          <SideBar />
+          {copayReceive}
+        </div>);
+    }
+  }
+}
+
+export default StakePool;

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -434,7 +434,7 @@ class StakePool extends Component{
           defaultValue={0}
           style={styles.selectStakePool}
           >
-          {currentStakePoolConfig !== null ?
+          {currentStakePoolConfig !== null && getNetworkResponse !== null ?
             currentStakePoolConfig.map((stakePool) => {
               if (stakePool.ApiKey == '' && stakePool.Network == getNetworkResponse.networkStr)
               return (

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -4,10 +4,11 @@ import ErrorScreen from '../ErrorScreen';
 import Button from '../ButtonTanel';
 import SideBar from '../SideBar';
 import Header from '../Header';
-import qr from 'qr-image';
+import ArrowDownMidBlue from '../icons/arrow-down-mid-blue.svg';
+import ArrowDownKeyBlue from '../icons/arrow-down-key-blue.svg';
 
 const styles = {
-  body: {
+ body: {
     position: 'fixed',
     left: '0px',
     top: '50%',
@@ -27,19 +28,368 @@ const styles = {
     float: 'right',
     backgroundColor: '#f3f6f6',
   },
+  viewNotificationError: {
+    display: 'inline-block',
+    marginRight: 'auto',
+    marginLeft: 'auto',
+    padding: '7px 20px',
+    borderRadius: '5px',
+    backgroundColor: '#fd714b',
+    boxShadow: '0 3px 10px 0 rgba(0, 0, 0, .2)',
+    color: '#fff',
+    fontSize: '13px',
+    textAlign: 'center',
+  },
+  viewNotificationSuccess: {
+    display: 'inline-block',
+    marginRight: 'auto',
+    marginLeft: 'auto',
+    padding: '7px 20px',
+    borderRadius: '5px',
+    backgroundColor: '#41bf53',
+    boxShadow: '0 3px 10px 0 rgba(0, 0, 0, .2)',
+    color: '#fff',
+    fontSize: '13px',
+    textAlign: 'center',
+    textDecoration: 'none',
+  },
+  transition1: {
+    transition: 'all 100ms ease-in-out',
+  },
+  headerMetaSend: {
+    height: '54px',
+    width: '480px',
+    paddingLeft: '50px',
+    color: '#0c1e3e',
+    fontSize: '14px',
+  },
   content: {
     overflow: 'auto',
     height: '556px',
     padding: '54px 60px 54px 80px',
   },
-  img: {
-    width: '250px',
-    paddingLeft: '244px',
+  contentNestSend: {
+    paddingTop: '1px',
+    backgroundColor: '#fff',
   },
-  center: {
+  contentNestDeleteAddress: {
+    width: '625px',
+    height: '54px',
+    paddingTop: '10px',
+    paddingLeft: '116px',
+    float: 'left',
+  },
+  contentNestPrefixSend: {
+    width: '100px',
+    paddingRight: '15px',
+    float: 'left',
+    height: '100%',
+    paddingTop: '5px',
+    fontSize: '19px',
+    textAlign: 'right',
+    textTransform: 'capitalize',
+  },
+  contentNestPrefixConfirm: {
+    width: '230px',
+    paddingRight: '15px',
+    float: 'left',
+    height: '100%',
+    paddingTop: '5px',
+    fontSize: '19px',
+    textAlign: 'right',
+    textTransform: 'capitalize',
+  },
+  contentNestFromAddress: {
+    width: '100%',
+    height: '54px',
+    paddingTop: '10px',
+    float: 'left',
+  },
+  contentNestToAddress: {
+    width: '100%',
+    height: '54px',
+    paddingTop: '10px',
+    float: 'left',
+  },
+  contentNestAddressHashTo: {
+    width: '100%',
+    height: '100%',
+    paddingTop: '9px',
+    paddingLeft: '10px',
+    borderStyle: 'none',
+    color: '#2971ff',
+    fontSize: '13px',
+    cursor: 'text',
+    ':focus': {
+      color: '#2971ff',
+    },
+  },
+  contentNestAddressHashBlock: {
+    position: 'relative',
+    overflow: 'hidden',
+    width: '300px',
+    height: '34px',
+    float: 'left',
+    borderBottom: '1px solid #a9b4bf',
+    fontSize: '13px',
+  },
+  contentNestAddressHashBlockConfirm: {
+    position: 'relative',
+    overflow: 'hidden',
+    width: '300px',
+    height: '34px',
+    paddingTop: '7px',
+    float: 'left',
+    fontSize: '17px',
+  },
+  contentNestGradient: {
+    position: 'absolute',
+    top: '0px',
+    right: '0px',
+    bottom: '0px',
+    width: '40px',
+    height: '100%',
+    backgroundImage: 'linear-gradient(90deg, transparent, #fff 80%)',
+  },
+  selectAccountsSend: {
+    width: '300px',
+    position: 'relative',
+    zIndex: '3',
+    overflow: 'visible',
+    height: '34px',
+    minWidth: '300px',
+    float: 'left',
+    borderBottom: '1px solid #2971ff',
+    backgroundColor: '#fff',
+    backgroundImage: `url(${ArrowDownMidBlue})`,
+    backgroundPosition: '100% 50%',
+    backgroundSize: '10px',
+    backgroundRepeat: 'no-repeat',
+    cursor: 'pointer',
+    ':hover': {
+      backgroundImage: `url(${ArrowDownKeyBlue})`,
+      backgroundSize: '10px',
+    }
+  },
+  selectAccount: {
+    display: 'block',
+    overflow: 'hidden',
+    width: '100%',
+    height: '100%',
+    color: '#0c1e3e',
+    fontSize: '19px',
+    ':hover': {
+      height: 'auto',
+    }
+  },
+  selectAccountNFirst: {
+    overflow: 'hidden',
+    height: '34px',
+    marginRight: '20px',
+    paddingTop: '5px',
+    paddingLeft: '10px',
+    color: '#2971ff',
+    fontSize: '19px',
+  },
+  selectAccountNTextSend: {
+    width: '200%',
+    paddingTop: '1px',
+    fontSize: '13px',
+  },
+  selectAccountNAmount: {
+    position: 'absolute',
+    top: '0px',
+    right: '0px',
+    bottom: '0px',
+    marginRight: '20px',
+    paddingTop: '7px',
+    paddingLeft: '40px',
+    backgroundImage: 'linear-gradient(90deg, transparent, #fff 28%)',
+    fontFamily: 'Inconsolata, monospace',
+    color: '#596d81',
+    fontSize: '11px',
+    fontWeight: '400',
+    textAlign: 'right',
+  },
+  selectAccountNAmountBold: {
+    fontFamily: 'Inconsolata, monospace',
+    fontWeight: '700',
+  },
+  selectAccountNNestSend: {
+    fontSize: '13px',
+    overflow: 'auto',
+    height: 'auto',
+    maxHeight: '413px',
+    paddingTop: '10px',
+    paddingBottom: '10px',
+    borderBottom: '1px solid #a9b4bf',
+    backgroundColor: '#fff',
+  },
+  selectAccountNGradient: {
+    position: 'absolute',
+    top: '0px',
+    right: '0px',
+    bottom: '0px',
+    width: '40px',
+    height: '100%',
+    backgroundImage: 'linear-gradient(90deg, transparent, #fff 75%)',
+  },
+  selectAccountN: {
+    position: 'relative',
+    overflow: 'hidden',
+    width: '100%',
+    paddingTop: '18px',
+    paddingBottom: '18px',
+    paddingLeft: '10px',
+    float: 'left',
+    ':hover': {
+      color: '#2971ff',
+    }
+  },
+  selectAccountNText: {
+    width: '200%',
+  },
+  inputForm: {
+    position: 'relative',
+    width: '100%',
+    height: 'auto',
+    minHeight: '44px',
+  },
+  contentNestAddressAmount: {
+    display: 'block',
+    height: '34px',
+    float: 'right',
+  },
+  contentNestAddressAmountSumAndCurrency: {
+    position: 'relative',
+    overflow: 'hidden',
+    width: '140px',
+    height: '100%',
+    marginRight: '20px',
+    float: 'right',
+    borderBottom: '1px solid #a9b4bf',
+    color: '#0c1e3e',
+    textAlign: 'right',
+  },
+  contentNestAddressAmountSumGradient: {
+    position: 'absolute',
+    top: '0px',
+    right: '0px',
+    bottom: '0px',
+    display: 'inline-block',
+    width: '37px',
+    height: '100%',
+    paddingTop: '9px',
+    paddingRight: '10px',
+    backgroundColor: '#fff',
+    fontFamily: 'Inconsolata, monospace',
+    fontSize: '13px',
+    textTransform: 'uppercase',
+  },
+  contentNestAddressAmountSum: {
+    display: 'block',
+    width: '100px',
+    height: '100%',
+    borderStyle: 'none',
+    fontFamily: 'Inconsolata, monospace',
+    fontSize: '19px',
+    fontWeight: '700',
+  },
+  contentNestToAddressAmountSumNumberFormatSmall: {
+    fontSize: '13px',
+  },
+  contentNestAddressAmountSumNumberFormatSmall: {
+    fontSize: '13px',
+  },
+  contentSend: {
+    marginTop: '20px',
+  },
+  contentSendSection: {
+    display: 'block',
+    width: '91%',
+    height: '22px',
+    paddingLeft: '30px',
+    float: 'left',
+    color: '#0c1e3e',
+  },
+  contentSendSectionCheckboxText: {
+    height: '100%',
+    paddingTop: '1px',
+    paddingLeft: '5px',
+    float: 'left',
+    textTransform: 'capitalize',
+  },
+  ontentSendSectionAmount: {
+    width: '160px',
+    height: '100%',
+    paddingTop: '1px',
+    paddingRight: '30px',
+    float: 'right',
+    fontFamily: 'Inconsolata, monospace',
+    fontSize: '13px',
+    textAlign: 'right',
+  },
+  contentSendSectionDescription: {
+    height: '100%',
+    paddingTop: '1px',
+    paddingRight: '20px',
+    float: 'right',
+    color: '#596d81',
+    fontSize: '13px',
+  },
+  contentSendSectionAmountCurrency: {
+    paddingLeft: '5px',
+  },
+  viewButtonKeyBlue: {
+    width: '9%',
+    float: 'left',
+    display: 'inline-block',
+    padding: '17px 18px 18px',
+    borderRadius: '5px',
+    backgroundColor: '#2971ff',
+    boxShadow: '0 0 10px 0 rgba(0, 0, 0, .2)',
+    transitionProperty: 'none',
+    color: '#fff',
+    fontSize: '13px',
+    lineHeight: '9px',
+    fontWeight: '600',
     textAlign: 'center',
-    justifyContent: 'center',
-    alignItems: 'center',
+    textDecoration: 'none',
+    textTransform: 'capitalize',
+    ':hover': {
+      backgroundColor: '#1b58ff',
+    },
+    ':active': {
+      boxShadow: '0 0 0 0 rgba(0, 0, 0, .2)',
+    }
+  },
+  viewButtonLightSlateGray: {
+    display: 'inline-block',
+    padding: '17px 18px 18px',
+    float: 'right',
+    borderRadius: '5px',
+    backgroundColor: '#8997a5',
+    boxShadow: '0 0 10px 0 rgba(0, 0, 0, .2)',
+    color: '#fff',
+    fontSize: '13px',
+    lineHeight: '9px',
+    fontWeight: '600',
+    textAlign: 'center',
+    textDecoration: 'none',
+    textTransform: 'capitalize',
+    ':hover': {
+      backgroundColor: '#596d81',
+    },
+    ':active': {
+      boxShadow: '0 0 0 0 rgba(0, 0, 0, .22)',
+    }
+  },
+  flexHeight: {
+    paddingTop: '1px',
+    backgroundColor: '#fff',
+    height:'372px',
+    overflowY: 'auto',
+    overflowX: 'hidden',
   }
 };
 
@@ -58,9 +408,10 @@ class StakePool extends Component{
   }
   setStakePoolInfo() {
     if (this.state.stakePoolHost == '' || this.state.apiKey == '') {
-      return;
+      //return;
     }
-    setStakePoolInformation(this.state.stakePoolHost, this.props.apiKey, this.props.account);
+    //setStakePoolInformation(this.state.stakePoolHost, this.props.apiKey, this.props.account);
+    this.props.setStakePoolInformation("https://teststakepool.decred.org", this.props.apiKey, 0);
   }
   updateApiKey(apiKey) {
     this.setState({apiKey: apiKey});
@@ -74,7 +425,6 @@ class StakePool extends Component{
   render() {
     const { walletService } = this.props;
     const { stakePoolInfoConfig } = this.props;
-    const { setStakePoolInformation } = this.props;
     const { getAccountsResponse } = this.props;
     var selectStakePool = (
       <div style={styles.selectStakePoolArea}>
@@ -129,6 +479,9 @@ class StakePool extends Component{
               style={styles.contentNestAddressAmountSum}
               placeholder="API Key"
               onBlur={(e) =>{this.updateApiKey(e.target.value);}}/>
+            <div style={styles.contentSend} onClick={() => this.setStakePoolInfo()}>
+              <div style={styles.viewButtonKeyBlue}>Confirm</div>
+            </div>
           </div>
         </div>
 			</div>

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -433,6 +433,10 @@ const styles = {
     height:'372px',
     overflowY: 'auto',
     overflowX: 'hidden',
+  },
+  loading: {
+    marginTop: '110px',
+    marginLeft: '268px',
   }
 };
 

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -1,14 +1,13 @@
 // @flow
 import React, { Component, PropTypes } from 'react';
 import ErrorScreen from '../ErrorScreen';
-import Button from '../ButtonTanel';
 import SideBar from '../SideBar';
 import Header from '../Header';
 import ArrowDownMidBlue from '../icons/arrow-down-mid-blue.svg';
 import ArrowDownKeyBlue from '../icons/arrow-down-key-blue.svg';
 
 const styles = {
- body: {
+  body: {
     position: 'fixed',
     left: '0px',
     top: '50%',
@@ -459,7 +458,7 @@ class StakePool extends Component{
     }
     //this.setState({addAnotherStakePool: false});
     //setStakePoolInformation(this.state.stakePoolHost, this.props.apiKey, this.props.account);
-    this.props.setStakePoolInformation("https://teststakepool.decred.org", this.state.apiKey, 0);
+    this.props.setStakePoolInformation('https://teststakepool.decred.org', this.state.apiKey, 0);
   }
   updateApiKey(apiKey) {
     this.setState({apiKey: apiKey});
@@ -472,7 +471,6 @@ class StakePool extends Component{
   }
   render() {
     const { walletService } = this.props;
-    const { getAccountsResponse } = this.props;
     const { currentStakePoolConfig, currentStakePoolConfigRequest, currentStakePoolConfigError, activeStakePoolConfig } = this.props;
     const { network } = this.props;
     var unconfigedStakePools = 0;
@@ -481,26 +479,6 @@ class StakePool extends Component{
         unconfigedStakePools++;
       }
     }
-    var configedStakePool = (
-      <div style={styles.selectStakePoolArea}>
-        <select
-          defaultValue={0}
-          style={styles.selectStakePool}
-          >
-          {currentStakePoolConfig !== null ?
-            currentStakePoolConfig.map((stakePool) => {
-              if (stakePool.ApiKey && stakePool.Network == network) {
-                return (
-                  <option style={styles.selectStakePoolNFirst} key={stakePool.Host} value={stakePool.Host}>
-                    {stakePool.Host}
-                  </option>
-                );
-              }
-             }):
-             null
-          }
-        </select>
-      </div>);
     var selectStakePool = (
       <div style={styles.selectStakePoolArea}>
         <select
@@ -516,33 +494,13 @@ class StakePool extends Component{
                   </option>
                 );
               }
-             }) :
+            }) :
             null
           }
         </select>
       </div>);
-    var selectAccounts = (
-      <div style={styles.selectAccountsSend}>
-        <select
-          defaultValue={0}
-          style={styles.selectAccount}
-          >
-          {getAccountsResponse !== null ?
-            getAccountsResponse.getAccountsList().map((account) => {
-              if (account.getAccountName() !== 'imported') {
-                return (
-                  <option style={styles.selectAccountNFirst} key={account.getAccountNumber()} value={account.getAccountNumber()}>
-                    {account.getAccountName()}
-                  </option>
-                );
-              }
-            }):
-            null
-          }
-        </select>
-      </div>);  
-    
-    var stakePoolConfigAInput = (
+
+    var stakePoolConfigInput = (
       <div style={styles.content}>
         <div style={styles.flexHeight}>
             <div style={styles.contentNestFromAddress}>
@@ -562,7 +520,7 @@ class StakePool extends Component{
                 </div>
               </div>
             </div>
-          </div> 
+          </div>
           <div style={styles.contentSend} onClick={() => this.setStakePoolInfo()}>
             <div style={styles.viewButtonKeyBlue}>Confirm</div>
           </div>
@@ -575,9 +533,9 @@ class StakePool extends Component{
               <div style={styles.contentNestPrefixConfigured}>Configured stake pools:</div>
             </div>
             <div id="dynamicInput">
-            {currentStakePoolConfig.map((stakePool,i) => {
+            {currentStakePoolConfig.map((stakePool) => {
               if (stakePool.ApiKey && stakePool.Network == network) {
-                return(       
+                return(
                 <div key={stakePool.Host} style={styles.contentNestStakePool}>
                   <div style={styles.contentNestStakePoolSettings}>
                     <div style={styles.contentNestPrefixStakePoolSettings}>URL:</div>
@@ -625,7 +583,7 @@ class StakePool extends Component{
           headerTitleOverview="Stake pool settings"
           headerMetaOverview={<div></div>}
         />
-        {!activeStakePoolConfig || this.state.addAnotherStakePool && !currentStakePoolConfigRequest ? 
+        {!activeStakePoolConfig || this.state.addAnotherStakePool && !currentStakePoolConfigRequest ?
           stakePoolConfigInput :
           configuredStakePoolInformation
         }

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -111,6 +111,12 @@ const styles = {
     textAlign: 'right',
     textTransform: 'capitalize',
   },
+  contentNestStakePoolSettingsBottom: {
+    width: '100%',
+    height: '20px',
+    marginTop: '30px',
+    float: 'left',
+  },
   contentNestContentStakePoolSettings: {
     position: 'relative',
     overflowY: 'hidden',
@@ -119,6 +125,7 @@ const styles = {
     height: '34px',
     float: 'left',
     fontSize: '13px',
+    paddingTop: '2px',
   },
   contentNestPrefixSend: {
     width: '100px',
@@ -167,11 +174,9 @@ const styles = {
   },
   contentNestAddressHashBlock: {
     position: 'relative',
-    overflow: 'hidden',
-    width: '300px',
+    width: '600px',
     height: '34px',
     float: 'left',
-    borderBottom: '1px solid #a9b4bf',
     fontSize: '13px',
   },
   contentNestAddressHashBlockConfirm: {
@@ -293,8 +298,7 @@ const styles = {
   inputForm: {
     position: 'relative',
     width: '100%',
-    height: 'auto',
-    minHeight: '44px',
+    height: '25px',
   },
   contentNestAddressAmount: {
     display: 'block',
@@ -329,10 +333,8 @@ const styles = {
   },
   contentNestAddressAmountSum: {
     display: 'block',
-    width: '100px',
+    width: '100%',
     height: '100%',
-    borderStyle: 'none',
-    fontFamily: 'Inconsolata, monospace',
     fontSize: '19px',
     fontWeight: '700',
   },
@@ -539,20 +541,10 @@ class StakePool extends Component{
           }
         </select>
       </div>);  
-    const stakePool = (
-      <div style={styles.view}>
-        <Header
-          headerTop={
-            currentStakePoolConfigError !== null ?
-            <div key="updateStakePoolError" style={styles.viewNotificationError}>{currentStakePoolConfigError}</div> :
-            <div key="updateStakePoolError" ></div>
-          }
-          headerTitleOverview="Stake pool settings"
-          headerMetaOverview={<div></div>}
-        />
-        {!activeStakePoolConfig || this.state.addAnotherStakePool ? 
-        <div style={styles.content}>
-          <div style={styles.flexHeight}>
+    
+    var stakePoolConfigAInput = (
+      <div style={styles.content}>
+        <div style={styles.flexHeight}>
             <div style={styles.contentNestFromAddress}>
               <div style={styles.contentNestPrefixSend}>Stake Pool:</div>
                 {selectStakePool}
@@ -574,7 +566,9 @@ class StakePool extends Component{
           <div style={styles.contentSend} onClick={() => this.setStakePoolInfo()}>
             <div style={styles.viewButtonKeyBlue}>Confirm</div>
           </div>
-        </div> :
+        </div>
+    );
+    var configuredStakePoolInformation = (
         <div style={styles.content}>
           <div style={styles.flexHeight}>
             <div style={styles.contentNestFromAddress}>
@@ -601,7 +595,7 @@ class StakePool extends Component{
                     <div style={styles.contentNestPrefixStakePoolSettings}>Script:</div>
                     <textarea disabled value={stakePool.Script} style={styles.contentNestContentStakePoolSettings}/>
                   </div>
-                  <div style={styles.contentNestStakePoolSettings}>
+                  <div style={styles.contentNestStakePoolSettingsBottom}>
                     <div style={styles.contentNestPrefixStakePoolSettings}>Pool Fees:</div>
                     <div style={styles.contentNestContentStakePoolSettings}>
                       {stakePool.PoolFees}
@@ -619,6 +613,21 @@ class StakePool extends Component{
           <div></div>
           }
         </div>
+    );
+    const stakePool = (
+      <div style={styles.view}>
+        <Header
+          headerTop={
+            currentStakePoolConfigError !== null ?
+            <div key="updateStakePoolError" style={styles.viewNotificationError}>{currentStakePoolConfigError}</div> :
+            <div key="updateStakePoolError" ></div>
+          }
+          headerTitleOverview="Stake pool settings"
+          headerMetaOverview={<div></div>}
+        />
+        {!activeStakePoolConfig || this.state.addAnotherStakePool && !currentStakePoolConfigRequest ? 
+          stakePoolConfigInput :
+          configuredStakePoolInformation
         }
       </div>
     );

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -404,12 +404,17 @@ class StakePool extends Component{
       stakePoolHost: '',
       apiKey: '',
       account: 0,
+      addAnotherStakePool: false,
     };
+  }
+  addAnotherStakePool() {
+    this.setState({addAnotherStakePool: true});
   }
   setStakePoolInfo() {
     if (this.state.stakePoolHost == '' || this.state.apiKey == '') {
       //return;
     }
+    //this.setState({addAnotherStakePool: false});
     //setStakePoolInformation(this.state.stakePoolHost, this.props.apiKey, this.props.account);
     this.props.setStakePoolInformation("https://teststakepool.decred.org", this.state.apiKey, 0);
   }
@@ -427,7 +432,13 @@ class StakePool extends Component{
     const { getAccountsResponse } = this.props;
     const { currentStakePoolConfig, currentStakePoolConfigRequest, currentStakePoolConfigError, activeStakePoolConfig } = this.props;
     const { getNetworkResponse } = this.props;
-
+    var unconfigedStakePools = 0;
+    console.log(this.state.addAnotherStakePool);
+    for (var i = 0; i < currentStakePoolConfig; i++) {
+      if (!currentStakePoolConfig[i].ApiKey && currentStakePoolConfig[i].Network == getNetworkResponse.networkStr) {
+        unconfigedStakePools++;
+      }
+    }
     var configedStakePool = (
       <div style={styles.selectStakePoolArea}>
         <select
@@ -499,28 +510,44 @@ class StakePool extends Component{
           headerTitleOverview="Stake pool settings"
           headerMetaOverview={<div></div>}
         />
+        {!activeStakePoolConfig || this.state.addAnotherStakePool ? 
         <div style={styles.content}>
-          <div style={styles.center}>
-            {!activeStakePoolConfig ? 
-              <div>
-                <div>{selectStakePool}</div>
-                <div>{selectAccounts}</div>
-                <input
-                  type="text"
-                  style={styles.contentNestAddressAmountSum}
-                  placeholder="API Key"
-                  onBlur={(e) =>{this.updateApiKey(e.target.value);}}/>
-                <div style={styles.contentSend} onClick={() => this.setStakePoolInfo()}>
-                  <div style={styles.viewButtonKeyBlue}>Confirm</div>
-                </div> 
-              </div> :
-              <div>
-                Configured stake pool
+          <div style={styles.flexHeight}>
+            <div style={styles.contentNestFromAddress}>
+              <div style={styles.contentNestPrefixSend}>Stake Pool:</div>
+                {selectStakePool}
+              <div style={styles.contentNestFromAddressWalletIcon}></div>
+            </div>
+            <div style={styles.contentNestToAddress}>
+              <div style={styles.contentNestPrefixSend}>Api Key:</div>
+              <div style={styles.contentNestAddressHashBlock}>
+                <div style={styles.inputForm}>
+                  <input
+                    type="text"
+                    style={styles.contentNestAddressAmountSum}
+                    placeholder="API Key"
+                    onBlur={(e) =>{this.updateApiKey(e.target.value);}}/>
+                </div>
               </div>
-            }
+            </div>
+          </div> 
+          <div style={styles.contentSend} onClick={() => this.setStakePoolInfo()}>
+            <div style={styles.viewButtonKeyBlue}>Confirm</div>
           </div>
+        </div> :
+        <div style={styles.content}>
+          <div style={styles.flexHeight}>
+            Configured stake pool
+          </div>
+          {unconfigedStakePools > 0 ?
+          <div style={styles.contentSend} onClick={() => this.addAnotherStakePool()}>
+            <div style={styles.viewButtonKeyBlue}>Add stakepool</div>
+          </div> :
+          <div></div>
+          }
         </div>
-			</div>
+        }
+      </div>
     );
     if (walletService === null) {
       return (<ErrorScreen />);

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -425,9 +425,29 @@ class StakePool extends Component{
   render() {
     const { walletService } = this.props;
     const { getAccountsResponse } = this.props;
-    const { currentStakePoolConfig, currentStakePoolConfigRequest, currentStakePoolConfigError } = this.props;
+    const { currentStakePoolConfig, currentStakePoolConfigRequest, currentStakePoolConfigError, activeStakePoolConfig } = this.props;
     const { getNetworkResponse } = this.props;
 
+    var configedStakePool = (
+      <div style={styles.selectStakePoolArea}>
+        <select
+          defaultValue={0}
+          style={styles.selectStakePool}
+          >
+          {currentStakePoolConfig !== null && getNetworkResponse !== null ?
+            currentStakePoolConfig.map((stakePool) => {
+              if (stakePool.ApiKey && stakePool.Network == getNetworkResponse.networkStr) {
+                return (
+                  <option style={styles.selectStakePoolNFirst} key={stakePool.Host} value={stakePool.Host}>
+                    {stakePool.Host}
+                  </option>
+                );
+              }
+             }):
+            null
+          }
+        </select>
+      </div>);
     var selectStakePool = (
       <div style={styles.selectStakePoolArea}>
         <select
@@ -436,12 +456,13 @@ class StakePool extends Component{
           >
           {currentStakePoolConfig !== null && getNetworkResponse !== null ?
             currentStakePoolConfig.map((stakePool) => {
-              if (!stakePool.ApiKey && stakePool.Network == getNetworkResponse.networkStr)
-              return (
-                <option style={styles.selectStakePoolNFirst} key={stakePool.Host} value={stakePool.Host}>
-                  {stakePool.Host}
-                </option>
-              );
+              if (!stakePool.ApiKey && stakePool.Network == getNetworkResponse.networkStr) {
+                return (
+                  <option style={styles.selectStakePoolNFirst} key={stakePool.Host} value={stakePool.Host}>
+                    {stakePool.Host}
+                  </option>
+                );
+              }
              }):
             null
           }
@@ -480,16 +501,23 @@ class StakePool extends Component{
         />
         <div style={styles.content}>
           <div style={styles.center}>
-            {selectStakePool}
-            {selectAccounts}
-            <input
-              type="text"
-              style={styles.contentNestAddressAmountSum}
-              placeholder="API Key"
-              onBlur={(e) =>{this.updateApiKey(e.target.value);}}/>
-            <div style={styles.contentSend} onClick={() => this.setStakePoolInfo()}>
-              <div style={styles.viewButtonKeyBlue}>Confirm</div>
-            </div>
+            {!activeStakePoolConfig ? 
+              <div>
+                <div>{selectStakePool}</div>
+                <div>{selectAccounts}</div>
+                <input
+                  type="text"
+                  style={styles.contentNestAddressAmountSum}
+                  placeholder="API Key"
+                  onBlur={(e) =>{this.updateApiKey(e.target.value);}}/>
+                <div style={styles.contentSend} onClick={() => this.setStakePoolInfo()}>
+                  <div style={styles.viewButtonKeyBlue}>Confirm</div>
+                </div> 
+              </div> :
+              <div>
+                Configured stake pool
+              </div>
+            }
           </div>
         </div>
 			</div>
@@ -497,7 +525,7 @@ class StakePool extends Component{
     if (walletService === null) {
       return (<ErrorScreen />);
     } else {
-      return(
+      return (
         <div style={styles.body}>
           <SideBar />
           {stakePool}

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -53,7 +53,7 @@ class StakePool extends Component{
   render() {
     const { walletService } = this.props;
     const { getNextAddressResponse, getNextAddressRequestAttempt } = this.props;
-
+    const { stakePoolInfoData } = this.props;
     const copayReceive = (
       <div style={styles.view}>
         <Header

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -449,7 +449,7 @@ class StakePool extends Component{
     var initStakePoolHost = '';
     for (var i = 0; i < this.props.currentStakePoolConfig.length; i++) {
       if (!this.props.currentStakePoolConfig[i].ApiKey) {
-        initStakePoolHost = this.props.currentStakePoolConfig[i].Host
+        initStakePoolHost = this.props.currentStakePoolConfig[i].Host;
         break;
       }
     }
@@ -590,7 +590,7 @@ class StakePool extends Component{
       <div style={styles.view}>
         <Header
           headerTop={
-            [
+          [
             currentStakePoolConfigError !== null ?
             <div key="updateStakePoolError" style={styles.viewNotificationError}>{currentStakePoolConfigError}</div> :
 
@@ -598,7 +598,7 @@ class StakePool extends Component{
             currentStakePoolConfigSuccessMessage !== undefined && currentStakePoolConfigSuccessMessage !== '' ?
             <div key="configSuccess"  style={styles.viewNotificationSuccess}>{currentStakePoolConfigSuccessMessage}</div> :
             <div key="configSuccess" ></div>
-            ]
+          ]
           }
           headerTitleOverview="Stake pool settings"
           headerMetaOverview={<div></div>}

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -484,6 +484,7 @@ class StakePool extends Component{
   render() {
     const { walletService } = this.props;
     const { currentStakePoolConfig, currentStakePoolConfigRequest, currentStakePoolConfigError, activeStakePoolConfig } = this.props;
+    const { currentStakePoolConfigSuccessMessage } = this.props;
     const { network } = this.props;
     var unconfigedStakePools = 0;
     for (var i = 0; i < currentStakePoolConfig.length; i++) {
@@ -589,9 +590,15 @@ class StakePool extends Component{
       <div style={styles.view}>
         <Header
           headerTop={
+            [
             currentStakePoolConfigError !== null ?
             <div key="updateStakePoolError" style={styles.viewNotificationError}>{currentStakePoolConfigError}</div> :
-            <div key="updateStakePoolError" ></div>
+
+            <div key="updateStakePoolError" ></div>,
+            currentStakePoolConfigSuccessMessage !== undefined && currentStakePoolConfigSuccessMessage !== '' ?
+            <div key="configSuccess"  style={styles.viewNotificationSuccess}>{currentStakePoolConfigSuccessMessage}</div> :
+            <div key="configSuccess" ></div>
+            ]
           }
           headerTitleOverview="Stake pool settings"
           headerMetaOverview={<div></div>}

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -446,9 +446,15 @@ class StakePool extends Component{
   };
   constructor(props) {
     super(props);
-
+    var initStakePoolHost = '';
+    for (var i = 0; i < this.props.currentStakePoolConfig.length; i++) {
+      if (!this.props.currentStakePoolConfig[i].ApiKey) {
+        initStakePoolHost = this.props.currentStakePoolConfig[i].Host
+        break;
+      }
+    }
     this.state = {
-      stakePoolHost: '',
+      stakePoolHost: initStakePoolHost,
       apiKey: '',
       account: 0,
       addAnotherStakePool: false,
@@ -459,11 +465,12 @@ class StakePool extends Component{
   }
   setStakePoolInfo() {
     if (this.state.stakePoolHost == '' || this.state.apiKey == '') {
-      //return;
+      return;
     }
     //this.setState({addAnotherStakePool: false});
     //setStakePoolInformation(this.state.stakePoolHost, this.props.apiKey, this.props.account);
-    this.props.setStakePoolInformation('https://teststakepool.decred.org', this.state.apiKey, 0);
+    this.props.setStakePoolInformation(this.state.stakePoolHost, this.state.apiKey, 0);
+    setTimeout(this.setState({addAnotherStakePool: false}), 1000);
   }
   updateApiKey(apiKey) {
     this.setState({apiKey: apiKey});
@@ -479,7 +486,7 @@ class StakePool extends Component{
     const { currentStakePoolConfig, currentStakePoolConfigRequest, currentStakePoolConfigError, activeStakePoolConfig } = this.props;
     const { network } = this.props;
     var unconfigedStakePools = 0;
-    for (var i = 0; i < currentStakePoolConfig; i++) {
+    for (var i = 0; i < currentStakePoolConfig.length; i++) {
       if (!currentStakePoolConfig[i].ApiKey && currentStakePoolConfig[i].Network == network) {
         unconfigedStakePools++;
       }
@@ -489,6 +496,7 @@ class StakePool extends Component{
         <select
           defaultValue={0}
           style={styles.selectStakePool}
+          onChange={(e) =>{this.updateStakePoolHost(e.target.value);}}
           >
           {currentStakePoolConfig !== null  ?
             currentStakePoolConfig.map((stakePool) => {

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -79,6 +79,40 @@ const styles = {
     paddingLeft: '116px',
     float: 'left',
   },
+  contentNestPrefixConfigured: {
+    width: '200px',
+    paddingRight: '15px',
+    float: 'left',
+    height: '100%',
+    paddingTop: '5px',
+    fontSize: '19px',
+    textAlign: 'right',
+    textTransform: 'capitalize',
+  },
+  contentNestStakePoolSettings: {
+    width: '100%',
+    height: '20px',
+    marginTop: '20px',
+    float: 'left',
+  },
+  contentNestPrefixStakePoolSettings: {
+    width: '125px',
+    paddingRight: '15px',
+    float: 'left',
+    height: '100%',
+    fontSize: '19px',
+    textAlign: 'right',
+    textTransform: 'capitalize',
+  },
+  contentNestContentStakePoolSettings: {
+    position: 'relative',
+    overflowY: 'hidden',
+    overflowX: 'auto',
+    width: '575px',
+    height: '34px',
+    float: 'left',
+    fontSize: '13px',
+  },
   contentNestPrefixSend: {
     width: '100px',
     paddingRight: '15px',
@@ -431,11 +465,10 @@ class StakePool extends Component{
     const { walletService } = this.props;
     const { getAccountsResponse } = this.props;
     const { currentStakePoolConfig, currentStakePoolConfigRequest, currentStakePoolConfigError, activeStakePoolConfig } = this.props;
-    const { getNetworkResponse } = this.props;
+    const { network } = this.props;
     var unconfigedStakePools = 0;
-    console.log(this.state.addAnotherStakePool);
     for (var i = 0; i < currentStakePoolConfig; i++) {
-      if (!currentStakePoolConfig[i].ApiKey && currentStakePoolConfig[i].Network == getNetworkResponse.networkStr) {
+      if (!currentStakePoolConfig[i].ApiKey && currentStakePoolConfig[i].Network == network) {
         unconfigedStakePools++;
       }
     }
@@ -445,9 +478,9 @@ class StakePool extends Component{
           defaultValue={0}
           style={styles.selectStakePool}
           >
-          {currentStakePoolConfig !== null && getNetworkResponse !== null ?
+          {currentStakePoolConfig !== null ?
             currentStakePoolConfig.map((stakePool) => {
-              if (stakePool.ApiKey && stakePool.Network == getNetworkResponse.networkStr) {
+              if (stakePool.ApiKey && stakePool.Network == network) {
                 return (
                   <option style={styles.selectStakePoolNFirst} key={stakePool.Host} value={stakePool.Host}>
                     {stakePool.Host}
@@ -455,7 +488,7 @@ class StakePool extends Component{
                 );
               }
              }):
-            null
+             null
           }
         </select>
       </div>);
@@ -465,16 +498,16 @@ class StakePool extends Component{
           defaultValue={0}
           style={styles.selectStakePool}
           >
-          {currentStakePoolConfig !== null && getNetworkResponse !== null ?
+          {currentStakePoolConfig !== null  ?
             currentStakePoolConfig.map((stakePool) => {
-              if (!stakePool.ApiKey && stakePool.Network == getNetworkResponse.networkStr) {
+              if (!stakePool.ApiKey && stakePool.Network == network) {
                 return (
                   <option style={styles.selectStakePoolNFirst} key={stakePool.Host} value={stakePool.Host}>
                     {stakePool.Host}
                   </option>
                 );
               }
-             }):
+             }) :
             null
           }
         </select>
@@ -537,7 +570,42 @@ class StakePool extends Component{
         </div> :
         <div style={styles.content}>
           <div style={styles.flexHeight}>
-            Configured stake pool
+            <div style={styles.contentNestFromAddress}>
+              <div style={styles.contentNestPrefixConfigured}>Configured stake pools:</div>
+            </div>
+            <div id="dynamicInput">
+            {currentStakePoolConfig.map((stakePool,i) => {
+              if (stakePool.ApiKey && stakePool.Network == network) {
+                return(       
+                <div key={stakePool.Host}>
+                  <div style={styles.contentNestStakePoolSettings}>
+                    <div style={styles.contentNestPrefixStakePoolSettings}>URL:</div>
+                    <div style={styles.contentNestContentStakePoolSettings}>
+                      {stakePool.Host}
+                    </div>
+                  </div>
+                  <div style={styles.contentNestStakePoolSettings}>
+                    <div style={styles.contentNestPrefixStakePoolSettings}>Ticket Address:</div>
+                    <div style={styles.contentNestContentStakePoolSettings}>
+                      {stakePool.TicketAddress}
+                    </div>
+                  </div>
+                  <div style={styles.contentNestStakePoolSettings}>
+                    <div style={styles.contentNestPrefixStakePoolSettings}>Script:</div>
+                    <div style={styles.contentNestContentStakePoolSettings}>
+                      {stakePool.Script}
+                    </div>
+                  </div>
+                  <div style={styles.contentNestStakePoolSettings}>
+                    <div style={styles.contentNestPrefixStakePoolSettings}>Pool Fees:</div>
+                    <div style={styles.contentNestContentStakePoolSettings}>
+                      {stakePool.PoolFees}
+                    </div>
+                  </div>
+                </div>);
+              }
+            })}
+            </div>
           </div>
           {unconfigedStakePools > 0 ?
           <div style={styles.contentSend} onClick={() => this.addAnotherStakePool()}>

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -56,15 +56,26 @@ class StakePool extends Component{
       account: 0,
     };
   }
-  submitSignPublishTx() {
+  setStakePoolInfo() {
     if (this.state.stakePoolHost == '' || this.state.apiKey == '') {
       return;
     }
-    this.props.signTransactionAttempt(this.state.privpass, this.props.constructTxResponse.getUnsignedTransaction());
+    setStakePoolInformation(this.state.stakePoolHost, this.props.apiKey, this.props.account);
+  }
+  updateApiKey(apiKey) {
+    this.setState({apiKey: apiKey});
+  }
+  updateAccountNumber(accountNum) {
+    this.setState({account: accountNum});
+  }
+  updateStakePoolHost(poolHost) {
+    this.setState({stakePoolHost: poolHost});
   }
   render() {
     const { walletService } = this.props;
     const { stakePoolInfoConfig } = this.props;
+    const { setStakePoolInformation } = this.props;
+    const { getAccountsResponse } = this.props;
     var selectStakePool = (
       <div style={styles.selectStakePoolArea}>
         <select
@@ -83,6 +94,26 @@ class StakePool extends Component{
           }
         </select>
       </div>);
+    var selectAccounts = (
+      <div style={styles.selectAccountsSend}>
+        <select
+          defaultValue={0}
+          style={styles.selectAccount}
+          >
+          {getAccountsResponse !== null ?
+            getAccountsResponse.getAccountsList().map((account) => {
+              if (account.getAccountName() !== 'imported') {
+                return (
+                  <option style={styles.selectAccountNFirst} key={account.getAccountNumber()} value={account.getAccountNumber()}>
+                    {account.getAccountName()}
+                  </option>
+                );
+              }
+            }):
+            null
+          }
+        </select>
+      </div>);  
     const copayReceive = (
       <div style={styles.view}>
         <Header
@@ -92,6 +123,12 @@ class StakePool extends Component{
         <div style={styles.content}>
           <div style={styles.center}>
             {selectStakePool}
+            {selectAccounts}
+            <input
+              type="text"
+              style={styles.contentNestAddressAmountSum}
+              placeholder="API Key"
+              onBlur={(e) =>{this.updateApiKey(e.target.value);}}/>
           </div>
         </div>
 			</div>

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -448,7 +448,7 @@ class StakePool extends Component{
     super(props);
     var initStakePoolHost = '';
     for (var i = 0; i < this.props.currentStakePoolConfig.length; i++) {
-      if (!this.props.currentStakePoolConfig[i].ApiKey) {
+      if (!this.props.currentStakePoolConfig[i].ApiKey && this.props.currentStakePoolConfig[i].Network == this.props.network) {
         initStakePoolHost = this.props.currentStakePoolConfig[i].Host;
         break;
       }

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -8,6 +8,7 @@ function mapStateToProps(state) {
   return {
     walletService: state.grpc.walletService,
     stakePoolInfoConfig: state.stakepool.stakePoolInfoConfig,
+    getAccountsResponse: state.grpc.getAccountsResponse,
   };
 }
 

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -10,6 +10,7 @@ function mapStateToProps(state) {
     currentStakePoolConfig: state.stakepool.currentStakePoolConfig,
     currentStakePoolConfigRequest: state.stakepool.currentStakePoolConfigRequest,
     currentStakePoolConfigError: state.stakepool.currentStakePoolConfigError,
+    activeStakePoolConfig: state.stakepool.activeStakePoolConfig,
     getAccountsResponse: state.grpc.getAccountsResponse,
     getNetworkResponse: state.grpc.getNetworkResponse,
   };

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -2,8 +2,7 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import StakePool from './StakePool';
-import * as ClientActions from '../../actions/ClientActions';
-import * as ControlActions from '../../actions/ControlActions';
+import * as StakePoolActions from '../../actions/ClientActions';
 
 function mapStateToProps(state) {
   return {
@@ -13,7 +12,7 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators(Object.assign({}, ClientActions, ControlActions), dispatch);
+  return bindActionCreators(Object.assign({}, StakePoolActions), dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(StakePool);

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -8,7 +8,7 @@ import * as ControlActions from '../../actions/ControlActions';
 function mapStateToProps(state) {
   return {
     walletService: state.grpc.walletService,
-    stakePoolInfoData: state.stakepool.stakePoolInfoData,
+    stakePoolInfoConfig: state.stakepool.stakePoolInfoConfig,
   };
 }
 

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -1,0 +1,18 @@
+// @flow
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import StakePool from './StakePool';
+import * as ClientActions from '../../actions/ClientActions';
+import * as ControlActions from '../../actions/ControlActions';
+
+function mapStateToProps(state) {
+  return {
+    walletService: state.grpc.walletService,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(Object.assign({}, ClientActions, ControlActions), dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(StakePool);

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -8,6 +8,7 @@ import * as ControlActions from '../../actions/ControlActions';
 function mapStateToProps(state) {
   return {
     walletService: state.grpc.walletService,
+    stakePoolInfoData: state.stakepool.stakePoolInfoData,
   };
 }
 

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -2,13 +2,14 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import StakePool from './StakePool';
-import * as StakePoolActions from '../../actions/ClientActions';
+import * as StakePoolActions from '../../actions/StakePoolActions';
 
 function mapStateToProps(state) {
   return {
     walletService: state.grpc.walletService,
-    stakePoolInfoConfig: state.stakepool.stakePoolInfoConfig,
+    currentStakePoolConfig: state.stakepool.currentStakePoolConfig,
     getAccountsResponse: state.grpc.getAccountsResponse,
+    getNetworkResponse: state.grpc.getNetworkResponse,
   };
 }
 

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -12,7 +12,7 @@ function mapStateToProps(state) {
     currentStakePoolConfigError: state.stakepool.currentStakePoolConfigError,
     activeStakePoolConfig: state.stakepool.activeStakePoolConfig,
     getAccountsResponse: state.grpc.getAccountsResponse,
-    getNetworkResponse: state.grpc.getNetworkResponse,
+    network: state.grpc.network,
   };
 }
 

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -12,6 +12,7 @@ function mapStateToProps(state) {
     currentStakePoolConfigError: state.stakepool.currentStakePoolConfigError,
     activeStakePoolConfig: state.stakepool.activeStakePoolConfig,
     getAccountsResponse: state.grpc.getAccountsResponse,
+    currentStakePoolConfigSuccessMessage: state.stakepool.currentStakePoolConfigSuccessMessage,
     network: state.grpc.network,
   };
 }

--- a/app/components/views/StakePoolPage.js
+++ b/app/components/views/StakePoolPage.js
@@ -8,6 +8,8 @@ function mapStateToProps(state) {
   return {
     walletService: state.grpc.walletService,
     currentStakePoolConfig: state.stakepool.currentStakePoolConfig,
+    currentStakePoolConfigRequest: state.stakepool.currentStakePoolConfigRequest,
+    currentStakePoolConfigError: state.stakepool.currentStakePoolConfigError,
     getAccountsResponse: state.grpc.getAccountsResponse,
     getNetworkResponse: state.grpc.getNetworkResponse,
   };

--- a/app/config.js
+++ b/app/config.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { stakePoolInfo } from './middleware/stakepoolapi';
 
 export function getCfg() {
   const Config = require('electron-config');
@@ -35,6 +36,27 @@ export function getCfg() {
   }
   if (!config.has('currency_display')) {
     config.set('currency_display','DCR');
+  }
+  if (!config.has('stakepools') || config.get('stakepools') == null) {
+    stakePoolInfo(function(response, err) {
+      if (response == null) {
+        console.log(err)
+      } else {
+        var stakePoolNames = Object.keys(response.data);
+        // Only add matching network stakepool info
+        var foundStakePoolConfigs = Array();
+        for (var i = 0; i < stakePoolNames.length; i++) {
+            foundStakePoolConfigs.push({
+              Host:response.data[stakePoolNames[i]].URL,
+              Network: response.data[stakePoolNames[i]].Network,
+              ApiKey:"",
+              MultigsigVoteScript:"",
+              VotingAccount:"",
+            });
+        }
+        config.set('stakepools', foundStakePoolConfigs)}
+      }
+    )
   }
   return(config);
 }

--- a/app/config.js
+++ b/app/config.js
@@ -49,9 +49,6 @@ export function getCfg() {
             foundStakePoolConfigs.push({
               Host:response.data[stakePoolNames[i]].URL,
               Network: response.data[stakePoolNames[i]].Network,
-              ApiKey:"",
-              MultigsigVoteScript:"",
-              VotingAccount:"",
             });
         }
         config.set('stakepools', foundStakePoolConfigs)}

--- a/app/config.js
+++ b/app/config.js
@@ -40,20 +40,20 @@ export function getCfg() {
   if (!config.has('stakepools') || config.get('stakepools') == null) {
     stakePoolInfo(function(response, err) {
       if (response == null) {
-        console.log(err)
+        console.log(err);
       } else {
         var stakePoolNames = Object.keys(response.data);
         // Only add matching network stakepool info
         var foundStakePoolConfigs = Array();
         for (var i = 0; i < stakePoolNames.length; i++) {
-            foundStakePoolConfigs.push({
-              Host:response.data[stakePoolNames[i]].URL,
-              Network: response.data[stakePoolNames[i]].Network,
-            });
+          foundStakePoolConfigs.push({
+            Host:response.data[stakePoolNames[i]].URL,
+            Network: response.data[stakePoolNames[i]].Network,
+          });
         }
-        config.set('stakepools', foundStakePoolConfigs)}
-      }
-    )
+        config.set('stakepools', foundStakePoolConfigs);}
+    }
+    );
   }
   return(config);
 }

--- a/app/config.js
+++ b/app/config.js
@@ -46,10 +46,12 @@ export function getCfg() {
         // Only add matching network stakepool info
         var foundStakePoolConfigs = Array();
         for (var i = 0; i < stakePoolNames.length; i++) {
-          foundStakePoolConfigs.push({
-            Host:response.data[stakePoolNames[i]].URL,
-            Network: response.data[stakePoolNames[i]].Network,
-          });
+          if (response.data[stakePoolNames[i]].APIEnabled) {
+            foundStakePoolConfigs.push({
+              Host:response.data[stakePoolNames[i]].URL,
+              Network: response.data[stakePoolNames[i]].Network,
+            });
+          }
         }
         config.set('stakepools', foundStakePoolConfigs);}
     }

--- a/app/index.js
+++ b/app/index.js
@@ -19,10 +19,12 @@ var totalDays = 0.0;
 var foundStakePoolConfig = false;
 var currentStakePoolConfig = cfg.get('stakepools');
 var network = cfg.get('network');
-for (var i = 0; i < currentStakePoolConfig.length; i++) {
-  if (currentStakePoolConfig[i].ApiKey && currentStakePoolConfig[i].Network == network) {
-    foundStakePoolConfig = true;
-    break;
+if (currentStakePoolConfig !== undefined) {
+  for (var i = 0; i < currentStakePoolConfig.length; i++) {
+    if (currentStakePoolConfig[i].ApiKey && currentStakePoolConfig[i].Network == network) {
+      foundStakePoolConfig = true;
+      break;
+    }
   }
 }
 if (network == 'testnet') {

--- a/app/index.js
+++ b/app/index.js
@@ -64,6 +64,7 @@ var initialState = {
     address: '127.0.0.1',
     port: grpcport,
     walletService: null,
+    network: cfg.network,
     getWalletServiceRequestAttempt: false,
     getWalletServiceError: '',
     // Balance

--- a/app/index.js
+++ b/app/index.js
@@ -16,7 +16,16 @@ var neededBlocks = 0;
 var today = new Date();
 var startDate = new Date();
 var totalDays = 0.0;
-if (cfg.get('network') == 'testnet') {
+var foundStakePoolConfig = false;
+var currentStakePoolConfig = cfg.get('stakepools');
+var network = cfg.get('network');
+for (var i = 0; i < currentStakePoolConfig.length; i++) {
+  if (currentStakePoolConfig[i].ApiKey && currentStakePoolConfig[i].Network == network) {
+    foundStakePoolConfig = true;
+    break;
+  }
+}
+if (network == 'testnet') {
   grpcport = cfg.get('wallet_port_testnet');
   startDate = new Date('01/27/2016');
   totalDays = (today.getTime() - startDate.getTime()) / 1000 / 60 / 60 / 24;
@@ -40,9 +49,10 @@ var initialState = {
     settingsChanged: false,
   },
   stakepool: {
-    currentStakePoolConfig: cfg.get('stakepools'),
+    currentStakePoolConfig: currentStakePoolConfig,
     currentStakePoolConfigRequest: false,
     currentStakePoolConfigError: null,
+    activeStakePoolConfig: foundStakePoolConfig,
   },
   version: {
     // RequiredVersion
@@ -64,7 +74,7 @@ var initialState = {
     address: '127.0.0.1',
     port: grpcport,
     walletService: null,
-    network: cfg.network,
+    network: network,
     getWalletServiceRequestAttempt: false,
     getWalletServiceError: '',
     // Balance

--- a/app/index.js
+++ b/app/index.js
@@ -41,13 +41,8 @@ var initialState = {
   },
   stakepool: {
     currentStakePoolConfig: cfg.get('stakepools'),
-    stakePoolInfoRequest: false,
-    stakePoolInfoError: null,
-    stakePoolInfoData: null,
-    selectedStakePoolData: null,
-    stakePoolInfoConfig: null,
-    stakePoolApiKeys: null,
-    stakePoolPurchaseInfo: null,
+    currentStakePoolConfigRequest: false,
+    currentStakePoolConfigError: null,
   },
   version: {
     // RequiredVersion

--- a/app/index.js
+++ b/app/index.js
@@ -43,6 +43,10 @@ var initialState = {
     stakePoolInfoRequest: false,
     stakePoolInfoError: null,
     stakePoolInfoData: null,
+    selectedStakePoolData: null,
+    stakePoolConfig: null,
+    stakePoolApiKeys: null,
+    stakePoolPurchaseInfo: null,
   },
   version: {
     // RequiredVersion

--- a/app/index.js
+++ b/app/index.js
@@ -44,7 +44,7 @@ var initialState = {
     stakePoolInfoError: null,
     stakePoolInfoData: null,
     selectedStakePoolData: null,
-    stakePoolConfig: null,
+    stakePoolInfoConfig: null,
     stakePoolApiKeys: null,
     stakePoolPurchaseInfo: null,
   },

--- a/app/index.js
+++ b/app/index.js
@@ -39,6 +39,11 @@ var initialState = {
     },
     settingsChanged: false,
   },
+  stakepool: {
+    stakePoolInfoRequest: false,
+    stakePoolInfoError: null,
+    stakePoolInfoData: null,
+  },
   version: {
     // RequiredVersion
     requiredVersion: '4.3.0',

--- a/app/index.js
+++ b/app/index.js
@@ -54,6 +54,7 @@ var initialState = {
     currentStakePoolConfig: currentStakePoolConfig,
     currentStakePoolConfigRequest: false,
     currentStakePoolConfigError: null,
+    currentStakePoolConfigSuccessMessage: '',
     activeStakePoolConfig: foundStakePoolConfig,
   },
   version: {

--- a/app/index.js
+++ b/app/index.js
@@ -40,6 +40,7 @@ var initialState = {
     settingsChanged: false,
   },
   stakepool: {
+    currentStakePoolConfig: cfg.get('stakepools'),
     stakePoolInfoRequest: false,
     stakePoolInfoError: null,
     stakePoolInfoData: null,

--- a/app/middleware/stakepoolapi.js
+++ b/app/middleware/stakepoolapi.js
@@ -18,7 +18,7 @@ export function setStakePoolAddress(apiUrl, apiToken, pKAddress, cb) {
       "Authorization": "Bearer " + apiToken,
     }
   }
-  var url = apiUrl+"address";
+  var url = apiUrl+"/api/v1/address";
   axios.post(url,
     querystring.stringify({
       UserPubKeyAddr: pKAddress,
@@ -38,7 +38,7 @@ export function getPurchaseInfo(apiUrl, apiToken, cb) {
       "Authorization": "Bearer " + apiToken,
     }
   }
-  var url = apiUrl+"getpurchaseinfo";
+  var url = apiUrl+"/api/v1/getpurchaseinfo";
   axios.get(url, config)
   .then(function(response) {
     cb(response);

--- a/app/middleware/stakepoolapi.js
+++ b/app/middleware/stakepoolapi.js
@@ -1,12 +1,28 @@
 import axios from 'axios';
-
+import querystring from 'querystring';
 export function stakePoolInfo(cb) {
   axios.get('https://decred.org/api/?c=gsd')
   .then(function (response) {
     cb(response);
   })
   .catch(function (error) {
-    cb(nil, error);
+    cb(null, error);
   });
 
+}
+
+export function apiClientRequest(apiUrl, request, apiToken, cb) {
+  var config = {
+    headers: { 
+      "Authorization": "Bearer " + apiToken,
+    }
+  }
+  console.log(apiUrl+request);
+  axios.get(apiUrl+request)
+  .then(function(response) {
+    cb(response);
+  })
+  .catch(function(error) {
+    cb(null, error);
+  });
 }

--- a/app/middleware/stakepoolapi.js
+++ b/app/middleware/stakepoolapi.js
@@ -12,7 +12,6 @@ export function stakePoolInfo(cb) {
 }
 
 export function setStakePoolAddress(apiUrl, apiToken, pKAddress, cb) {
-
   console.log(pKAddress);
   var config = {
     headers: { 

--- a/app/middleware/stakepoolapi.js
+++ b/app/middleware/stakepoolapi.js
@@ -14,11 +14,11 @@ export function stakePoolInfo(cb) {
 export function setStakePoolAddress(apiUrl, apiToken, pKAddress, cb) {
   console.log(pKAddress);
   var config = {
-    headers: { 
-      "Authorization": "Bearer " + apiToken,
+    headers: {
+      'Authorization': 'Bearer ' + apiToken,
     }
-  }
-  var url = apiUrl+"/api/v1/address";
+  };
+  var url = apiUrl+'/api/v1/address';
   axios.post(url,
     querystring.stringify({
       UserPubKeyAddr: pKAddress,
@@ -34,11 +34,11 @@ export function setStakePoolAddress(apiUrl, apiToken, pKAddress, cb) {
 
 export function getPurchaseInfo(apiUrl, apiToken, cb) {
   var config = {
-    headers: { 
-      "Authorization": "Bearer " + apiToken,
+    headers: {
+      'Authorization': 'Bearer ' + apiToken,
     }
-  }
-  var url = apiUrl+"/api/v1/getpurchaseinfo";
+  };
+  var url = apiUrl+'/api/v1/getpurchaseinfo';
   axios.get(url, config)
   .then(function(response) {
     cb(response);

--- a/app/middleware/stakepoolapi.js
+++ b/app/middleware/stakepoolapi.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+export function stakePoolInfo(cb) {
+  axios.get('https://decred.org/api/?c=gsd')
+  .then(function (response) {
+    cb(response);
+  })
+  .catch(function (error) {
+    cb(nil, error);
+  });
+
+}

--- a/app/middleware/stakepoolapi.js
+++ b/app/middleware/stakepoolapi.js
@@ -11,14 +11,36 @@ export function stakePoolInfo(cb) {
 
 }
 
-export function apiClientRequest(apiUrl, request, apiToken, cb) {
+export function setStakePoolAddress(apiUrl, apiToken, pKAddress, cb) {
+
+  console.log(pKAddress);
   var config = {
     headers: { 
       "Authorization": "Bearer " + apiToken,
     }
   }
-  console.log(apiUrl+request);
-  axios.get(apiUrl+request)
+  var url = apiUrl+"address";
+  axios.post(url,
+    querystring.stringify({
+      UserPubKeyAddr: pKAddress,
+    }),
+    config)
+  .then(function(response) {
+    cb(response);
+  })
+  .catch(function(error) {
+    cb(null, error);
+  });
+}
+
+export function getPurchaseInfo(apiUrl, apiToken, cb) {
+  var config = {
+    headers: { 
+      "Authorization": "Bearer " + apiToken,
+    }
+  }
+  var url = apiUrl+"getpurchaseinfo";
+  axios.get(url, config)
   .then(function(response) {
     cb(response);
   })

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -16,6 +16,7 @@ const rootReducer = combineReducers({
   control,
   version,
   settings,
+  stakepool,
   routing
 });
 

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -8,6 +8,8 @@ import notifications from './notifications';
 import control from './control';
 import version from './version';
 import settings from './settings';
+import stakepool from './stakepool';
+
 const rootReducer = combineReducers({
   grpc,
   walletLoader,

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -1,0 +1,25 @@
+import {
+    GETSTAKEPOOLINFO_ATTEMPT, GETSTAKEPOOLINFO_FAILED, GETSTAKEPOOLINFO_SUCCESS
+} from '../actions/StakePoolActions';
+
+export default function stakepool(state = {}, action) {
+  switch (action.type) {
+  case GETSTAKEPOOLINFO_ATTEMPT:
+    return {...state,
+      stakePoolInfoRequest: true,
+      stakePoolInfoError: null,
+    };
+  case GETSTAKEPOOLINFO_FAILED:
+    return {...state,
+      stakePoolInfoRequest: false,
+      stakePoolInfoError: action.error,
+    };
+  case GETSTAKEPOOLINFO_SUCCESS:
+    return {...state,
+      stakePoolInfoRequest: false,
+      stakePoolInfoData: action.data,
+    };
+  default:
+    return state;
+  }
+}

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -1,5 +1,6 @@
 import {
-    GETSTAKEPOOLINFO_ATTEMPT, GETSTAKEPOOLINFO_FAILED, GETSTAKEPOOLINFO_SUCCESS
+    GETSTAKEPOOLINFO_ATTEMPT, GETSTAKEPOOLINFO_FAILED, GETSTAKEPOOLINFO_SUCCESS,
+    SETSTAKEPOOLAPIKEY 
 } from '../actions/StakePoolActions';
 
 export default function stakepool(state = {}, action) {
@@ -19,6 +20,10 @@ export default function stakepool(state = {}, action) {
       stakePoolInfoRequest: false,
       stakePoolInfoConfig: action.stakePoolConfig,
     };
+  case SETSTAKEPOOLAPIKEY:
+    return {...state,
+      stakePoolInfoConfig: action.updatedStakePoolConfig,
+    };  
   default:
     return state;
   }

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -8,18 +8,18 @@ export default function stakepool(state = {}, action) {
     return {...state,
       currentStakePoolConfigRequest: true,
       currentStakePoolConfigError: null,
-    };  
+    };
   case UPDATESTAKEPOOLCONFIG_FAILED:
     return {...state,
       currentStakePoolConfigRequest: false,
       currentStakePoolConfigError: action.error,
-    }; 
+    };
   case UPDATESTAKEPOOLCONFIG_SUCCESS:
     return {...state,
       currentStakePoolConfigRequest: false,
       currentStakePoolConfig: action.currentStakePoolConfig,
       activeStakePoolConfig: true,
-    };     
+    };
   default:
     return state;
   }

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -17,7 +17,7 @@ export default function stakepool(state = {}, action) {
   case GETSTAKEPOOLINFO_SUCCESS:
     return {...state,
       stakePoolInfoRequest: false,
-      stakePoolInfoData: action.data,
+      stakePoolInfoConfig: action.stakePoolConfig,
     };
   default:
     return state;

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -18,6 +18,7 @@ export default function stakepool(state = {}, action) {
     return {...state,
       currentStakePoolConfigRequest: false,
       currentStakePoolConfig: action.currentStakePoolConfig,
+      activeStakePoolConfig: true,
     };     
   default:
     return state;

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -8,6 +8,7 @@ export default function stakepool(state = {}, action) {
     return {...state,
       currentStakePoolConfigRequest: true,
       currentStakePoolConfigError: null,
+      currentStakePoolConfigSuccessMessage: '',
     };
   case UPDATESTAKEPOOLCONFIG_FAILED:
     return {...state,
@@ -17,6 +18,7 @@ export default function stakepool(state = {}, action) {
   case UPDATESTAKEPOOLCONFIG_SUCCESS:
     return {...state,
       currentStakePoolConfigRequest: false,
+      currentStakePoolConfigSuccessMessage: action.successMessage,
       currentStakePoolConfig: action.currentStakePoolConfig,
       activeStakePoolConfig: true,
     };

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -1,29 +1,24 @@
 import {
-    GETSTAKEPOOLINFO_ATTEMPT, GETSTAKEPOOLINFO_FAILED, GETSTAKEPOOLINFO_SUCCESS,
-    SETSTAKEPOOLAPIKEY 
+    UPDATESTAKEPOOLCONFIG_ATTEMPT, UPDATESTAKEPOOLCONFIG_FAILED, UPDATESTAKEPOOLCONFIG_SUCCESS,
 } from '../actions/StakePoolActions';
 
 export default function stakepool(state = {}, action) {
   switch (action.type) {
-  case GETSTAKEPOOLINFO_ATTEMPT:
+  case UPDATESTAKEPOOLCONFIG_ATTEMPT:
     return {...state,
-      stakePoolInfoRequest: true,
-      stakePoolInfoError: null,
-    };
-  case GETSTAKEPOOLINFO_FAILED:
-    return {...state,
-      stakePoolInfoRequest: false,
-      stakePoolInfoError: action.error,
-    };
-  case GETSTAKEPOOLINFO_SUCCESS:
-    return {...state,
-      stakePoolInfoRequest: false,
-      stakePoolInfoConfig: action.stakePoolConfig,
-    };
-  case SETSTAKEPOOLAPIKEY:
-    return {...state,
-      stakePoolInfoConfig: action.updatedStakePoolConfig,
+      currentStakePoolConfigRequest: true,
+      currentStakePoolConfigError: null,
     };  
+  case UPDATESTAKEPOOLCONFIG_FAILED:
+    return {...state,
+      currentStakePoolConfigRequest: false,
+      currentStakePoolConfigError: action.error,
+    }; 
+  case UPDATESTAKEPOOLCONFIG_SUCCESS:
+    return {...state,
+      currentStakePoolConfigRequest: false,
+      currentStakePoolConfig: action.currentStakePoolConfig,
+    };     
   default:
     return state;
   }

--- a/app/routes.js
+++ b/app/routes.js
@@ -7,6 +7,7 @@ import HistoryPage from './components/views/HistoryPage';
 import SendPage from './components/views/SendPage';
 import ReceivePage from './components/views/ReceivePage';
 import SettingsPage from './components/views/SettingsPage';
+import StakePoolPage from './components/views/StakePoolPage';
 import GetStartedPage from './components/views/GetStartedPage';
 import WalletError from './components/views/WalletError';
 
@@ -18,6 +19,7 @@ export default (
     <Route path="/send" component={SendPage} />
     <Route path="/receive" component={ReceivePage} />
     <Route path="/settings" component={SettingsPage} />
+    <Route path="/stakepool" component={StakePool} />
     <Route path="/walletError" component={WalletError} />
   </Route>
 );

--- a/app/routes.js
+++ b/app/routes.js
@@ -19,7 +19,7 @@ export default (
     <Route path="/send" component={SendPage} />
     <Route path="/receive" component={ReceivePage} />
     <Route path="/settings" component={SettingsPage} />
-    <Route path="/stakepool" component={StakePool} />
+    <Route path="/stakepool" component={StakePoolPage} />
     <Route path="/walletError" component={WalletError} />
   </Route>
 );

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "webpack-validator": "^2.2.9"
   },
   "dependencies": {
+    "axios": "^0.15.3",
     "electron-debug": "^1.0.1",
     "eslint-formatter-pretty": "^1.1.0",
     "eslint-plugin-react": "^6.9.0",


### PR DESCRIPTION
To allow for communications between decrediton and various stakepools' apis, 
we added functionality for users to be able to set their APIKey given out by the 
pools.  Once that APIKey has been confirmed that corresponding users' purchase 
Information is polled. If the user has not yet provided a pubkey address then one
 is created from an address from the default account.  Since there is currently no
 method of adding accounts, the default account is set automatically.  When the
 functionality for adding accounts is added, that dropdown will also be added to 
the stakepool configuration page.

Close #267 