### PR TITLE
Tell travis not to run install step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ sudo: required
 services:
   - docker
 
+install: true
+
 script:
 - ./build-docker.sh


### PR DESCRIPTION
Installing the code is taken care of by the build-docker.sh script.

Closes #421 