### PR TITLE
Use non-standard ports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cd code
 git clone https://github.com/decred/decrediton.git
 git clone https://github.com/grpc/grpc
 cd grpc
-git checkout cc2e048e84eaa418cab393553594a3fefb891037 
+git checkout cc2e048e84eaa418cab393553594a3fefb891037
 git submodule update --init
 npm install
 cd ../decrediton
@@ -105,19 +105,19 @@ NOT already have rpc certs from dcrwallet so it is easiest to start
 with an emtpy $HOME/.dcrwallet
 
 ```bash
-dcrd --testnet -u USER -P PASSWORD --rpclisten=127.0.0.1:19109 --rpccert=$HOME/.dcrd/rpc.cert
+dcrd --testnet -u USER -P PASSWORD --rpclisten=127.0.0.1:19119 --rpccert=$HOME/.dcrd/rpc.cert
 ```
 
 ```bash
-dcrwallet --testnet --grpclisten=127.0.0.1:19112 --noinitialload --tlscurve=P-256 --onetimetlskey --appdata=~/.config/decrediton
+dcrwallet --testnet --rpcconnect=127.0.0.1:19119 --grpclisten=127.0.0.1:19121 --noinitialload --tlscurve=P-256 --onetimetlskey --appdata=~/.config/decrediton
 ```
 
 On macOS you should use:
 ```bash
-dcrd --testnet -u USER -P PASSWORD --rpclisten=127.0.0.1:19109 --rpccert=$HOME/Library/Application\ Support/Dcrd/rpc.cert
+dcrd --testnet -u USER -P PASSWORD --rpclisten=127.0.0.1:19119 --rpccert=$HOME/Library/Application\ Support/Dcrd/rpc.cert
 ```
 ```bash
-dcrwallet --testnet --grpclisten=127.0.0.1:19112 --noinitialload --tlscurve=P-256 --onetimetlskey --appdata=$HOME/Library/Application\ Support/decrediton
+dcrwallet --testnet --rpcconnect=127.0.0.1:19119 --grpclisten=127.0.0.1:19121 --noinitialload --tlscurve=P-256 --onetimetlskey --appdata=$HOME/Library/Application\ Support/decrediton
 ```
 
 Start decrediton

--- a/app/config.js
+++ b/app/config.js
@@ -12,19 +12,19 @@ export function getCfg(update) {
     config.set('network', 'mainnet');
   }
   if (!config.has('wallet_port_testnet')) {
-    config.set('wallet_port_testnet', '19112');
+    config.set('wallet_port_testnet', '19121');
   }
   if (!config.has('wallet_port')) {
-    config.set('wallet_port', '9112');
+    config.set('wallet_port', '9121');
   }
   if (!config.has('cert_path')) {
     config.set('cert_path','');
   }
   if (!config.has('daemon_port')) {
-    config.set('daemon_port','9109');
+    config.set('daemon_port','9119');
   }
   if (!config.has('daemon_port_testnet')) {
-    config.set('daemon_port_testnet','19109');
+    config.set('daemon_port_testnet','19119');
   }
   if (!config.has('daemon_cert_path')) {
     config.set('daemon_cert_path','');
@@ -244,6 +244,7 @@ export function writeCfgs() {
       username: cfg.get('rpc_user'),
       password: cfg.get('rpc_pass'),
       appdata: appDataDirectory(),
+      rpcconnect: '127.0.0.1:' + RPCDaemonPort(),
       grpclisten: '127.0.0.1:' + GRPCWalletPort(),
       tlscurve: 'P-256',
       noinitialload: '1',


### PR DESCRIPTION
Move dcrd rpc and dcrwallet grpc servers to non-standard ports
similar to what Paymetheus does (but different ports).

Closes #390 