### PR TITLE
Remove react-router-redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,45 +65,30 @@ decrediton --extrawalletargs='-d=debug'
 ## Developing
 
 Due to potential compatibility issues, for now, all work should be
-done with node v6.9.5 and electron 1.4.15.  The recommended way to install
-node is using nvm.
+done with electron 1.4.15.
 
-This has primarily been tested on Linux at the moment although OSX
-should work similarly.
-
-``` bash
-git clone https://github.com/creationix/nvm.git ~/.nvm && cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`
-. ~/.nvm/nvm.sh
-nvm install v6.9.5
-nvm use v6.9.5
-nvm alias default v6.9.5
-npm install -g npm
-cd
-```
+This has been tested on Linux and OSX.
 
 Adjust the following steps for the paths you want to use.
 
 ``` bash
 go get -u -v github.com/decred/dcrd
 go get -u -v github.com/decred/dcrwallet
-go get -u -v github.com/Masterminds/glide
 go get -u -v github.com/golang/dep/cmd/dep
 cd $GOPATH/src/github.com/decred/dcrd
-glide i
+$GOPATH/bin/dep ensure
 go install . ./cmd/dcrctl/
 cd ../dcrwallet
-dep ensure
+$GOPATH/bin/dep ensure
 go install
 mkdir code
 cd code
 git clone https://github.com/decred/decrediton.git
 cd decrediton
-npm install
+yarn
 mkdir app/bin/
-cp `which dcrd` app/bin/
-cp `which dcrctl` app/bin/
-cp `which dcrwallet` app/bin/
-npm run dev
+cp $GOPATH/bin/dcr* app/bin/
+yarn dev
 ```
 
 ### Note about developing with testnet

--- a/app/index.js
+++ b/app/index.js
@@ -3,7 +3,6 @@ import React from "react";
 import { render } from "react-dom";
 import { Provider } from "react-redux";
 import { Router, hashHistory } from "react-router";
-import { syncHistoryWithStore } from "react-router-redux";
 import injectTapEventPlugin from "react-tap-event-plugin";
 import routes from "./routes";
 import configureStore from "./store/configureStore";
@@ -329,11 +328,10 @@ var initialState = {
 injectTapEventPlugin();
 
 const store = configureStore(initialState);
-const history = syncHistoryWithStore(hashHistory, store);
 
 render(
   <Provider store={store}>
-    <Router history={history} routes={routes} />
+    <Router history={hashHistory} routes={routes} />
   </Provider>,
   document.getElementById("root")
 );

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,7 +1,6 @@
 // @flow
 import { combineReducers } from "redux";
 import { reducer as form } from "redux-form";
-import { routerReducer as routing } from "react-router-redux";
 import grpc from "./grpc";
 import walletLoader from "./walletLoader";
 import notifications from "./notifications";
@@ -23,7 +22,6 @@ const rootReducer = combineReducers({
   stakepool,
   daemon,
   locales,
-  routing,
   form,
   sidebar,
 });

--- a/app/store/configureStore.development.js
+++ b/app/store/configureStore.development.js
@@ -1,32 +1,20 @@
 import { createStore, applyMiddleware, compose } from "redux";
 import thunk from "redux-thunk";
-import { hashHistory } from "react-router";
-import { routerMiddleware, push } from "react-router-redux";
 import createLogger from "redux-logger";
 import rootReducer from "../reducers";
-
-const actionCreators = {
-  push,
-};
 
 const logger = createLogger({
   level: "info",
   collapsed: true
 });
 
-const router = routerMiddleware(hashHistory);
-
 // If Redux DevTools Extension is installed use it, otherwise use Redux compose
 /* eslint-disable no-underscore-dangle */
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
-  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-    // Options: http://zalmoxisus.github.io/redux-devtools-extension/API/Arguments.html
-    actionCreators,
-  }) :
-  compose;
+  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({}) : compose;
 /* eslint-enable no-underscore-dangle */
 const enhancer = composeEnhancers(
-  applyMiddleware(thunk, router, logger)
+  applyMiddleware(thunk, logger)
 );
 
 export default function configureStore(initialState: Object) {

--- a/app/store/configureStore.production.js
+++ b/app/store/configureStore.production.js
@@ -1,13 +1,9 @@
 // @flow
 import { createStore, applyMiddleware } from "redux";
 import thunk from "redux-thunk";
-import { hashHistory } from "react-router";
-import { routerMiddleware } from "react-router-redux";
 import rootReducer from "../reducers";
 
-const router = routerMiddleware(hashHistory);
-
-const enhancer = applyMiddleware(thunk, router);
+const enhancer = applyMiddleware(thunk);
 
 export default function configureStore(initialState: Object) {
   return createStore(rootReducer, initialState, enhancer);


### PR DESCRIPTION
@go1dfish confirmed that this would be OK to do since we're not using it and it's preventing us from upgrading to react-router v4