### PR TITLE
Fix race in getTransactions and clean up

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -376,11 +376,11 @@ function getTransactionsInfoProgress(response) {
     const { ticketTransactionsInfo } = getState().grpc;
     const { voteTransactionsInfo } = getState().grpc;
     const { revokeTransactionsInfo } = getState().grpc;
-    var updatedRegular = regularTransactionsInfo;
-    var updatedCoinbase = coinbaseTransactionsInfo;
-    var updatedTicket = ticketTransactionsInfo;
-    var updatedVote = voteTransactionsInfo;
-    var updatedRevoke = revokeTransactionsInfo;
+    var updatedRegular = regularTransactionsInfo.slice();
+    var updatedCoinbase = coinbaseTransactionsInfo.slice();
+    var updatedTicket = ticketTransactionsInfo.slice();
+    var updatedVote = voteTransactionsInfo.slice();
+    var updatedRevoke = revokeTransactionsInfo.slice();
     for (var i = 0; i < response.getMinedTransactions().getTransactionsList().length; i++) {
       var newHeight = response.getMinedTransactions().getHeight();
       var tx = {
@@ -405,7 +405,6 @@ function getTransactionsInfoProgress(response) {
       }
     }
     if (updatedRegular.length !== regularTransactionsInfo.length) {
-      console.log("here?", updatedRegular.length);
       dispatch({ regularTransactionsInfo: updatedRegular, type: GETTRANSACTIONS_PROGRESS_REGULAR });
     }
     if (updatedCoinbase.length !== coinbaseTransactionsInfo.length) {

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -405,6 +405,7 @@ function getTransactionsInfoProgress(response) {
       }
     }
     if (updatedRegular.length !== regularTransactionsInfo.length) {
+      console.log("here?", updatedRegular.length);
       dispatch({ regularTransactionsInfo: updatedRegular, type: GETTRANSACTIONS_PROGRESS_REGULAR });
     }
     if (updatedCoinbase.length !== coinbaseTransactionsInfo.length) {

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -89,6 +89,7 @@ function transactionNtfnsData(response) {
           }
           if (unmined.length != updatedUnmined.length) {
             if (updatedRegular.length !== regularTransactionsInfo.length) {
+              console.log("ntfns here?", updatedRegular.length);
               dispatch({ regularTransactionsInfo: updatedRegular, type: GETTRANSACTIONS_PROGRESS_REGULAR });
             }
             if (updatedCoinbase.length !== coinbaseTransactionsInfo.length) {

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -89,7 +89,6 @@ function transactionNtfnsData(response) {
           }
           if (unmined.length != updatedUnmined.length) {
             if (updatedRegular.length !== regularTransactionsInfo.length) {
-              console.log("ntfns here?", updatedRegular.length);
               dispatch({ regularTransactionsInfo: updatedRegular, type: GETTRANSACTIONS_PROGRESS_REGULAR });
             }
             if (updatedCoinbase.length !== coinbaseTransactionsInfo.length) {

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -43,11 +43,11 @@ function transactionNtfnsData(response) {
           const { ticketTransactionsInfo } = getState().grpc;
           const { voteTransactionsInfo } = getState().grpc;
           const { revokeTransactionsInfo } = getState().grpc;
-          var updatedRegular = regularTransactionsInfo;
-          var updatedCoinbase = coinbaseTransactionsInfo;
-          var updatedTicket = ticketTransactionsInfo;
-          var updatedVote = voteTransactionsInfo;
-          var updatedRevoke = revokeTransactionsInfo;
+          var updatedRegular = regularTransactionsInfo.slice();
+          var updatedCoinbase = coinbaseTransactionsInfo.slice();
+          var updatedTicket = ticketTransactionsInfo.slice();
+          var updatedVote = voteTransactionsInfo.slice();
+          var updatedRevoke = revokeTransactionsInfo.slice();
           for (var k = 0; k < unmined.length; k++) {
             var unminedFound = false;
             for (var j = 0; j < attachedBlocks.length; j++){

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -221,6 +221,11 @@ export default function grpc(state = {}, action) {
     return {
       ...state,
       getTransactionsRequestError: "",
+      regularTransactionsInfo: action.regularTransactionsInfo,
+      coinbaseTransactionsInfo: action.coinbaseTransactionsInfo,
+      ticketTransactionsInfo: action.ticketTransactionsInfo,
+      voteTransactionsInfo: action.voteTransactionsInfo,
+      revokeTransactionsInfo: action.revokeTransactionsInfo,
       getTransactionsRequestAttempt: false,
     };
   case GETTRANSACTIONS_PROGRESS_REGULAR:


### PR DESCRIPTION
Previously there was an issue with the way in which get transaction's streamed progress was being handled by the actions.  If you don't do a shallow copy with `var array = arrayToCopy.slice()`  and just do `var array = arrayToCopy`  all changes to that `array` will be made to the redux state of `arrayToCopy` as well. 

This removes all that anyways and just accumulates the get transaction data stream then commits that to state upon GETTRANSACTIONS_COMPLETE signal.

Also add a check to return if getTransactionsRequestAttempt is true (which basically means) there is an existing request being processed.
Fixes #689