### PR TITLE
Fix bug where agenda overview and card are displayed at the same time

### DIFF
--- a/app/components/VotingPrefs/Page.js
+++ b/app/components/VotingPrefs/Page.js
@@ -28,7 +28,7 @@ const VotingPrefsPage = ({
     </div>
     {(stakePool && stakePool.isVersionValid) ? (
       <div className="stakepool-voting-agenda-area">
-        {(selectedAgenda && stakePool) ? (
+        {selectedAgenda ? (
           <AgendaOverview
             agenda={selectedAgenda}
             selectedChoice={getAgendaSelectedChoice(selectedAgenda)}

--- a/app/components/VotingPrefs/Page.js
+++ b/app/components/VotingPrefs/Page.js
@@ -38,7 +38,7 @@ const VotingPrefsPage = ({
         ) : null}
         {(agendas.length > 0) ? (
           agendas.map(agenda =>
-            (!selectedAgenda || (selectedAgenda && agenda.getId() !== selectedAgenda.getId())) ? (
+            (!selectedAgenda || selectedAgenda.getId() !== agenda.getId()) ? (
               <AgendaCard
                 key={agenda.getId()}
                 agenda={agenda}

--- a/app/components/VotingPrefs/Page.js
+++ b/app/components/VotingPrefs/Page.js
@@ -38,7 +38,7 @@ const VotingPrefsPage = ({
         ) : null}
         {(agendas.length > 0) ? (
           agendas.map(agenda =>
-            (!selectedAgenda || (selectedAgenda && agenda.getId() === selectedAgenda.getId())) ? (
+            (!selectedAgenda || (selectedAgenda && agenda.getId() !== selectedAgenda.getId())) ? (
               <AgendaCard
                 key={agenda.getId()}
                 agenda={agenda}


### PR DESCRIPTION
Fixes an issue on the vote settings screen where selecting an agenda card to show the overview didn't hide the card:

![image](https://user-images.githubusercontent.com/1452379/30432208-eecc5322-992e-11e7-97a8-faae21cc0c86.png)