### PR TITLE
Add specialized loader to include native node add-ons

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -316,7 +316,7 @@ const launchDCRD = () => {
   if (os.platform() == "win32") {
     try {
       const util = require("util");
-      const win32ipc = require("./node_modules/win32ipc/build/Release/win32ipc");
+      const win32ipc = require("win32ipc");
       var pipe = win32ipc.createPipe("out");
       args.push(util.format("--piperx=%d", pipe.readEnd));
     } catch(e) {
@@ -377,7 +377,7 @@ const launchDCRWallet = () => {
   if (os.platform() == "win32") {
     try {
       const util = require("util");
-      const win32ipc = require("./node_modules/win32ipc/build/Release/win32ipc");
+      const win32ipc = require("win32ipc");
       var pipe = win32ipc.createPipe("out");
       args.push(util.format("--piperx=%d", pipe.readEnd));
     } catch (e) {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -316,7 +316,7 @@ const launchDCRD = () => {
   if (os.platform() == "win32") {
     try {
       const util = require("util");
-      const win32ipc = require("win32ipc");
+      const win32ipc = require("./node_modules/win32ipc/build/Release/win32ipc.node");
       var pipe = win32ipc.createPipe("out");
       args.push(util.format("--piperx=%d", pipe.readEnd));
     } catch(e) {
@@ -377,7 +377,7 @@ const launchDCRWallet = () => {
   if (os.platform() == "win32") {
     try {
       const util = require("util");
-      const win32ipc = require("win32ipc");
+      const win32ipc = require("./node_modules/win32ipc/build/Release/win32ipc.node");
       var pipe = win32ipc.createPipe("out");
       args.push(util.format("--piperx=%d", pipe.readEnd));
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
       "package.json"
     ],
     "extraResources": [
-      { "from": "bin", "to": "bin"}
+      { "from": "bin", "to": "bin"},
+      "*.node"
     ],
     "win": {
       "target": "nsis"
@@ -191,7 +192,7 @@
     "lodash": "^4.17.4",
     "material-ui": "^0.17.4",
     "mv": "^2.1.1",
-    "node-addon-loader": "0.0.3",
+    "node-addon-loader": "alexlyp/node-addon-loader#master",
     "prop-types": "^15.5.10",
     "qr-image": "^3.2.0",
     "react": "^15.3.2",

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "lodash": "^4.17.4",
     "material-ui": "^0.17.4",
     "mv": "^2.1.1",
+    "node-addon-loader": "0.0.3",
     "prop-types": "^15.5.10",
     "qr-image": "^3.2.0",
     "react": "^15.3.2",

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -52,7 +52,7 @@ export default {
     mainFields: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"],
     root: [
       path.resolve("./app/node_modules"),
-      path.resolve("./app/modules/win32ipc/build/Release")
+      path.resolve("./app/node_modules/win32ipc/build/Release")
     ],
     moduleDirectories: []
   },

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -53,8 +53,7 @@ export default {
     root: [
       path.resolve("./app/node_modules"),
       path.resolve("./app/node_modules/win32ipc/build/Release")
-    ],
-    moduleDirectories: []
+    ]
   },
 
   plugins: [],

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -50,10 +50,7 @@ export default {
   resolve: {
     extensions: [".js", ".jsx", ".json", ".node"],
     mainFields: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"],
-    root: [
-      path.resolve("./app/node_modules"),
-      path.resolve("./app/node_modules/win32ipc/build/Release")
-    ]
+    modules: [path.resolve(__dirname,"app/node_modules/win32ipc/build/Release"), "node_modules" ],
   },
 
   plugins: [],

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -54,10 +54,7 @@ export default {
   // https://webpack.github.io/docs/configuration.html#resolve
   resolve: {
     extensions: [".js", ".jsx", ".json", ".node"],
-    mainFields: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"],
-    alias: {
-      "win32ipc": path.resolve(__dirname,"app/node_modules/win32ipc/build/Release/win32ipc.node")
-    }
+    mainFields: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"]
   },
 
   plugins: [],

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -50,6 +50,11 @@ export default {
   resolve: {
     extensions: [".js", ".jsx", ".json", ".node"],
     mainFields: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"],
+    root: [
+      path.resolve("./app/node_modules"),
+      path.resolve("./app/modules/win32ipc/build/Release")
+    ],
+    moduleDirectories: []
   },
 
   plugins: [],

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -30,7 +30,7 @@ export default {
           limit: 8192
         }
       }]
-    }, 
+    },
     {
       test: /\.node$/,
       use: [{

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -30,12 +30,17 @@ export default {
           limit: 8192
         }
       }]
-    }, {
+    }, 
+    {
       test: /\.node$/,
       use: [{
-        loader: "node-loader"
+        loader: "node-addon-loader",
+        options: {
+          basePath: path.resolve(__dirname, "app/node_modules/win32ipc/build/Release")
+        }
       }]
-    },]
+    }
+    ]
   },
 
   output: {
@@ -50,7 +55,9 @@ export default {
   resolve: {
     extensions: [".js", ".jsx", ".json", ".node"],
     mainFields: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"],
-    modules: [path.resolve(__dirname,"app/node_modules/win32ipc/build/Release"), "node_modules" ],
+    alias: {
+      "win32ipc": path.resolve(__dirname,"app/node_modules/win32ipc/build/Release/win32ipc.node")
+    }
   },
 
   plugins: [],

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -36,7 +36,7 @@ export default {
       use: [{
         loader: "node-addon-loader",
         options: {
-          basePath: path.resolve(__dirname, "app/node_modules/win32ipc/build/Release")
+          basePath: path.resolve(__dirname, "bin")
         }
       }]
     }


### PR DESCRIPTION
Previously the pathing for the win32ipc was incorrect and resulted in absolute paths of the build machine being used which caused the installed versions of decrediton not to be able to locate the required `.node` file.  

I forked https://github.com/ushu/node-addon-loader and added a special case path to look in the `resources/` path relative to the executable.  This with the additional extraResources file inclusion should make builds always work on windows.