### PR TITLE
Update styling on incoming transaction notifications

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -332,7 +332,9 @@ function importScriptAction(votingAddress, cb) {
             }
           }
         } else {
-          setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 1000);
+          if (!votingAddress && !cb) {
+            setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 1000);
+          }
           dispatch(importScriptSuccess(importScriptResponse, votingAddress, cb));
         }
       });
@@ -519,7 +521,7 @@ function publishTransactionError(error) {
 function publishTransactionSuccess(publishTransactionResponse) {
   return (dispatch) => {
     dispatch({ publishTransactionResponse: Buffer.from(publishTransactionResponse.getTransactionHash()), type: PUBLISHTX_SUCCESS });
-    dispatch(getAccountsAttempt());
+    setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
   };
 }
 
@@ -604,8 +606,8 @@ function purchaseTicketsSuccess(purchaseTicketsResponse) {
   return (dispatch) => {
     var success = 'You successfully purchased ' + purchaseTicketsResponse.getTicketHashesList().length + ' tickets.';
     dispatch({ success: success, purchaseTicketsResponse: purchaseTicketsResponse, type: PURCHASETICKETS_SUCCESS });
-    dispatch(getAccountsAttempt());
-    setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 1000);
+    setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
+    setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 4000);
   };
 }
 

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -123,15 +123,15 @@ function transactionNtfnsData(response) {
             break;
           }
         }
-        if (!found) { 
+        if (!found) {
           var type = 'Regular';
           var fee = response.getUnminedTransactionsList()[z].getFee();
           var inputAmts = 0;
           var outputAmts = 0;
-          for (var i = 0; i < response.getUnminedTransactionsList()[z].getDebitsList().length; i++) {
+          for (i = 0; i < response.getUnminedTransactionsList()[z].getDebitsList().length; i++) {
             inputAmts += response.getUnminedTransactionsList()[z].getDebitsList()[i].getPreviousAmount();
           }
-          for (var i = 0; i < response.getUnminedTransactionsList()[z].getCreditsList().length; i++) {
+          for (i = 0; i < response.getUnminedTransactionsList()[z].getCreditsList().length; i++) {
             outputAmts += response.getUnminedTransactionsList()[z].getCreditsList()[i].getAmount();
           }
           var amount = outputAmts - inputAmts;
@@ -144,23 +144,21 @@ function transactionNtfnsData(response) {
             type = 'Vote';
           } else if (response.getUnminedTransactionsList()[z].getTransactionType() == TransactionDetails.TransactionType.REVOKE) {
             type = 'Revoke';
-          }            
-          
+          }
+
           if (type == 'Regular' && amount > 0) {
             type = 'Receive';
           } else if (type == 'Regular' && amount < 0 && (fee == Math.abs(amount))) {
             type = 'Transfer';
           } else if (type == 'Regular' && amount < 0 && (fee != Math.abs(amount))) {
-            console.log(fee, amount);
             type = 'Send';
           }
-
           var message = {
             txHash: reverseHash(Buffer.from(response.getUnminedTransactionsList()[z].getHash()).toString('hex')),
-            type: type, 
+            type: type,
             amount: amount,
             fee: fee,
-          }
+          };
           dispatch({unmined: response.getUnminedTransactionsList()[z], unminedMessage: message, type: TRANSACTIONNTFNS_DATA_UNMINED });
         }
       }

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -144,12 +144,12 @@ function transactionNtfnsData(response) {
             setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
           } else if (response.getUnminedTransactionsList()[z].getTransactionType() == TransactionDetails.TransactionType.REVOKE) {
             type = 'Revoke';
-              setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
+            setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
           }
 
           if (type == 'Regular' && amount > 0) {
             type = 'Receive';
-              setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
+            setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
           } else if (type == 'Regular' && amount < 0 && (fee == Math.abs(amount))) {
             type = 'Transfer';
           } else if (type == 'Regular' && amount < 0 && (fee != Math.abs(amount))) {

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -114,7 +114,6 @@ function transactionNtfnsData(response) {
         dispatch({currentHeight: currentHeight, timeBackString: timeBackString(daysBack), type: TRANSACTIONNTFNS_SYNCING });
       }
     } else if (response.getUnminedTransactionsList().length > 0) {
-      setTimeout( () => {dispatch(getAccountsAttempt());}, 1000);
       for (var z = 0; z < response.getUnminedTransactionsList().length; z++) {
         var found = false;
         for (var y = 0; y < unmined.length; y++) {
@@ -142,12 +141,15 @@ function transactionNtfnsData(response) {
             type = 'Ticket';
           } else if (response.getUnminedTransactionsList()[z].getTransactionType() == TransactionDetails.TransactionType.VOTE) {
             type = 'Vote';
+            setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
           } else if (response.getUnminedTransactionsList()[z].getTransactionType() == TransactionDetails.TransactionType.REVOKE) {
             type = 'Revoke';
+              setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
           }
 
           if (type == 'Regular' && amount > 0) {
             type = 'Receive';
+              setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
           } else if (type == 'Regular' && amount < 0 && (fee == Math.abs(amount))) {
             type = 'Transfer';
           } else if (type == 'Regular' && amount < 0 && (fee != Math.abs(amount))) {

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -134,18 +134,26 @@ class Header extends React.Component {
     super(props);
     this.state = {
       open: false,
+      ntfns: null,
     };
   }
   componentWillReceiveProps(nextProps) {
-    if (this.props.newUnminedMessage !== nextProps.newUnminedMessage) {
-      this.setState({
-        open: true,
-      });
+    if (this.state.ntfns == null && this.props.newUnminedMessage !== nextProps.newUnminedMessage) {
+        this.setState({
+          open: true,
+          ntfns: nextProps.newUnminedMessage
+        });
+    } else if (this.props.newUnminedMessage !== nextProps.newUnminedMessage) {
+        setTimeout(()=>this.setState({
+          open: true,
+          ntfns: nextProps.newUnminedMessage
+        }), 4000);
     }
   }
   handleRequestClose() {
     this.setState({
       open: false,
+      ntfns: null
     });
   }
 
@@ -163,37 +171,37 @@ class Header extends React.Component {
       );
     } else {
       var snackbarContentStyle;
-      if (this.props.newUnminedMessage !== null) {
-        if (this.props.newUnminedMessage.type == 'Ticket' || this.props.newUnminedMessage.type == 'Vote' || this.props.newUnminedMessage.type == 'Revoke') {
+      if (this.state.ntfns !== null) {
+        if (this.state.ntfns.type == 'Ticket' || this.state.ntfns.type == 'Vote' || this.state.ntfns.type == 'Revoke') {
           snackbarContentStyle = styles.SnackbarContentStake;
-        } else if (this.props.newUnminedMessage.type == 'Receive') {
+        } else if (this.state.ntfns.type == 'Receive') {
           snackbarContentStyle = styles.SnackbarContentReceive;
-        } else if (this.props.newUnminedMessage.type == 'Send') {
+        } else if (this.state.ntfns.type == 'Send') {
           snackbarContentStyle = styles.SnackbarContentSend;
-        } else if (this.props.newUnminedMessage.type == 'Transfer') {
+        } else if (this.state.ntfns.type == 'Transfer') {
           snackbarContentStyle = styles.SnackbarContentTransfer;
         }
       }
       var newNtfns = '';
-      if (this.props.newUnminedMessage !== null) {
-        if (this.props.newUnminedMessage.type == 'Ticket' || this.props.newUnminedMessage.type == 'Send' || this.props.newUnminedMessage.type == 'Transfer' || this.props.newUnminedMessage.type == 'Receive') {
+      if (this.state.ntfns !== null) {
+        if (this.state.ntfns.type == 'Ticket' || this.state.ntfns.type == 'Send' || this.state.ntfns.type == 'Transfer' || this.state.ntfns.type == 'Receive') {
           newNtfns = (<div style={styles.SnackbarInformation}>
                         <div style={styles.SnackbarInformationRow}>
-                          <div style={styles.SnackbarInformationRowTx}>{this.props.newUnminedMessage.txHash}</div>
+                          <div style={styles.SnackbarInformationRowTx}>{this.state.ntfns.txHash}</div>
                         </div>
                         <div style={styles.SnackbarInformationRow}>
-                          <div style={styles.SnackbarInformationRowType}>{this.props.newUnminedMessage.type}</div>
-                          <div style={styles.SnackbarInformationRowAmount}>Amount  <Balance amount={this.props.newUnminedMessage.amount}/></div>
-                          <div style={styles.SnackbarInformationRowFee}>Fee  <Balance amount={this.props.newUnminedMessage.fee}/></div>
+                          <div style={styles.SnackbarInformationRowType}>{this.state.ntfns.type}</div>
+                          <div style={styles.SnackbarInformationRowAmount}>Amount  <Balance amount={this.state.ntfns.amount}/></div>
+                          <div style={styles.SnackbarInformationRowFee}>Fee  <Balance amount={this.state.ntfns.fee}/></div>
                         </div>
                       </div>);
         } else {
           newNtfns = (<div style={styles.SnackbarInformation}>
                         <div style={styles.SnackbarInformationRow}>
-                          <div style={styles.SnackbarInformationRowTx}>{this.props.newUnminedMessage.txHash}</div>
+                          <div style={styles.SnackbarInformationRowTx}>{this.state.ntfns.txHash}</div>
                         </div>
                         <div style={styles.SnackbarInformationRow}>
-                          <div style={styles.SnackbarInformationRowType}>{this.props.newUnminedMessage.type}</div>
+                          <div style={styles.SnackbarInformationRowType}>{this.state.ntfns.type}</div>
                         </div>
                       </div>);
         }

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -134,26 +134,68 @@ class Header extends React.Component {
     super(props);
     this.state = {
       open: false,
-      ntfns: null,
+      ntfns: '',
+      snackBarContent: {},
     };
   }
   componentWillReceiveProps(nextProps) {
-    if (this.state.ntfns == null && this.props.newUnminedMessage !== nextProps.newUnminedMessage) {
-      this.setState({
-        open: true,
-        ntfns: nextProps.newUnminedMessage
-      });
-    } else if (this.props.newUnminedMessage !== nextProps.newUnminedMessage) {
-      setTimeout(()=>this.setState({
-        open: true,
-        ntfns: nextProps.newUnminedMessage
-      }), 4000);
+    if (this.props.newUnminedMessage !== nextProps.newUnminedMessage) {
+      var snackbarContentStyle = {};
+      if (nextProps.newUnminedMessage !== null) {
+        if (nextProps.newUnminedMessage.type == 'Ticket' || nextProps.newUnminedMessage.type == 'Vote' || nextProps.newUnminedMessage.type == 'Revoke') {
+          snackbarContentStyle = styles.SnackbarContentStake;
+        } else if (nextProps.newUnminedMessage.type == 'Receive') {
+          snackbarContentStyle = styles.SnackbarContentReceive;
+        } else if (nextProps.newUnminedMessage.type == 'Send') {
+          snackbarContentStyle = styles.SnackbarContentSend;
+        } else if (nextProps.newUnminedMessage.type == 'Transfer') {
+          snackbarContentStyle = styles.SnackbarContentTransfer;
+        }
+      }
+      var newNtfns;
+      if (nextProps.newUnminedMessage !== null) {
+        if (nextProps.newUnminedMessage.type == 'Ticket' || nextProps.newUnminedMessage.type == 'Send' || nextProps.newUnminedMessage.type == 'Transfer' || nextProps.newUnminedMessage.type == 'Receive') {
+          newNtfns = (<div style={styles.SnackbarInformation}>
+                        <div style={styles.SnackbarInformationRow}>
+                          <div style={styles.SnackbarInformationRowTx}>{nextProps.newUnminedMessage.txHash}</div>
+                        </div>
+                        <div style={styles.SnackbarInformationRow}>
+                          <div style={styles.SnackbarInformationRowType}>{nextProps.newUnminedMessage.type}</div>
+                          <div style={styles.SnackbarInformationRowAmount}>Amount  <Balance amount={nextProps.newUnminedMessage.amount}/></div>
+                          <div style={styles.SnackbarInformationRowFee}>Fee  <Balance amount={nextProps.newUnminedMessage.fee}/></div>
+                        </div>
+                      </div>);
+        } else {
+          newNtfns = (<div style={styles.SnackbarInformation}>
+                        <div style={styles.SnackbarInformationRow}>
+                          <div style={styles.SnackbarInformationRowTx}>{nextProps.newUnminedMessage.txHash}</div>
+                        </div>
+                        <div style={styles.SnackbarInformationRow}>
+                          <div style={styles.SnackbarInformationRowType}>{nextProps.newUnminedMessage.type}</div>
+                        </div>
+                      </div>);
+        }
+      }
+      if (this.state.ntfns == '') {
+        this.setState({
+          open: true,
+          ntfns: newNtfns,
+          snackbarContentStyle: snackbarContentStyle,
+        });
+      } else {
+        setTimeout(()=>this.setState({
+          open: true,
+          ntfns: newNtfns,
+          snackbarContentStyle: snackbarContentStyle,
+        }), 4500);
+      }
     }
   }
   handleRequestClose() {
     this.setState({
       open: false,
-      ntfns: null
+      ntfns: '',
+      snackbarContentStyle: {},
     });
   }
 
@@ -170,50 +212,14 @@ class Header extends React.Component {
         </div>
       );
     } else {
-      var snackbarContentStyle;
-      if (this.state.ntfns !== null) {
-        if (this.state.ntfns.type == 'Ticket' || this.state.ntfns.type == 'Vote' || this.state.ntfns.type == 'Revoke') {
-          snackbarContentStyle = styles.SnackbarContentStake;
-        } else if (this.state.ntfns.type == 'Receive') {
-          snackbarContentStyle = styles.SnackbarContentReceive;
-        } else if (this.state.ntfns.type == 'Send') {
-          snackbarContentStyle = styles.SnackbarContentSend;
-        } else if (this.state.ntfns.type == 'Transfer') {
-          snackbarContentStyle = styles.SnackbarContentTransfer;
-        }
-      }
-      var newNtfns = '';
-      if (this.state.ntfns !== null) {
-        if (this.state.ntfns.type == 'Ticket' || this.state.ntfns.type == 'Send' || this.state.ntfns.type == 'Transfer' || this.state.ntfns.type == 'Receive') {
-          newNtfns = (<div style={styles.SnackbarInformation}>
-                        <div style={styles.SnackbarInformationRow}>
-                          <div style={styles.SnackbarInformationRowTx}>{this.state.ntfns.txHash}</div>
-                        </div>
-                        <div style={styles.SnackbarInformationRow}>
-                          <div style={styles.SnackbarInformationRowType}>{this.state.ntfns.type}</div>
-                          <div style={styles.SnackbarInformationRowAmount}>Amount  <Balance amount={this.state.ntfns.amount}/></div>
-                          <div style={styles.SnackbarInformationRowFee}>Fee  <Balance amount={this.state.ntfns.fee}/></div>
-                        </div>
-                      </div>);
-        } else {
-          newNtfns = (<div style={styles.SnackbarInformation}>
-                        <div style={styles.SnackbarInformationRow}>
-                          <div style={styles.SnackbarInformationRowTx}>{this.state.ntfns.txHash}</div>
-                        </div>
-                        <div style={styles.SnackbarInformationRow}>
-                          <div style={styles.SnackbarInformationRowType}>{this.state.ntfns.type}</div>
-                        </div>
-                      </div>);
-        }
-      }
       return (
         <div>
           <Snackbar
             style={styles.Snackbar}
             open={this.state.open}
-            message={newNtfns}
+            message={this.state.ntfns}
             autoHideDuration={4000}
-            bodyStyle={snackbarContentStyle}
+            bodyStyle={this.state.snackbarContentStyle}
             onRequestClose={(reason) => {
               if (reason != 'clickaway')
                 this.handleRequestClose();

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -100,7 +100,7 @@ const styles = {
     backgroundSize: '20px',
     backgroundRepeat: 'no-repeat',
   },
-  SnackbarInformation: {    
+  SnackbarInformation: {
     fontFamily: 'Source Sans Pro, sans-serif',
     width: '100%',
   },
@@ -163,20 +163,20 @@ class Header extends React.Component {
       );
     } else {
       var snackbarContentStyle;
-      if (this.props.newUnminedMessage !== null) { 
+      if (this.props.newUnminedMessage !== null) {
         if (this.props.newUnminedMessage.type == 'Ticket' || this.props.newUnminedMessage.type == 'Vote' || this.props.newUnminedMessage.type == 'Revoke') {
-          snackbarContentStyle = styles.SnackbarContentStake
+          snackbarContentStyle = styles.SnackbarContentStake;
         } else if (this.props.newUnminedMessage.type == 'Receive') {
-          snackbarContentStyle = styles.SnackbarContentReceive
+          snackbarContentStyle = styles.SnackbarContentReceive;
         } else if (this.props.newUnminedMessage.type == 'Send') {
-          snackbarContentStyle = styles.SnackbarContentSend
+          snackbarContentStyle = styles.SnackbarContentSend;
         } else if (this.props.newUnminedMessage.type == 'Transfer') {
-          snackbarContentStyle = styles.SnackbarContentTransfer
+          snackbarContentStyle = styles.SnackbarContentTransfer;
         }
       }
       var newNtfns = '';
       if (this.props.newUnminedMessage !== null) {
-        if (this.props.newUnminedMessage.type == 'Ticket' || this.props.newUnminedMessage.type == 'Send' || this.props.newUnminedMessage.type == 'Transfer' || this.props.newUnminedMessage.type == 'Receive') { 
+        if (this.props.newUnminedMessage.type == 'Ticket' || this.props.newUnminedMessage.type == 'Send' || this.props.newUnminedMessage.type == 'Transfer' || this.props.newUnminedMessage.type == 'Receive') {
           newNtfns = (<div style={styles.SnackbarInformation}>
                         <div style={styles.SnackbarInformationRow}>
                           <div style={styles.SnackbarInformationRowTx}>{this.props.newUnminedMessage.txHash}</div>
@@ -185,13 +185,13 @@ class Header extends React.Component {
                           <div style={styles.SnackbarInformationRowType}>{this.props.newUnminedMessage.type}</div>
                           <div style={styles.SnackbarInformationRowAmount}>Amount  <Balance amount={this.props.newUnminedMessage.amount}/></div>
                           <div style={styles.SnackbarInformationRowFee}>Fee  <Balance amount={this.props.newUnminedMessage.fee}/></div>
-                        </div> 
+                        </div>
                       </div>);
         } else {
           newNtfns = (<div style={styles.SnackbarInformation}>
                         <div style={styles.SnackbarInformationRow}>
                           <div style={styles.SnackbarInformationRowTx}>{this.props.newUnminedMessage.txHash}</div>
-                        </div> 
+                        </div>
                         <div style={styles.SnackbarInformationRow}>
                           <div style={styles.SnackbarInformationRowType}>{this.props.newUnminedMessage.type}</div>
                         </div>

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -6,6 +6,7 @@ import WalletGray from './icons/wallet-gray.svg';
 import TicketSmall from './icons/tickets-ticket.svg';
 import PlusBig from './icons/plus-big.svg';
 import MinusBig from './icons/minus-big.svg';
+import Balance from './Balance';
 
 function mapStateToProps(state) {
   return {
@@ -59,11 +60,12 @@ const styles = {
     fontSize: '53px',
   },
   Snackbar: {
+    fontFamily: 'inherit',
     position: 'absolute',
     left: '61%',
   },
   SnackbarContentSend: {
-    height: '110px',
+    height: '78px',
     padding: '0px 50px',
     backgroundColor: 'rgba(12, 30, 62, 0.5)',
     backgroundImage: `url(${MinusBig})`,
@@ -72,7 +74,7 @@ const styles = {
     backgroundRepeat: 'no-repeat',
   },
   SnackbarContentReceive: {
-    height: '110px',
+    height: '78px',
     padding: '0px 50px',
     backgroundColor: 'rgba(12, 30, 62, 0.5)',
     backgroundImage: `url(${PlusBig})`,
@@ -81,7 +83,7 @@ const styles = {
     backgroundRepeat: 'no-repeat',
   },
   SnackbarContentStake: {
-    height: '110px',
+    height: '78px',
     padding: '0px 50px',
     backgroundColor: 'rgba(12, 30, 62, 0.5)',
     backgroundImage: `url(${TicketSmall})`,
@@ -90,13 +92,41 @@ const styles = {
     backgroundRepeat: 'no-repeat',
   },
   SnackbarContentTransfer: {
-    height: '110px',
+    height: '78px',
     padding: '0px 50px',
     backgroundColor: 'rgba(12, 30, 62, 0.5)',
     backgroundImage: `url(${WalletGray})`,
     backgroundPosition: '15px 50%',
     backgroundSize: '20px',
     backgroundRepeat: 'no-repeat',
+  },
+  SnackbarInformation: {    
+    fontFamily: 'Source Sans Pro, sans-serif',
+    width: '100%',
+  },
+  SnackbarInformationRow: {
+    width: '100%',
+    float: 'left',
+    height: '25px',
+  },
+  SnackbarInformationRowType: {
+    width: '30%',
+    float: 'left',
+  },
+  SnackbarInformationRowAmount: {
+    width: '40%',
+    float: 'left',
+  },
+  SnackbarInformationRowFee: {
+    width: '30%',
+    float: 'left',
+    textAlign: 'right',
+  },
+  SnackbarInformationRowTx: {
+    width: '100%',
+    float: 'left',
+    textAlign: 'center',
+    fontFamily: 'Inconsolata, monospace',
   }
 };
 class Header extends React.Component {
@@ -132,14 +162,50 @@ class Header extends React.Component {
         </div>
       );
     } else {
+      var snackbarContentStyle;
+      if (this.props.newUnminedMessage !== null) { 
+        if (this.props.newUnminedMessage.type == 'Ticket' || this.props.newUnminedMessage.type == 'Vote' || this.props.newUnminedMessage.type == 'Revoke') {
+          snackbarContentStyle = styles.SnackbarContentStake
+        } else if (this.props.newUnminedMessage.type == 'Receive') {
+          snackbarContentStyle = styles.SnackbarContentReceive
+        } else if (this.props.newUnminedMessage.type == 'Send') {
+          snackbarContentStyle = styles.SnackbarContentSend
+        } else if (this.props.newUnminedMessage.type == 'Transfer') {
+          snackbarContentStyle = styles.SnackbarContentTransfer
+        }
+      }
+      var newNtfns = '';
+      if (this.props.newUnminedMessage !== null) {
+        if (this.props.newUnminedMessage.type == 'Ticket' || this.props.newUnminedMessage.type == 'Send' || this.props.newUnminedMessage.type == 'Transfer' || this.props.newUnminedMessage.type == 'Receive') { 
+          newNtfns = (<div style={styles.SnackbarInformation}>
+                        <div style={styles.SnackbarInformationRow}>
+                          <div style={styles.SnackbarInformationRowTx}>{this.props.newUnminedMessage.txHash}</div>
+                        </div>
+                        <div style={styles.SnackbarInformationRow}>
+                          <div style={styles.SnackbarInformationRowType}>{this.props.newUnminedMessage.type}</div>
+                          <div style={styles.SnackbarInformationRowAmount}>Amount  <Balance amount={this.props.newUnminedMessage.amount}/></div>
+                          <div style={styles.SnackbarInformationRowFee}>Fee  <Balance amount={this.props.newUnminedMessage.fee}/></div>
+                        </div> 
+                      </div>);
+        } else {
+          newNtfns = (<div style={styles.SnackbarInformation}>
+                        <div style={styles.SnackbarInformationRow}>
+                          <div style={styles.SnackbarInformationRowTx}>{this.props.newUnminedMessage.txHash}</div>
+                        </div> 
+                        <div style={styles.SnackbarInformationRow}>
+                          <div style={styles.SnackbarInformationRowType}>{this.props.newUnminedMessage.type}</div>
+                        </div>
+                      </div>);
+        }
+      }
       return (
         <div>
           <Snackbar
             style={styles.Snackbar}
             open={this.state.open}
-            message={this.props.newUnminedMessage !== null ? this.props.newUnminedMessage : ''}
-            autoHideDuration={5000}
-            bodyStyle={styles.SnackbarContentTransfer}
+            message={newNtfns}
+            autoHideDuration={4000}
+            bodyStyle={snackbarContentStyle}
             onRequestClose={(reason) => {
               if (reason != 'clickaway')
                 this.handleRequestClose();

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -139,15 +139,15 @@ class Header extends React.Component {
   }
   componentWillReceiveProps(nextProps) {
     if (this.state.ntfns == null && this.props.newUnminedMessage !== nextProps.newUnminedMessage) {
-        this.setState({
-          open: true,
-          ntfns: nextProps.newUnminedMessage
-        });
+      this.setState({
+        open: true,
+        ntfns: nextProps.newUnminedMessage
+      });
     } else if (this.props.newUnminedMessage !== nextProps.newUnminedMessage) {
-        setTimeout(()=>this.setState({
-          open: true,
-          ntfns: nextProps.newUnminedMessage
-        }), 4000);
+      setTimeout(()=>this.setState({
+        open: true,
+        ntfns: nextProps.newUnminedMessage
+      }), 4000);
     }
   }
   handleRequestClose() {

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -2,6 +2,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Snackbar from 'material-ui/Snackbar';
+import WalletGray from './icons/wallet-gray.svg';
+import TicketSmall from './icons/tickets-ticket.svg';
+import PlusBig from './icons/plus-big.svg';
+import MinusBig from './icons/minus-big.svg';
 
 function mapStateToProps(state) {
   return {
@@ -55,15 +59,44 @@ const styles = {
     fontSize: '53px',
   },
   Snackbar: {
-    width: '100%',
-    backgroundColor: 'rgb(12, 30, 62)',
-    transform: '',
-    bottom: '697px',
-    left: '298px',
+    position: 'absolute',
+    left: '61%',
   },
-  SnackbarContent: {
-    backgroundColor: 'rgb(12, 30, 62)',
-    maxWidth: '100%',
+  SnackbarContentSend: {
+    height: '110px',
+    padding: '0px 50px',
+    backgroundColor: 'rgba(12, 30, 62, 0.5)',
+    backgroundImage: `url(${MinusBig})`,
+    backgroundPosition: '15px 50%',
+    backgroundSize: '20px',
+    backgroundRepeat: 'no-repeat',
+  },
+  SnackbarContentReceive: {
+    height: '110px',
+    padding: '0px 50px',
+    backgroundColor: 'rgba(12, 30, 62, 0.5)',
+    backgroundImage: `url(${PlusBig})`,
+    backgroundPosition: '15px 50%',
+    backgroundSize: '20px',
+    backgroundRepeat: 'no-repeat',
+  },
+  SnackbarContentStake: {
+    height: '110px',
+    padding: '0px 50px',
+    backgroundColor: 'rgba(12, 30, 62, 0.5)',
+    backgroundImage: `url(${TicketSmall})`,
+    backgroundPosition: '15px 50%',
+    backgroundSize: '20px',
+    backgroundRepeat: 'no-repeat',
+  },
+  SnackbarContentTransfer: {
+    height: '110px',
+    padding: '0px 50px',
+    backgroundColor: 'rgba(12, 30, 62, 0.5)',
+    backgroundImage: `url(${WalletGray})`,
+    backgroundPosition: '15px 50%',
+    backgroundSize: '20px',
+    backgroundRepeat: 'no-repeat',
   }
 };
 class Header extends React.Component {
@@ -105,8 +138,8 @@ class Header extends React.Component {
             style={styles.Snackbar}
             open={this.state.open}
             message={this.props.newUnminedMessage !== null ? this.props.newUnminedMessage : ''}
-            autoHideDuration={4000}
-            bodyStyle={styles.SnackbarContent}
+            autoHideDuration={5000}
+            bodyStyle={styles.SnackbarContentTransfer}
             onRequestClose={(reason) => {
               if (reason != 'clickaway')
                 this.handleRequestClose();


### PR DESCRIPTION
Will be sticking with material-ui Snackbar implementation for now until a better/more flexible solution can be developed.  Ideally we can add an onClick that would go to the transaction details page and also the ability to 'stack' notifications.  Currently it just shows one then disappears.