### PR TITLE
Update stakepool apikey entry

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -332,6 +332,7 @@ function importScriptAction(votingAddress, cb) {
             }
           }
         } else {
+          setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 1000);
           dispatch(importScriptSuccess(importScriptResponse, votingAddress, cb));
         }
       });
@@ -631,7 +632,7 @@ numTickets, expiry, ticketFee, txFee, stakepool) {
     dispatch({
       request: request,
       type: PURCHASETICKETS_ATTEMPT });
-    dispatch(importScriptAttempt(passphrase, stakepool.Script, true, 0, stakepool.TicketAddress, (error) => {
+    dispatch(importScriptAttempt(passphrase, stakepool.Script, false, 0, stakepool.TicketAddress, (error) => {
       if (error) {
         dispatch(purchaseTicketsError(error));
       } else {

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -327,7 +327,7 @@ function importScriptAction(votingAddress, cb) {
             if (error.indexOf('master private key') !== -1) {
               dispatch(() => cb(err + ' Please try again.'));
             } else {
-              err = err + '. This probably means you are trying to use a stakepool account that is already associated with another wallet.  If you have previously used a voting account, please create a new account (with any name) and try again.  Otherwise, please set up a new stakepool account for this wallet.';
+              err = err + '. This probably means you are trying to use a stakepool account that is already associated with another wallet.  If you have previously used a voting account, please create a new account and try again.  Otherwise, please set up a new stakepool account for this wallet.';
               dispatch(() => cb(err));
             }
           }

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -283,10 +283,10 @@ function importScriptSuccess(importScriptResponse, votingAddress, cb) {
       dispatch({ importScriptSuccess: message, importScriptResponse: importScriptResponse, type: IMPORTSCRIPT_SUCCESS });
     } else {
       if (importScriptResponse.getP2shAddress() == votingAddress) {
-        dispatch(cb());
+        dispatch(() => cb());
       } else {
         var error = 'The stakepool voting address is not the P2SH address of the voting redeem script. This could be due to trying to use a stakepool that is configured for a different wallet. If this is not the case, please report this to the stakepool administrator and the Decred devs.';
-        dispatch(cb(error));
+        dispatch(() => cb(error));
       }
     }
   };
@@ -323,7 +323,7 @@ function importScriptAction(votingAddress, cb) {
           if (!votingAddress && !cb) {
             dispatch(importScriptError(err + ' Please try again'));
           } else {
-            dispatch(cb(err));
+            dispatch(() => cb(err));
           }
         } else {
           dispatch(importScriptSuccess(importScriptResponse, votingAddress, cb));

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -323,7 +323,13 @@ function importScriptAction(votingAddress, cb) {
           if (!votingAddress && !cb) {
             dispatch(importScriptError(err + ' Please try again'));
           } else {
-            dispatch(() => cb(err));
+            var error = err + '';
+            if (error.indexOf('master private key') !== -1) {
+              dispatch(() => cb(err + ' Please try again.'));
+            } else {
+              err = err + '. This probably means you are trying to use a stakepool account that is already associated with another wallet.  If you have previously used a voting account, please create a new account (with any name) and try again.  Otherwise, please set up a new stakepool account for this wallet.';
+              dispatch(() => cb(err));
+            }
           }
         } else {
           dispatch(importScriptSuccess(importScriptResponse, votingAddress, cb));

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -2,6 +2,7 @@
 import { getPurchaseInfo, setStakePoolAddress, setVoteChoices } from '../middleware/stakepoolapi';
 import { NextAddressRequest } from '../middleware/walletrpc/api_pb';
 import { getCfg } from '../config.js';
+import { importScriptAttempt } from './ControlActions'
 
 export const UPDATESTAKEPOOLCONFIG_ATTEMPT = 'UPDATESTAKEPOOLCONFIG_ATTEMPT';
 export const UPDATESTAKEPOOLCONFIG_FAILED = 'UPDATESTAKEPOOLCONFIG_FAILED';
@@ -37,7 +38,7 @@ export function updateStakepoolPurchaseInformation() {
   };
 }
 
-export function setStakePoolInformation(poolHost, apiKey, accountNum, internal) {
+export function setStakePoolInformation(privpass, poolHost, apiKey, accountNum, internal) {
   return (dispatch) => {
     if (!internal) {
       dispatch({ type: UPDATESTAKEPOOLCONFIG_ATTEMPT });
@@ -53,7 +54,7 @@ export function setStakePoolInformation(poolHost, apiKey, accountNum, internal) 
         } else {
           // parse response data for no err
           if (response.data.status == 'success') {
-            dispatch(updateSavedConfig(response.data.data, poolHost, apiKey, accountNum));
+            dispatch(importScriptAttempt(privpass, response.data.data.Script, true, 0, response.data.data.TicketAddress, () => updateSavedConfig(response.data.data, poolHost, apiKey, accountNum)));
           } else if (response.data.status == 'error') {
             if (response.data.message == 'purchaseinfo error - no address submitted') {
               dispatch(setStakePoolAddressAction(poolHost, apiKey, accountNum));

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -54,8 +54,7 @@ export function setStakePoolInformation(privpass, poolHost, apiKey, accountNum, 
           if (response.data.status == 'success') {
             dispatch(importScriptAttempt(privpass, response.data.data.Script, true, 0, response.data.data.TicketAddress, (error) => {
               if (error) {
-                var err = error + '. Please set up a new stakepool account for this wallet.';
-                dispatch({ error: err, type: UPDATESTAKEPOOLCONFIG_FAILED });
+                dispatch({ error: error, type: UPDATESTAKEPOOLCONFIG_FAILED });
               } else {
                 dispatch(updateSavedConfig(response.data.data, poolHost, apiKey, accountNum));
               }

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component } from 'react';
+import { shell } from 'electron';
 import { PropTypes } from 'prop-types';
 import CircularProgress from 'material-ui/CircularProgress';
 import ErrorScreen from '../ErrorScreen';
@@ -576,9 +577,22 @@ class StakePool extends Component{
                 {selectStakePoolApiKey}
               <div style={StakePoolStyles.contentNestFromAddressWalletIcon}></div>
             </div>
+            <div style={StakePoolStyles.contentNestApiKeyInstructions}>
+              <span>
+                Please select your desired stakepool from the above dropdown and follow these instructions:
+                <br/>1) Create an account or login to your existing account at <a style={StakePoolStyles.stakepoolLink} onClick={function(x){shell.openExternal(x);}.bind(null, this.state.stakePoolHost)}>{this.state.stakePoolHost}</a>.
+                <br/>2) Once logged in, select the 'Settings' tab.
+                <br/>3) Copy and paste your Api Key into the field below (typically starts with 'eyJhb...').
+                <br/>4) Click Add and enter your private passphrase.
+                <br/>
+                <br/>
+                <span style={StakePoolStyles.highlighTextOrange}>Notice!</span> If you receive an error about the script not being redeemable when attempting to add your stakepool, you can try the following:
+                <br/> - Each stakepool account you create can only be associated with 1 wallet.  If you have previously created this stakepool account with a different wallet (different seed), then you must create a new account.
+                <br/> - If you had previously used a 'voting account', for your ticket purchases, please go to the Accounts page and create a new account (with any name).  This will now allow you to successfully import your script for your stakepool.
+              </span>
+            </div>
             <div style={StakePoolStyles.contentNestToAddress}>
-              <div style={StakePoolStyles.contentNestPrefixSend}>Api Key:</div>
-              <div style={StakePoolStyles.contentNestAddressHashBlock}>
+              <div style={StakePoolStyles.contentNestApiKey}>
                 <div style={StakePoolStyles.inputForm}>
                   <input
                     type="text"
@@ -587,9 +601,9 @@ class StakePool extends Component{
                     onBlur={(e) =>{this.updateApiKey(e.target.value);}}/>
                 </div>
               </div>
-            </div>
-            <div style={StakePoolStyles.apiKeyError}>
-              {this.state.apiKeyError}
+              <div style={StakePoolStyles.apiKeyError}>
+                {this.state.apiKeyError}
+              </div>
             </div>
           </div>
           <KeyBlueButton style={StakePoolStyles.contentSend} disabled={this.state.apiKey == ''} onClick={this.state.apiKey == '' ? null : () => this.showPassphraseModal(apiKeyHeading, apiKeyDescription, apiKeyFunc)}>

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -588,7 +588,7 @@ class StakePool extends Component{
                 <br/>
                 <span style={StakePoolStyles.highlighTextOrange}>Notice!</span> If you receive an error about the script not being redeemable when attempting to add your stakepool, you can try the following:
                 <br/> - Each stakepool account you create can only be associated with 1 wallet.  If you have previously created this stakepool account with a different wallet (different seed), then you must create a new account.
-                <br/> - If you had previously used a 'voting account', for your ticket purchases, please go to the Accounts page and create a new account (with any name).  This will now allow you to successfully import your script for your stakepool.
+                <br/> - If you had previously used a 'voting account', for your ticket purchases, please go to the Accounts page and create a new account.  This may now allow you to successfully import your script for your stakepool.
               </span>
             </div>
             <div style={StakePoolStyles.contentNestToAddress}>

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -337,7 +337,7 @@ class StakePool extends Component{
   cancelAddAnotherStakePool() {
     this.setState({addAnotherStakePool: false});
   }
-  setStakePoolInfo() {
+  setStakePoolInfo(privpass) {
     if (this.state.apiKey == '') {
       this.setState({apiKeyError: '*Please enter your API key'});
       return;
@@ -345,7 +345,7 @@ class StakePool extends Component{
     if (this.state.stakePoolHost == '' || this.state.apiKeyError !== null) {
       return;
     }
-    this.props.setStakePoolInformation(this.state.stakePoolHost, this.state.apiKey, 0);
+    this.props.setStakePoolInformation(privpass, this.state.stakePoolHost, this.state.apiKey, 0);
     setTimeout(this.setState({addAnotherStakePool: false}), 1000);
   }
   updateApiKey(apiKey) {
@@ -554,42 +554,56 @@ class StakePool extends Component{
         </select>);
     var selectNumTickets = (
       <NumTicketsInput numTickets={this.state.numTickets} incrementNumTickets={()=>this.incrementNumTickets()} decrementNumTickets={()=>this.decrementNumTickets()}/>);
-
+    var apiKeyDescription = (
+      <div>
+      </div>
+    );
+    var apiKeyHeading = 'Enter Passphrase to connect to you stakepool';
+    var apiKeyFunc = (privPass) => this.setStakePoolInfo(privPass);
     var stakePoolConfigInput = (
-      <div style={StakePoolStyles.content}>
-        <div style={StakePoolStyles.flexHeight}>
-          <div style={StakePoolStyles.contentNestFromAddress}>
-            <div style={StakePoolStyles.contentNestPrefixSend}>Stake Pool:</div>
-              {selectStakePoolApiKey}
-            <div style={StakePoolStyles.contentNestFromAddressWalletIcon}></div>
-          </div>
-          <div style={StakePoolStyles.contentNestToAddress}>
-            <div style={StakePoolStyles.contentNestPrefixSend}>Api Key:</div>
-            <div style={StakePoolStyles.contentNestAddressHashBlock}>
-              <div style={StakePoolStyles.inputForm}>
-                <input
-                  type="text"
-                  style={StakePoolStyles.contentNestAddressAmountSum}
-                  placeholder="API Key"
-                  onBlur={(e) =>{this.updateApiKey(e.target.value);}}/>
+      <div>
+        <PassphraseModal
+          hidden={!this.state.passphraseModalOpen}
+          submitPassphrase={this.state.modalSubmitFunc}
+          cancelPassphrase={()=>this.setState({modalHeading: null, modalDescription: null, modalSubmitFunc: null, passphraseModalOpen: false})}
+          heading={this.state.modalHeading}
+          description={this.state.modalDescription}
+        />
+        <div style={!this.state.passphraseModalOpen ? StakePoolStyles.content : StakePoolStyles.contentBlur}>
+          <div style={StakePoolStyles.flexHeight}>
+            <div style={StakePoolStyles.contentNestFromAddress}>
+              <div style={StakePoolStyles.contentNestPrefixSend}>Stake Pool:</div>
+                {selectStakePoolApiKey}
+              <div style={StakePoolStyles.contentNestFromAddressWalletIcon}></div>
+            </div>
+            <div style={StakePoolStyles.contentNestToAddress}>
+              <div style={StakePoolStyles.contentNestPrefixSend}>Api Key:</div>
+              <div style={StakePoolStyles.contentNestAddressHashBlock}>
+                <div style={StakePoolStyles.inputForm}>
+                  <input
+                    type="text"
+                    style={StakePoolStyles.contentNestAddressAmountSum}
+                    placeholder="API Key"
+                    onBlur={(e) =>{this.updateApiKey(e.target.value);}}/>
+                </div>
               </div>
             </div>
+            <div style={StakePoolStyles.apiKeyError}>
+              {this.state.apiKeyError}
+            </div>
           </div>
-          <div style={StakePoolStyles.apiKeyError}>
-            {this.state.apiKeyError}
-          </div>
+          <KeyBlueButton style={StakePoolStyles.contentSend} onClick={() => this.showPassphraseModal(apiKeyHeading, apiKeyDescription, apiKeyFunc)}>
+            Add
+          </KeyBlueButton>
+          {this.state.purchaseTicketsStakePoolConfig ?
+            <SlateGrayButton
+              style={StakePoolStyles.hideStakePoolConfig}
+              onClick={() => this.cancelAddAnotherStakePool()}>
+              Cancel
+            </SlateGrayButton> :
+            <div></div>
+          }
         </div>
-        <KeyBlueButton style={StakePoolStyles.contentSend} onClick={() => this.setStakePoolInfo()}>
-          Confirm
-        </KeyBlueButton>
-        {this.state.purchaseTicketsStakePoolConfig ?
-          <SlateGrayButton
-            style={StakePoolStyles.hideStakePoolConfig}
-            onClick={() => this.cancelAddAnotherStakePool()}>
-            Cancel
-          </SlateGrayButton> :
-          <div></div>
-        }
       </div>
     );
     var votingGuiView = (
@@ -712,7 +726,6 @@ class StakePool extends Component{
     );
     var importScriptHeading = 'Enter Passphrase to Import Script';
     var importScriptFunc = (privPass, script) => this.importScript(privPass, script);
-
     var purchaseTicketsView = (
       <div>
         <PassphraseModal

--- a/app/components/views/StakePool.js
+++ b/app/components/views/StakePool.js
@@ -346,7 +346,7 @@ class StakePool extends Component{
       return;
     }
     this.props.setStakePoolInformation(privpass, this.state.stakePoolHost, this.state.apiKey, 0);
-    setTimeout(this.setState({addAnotherStakePool: false}), 1000);
+    setTimeout(this.setState({passphraseModalOpen: false, addAnotherStakePool: false}), 1000);
   }
   updateApiKey(apiKey) {
     if (apiKey != '') {
@@ -558,7 +558,7 @@ class StakePool extends Component{
       <div>
       </div>
     );
-    var apiKeyHeading = 'Enter Passphrase to connect to you stakepool';
+    var apiKeyHeading = 'Enter private passphrase to connect to your stakepool';
     var apiKeyFunc = (privPass) => this.setStakePoolInfo(privPass);
     var stakePoolConfigInput = (
       <div>
@@ -592,7 +592,7 @@ class StakePool extends Component{
               {this.state.apiKeyError}
             </div>
           </div>
-          <KeyBlueButton style={StakePoolStyles.contentSend} onClick={() => this.showPassphraseModal(apiKeyHeading, apiKeyDescription, apiKeyFunc)}>
+          <KeyBlueButton style={StakePoolStyles.contentSend} disabled={this.state.apiKey == ''} onClick={this.state.apiKey == '' ? null : () => this.showPassphraseModal(apiKeyHeading, apiKeyDescription, apiKeyFunc)}>
             Add
           </KeyBlueButton>
           {this.state.purchaseTicketsStakePoolConfig ?

--- a/app/components/views/ViewStyles.js
+++ b/app/components/views/ViewStyles.js
@@ -1106,6 +1106,12 @@ export const StakePoolStyles = {
     height: '556px',
     padding: '54px 60px 54px 80px',
   },
+  contentBlur: {
+    filter: 'blur(6px)',
+    overflow: 'auto',
+    height: '556px',
+    padding: '54px 60px 54px 80px',
+  },
   contentVotingGui: {
     overflow: 'auto',
     height: '556px',

--- a/app/components/views/ViewStyles.js
+++ b/app/components/views/ViewStyles.js
@@ -1267,6 +1267,20 @@ export const StakePoolStyles = {
     paddingTop: '10px',
     float: 'left',
   },
+  contentNestApiKeyInstructions: {
+    width: '600px',
+    height: '260px',
+    paddingLeft: '30px',
+    float: 'left',
+  },
+  contentNestApiKey: {
+    position: 'relative',
+    paddingLeft: '65px',
+    width: '600px',
+    height: '34px',
+    float: 'left',
+    fontSize: '13px',
+  },
   contentNestToAddress: {
     width: '100%',
     height: '54px',
@@ -1411,6 +1425,9 @@ export const StakePoolStyles = {
   },
   highlightTextNeonGreen: {
     color: '#2ed8a3',
+  },
+  highlighTextOrange: {
+    color: '#fd714b',
   },
   numTicketsInput: {
     width: '111px',
@@ -2207,9 +2224,15 @@ export const StakePoolStyles = {
     width: '100%',
   },
   apiKeyError: {
-    paddingLeft: '118px',
+    paddingLeft: '70px',
     textAlign: 'left',
+    float: 'left',
     color: 'red',
+  },
+  stakepoolLink: {
+    color: '#2971ff',
+    fontWeight: 'bold',
+    cursor: 'pointer',
   },
   flexHeight: {
     paddingTop: '1px',


### PR DESCRIPTION
- Added instructions for better clarity about how to enter/set up your stakepool with decrediton. 
- Added import script check when apikey is entered to avoid situations where the stakepool account is not associated with the current wallet.  Now to link a stakepool via apikey it MUST be for that wallet.  This is also the reason for the private pass request when adding the stakepool.