### PR TITLE
Speed up docker builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM ubuntu:trusty
 
 LABEL description="Decrediton builder image"
-LABEL version="1.0"
+LABEL version="1.1"
 LABEL maintainer "peter@prioritylane.com"
 
 ENV NODE_VERSION v6.9.5
+ENV GRPC_COMMIT=cc2e048e84eaa418cab393553594a3fefb891037
 ENV TERM linux
 ENV USER build
 
@@ -37,3 +38,9 @@ RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh
     nvm install $NODE_VERSION && \
     nvm use $NODE_VERSION && \
     npm set progress=false; npm set cache-min 999999999
+
+# Install & build grpc
+RUN   git clone https://github.com/grpc/grpc && \
+  cd grpc && \
+  git checkout $GRPC_COMMIT && \
+  git submodule update --init


### PR DESCRIPTION
Post docker image to docker repo and use that
rather than building each time.

Move grpc build into the docker image so it is
only done once.

The docker image will be moved to a decred repo in a future commit.

Closes #399 