### PR TITLE
fixed overlapping divs in AgendaCard

### DIFF
--- a/app/style/AgendaCard.less
+++ b/app/style/AgendaCard.less
@@ -105,7 +105,7 @@
 
 .agenda-card-bottom-cfg {
   height: 80px;
-  margin-bottom: 20px;
+  margin-bottom: 55px;
   float: left;
   color: #596d81;
 }


### PR DESCRIPTION
Fixes #696 

Both .agenda-card-indicator-pending and .agenda-card-bottom-cfg had margin-bottom set to 20px, causing an overlap.  I updated the .agenda-card-indicator-cfg to have a margin-bottom of 55px.

![screen shot 2017-09-23 at 6 05 50 pm](https://user-images.githubusercontent.com/9039877/30778450-1bde4a4c-a08b-11e7-9a8f-f76bf6aaf84d.png)
