### PR TITLE
Make startup more async friendly

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -45,8 +45,6 @@ if (process.env.NODE_ENV === 'development') {
 // Always use reasonable path for save data.
 app.setPath('userData', appDataDirectory());
 var cfg = getCfg();
-// Write application config files.
-writeCfgs();
 
 if (debug) {
   console.log('Using config/data from:', app.getPath('userData'));
@@ -236,15 +234,17 @@ const launchDCRWallet = () => {
 
 app.on('ready', async () => {
   await installExtensions();
+  // Write application config files.
+  await writeCfgs();
 
   if (process.env.NODE_ENV === 'production') {
     try {
-      launchDCRD();
+      await launchDCRD();
     } catch (e) {
       console.log('error launching dcrd: ' + e);
     }
     try {
-      launchDCRWallet();
+      await launchDCRWallet();
     } catch (e) {
       console.log('error launching dcrwallet: ' + e);
     }


### PR DESCRIPTION
When changing modes (testnet vs. mainnet) the daemons may sometimes
start before the config files are written causing them to use
incorrect values.  This commit makes the startup of each cli program
wait until after we have written the config files.  This also fixes a
cases where a totally fresh install will try to start before ANY cli
config file has been written.

There may be more ordering/waiting issues during initial bringup, but
this is a significant improvement over the previous behavior.

Closes #357 
