### PR TITLE
Final audit/fixing of currently transaction history/pagination

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -417,22 +417,6 @@ function getTransactionsInfoProgress(response) {
 function getTransactionsInfoEnd() {
   return (dispatch) => {
     setTimeout(() => { dispatch({ type: GETTRANSACTIONS_COMPLETE });}, 1000);
-    setTimeout(() => { dispatch(getMinedPaginatedTransactions(0)); }, 1500);
-  };
-}
-
-export function getMinedPaginatedTransactions(pageNumber) {
-  return (dispatch, getState) => {
-    const { transactionsInfo, txPerPage } = getState().grpc;
-    if (transactionsInfo.length === 0) {
-      return;
-    }
-    var startTx = pageNumber * txPerPage;
-    var endTx = startTx + txPerPage;
-    if (endTx > transactionsInfo.length) {
-      endTx = transactionsInfo.length;
-    }
-    dispatch({ paginatedTxs: transactionsInfo.slice(startTx, endTx), currentPage: pageNumber, type: PAGINATETRANSACTIONS });
   };
 }
 

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -1,6 +1,6 @@
 import { transactionNtfs, spentnessNtfs, accountNtfs } from '../middleware/grpc/client';
 import { getAccountsAttempt, getBalanceAttempt, getStakeInfoAttempt,
-  getTicketPriceAttempt, getNetworkAttempt, getMinedPaginatedTransactions } from './ClientActions';
+  getTicketPriceAttempt, getNetworkAttempt } from './ClientActions';
 import { timeBackString } from '../helpers/dateFormat.js';
 import { reverseHash } from '../helpers/byteActions';
 import { TransactionNotificationsRequest, SpentnessNotificationsRequest, AccountNotificationsRequest} from '../middleware/walletrpc/api_pb';
@@ -70,7 +70,6 @@ function transactionNtfnsData(response) {
           if (unmined.length != updatedUnmined.length) {
             dispatch({ transactionsInfo: updatedTransactionInfo, type: GETTRANSACTIONS_PROGRESS });
             dispatch({unmined: updatedUnmined, type: TRANSACTIONNTFNS_DATA_UNMINED_UPDATE});
-            setTimeout(() => { dispatch(getMinedPaginatedTransactions(0)); }, 1500);
           }
         } else if (attachedBlocks[attachedBlocks.length-1].getHeight()%100 == 0) {
           dispatch({response: response, type: TRANSACTIONNTFNS_DATA });

--- a/app/components/views/History.js
+++ b/app/components/views/History.js
@@ -93,24 +93,23 @@ class History extends Component{
       paginatedTxs: props.transactionsInfo.length >= props.txPerPage  ? props.transactionsInfo.slice(0,props.txPerPage) : props.transactionsInfo.slice(0,props.transactionsInfo.length),
     };
   }
-  updateShownTransactions(pageNumber) {
+  pageForward() {
     const { transactionsInfo, txPerPage } = this.props;
     const { currentPage } = this.state;
-    var newPaginatedTxs;
-    console.log(currentPage, pageNumber);
-    if (currentPage > pageNumber) {
-      newPaginatedTxs = pageNumber == 0 ?
-        transactionsInfo.slice(0, pageNumber * txPerPage) :
-        transactionsInfo.slice(pageNumber * txPerPage, currentPage*txPerPage);
-      this.setState({paginatedTxs: newPaginatedTxs, currentPage: pageNumber});
-    } else {
-      newPaginatedTxs = pageNumber * txPerPage > transactionsInfo.length ?
-        transactionsInfo.slice(currentPage*txPerPage, transactionsInfo.length) :
-        transactionsInfo.slice(currentPage*txPerPage, pageNumber * txPerPage);
-      this.setState({paginatedTxs: newPaginatedTxs, currentPage: pageNumber});
-    }
+    var newPaginatedTxs = (currentPage+1) * txPerPage > transactionsInfo.length ?
+      transactionsInfo.slice(currentPage*txPerPage, transactionsInfo.length) :
+      transactionsInfo.slice(currentPage*txPerPage, (currentPage+1) * txPerPage);
+    this.setState({paginatedTxs: newPaginatedTxs, currentPage: currentPage+1});
+  }
+
+  pageBackward() {
+    const { transactionsInfo, txPerPage } = this.props;
+    const { currentPage } = this.state;
+    var newPaginatedTxs = transactionsInfo.slice((currentPage-1) * txPerPage, currentPage*txPerPage);
+    this.setState({paginatedTxs: newPaginatedTxs, currentPage: currentPage-1});
   }
   render() {
+    console.log(this.state.currentPage);
     const { walletService, getBalanceResponse, getAccountsResponse } = this.props;
     const { transactionDetails, setTransactionDetails, clearTransactionDetails } = this.props;
     const { txPerPage, transactionsInfo } = this.props;
@@ -132,9 +131,9 @@ class History extends Component{
           <div style={styles.contentTitle}>
             <div style={styles.contentTitleText}>Recent Transactions</div>
             <div style={styles.contentTitleButtonsArea}>
-              <button style={styles.contentTitleButtonsLeft} disabled={this.state.currentPage < 1} onClick={()=>this.updateShownTransactions(this.state.currentPage-1)}>&lt;</button>
+              <button style={styles.contentTitleButtonsLeft} disabled={this.state.currentPage < 1} onClick={()=>this.pageBackward()}>&lt;</button>
               <span style={styles.contentTitleButtonsText}>{this.state.currentPage + 1} of {totalPages}</span>
-              <button style={styles.contentTitleButtonsRight} disabled={(this.state.currentPage + 1) * txPerPage > transactionsInfo.length}onClick={()=>this.updateShownTransactions(this.state.currentPage+1)}>&gt;</button>
+              <button style={styles.contentTitleButtonsRight} disabled={(this.state.currentPage + 1) * txPerPage > transactionsInfo.length}onClick={()=>this.pageForward()}>&gt;</button>
             </div>
           </div>
           <div style={styles.contentNest}>

--- a/app/components/views/History.js
+++ b/app/components/views/History.js
@@ -86,12 +86,36 @@ class History extends Component{
   static propTypes = {
     walletService: PropTypes.object,
   };
-
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentPage: 0,
+      paginatedTxs: props.transactionsInfo.length >= props.txPerPage  ? props.transactionsInfo.slice(0,props.txPerPage) : props.transactionsInfo.slice(0,props.transactionsInfo.length),
+    };
+  }
+  updateShownTransactions(pageNumber) {
+    const { transactionsInfo, txPerPage } = this.props;
+    const { currentPage } = this.state;
+    var newPaginatedTxs;
+    console.log(currentPage, pageNumber);
+    if (currentPage > pageNumber) {
+      newPaginatedTxs = pageNumber == 0 ?
+        transactionsInfo.slice(0, pageNumber * txPerPage) :
+        transactionsInfo.slice(pageNumber * txPerPage, currentPage*txPerPage);
+      this.setState({paginatedTxs: newPaginatedTxs, currentPage: pageNumber});
+    } else {
+      newPaginatedTxs = pageNumber * txPerPage > transactionsInfo.length ?
+        transactionsInfo.slice(currentPage*txPerPage, transactionsInfo.length) :
+        transactionsInfo.slice(currentPage*txPerPage, pageNumber * txPerPage);
+      this.setState({paginatedTxs: newPaginatedTxs, currentPage: pageNumber});
+    }
+  }
   render() {
-    const { walletService, getBalanceResponse,getAccountsResponse } = this.props;
+    const { walletService, getBalanceResponse, getAccountsResponse } = this.props;
     const { transactionDetails, setTransactionDetails, clearTransactionDetails } = this.props;
-    const { txPerPage, transactionsInfo, paginatedTxs, getMinedPaginatedTransactions, currentPage } = this.props;
+    const { txPerPage, transactionsInfo } = this.props;
     const { getNetworkResponse } = this.props;
+
 
     var totalPages = 1;
     if (transactionsInfo.length > 0) {
@@ -108,14 +132,14 @@ class History extends Component{
           <div style={styles.contentTitle}>
             <div style={styles.contentTitleText}>Recent Transactions</div>
             <div style={styles.contentTitleButtonsArea}>
-              <button style={styles.contentTitleButtonsLeft} disabled={currentPage < 1} onClick={()=>getMinedPaginatedTransactions(currentPage-1)}>&lt;</button>
-              <span style={styles.contentTitleButtonsText}>{currentPage + 1} of {totalPages}</span>
-              <button style={styles.contentTitleButtonsRight} disabled={(currentPage + 1) * txPerPage > transactionsInfo.length}onClick={()=>getMinedPaginatedTransactions(currentPage+1)}>&gt;</button>
+              <button style={styles.contentTitleButtonsLeft} disabled={this.state.currentPage < 1} onClick={()=>this.updateShownTransactions(this.state.currentPage-1)}>&lt;</button>
+              <span style={styles.contentTitleButtonsText}>{this.state.currentPage + 1} of {totalPages}</span>
+              <button style={styles.contentTitleButtonsRight} disabled={(this.state.currentPage + 1) * txPerPage > transactionsInfo.length}onClick={()=>this.updateShownTransactions(this.state.currentPage+1)}>&gt;</button>
             </div>
           </div>
           <div style={styles.contentNest}>
-            {paginatedTxs.length > 0 ?
-              <TxHistory mined={paginatedTxs} showTxDetail={setTransactionDetails}/>  :
+            {this.state.paginatedTxs.length > 0 ?
+              <TxHistory mined={this.state.paginatedTxs} showTxDetail={setTransactionDetails}/>  :
               <p>No transactions</p>
             }
           </div>

--- a/app/components/views/History.js
+++ b/app/components/views/History.js
@@ -96,25 +96,23 @@ class History extends Component{
   pageForward() {
     const { transactionsInfo, txPerPage } = this.props;
     const { currentPage } = this.state;
-    var newPaginatedTxs = (currentPage+1) * txPerPage > transactionsInfo.length ?
-      transactionsInfo.slice(currentPage*txPerPage, transactionsInfo.length) :
-      transactionsInfo.slice(currentPage*txPerPage, (currentPage+1) * txPerPage);
+    var newPaginatedTxs = (currentPage+2) * txPerPage > transactionsInfo.length ?
+      transactionsInfo.slice((currentPage+1)*txPerPage, transactionsInfo.length) :
+      transactionsInfo.slice((currentPage+1)*txPerPage, (currentPage+2) * txPerPage);
     this.setState({paginatedTxs: newPaginatedTxs, currentPage: currentPage+1});
   }
 
   pageBackward() {
     const { transactionsInfo, txPerPage } = this.props;
     const { currentPage } = this.state;
-    var newPaginatedTxs = transactionsInfo.slice((currentPage-1) * txPerPage, currentPage*txPerPage);
+    var newPaginatedTxs = transactionsInfo.slice((currentPage-1) * txPerPage, (currentPage)*txPerPage);
     this.setState({paginatedTxs: newPaginatedTxs, currentPage: currentPage-1});
   }
   render() {
-    console.log(this.state.currentPage);
     const { walletService, getBalanceResponse, getAccountsResponse } = this.props;
     const { transactionDetails, setTransactionDetails, clearTransactionDetails } = this.props;
     const { txPerPage, transactionsInfo } = this.props;
     const { getNetworkResponse } = this.props;
-
 
     var totalPages = 1;
     if (transactionsInfo.length > 0) {

--- a/app/components/views/Home.js
+++ b/app/components/views/Home.js
@@ -135,13 +135,15 @@ class Home extends Component{
 
   render() {
     const { walletService } = this.props;
-    const { paginatedTxs } = this.props;
+    const { transactionsInfo, txPerPage } = this.props;
     const { getBalanceResponse } = this.props;
     const { getTransactionsRequestAttempt } = this.props;
     const { rescanRequest, rescanResponse } = this.props;
     const { getAccountsResponse } = this.props;
     const { synced } = this.props;
     const { unmined } = this.props;
+
+    var paginatedTxs = transactionsInfo.length >= txPerPage ? transactionsInfo.slice(0,txPerPage) : transactionsInfo.slice(0,transactionsInfo.length);
 
     var rescanPercFisnished;
     if (rescanResponse !== null && getAccountsResponse !== null && rescanRequest != null) {

--- a/app/components/views/Home.js
+++ b/app/components/views/Home.js
@@ -143,7 +143,14 @@ class Home extends Component{
     const { synced } = this.props;
     const { unmined } = this.props;
 
-    var paginatedTxs = transactionsInfo.length >= txPerPage ? transactionsInfo.slice(0,txPerPage) : transactionsInfo.slice(0,transactionsInfo.length);
+    var transactionMessage = '';
+    if (transactionsInfo.length == 0) {
+      transactionMessage = 'No transactions';
+    }
+    var paginatedTxs = unmined.length > 0 ?
+    unmined.length > txPerPage ? Array() :
+    transactionsInfo.length + unmined.length >= txPerPage  ? transactionsInfo.slice(0,txPerPage-unmined.length) : transactionsInfo.slice(0,transactionsInfo.length+unmined.length):
+    transactionsInfo.length >= txPerPage  ? transactionsInfo.slice(0,txPerPage) : transactionsInfo.slice(0,transactionsInfo.length);
 
     var rescanPercFisnished;
     if (rescanResponse !== null && getAccountsResponse !== null && rescanRequest != null) {
@@ -194,7 +201,7 @@ class Home extends Component{
               }
               {paginatedTxs.length > 0 ?
                 <TxHistory mined={paginatedTxs}/>  :
-                <p>No transactions</p>
+                <p>{transactionMessage}</p>
               }
             </div>
           </div> :

--- a/app/components/views/HomePage.js
+++ b/app/components/views/HomePage.js
@@ -9,7 +9,6 @@ import * as ControlActions from '../../actions/ControlActions';
 function mapStateToProps(state) {
   return {
     walletService: state.grpc.walletService,
-    paginatedTxs: state.grpc.paginatedTxs,
     getBalanceRequestAttempt: state.grpc.getBalanceRequestAttempt,
     getBalanceResponse: state.grpc.getBalanceResponse,
     getStakeInfoRequestAttempt: state.grpc.getStakeInfoRequestAttempt,
@@ -23,6 +22,8 @@ function mapStateToProps(state) {
     unminedTransactions: state.grpc.unminedTransactions,
     unmined: state.notifications.unmined,
     getTransactionsRequestAttempt: state.grpc.getTransactionsRequestAttempt,
+    transactionsInfo: state.grpc.transactionsInfo,
+    txPerPage: state.grpc.txPerPage,
   };
 }
 


### PR DESCRIPTION
WIth the current method of querying for transaction history on decrediton bringup and no noticeable issue with memory, these fixes allow easy pagination with minamal redux state changes. 

If/when we update the getTransaction rpc we can do another round of optimization.  Results are unclear on huge wallets with thousands and thousands of transactions.  But for general/everyday usage this should suffice for the time being.
Closes #233 
