### PR TITLE
Force specific version of electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ decrediton --extrawalletargs='-d=debug'
 ## Developing
 
 Due to potential compatibility issues, for now, all work should be
-done with node v6.9.5 and electron 1.4.6.  The recommended way to install
+done with node v6.9.5 and electron 1.4.15.  The recommended way to install
 node is using nvm.
 
 This has primarily been tested on Linux at the moment although OSX

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "css-loader": "^0.25.0",
     "dateformat": "^2.0.0",
     "devtron": "^1.4.0",
-    "electron": "^1.4.4",
+    "electron": "1.4.15",
     "electron-builder": "^8.3.0",
     "electron-devtools-installer": "^2.0.1",
     "enzyme": "^2.5.1",


### PR DESCRIPTION
npm seems to mean something different by compatible with than I do so
just specify the version that we are using.  Also list the correct
version in the README.md

Closes #345 