### PR TITLE
Add JSON validation of config file on startup

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -129,9 +129,19 @@ export function getCfg(update) {
 }
 
 export function getCfgPath() {
-  const Config = require("electron-config");
-  const config = new Config();
-  return config.path;
+  return path.resolve(appDataDirectory(), "config.json");
+}
+
+export function validateCfgFile() {
+  try {
+    JSON.parse(fs.readFileSync(getCfgPath(), "utf8"));
+  }
+  catch(err) {
+    console.log(err);
+    return err;
+  }
+
+  return null;
 }
 
 // In all the functions below the Windows path is constructed based on

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,5 +1,5 @@
-import { app, BrowserWindow, Menu, shell } from "electron";
-import { getCfg, appDataDirectory, dcrdCfg, dcrwCfg, writeCfgs, getDcrdPath } from "./config.js";
+import { app, BrowserWindow, Menu, shell, dialog } from "electron";
+import { getCfg, appDataDirectory, validateCfgFile, getCfgPath, dcrdCfg, dcrwCfg, writeCfgs, getDcrdPath } from "./config.js";
 import path from "path";
 import os from "os";
 import parseArgs from "minimist";
@@ -54,6 +54,15 @@ if (process.env.NODE_ENV === "development") {
 
 // Always use reasonable path for save data.
 app.setPath("userData", appDataDirectory());
+
+// Verify that config.json is valid JSON before fetching it, because
+// it will silently fail when fetching.
+let err = validateCfgFile();
+if(err !== null) {
+  let errMessage = "There was an error while trying to load the config file, the format is invalid.\n\nFile: " + getCfgPath() + "\nError: " + err;
+  dialog.showErrorBox("Config File Error", errMessage);
+  app.quit();
+}
 var cfg = getCfg();
 
 var logger = new (winston.Logger)({


### PR DESCRIPTION
If JSON validation fails for `config.json`, the `electron-config` library silently fails and overwrites the file with default values. We shouldn't punish the user for making a minor mistake like this, so I've added validation before the file is initially fetched. I've also changed the implementation of `getCfgPath` because simply creating a new instance from the `electron-config` library will cause the config file to be overwritten.

An error dialog will be shown if JSON validation fails and the app will exit:

![image](https://user-images.githubusercontent.com/1452379/29569637-1f7c0c66-8722-11e7-96d7-fd678a311885.png)

