### PR TITLE
Feature/add clickable snackbar notification

### DIFF
--- a/app/components/Header/Notification/Transfer.js
+++ b/app/components/Header/Notification/Transfer.js
@@ -12,7 +12,7 @@ const Transfer = ({
 }) => (
   <div className="snackbar-information">
     <div className="snackbar-information-row">
-      <div className="snackbar-information-row-tx"><Link to={`/transactions/${txHash}`}>{txHash}</Link></div>
+      <div className="snackbar-information-row-tx"><Link to={`/transactions/history/${txHash}`}>{txHash}</Link></div>
     </div>
     <div className="snackbar-information-row">
       <div className="snackbar-information-row-type">{type}</div>

--- a/app/components/Header/Notification/Transfer.js
+++ b/app/components/Header/Notification/Transfer.js
@@ -1,5 +1,6 @@
 // @flow
 import React from "react";
+import { Link } from "react-router";
 import Balance from "../../Balance";
 import "../../../style/Header.less";
 
@@ -11,7 +12,7 @@ const Transfer = ({
 }) => (
   <div className="snackbar-information">
     <div className="snackbar-information-row">
-      <div className="snackbar-information-row-tx">{txHash}</div>
+      <div className="snackbar-information-row-tx"><Link to={`/transactions/${txHash}`}>{txHash}</Link></div>
     </div>
     <div className="snackbar-information-row">
       <div className="snackbar-information-row-type">{type}</div>

--- a/app/components/TxHistory.js
+++ b/app/components/TxHistory.js
@@ -3,14 +3,13 @@ import TxHistoryRow from "./TxHistoryRow";
 import dateFormat from "dateformat";
 import "../style/Fonts.less";
 
-const TxHistory = ({ transactions=[], showTxDetail }) => (
+const TxHistory = ({ transactions=[] }) => (
   <div>
     <div>
       {transactions.map(tx => (
         <TxHistoryRow
           key={tx.txHash}
           pending={tx.txTimestamp ? false : true}
-          showTxDetail={tx.txTimestamp ? showTxDetail : false}
           {...{ tx }}
           date={tx.txTimestamp ? dateFormat(new Date(tx.txTimestamp*1000), "mmm d yyyy, HH:MM:ss") : null}
         />

--- a/app/components/TxHistoryRow/index.js
+++ b/app/components/TxHistoryRow/index.js
@@ -36,7 +36,7 @@ class TxRow extends Component {
           ...tx,
           date,
           pending,
-          onClick: () => this.context.router.push(`/transactions/${tx.txHash}`),
+          onClick: () => this.context.router.push(`/transactions/history/${tx.txHash}`),
           receiveAddressStr: (tx.txDescription.addressStr || []).join(", "),
         }}
       />

--- a/app/components/TxHistoryRow/index.js
+++ b/app/components/TxHistoryRow/index.js
@@ -1,4 +1,6 @@
-import React from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { autobind } from "core-decorators";
 import TicketPurchase from "./TicketPurchase";
 import Vote from "./Vote";
 import Revocation from "./Revocation";
@@ -6,36 +8,44 @@ import Send from "./Send";
 import Receive from "./Receive";
 import Transfer from "./Transfer";
 
-const TxRow = ({
-  showTxDetail,
-  date,
-  pending,
-  tx
-}) => {
-  const Component = (tx.txType === "Ticket") ? (
-    TicketPurchase
-  ) : (tx.txType === "Vote") ? (
-    Vote
-  ) : (tx.txType === "Revocation") ? (
-    Revocation
-  ) : (tx.txDirection === "out") ? (
-    Send
-  ) : (tx.txDirection === "in") ? (
-    Receive
-  ) : (tx.txDirection === "transfer") ? (
-    Transfer
-  ) : null;
-  return Component ? (
-    <Component
-      {...{
-        ...tx,
-        date,
-        pending,
-        onClick: showTxDetail ? () => showTxDetail(tx) : null,
-        receiveAddressStr: (tx.txDescription.addressStr || []).join(", "),
-      }}
-    />
-  ) : null;
+@autobind
+class TxRow extends Component {
+  render() {
+    const {
+      date,
+      pending,
+      tx
+    } = this.props;
+    const Component = (tx.txType === "Ticket") ? (
+      TicketPurchase
+    ) : (tx.txType === "Vote") ? (
+      Vote
+    ) : (tx.txType === "Revocation") ? (
+      Revocation
+    ) : (tx.txDirection === "out") ? (
+      Send
+    ) : (tx.txDirection === "in") ? (
+      Receive
+    ) : (tx.txDirection === "transfer") ? (
+      Transfer
+    ) : null;
+
+    return Component ? (
+      <Component
+        {...{
+          ...tx,
+          date,
+          pending,
+          onClick: () => this.context.router.push(`/transactions/${tx.txHash}`),
+          receiveAddressStr: (tx.txDescription.addressStr || []).join(", "),
+        }}
+      />
+    ) : null;
+  }
+}
+
+TxRow.contextTypes = {
+  router: PropTypes.object.isRequired,
 };
 
 export default TxRow;

--- a/app/components/views/HistoryPage/Page.js
+++ b/app/components/views/HistoryPage/Page.js
@@ -2,14 +2,12 @@ import React from "react";
 import SideBar from "../../SideBar";
 import TxHistory from "../../TxHistory";
 import Balance from "../../Balance";
-import TxDetails from "./../TxDetails";
 import Header from "../../Header";
 import Select from "react-select";
 import "../../../style/Layout.less";
 import "../../../style/HistoryPage.less";
 
 const Page = ({
-  transactionDetails,
   spendableTotalBalance,
   selectedType,
   txTypes,
@@ -17,16 +15,11 @@ const Page = ({
   currentPage,
   totalPages,
   onChangeSelectedType,
-  onShowTxDetail,
-  onClearTxDetail,
   onPageBackward,
   onPageForward
 }) => (
   <div className="page-body">
     <SideBar />
-    {transactionDetails ? (
-      <TxDetails tx={transactionDetails} {...{ onClearTxDetail }} />
-    ) : (
       <div className="page-view">
         <Header
           headerTitleOverview="Available Balance"
@@ -54,7 +47,6 @@ const Page = ({
             {paginatedTxs.length > 0 ? (
               <TxHistory
                 transactions={paginatedTxs}
-                showTxDetail={onShowTxDetail}
               />
             ) : <p>No transactions</p>}
           </div>
@@ -73,7 +65,6 @@ const Page = ({
           </div>
         </div>
       </div>
-    )}
   </div>
 );
 

--- a/app/components/views/TransactionPage/Page.js
+++ b/app/components/views/TransactionPage/Page.js
@@ -1,0 +1,14 @@
+import React from "react";
+import SideBar from "../../SideBar";
+import TxDetails from "./../TxDetails";
+
+const Page = ({ transactionDetails }) => (
+  <div className="page-body">
+    <SideBar />
+    {transactionDetails ? (
+      <TxDetails tx={transactionDetails} />
+    ) : <p>Transaction not found</p>}
+  </div>
+);
+
+export default Page;

--- a/app/components/views/TransactionPage/index.js
+++ b/app/components/views/TransactionPage/index.js
@@ -1,28 +1,13 @@
-import React, { Component } from "react";
-import { autobind } from "core-decorators";
-import { find } from "lodash";
+import React from "react";
 import ErrorScreen from "../../ErrorScreen";
 import TransactionPage from "./Page";
 import transactionPageConnector from "../../../connectors/transactionPage";
 
-@autobind
-class Transaction extends Component {
-  render() {
-    return  !this.props.walletService ? <ErrorScreen /> : (
-      <TransactionPage
-        {...{
-          ...this.props,
-          ...this.state,
-          transactionDetails: this.getTransaction(),
-        }}
-      />
-    );
-  }
-
-  getTransaction() {
-    const { transactions, params } = this.props;
-    return find(transactions.All, { txHash: params.txHash });
-  }
-}
-
+const Transaction = ({ walletService, viewedTransaction }) => (!walletService ? <ErrorScreen /> : (
+  <TransactionPage
+    {...{
+      transactionDetails: viewedTransaction,
+    }}
+  />
+));
 export default transactionPageConnector(Transaction);

--- a/app/components/views/TransactionPage/index.js
+++ b/app/components/views/TransactionPage/index.js
@@ -1,0 +1,28 @@
+import React, { Component } from "react";
+import { autobind } from "core-decorators";
+import { find } from "lodash";
+import ErrorScreen from "../../ErrorScreen";
+import TransactionPage from "./Page";
+import transactionPageConnector from "../../../connectors/transactionPage";
+
+@autobind
+class Transaction extends Component {
+  render() {
+    return  !this.props.walletService ? <ErrorScreen /> : (
+      <TransactionPage
+        {...{
+          ...this.props,
+          ...this.state,
+          transactionDetails: this.getTransaction(),
+        }}
+      />
+    );
+  }
+
+  getTransaction() {
+    const { transactions, params } = this.props;
+    return find(transactions.All, { txHash: params.txHash });
+  }
+}
+
+export default transactionPageConnector(Transaction);

--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -18,7 +18,7 @@ const getHeaderClassName = txDirection => ({
   in: "txdetails-header-meta-in"
 })[txDirection];
 
-const getFormattedDate = timestamp => timestamp ? dateFormat(new Date(timestamp*1000), "mmm d yyyy, HH:MM:ss") : 'N/A';
+const getFormattedDate = timestamp => timestamp ? dateFormat(new Date(timestamp*1000), "mmm d yyyy, HH:MM:ss") : "N/A";
 
 const TxDetails = ({
   tx: {

--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -21,87 +21,95 @@ const getHeaderClassName = txDirection => ({
 const getFormattedDate = timestamp => timestamp ? dateFormat(new Date(timestamp*1000), "mmm d yyyy, HH:MM:ss") : "N/A";
 
 const TxDetails = ({
-  tx: {
-    txHash,
-    txUrl,
-    txHeight,
-    txType,
-    txInputs,
-    txOutputs,
-    txBlockHash,
-    txBlockUrl,
-    txAmount,
-    txFee,
-    txDirection,
-    txTimestamp
-  },
-  currentBlockHeight,
-}, { router }) => (
-  <div className="page-view">
-    <Header
-      headerTitleOverview={<SlateGrayButton key="back" style={{float: "right"}} onClick={() => router.goBack()}>back</SlateGrayButton>}
-      headerMetaOverview={txType ? (
-        <div className="txdetails-header-meta-stake-tx">
-          {txType}
-          <div className="txdetails-header-meta-time-and-date">{getFormattedDate(txTimestamp)}</div>
-        </div>
-      ) : (
-        <div className={getHeaderClassName(txDirection)}>
-          {txDirection === "in" ? "" : "-"}<Balance amount={txAmount} />
-          <div className="txdetails-header-meta-time-and-date">{getFormattedDate(txTimestamp)}</div>
-        </div>
-      )}
-    />
-    <div className="page-content">
-      <div className="txdetails-content-nest">
-        <div className="txdetails-top">
-          <div className="txdetails-name">Transaction:</div>
-          <div className="txdetails-value">
-            <a onClick={() => shell.openExternal(txUrl)} style={{cursor: "pointer"}}>{txHash}</a>
+                     tx: {
+                       txHash,
+                       txUrl,
+                       txHeight,
+                       txType,
+                       txInputs,
+                       txOutputs,
+                       txBlockHash,
+                       txBlockUrl,
+                       txAmount,
+                       txFee,
+                       txDirection,
+                       txTimestamp
+                     },
+                     currentBlockHeight,
+                   }, { router }) => {
+  const isConfirmed = !!txTimestamp;
+
+  return (
+    <div className="page-view">
+
+      <Header
+        headerTitleOverview={<SlateGrayButton key="back" style={{ float: "right" }} onClick={() => router.goBack()}>back</SlateGrayButton>}
+        headerMetaOverview={txType ? (
+          <div className="txdetails-header-meta-stake-tx">
+            {txType}
+            { isConfirmed ? <div className="txdetails-header-meta-time-and-date">{getFormattedDate(txTimestamp)}</div> : null }
           </div>
-          <div className="txdetails-name">
-            {txTimestamp ? (<div className="txdetails-indicator-confirmed">confirmed</div>) : (<div className="txdetails-indicator-pending">Pending</div>)}
+        ) : (
+          <div className={getHeaderClassName(txDirection)}>
+            {txDirection === "in" ? "" : "-"}<Balance amount={txAmount} />
+            { isConfirmed ? <div className="txdetails-header-meta-time-and-date">{getFormattedDate(txTimestamp)}</div> : null }
           </div>
-          <div className="txdetails-value">{currentBlockHeight - txHeight} <span className="txdetails-value-text">confirmations</span></div>
-          <div className="txdetails-overview">
-            <div className="txdetails-input-area">
-              <div className="txdetails-overview-title-consumed">Used Inputs</div>
-              <div className="txdetails-input-arrow"></div>
-              {txInputs.map(({ accountName, amount }, idx) => (
-                <div key={idx} className="txdetails-row">
-                  <div className="txdetails-address">{accountName}</div>
-                  <div className="txdetails-amount"><Balance amount={amount}/></div>
-                </div>
-              ))}
+        )}
+      />
+      <div className="page-content">
+        <div className="txdetails-content-nest">
+          <div className="txdetails-top">
+            <div className="txdetails-name">Transaction:</div>
+            <div className="txdetails-value">
+              <a onClick={() => shell.openExternal(txUrl)} style={{ cursor: "pointer" }}>{txHash}</a>
             </div>
-            <div className="txdetails-output-area">
-              <div className="txdetails-overview-title-created">New Wallet Outputs</div>
-              {txOutputs.map(({ address, amount }, idx) => (
-                <div key={idx} className="txdetails-row">
-                  <div className="txdetails-address">{addSpacingAroundText(address)}</div>
-                  <div className="txdetails-amount"><Balance amount={amount}/></div>
-                </div>
-              ))}
+            <div className="txdetails-name">
+              {isConfirmed ? (<div className="txdetails-indicator-confirmed">confirmed</div>) : (<div className="txdetails-indicator-pending">Pending</div>)}
+            </div>
+            <div className="txdetails-value">{isConfirmed ? currentBlockHeight - txHeight : 0} <span className="txdetails-value-text">confirmations</span></div>
+            <div className="txdetails-overview">
+              <div className="txdetails-input-area">
+                <div className="txdetails-overview-title-consumed">Used Inputs</div>
+                <div className="txdetails-input-arrow"></div>
+                {txInputs.map(({ accountName, amount }, idx) => (
+                  <div key={idx} className="txdetails-row">
+                    <div className="txdetails-address">{accountName}</div>
+                    <div className="txdetails-amount"><Balance amount={amount} /></div>
+                  </div>
+                ))}
+              </div>
+              <div className="txdetails-output-area">
+                <div className="txdetails-overview-title-created">New Wallet Outputs</div>
+                {txOutputs.map(({ address, amount }, idx) => (
+                  <div key={idx} className="txdetails-row">
+                    <div className="txdetails-address">{addSpacingAroundText(address)}</div>
+                    <div className="txdetails-amount"><Balance amount={amount} /></div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div>
+              <div className="txdetails-name">Transaction fee:</div>
+              <div className="txdetails-value"><Balance amount={txFee} /></div>
             </div>
           </div>
-          <div>
-            <div className="txdetails-name">Transaction fee:</div>
-            <div className="txdetails-value"><Balance amount={txFee} /></div>
-          </div>
-        </div>
-        <div className="txdetails-details">
-          <div className="txdetails-title">Properties</div>
-          <div className="txdetails-name">Block:</div>
-          <div className="txdetails-value">
-            <a onClick={() => shell.openExternal(txBlockUrl)} style={{cursor: "pointer"}}>{txBlockHash}</a>
-          </div>
-          <div className="txdetails-name">Height:</div>
-          <div className="txdetails-value">{txHeight}</div>
+          {isConfirmed ?
+            <div className="txdetails-details">
+              <div className="txdetails-title">Properties</div>
+              <div className="txdetails-name">Block:</div>
+              <div className="txdetails-value">
+                <a onClick={() => shell.openExternal(txBlockUrl)} style={{ cursor: "pointer" }}>{txBlockHash}</a>
+              </div>
+              <div className="txdetails-name">Height:</div>
+              <div className="txdetails-value">{txHeight}</div>
+            </div>
+            : null
+          }
         </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 TxDetails.contextTypes = {
   router: PropTypes.object.isRequired,

--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -1,5 +1,6 @@
 // @flow
 import React from "react";
+import PropTypes from "prop-types";
 import Balance from "../Balance";
 import Header from "../Header";
 import { shell } from "electron";
@@ -17,7 +18,7 @@ const getHeaderClassName = txDirection => ({
   in: "txdetails-header-meta-in"
 })[txDirection];
 
-const getFormattedDate = timestamp => dateFormat(new Date(timestamp*1000), "mmm d yyyy, HH:MM:ss");
+const getFormattedDate = timestamp => timestamp ? dateFormat(new Date(timestamp*1000), "mmm d yyyy, HH:MM:ss") : 'N/A';
 
 const TxDetails = ({
   tx: {
@@ -35,11 +36,10 @@ const TxDetails = ({
     txTimestamp
   },
   currentBlockHeight,
-  onClearTxDetail
-}) => (
+}, { router }) => (
   <div className="page-view">
     <Header
-      headerTitleOverview={<SlateGrayButton key="back" style={{float: "right"}} onClick={onClearTxDetail}>back</SlateGrayButton>}
+      headerTitleOverview={<SlateGrayButton key="back" style={{float: "right"}} onClick={() => router.goBack()}>back</SlateGrayButton>}
       headerMetaOverview={txType ? (
         <div className="txdetails-header-meta-stake-tx">
           {txType}
@@ -60,7 +60,7 @@ const TxDetails = ({
             <a onClick={() => shell.openExternal(txUrl)} style={{cursor: "pointer"}}>{txHash}</a>
           </div>
           <div className="txdetails-name">
-            <div className="txdetails-indicator-confirmed">confirmed</div>
+            {txTimestamp ? (<div className="txdetails-indicator-confirmed">confirmed</div>) : (<div className="txdetails-indicator-pending">Pending</div>)}
           </div>
           <div className="txdetails-value">{currentBlockHeight - txHeight} <span className="txdetails-value-text">confirmations</span></div>
           <div className="txdetails-overview">
@@ -102,5 +102,9 @@ const TxDetails = ({
     </div>
   </div>
 );
+
+TxDetails.contextTypes = {
+  router: PropTypes.object.isRequired,
+};
 
 export default transactionDetails(TxDetails);

--- a/app/connectors/transactionPage.js
+++ b/app/connectors/transactionPage.js
@@ -1,0 +1,12 @@
+import { connect } from "react-redux";
+import { selectorMap } from "../fp";
+import * as sel from "../selectors";
+
+const mapStateToProps = () => {
+  return selectorMap({
+    walletService: sel.walletService,
+    transactions: sel.transactions,
+  });
+};
+
+export default connect(mapStateToProps);

--- a/app/connectors/transactionPage.js
+++ b/app/connectors/transactionPage.js
@@ -2,11 +2,9 @@ import { connect } from "react-redux";
 import { selectorMap } from "../fp";
 import * as sel from "../selectors";
 
-const mapStateToProps = () => {
-  return selectorMap({
-    walletService: sel.walletService,
-    transactions: sel.transactions,
-  });
-};
+const mapStateToProps = selectorMap({
+  walletService: sel.walletService,
+  viewedTransaction: sel.viewedTransaction,
+});
 
 export default connect(mapStateToProps);

--- a/app/routes.js
+++ b/app/routes.js
@@ -19,7 +19,7 @@ export default (
     <IndexRoute component={GetStartedPage} />
     <Route path="/home" component={HomePage} />
     <Route path="/history" component={HistoryPage} />
-    <Route path="/transactions/:txHash" component={TransactionPage} />
+    <Route path="/transactions/history/:txHash" component={TransactionPage} />
     <Route path="/send" component={SendPage} />
     <Route path="/receive" component={ReceivePage} />
     <Route path="/settings" component={SettingsPage} />

--- a/app/routes.js
+++ b/app/routes.js
@@ -4,6 +4,7 @@ import { Route, IndexRoute } from "react-router";
 import App from "./containers/App";
 import HomePage from "./components/views/HomePage";
 import HistoryPage from "./components/views/HistoryPage";
+import TransactionPage from "./components/views/TransactionPage";
 import SendPage from "./components/views/SendPage";
 import ReceivePage from "./components/views/ReceivePage";
 import SettingsPage from "./components/views/SettingsPage";
@@ -18,6 +19,7 @@ export default (
     <IndexRoute component={GetStartedPage} />
     <Route path="/home" component={HomePage} />
     <Route path="/history" component={HistoryPage} />
+    <Route path="/transactions/:txHash" component={TransactionPage} />
     <Route path="/send" component={SendPage} />
     <Route path="/receive" component={ReceivePage} />
     <Route path="/settings" component={SettingsPage} />

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -253,6 +253,11 @@ export const transactions = createSelector(
   })
 );
 
+export const viewedTransaction = createSelector(
+  [transactions, (state, { params: { txHash }}) => txHash],
+  (transactions, txHash) => find({ txHash }, transactions.All)
+);
+
 const rescanResponse = get(["control", "rescanResponse"]);
 export const rescanRequest = get(["control", "rescanRequest"]);
 export const synced = get(["notifications", "synced"]);


### PR DESCRIPTION
I'm not confident about reselect and had a lot of problem to get only one transaction, I decided to take the `transactions` like the `HistoryPage` and do a `find` on it.

- Each transaction can be accessible via `/transactions/:txHash`
- The `TxDetails` page can be accessible during the pending state
- The snackbar transaction is now clickable

![](https://i.gyazo.com/82e863961fd5666ed176c07dcc6a5af3.png)