### PR TITLE
Change timestamp for winston logs to match dcrd and dcrwallet logs

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -66,7 +66,7 @@ var logger = new (winston.Logger)({
         // Format the timestamp in local time like the dcrd and dcrwallet logs.
         let pad = (s, n) => {
           n = n || 2;
-          s = Array(n).join("0").substring(0, n) + s;
+          s = Array(n).join("0") + s;
           return s.substring(s.length - n);
         };
 

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -59,7 +59,28 @@ var cfg = getCfg();
 
 var logger = new (winston.Logger)({
   transports: [
-    new (winston.transports.File)({ json: false, filename: path.join(app.getPath("userData"),"decrediton.log") })
+    new (winston.transports.File)({
+      json: false,
+      filename: path.join(app.getPath("userData"),"decrediton.log"),
+      timestamp: function() {
+        // Format the timestamp in local time like the dcrd and dcrwallet logs.
+        let pad = (s, n) => {
+          n = n || 2;
+          s = Array(n).join("0").substring(0, n) + s;
+          return s.substring(s.length - n);
+        };
+
+        let date = new Date();
+        let y = date.getFullYear();
+        let mo = pad(date.getMonth() + 1);
+        let d = pad(date.getDate());
+        let h = pad(date.getHours());
+        let mi = pad(date.getMinutes());
+        let s = pad(date.getSeconds());
+        let ms = pad(date.getMilliseconds(), 3);
+        return `${y}-${mo}-${d} ${h}:${mi}:${s}.${ms}`;
+      }
+    })
   ]
 });
 


### PR DESCRIPTION
This changes the logfile timestamps from the format `2017-08-01T15:16:29.794Z` (in GMT) to `2017-08-01 13:00:38.199` (local time), which matches the format used by dcrd and dcrwallet log files.