### PR TITLE
Make menu items more consistant between prod and dev mode.

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -371,29 +371,20 @@ app.on('ready', async () => {
       }]
     }, {
       label: 'View',
-      submenu: (process.env.NODE_ENV === 'development') ? [{
-        label: 'Reload',
-        accelerator: 'Command+R',
-        click() {
-          mainWindow.webContents.reload();
-        }
-      }, {
+      submenu: [{
         label: 'Toggle Full Screen',
         accelerator: 'Ctrl+Command+F',
         click() {
           mainWindow.setFullScreen(!mainWindow.isFullScreen());
         }
-      }, {
+      }]
+    }, {
+      label: 'Advanced',
+      submenu: [{
         label: 'Toggle Developer Tools',
         accelerator: 'Alt+Command+I',
         click() {
           mainWindow.toggleDevTools();
-        }
-      }] : [{
-        label: 'Toggle Full Screen',
-        accelerator: 'Ctrl+Command+F',
-        click() {
-          mainWindow.setFullScreen(!mainWindow.isFullScreen());
         }
       }]
     }, {
@@ -454,29 +445,20 @@ app.on('ready', async () => {
       }]
     }, {
       label: '&View',
-      submenu: (process.env.NODE_ENV === 'development') ? [{
-        label: '&Reload',
-        accelerator: 'Ctrl+R',
-        click() {
-          mainWindow.webContents.reload();
-        }
-      }, {
+      submenu: [{
         label: 'Toggle &Full Screen',
         accelerator: 'F11',
         click() {
           mainWindow.setFullScreen(!mainWindow.isFullScreen());
         }
-      }, {
+      }]
+    }, {
+      label: '&Advanced',
+      submenu: [{
         label: 'Toggle &Developer Tools',
         accelerator: 'Alt+Ctrl+I',
         click() {
           mainWindow.toggleDevTools();
-        }
-      }] : [{
-        label: 'Toggle &Full Screen',
-        accelerator: 'F11',
-        click() {
-          mainWindow.setFullScreen(!mainWindow.isFullScreen());
         }
       }]
     }, {


### PR DESCRIPTION
Allow dev tools in production mode (but default to off).  Move to
advanced menu.  Remove reload from menu since it was only in dev mode,
never worked, and should never be needed.

Closes #415 