### PR TITLE
Fixes/improvements for config loading

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -129,3 +129,20 @@ export function getDcrdCert() {
   var cert = fs.readFileSync(certPath);
   return(cert);
 }
+
+export function GRPCWalletPort() {
+  var cfg = getCfg();
+  if (cfg.get('network') == 'mainnet') {
+    return cfg.get('wallet_port');
+  }
+  return cfg.get('wallet_port_testnet');
+}
+
+export function RPCDaemonPort() {
+  var cfg = getCfg();
+  if (cfg.get('network') == 'mainnet') {
+    return cfg.get('daemon_port');
+  }
+  return cfg.get('daemon_port_testnet');
+}
+


### PR DESCRIPTION
When the getCfg() function started returning the raw config object,
the code that starts the daemon and wallet in production mode was not
updated to properly read from that, preventing them from starting
properly.

Some config related logging added when using --debug.

Move GRPCWalletPort() and RPCDaemonPort() to config.js.

Closes #306 