### PR TITLE
tooltip rebuild needed in componentDidUpdate()

### DIFF
--- a/app/components/views/TicketsPage/index.js
+++ b/app/components/views/TicketsPage/index.js
@@ -54,7 +54,7 @@ class Tickets extends Component {
       });
     }
   }
-  
+
   componentDidUpdate (prevProps, prevState) {
     if (prevState != this.state) {
       ReactToolTip.rebuild();

--- a/app/components/views/TicketsPage/index.js
+++ b/app/components/views/TicketsPage/index.js
@@ -6,6 +6,7 @@ import ticketsPage from "../../../connectors/ticketsPage";
 import ErrorScreen from "../../ErrorScreen";
 import TicketsPage from "./Page";
 import { FormattedMessage as T } from "react-intl";
+import ReactToolTip from "react-tooltip";
 
 @autobind
 class Tickets extends Component {
@@ -51,6 +52,12 @@ class Tickets extends Component {
         stakePool: nextProps.defaultStakePool,
         isShowingStakePools: false
       });
+    }
+  }
+  
+  componentDidUpdate (prevProps, prevState) {
+    if (prevState != this.state) {
+      ReactToolTip.rebuild();
     }
   }
 


### PR DESCRIPTION
Issue #755 - componentDidMount() is not called when this component is first viewed by a user. That's where ReactToolTip is usually initialized and built. Here we explicitly call it in componentDidUpdate() and place a check to prevent unnecessary rebuilds since this is a high-volume method (one that is called frequently).