### PR TITLE
Read version from binaries and display in about window

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -413,7 +413,7 @@ const readExesVersion = () => {
       continue;
     }
 
-    let decodedLine = versionLine.match(/\w+ version ([^\s\+]+)/);
+    let decodedLine = versionLine.match(/\w+ version ([^\s]+)/);
     if (decodedLine !== null) {
       versions[exe] = decodedLine[1];
     } else {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -390,6 +390,40 @@ const launchDCRWallet = () => {
   return dcrwPID;
 };
 
+const readExesVersion = () => {
+  let spawn = require("child_process").spawnSync;
+  let args = ["--version"];
+  let exes = ["dcrd", "dcrwallet", "dcrctl"];
+  let versions = {
+    decrediton: app.getVersion()
+  };
+
+  for (let exe of exes) {
+    let exePath = path.join(execPath, "bin", "dcrd");
+
+    let proc = spawn(exePath, args, { encoding: "utf8" });
+    if (proc.error) {
+      logger.log("error", `Error trying to read version of ${exe}: ${proc.error}`);
+      continue;
+    }
+
+    let versionLine = proc.stdout.toString();
+    if (!versionLine) {
+      logger.log("error", `Empty version line when reading version of ${exe}`);
+      continue;
+    }
+
+    let decodedLine = versionLine.match(/\w+ version ([^\s\+]+)/);
+    if (decodedLine !== null) {
+      versions[exe] = decodedLine[1];
+    } else {
+      logger.log("error", `Unable to decode version line ${versionLine}`);
+    }
+  }
+
+  return versions;
+};
+
 app.on("ready", async () => {
   await installExtensions();
   // Write application config files.
@@ -592,6 +626,7 @@ app.on("ready", async () => {
             versionWin.loadURL(`file://${__dirname}/version/version.html`);
 
             versionWin.once("ready-to-show", () => {
+              versionWin.webContents.send("exes-versions", readExesVersion());
               versionWin.show();
             });
           }

--- a/app/version/version.html
+++ b/app/version/version.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>About</title>
+    <script src="version.js"></script>
     <style>
       body {
         background-color: #0c1e3e;
@@ -39,10 +40,10 @@
       <svg height="250px" width="250px" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500"><defs><style>.cls-1{fill:#2ed8a3;}.cls-2{fill:#2972ff;}</style></defs><title>decred - symbol -primary - positive</title><g id="_Group_" data-name="&lt;Group&gt;"><g id="_Group_2" data-name="&lt;Group&gt;"><g id="_Group_3" data-name="&lt;Group&gt;"><path id="_Path_" data-name="&lt;Path&gt;" class="cls-1" d="M231.88,278.06H306.1a50,50,0,0,0,0-100H282.45l-50.57-43.9H306.1a93.92,93.92,0,0,1,35.37,180.92L400,365.86H333Z"/></g><g id="_Group_4" data-name="&lt;Group&gt;"><path id="_Path_2" data-name="&lt;Path&gt;" class="cls-2" d="M268.12,221.95H193.9a50,50,0,0,0,0,100h23.64l50.57,43.9H193.9a93.92,93.92,0,0,1-35.38-180.92L100,134.14h67Z"/></g></g></g></svg>
     </div>
     <div class="version-area">
-      <h1>Decrediton <span class="smaller">v1.1.0</span></h1>
-      <h3><a target="_blank" href="https://github.com/decred/decred-binaries/releases/tag/v1.1.0">What's New</a></h3>
-      <h3>dcrd <span class="smaller">v1.1.0</span></h3>
-      <h3>dcrwallet <span class="smaller">v1.1.0</span></h3>
+      <h1>Decrediton <span class="smaller" id="decreditonVersion"></span></h1>
+      <h3><a target="_blank" id="whatsNewLink">What's New</a></h3>
+      <h3>dcrd <span class="smaller" id="dcrdVersion"></span></h3>
+      <h3>dcrwallet <span class="smaller" id="dcrwalletVersion"></span></h3>
     </div>
   </body>
 </html>

--- a/app/version/version.js
+++ b/app/version/version.js
@@ -1,0 +1,9 @@
+
+let ipcRenderer = require("electron").ipcRenderer;
+ipcRenderer.on("exes-versions", function (event, versions) {
+  document.getElementById("decreditonVersion").innerHTML = versions["decrediton"];
+  document.getElementById("dcrdVersion").innerHTML = versions["dcrd"];
+  document.getElementById("dcrwalletVersion").innerHTML = versions["dcrwallet"];
+  document.getElementById("whatsNewLink").href =
+    `https://github.com/decred/decred-binaries/releases/tag/v${versions["decrediton"]}`;
+});


### PR DESCRIPTION
Fixes first part of #669.

During development, Decrediton version will **not** show up correctly because of [issue 7085 of electron package](https://github.com/electron/electron/issues/7085).