### PR TITLE
Add checks, options, and docs to docker builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ npm install
 npm run package
 ```
 
+## Docker
+
+A docker file for building decrediton is also provided.  With no options it builds from master.  It is also possible to build from a fork or branch using the docker scripts:
+
+```
+$ ./build-docker.sh <BRANCH> <OS> amd64 <GITHUBID>
+```
+
 ## Contact
 
 If you have any further questions you can find us at:

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -5,6 +5,7 @@ set -e
 BUILD_TAG=${1:-master}
 BUILD_OS=${2:-linux}
 BUILD_ARCH=${3:-amd64}
+BUILD_REPO=${4:-decred}
 
 DCRD_RELEASE=v1.0.1
 
@@ -24,7 +25,7 @@ if [ "$BUILD_OS" == "darwin" ]; then
 fi
 
 echo "------------------------------------------"
-echo " Building $BUILD_TAG for $BUILD_OS:$BUILD_ARCH"
+echo " Building $BUILD_TAG for $BUILD_OS:$BUILD_ARCH from $BUILD_REPO on github"
 echo "------------------------------------------"
 echo
 
@@ -39,15 +40,16 @@ docker build -t $DOCKER_IMAGE_TAG .
 
 docker run --rm -it -v $DIST_DIR:/release $DOCKER_IMAGE_TAG /bin/bash -c "\
   . \$HOME/.nvm/nvm.sh && \
-  git clone -b $BUILD_TAG https://github.com/decred/decrediton && \
+  git clone -b $BUILD_TAG https://github.com/$BUILD_REPO/decrediton && \
   git clone https://github.com/grpc/grpc && \
   cd grpc && \
   git checkout $GRPC_COMMIT && \
   git submodule update --init && \
   cd ../decrediton && \
   npm install && \
+  npm run lint && \
   mkdir bin && \
-  curl -L ${DCRD_RELEASE_URL} | tar zxvf - --strip-components=1 -C ./bin/
+  curl -L ${DCRD_RELEASE_URL} | tar zxvf - --strip-components=1 -C ./bin/ && \
   npm run package-$BUILD_TARGET && \
   rsync -ra ./release/ /release/"
 


### PR DESCRIPTION
This makes the docker build run the linter and fails if the linter
fails.  This will also catch compile errors.  It is necessary for
using this in a CI system, but also generally useful.

Added the ability to specify a github id to build from (to build a
fork).

Add some doc in the README.md for the docker build.

Closes #392 