### PR TITLE
Ignore grpc api headers on babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,8 @@
     "transform-decorators-legacy",
     "./scripts/aliasDefaultMessage.js",
     ["react-intl", {"messagesDir": "app/i18n/extracted"}]
+  ],
+  "ignore": [
+    "app/middleware/walletrpc/*.js"
   ]
 }


### PR DESCRIPTION
Babel is not needed for the api headers compiled by protoc.

This shaves a few seconds off decrediton's initialization during development.