### PR TITLE
Adds Tooltip w/ no external library dependencies

### DIFF
--- a/app/components/shared/Tooltip.js
+++ b/app/components/shared/Tooltip.js
@@ -1,0 +1,26 @@
+import React from "react";
+import "style/Tooltip.less";
+
+const Tooltip = ({ text, children }) => {
+  let tooltip = null;
+
+  const onMouseMove = ({clientX, clientY}) => {
+    tooltip.style.left =
+      clientX + tooltip.clientWidth + 10 < window.innerWidth ?
+      clientX + 10 + "px" : window.innerWidth + 5 - tooltip.clientWidth + "px";
+    tooltip.style.top =
+      clientY + tooltip.clientHeight + 10 < window.innerHeight ?
+      clientY + 10 + "px" : window.innerHeight + 5 - tooltip.clientHeight + "px";
+  };
+
+  return (
+    <div className="tooltipContainer" onMouseMove={ onMouseMove }>
+      { children }
+      <span className="tip" ref={ tip => tooltip = tip }>
+        { text }
+      </span>
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/app/components/shared/index.js
+++ b/app/components/shared/index.js
@@ -1,0 +1,1 @@
+export { default as Tooltip } from "./Tooltip";

--- a/app/components/views/AccountsPage/Accounts/AccountRow/Row.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/Row.js
@@ -1,30 +1,18 @@
 // @flow
 import React from "react";
-import SlateGrayButton from "../../../../SlateGrayButton";
-import KeyBlueButton from "../../../../KeyBlueButton";
-import Balance from "../../../../Balance";
-import ReactToolTip from "react-tooltip";
+import SlateGrayButton from "SlateGrayButton";
+import KeyBlueButton from "KeyBlueButton";
+import Balance from "Balance";
+import { Tooltip } from "shared";
 import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
-import "../../../../../style/Fonts.less";
-import "../../../../../style/AccountRow.less";
+import "style/Fonts.less";
+import "style/AccountRow.less";
 
 const messages = defineMessages({
   newNamePlaceholder: {
     id: "accounts.rename.newNamePlaceholder",
     defaultMessage: "New Account Name"
   },
-  renameAccountTip: {
-    id: "accounts.rename.tip",
-    defaultMessage: "Rename Account"
-  },
-  showTip: {
-    id: "accounts.show.tip",
-    defaultMessage: "Show"
-  },
-  hideTip: {
-    id: "accounts.hide.tip",
-    defaultMessage: "Hide"
-  }
 });
 
 const Row = ({
@@ -194,31 +182,22 @@ const Row = ({
           </div>
           <div className="account-actions">
             {account.accountName !== "imported" ?
-              <div
-                key={"renameAccountButton"+account.accountNumber}
-                className="rename-account-button"
-                onClick={showRenameAccount}
-                data-tip={intl.formatMessage(messages.renameAccountTip)}/>:
+              <Tooltip text={ <T id="accounts.rename.tip" m="Rename Account" /> }>
+                <div className="rename-account-button" onClick={showRenameAccount}/>
+              </Tooltip> :
               <div></div>
             }
             {account.accountName !== "imported" && account.accountName !== "default" && account.total == 0 && !hidden ?
-              <div
-                key={"hideAccountButton"+account.accountNumber}
-                className="hide-account-button"
-                onClick={hideAccount}
-                data-for="accountTip"
-                data-tip={intl.formatMessage(messages.hideTip)}/>:
+              <Tooltip text={ <T id="accounts.show.tip" m="Show" /> }>
+                <div className="hide-account-button" onClick={hideAccount} />
+              </Tooltip> :
               account.accountName !== "imported" && account.accountName !== "default" && hidden ?
-              <div
-                className="show-account-button"
-                key={"showAccountButton"+account.accountNumber}
-                onClick={showAccount}
-                data-for="accountTip"
-                data-tip={intl.formatMessage(messages.showTip)}/>:
+              <Tooltip text={ <T id="accounts.hide.tip" m="Hide" /> }>
+                <div className="show-account-button" onClick={showAccount} />
+              </Tooltip> :
               <div></div>
             }
           </div>
-          <ReactToolTip id="accountTip" type="info" effect="solid" getContent={[() => { return (hidden) ? intl.formatMessage(messages.showTip): intl.formatMessage(messages.hideTip); }]}/>
          </div>
        )
     }

--- a/app/components/views/AccountsPage/Accounts/AccountRow/index.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/index.js
@@ -2,7 +2,6 @@
 import React, { Component } from "react";
 import { autobind } from "core-decorators";
 import Row from "./Row";
-import ReactTooltip from "react-tooltip";
 
 @autobind
 class AccountRow extends Component {
@@ -16,13 +15,6 @@ class AccountRow extends Component {
       renameAccountNumber: this.props.account.accountNumber,
       hidden: this.props.account.hidden,
     };
-  }
-  componentDidUpdate(prevProps, prevState) {
-    if(prevState.hidden != this.state.hidden) {
-      // The tooltips need to be rebuilt because either the Show or Hide button
-      // is now being rendered.
-      ReactTooltip.rebuild();
-    }
   }
 
   updateRenameAccountName(accountName) {

--- a/app/style/Tooltip.less
+++ b/app/style/Tooltip.less
@@ -1,0 +1,19 @@
+.tooltipContainer {
+  display: inline-block;
+}
+
+.tooltipContainer:hover .tip {
+  display: block;
+}
+
+.tip {
+  display: none;
+  position: fixed;
+  white-space: nowrap;
+  background: #f3f6f6;
+  color: #596d81;
+  border-radius: 5px;
+  box-shadow: 3px 3px 6px 0px rgba(0, 0, 0, 0.16);
+  padding: 5px;
+  z-index: 1000;
+}

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -55,7 +55,11 @@ export default {
   resolve: {
     extensions: [".js", ".jsx", ".json", ".node"],
     mainFields: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"],
-    modules: [path.resolve(__dirname, "app"), "node_modules"]
+    modules: [
+      path.resolve(__dirname, "app"),
+      path.resolve(__dirname, "app/components"),
+      "node_modules"
+    ]
   },
 
   plugins: [],


### PR DESCRIPTION
I reworked the tooltip, pulled it out of the other PR, and implemented it using less class declarations in app/styles/Tooltip.less

I also applied it in one location as a PoC

I picked a location that allows us to remove a react-tooltip rebuild, allowing us to remove a state container altogether.