### PR TITLE
Re-enable unmined transaction notifications

### DIFF
--- a/app/components/Snackbar/Notification/Transaction.js
+++ b/app/components/Snackbar/Notification/Transaction.js
@@ -39,9 +39,11 @@ const Transaction = ({
       <div className="snackbar-information-row-amount">
         <T id="notification.transfer.amount" m="Amount" />  <Balance amount={message.amount}/>
       </div>
-      <div className="snackbar-information-row-fee">
-        <T id="notification.transfer.fee" m="Fee" />  <Balance amount={message.fee}/>
-      </div>
+      {message.fee > 0 &&
+        <div className="snackbar-information-row-fee">
+          <T id="notification.transfer.fee" m="Fee" />  <Balance amount={message.fee}/>
+        </div>
+      }
     </div>
   </div>
 );

--- a/app/components/Snackbar/Notification/Transaction.js
+++ b/app/components/Snackbar/Notification/Transaction.js
@@ -1,9 +1,9 @@
 // @flow
 import React from "react";
 import { Link } from "react-router";
-import Balance from "../../Balance";
+import Balance from "Balance";
 import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
-import "../../../style/Header.less";
+import "style/Header.less";
 
 const messages = defineMessages({
   //same as the types used in index.js
@@ -27,22 +27,20 @@ const messages = defineMessages({
 
 const Transaction = ({
   type,
-  txHash,
-  amount,
-  fee,
+  message,
   intl
 }) => (
   <div className="snackbar-information">
     <div className="snackbar-information-row">
-      <div className="snackbar-information-row-tx"><Link to={`/transactions/history/${txHash}`}>{txHash}</Link></div>
+      <div className="snackbar-information-row-tx"><Link to={`/transactions/history/${message.txHash}`}>{message.txHash}</Link></div>
     </div>
     <div className="snackbar-information-row">
       <div className="snackbar-information-row-type">{intl.formatMessage(messages[type])}</div>
       <div className="snackbar-information-row-amount">
-        <T id="notification.transfer.amount" m="Amount" />  <Balance amount={amount}/>
+        <T id="notification.transfer.amount" m="Amount" />  <Balance amount={message.amount}/>
       </div>
       <div className="snackbar-information-row-fee">
-        <T id="notification.transfer.fee" m="Fee" />  <Balance amount={fee}/>
+        <T id="notification.transfer.fee" m="Fee" />  <Balance amount={message.fee}/>
       </div>
     </div>
   </div>

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -1,7 +1,6 @@
-import { reverseHash } from "../helpers/byteActions";
 import { defineMessages } from "react-intl";
 import {
-  PUBLISHTX_SUCCESS, PUBLISHTX_FAILED,
+  PUBLISHTX_FAILED,
   SIGNTX_FAILED, CONSTRUCTTX_FAILED,
   PURCHASETICKETS_SUCCESS, PURCHASETICKETS_FAILED,
   STARTAUTOBUYER_SUCCESS, STARTAUTOBUYER_FAILED,
@@ -100,13 +99,6 @@ export default function snackbar(state = {}, action) {
     type = action.unminedMessage.type;
     break;
   }
-  // events that generate a snackbar message
-  case PUBLISHTX_SUCCESS: {
-    const r = action.publishTransactionResponse;
-    values = { hash: reverseHash(r.toString("hex")) };
-    type = "Success";
-    break;
-  }
 
   case PUBLISHTX_FAILED:
     values = { originalError: String(action.error) };
@@ -182,11 +174,18 @@ export default function snackbar(state = {}, action) {
     type = "Error";
     break;
   }
-  if (values || type) {
+  if ((values || type) && action.type !== TRANSACTIONNTFNS_DATA_UNMINED) {
     state.messages = state.messages.slice();
     state.messages.push({
       type: type,
       message: messages[action.type],
+      values: values
+    });
+  } else if (action.type == TRANSACTIONNTFNS_DATA_UNMINED) {
+    state.messages = state.messages.slice();
+    state.messages.push({
+      type: type,
+      message: action.unminedMessage,
       values: values
     });
   }

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -13,6 +13,7 @@ import {
   UPDATESTAKEPOOLCONFIG_SUCCESS, UPDATESTAKEPOOLCONFIG_FAILED,
   SETSTAKEPOOLVOTECHOICES_SUCCESS, SETSTAKEPOOLVOTECHOICES_FAILED
 } from "../actions/StakePoolActions";
+import { TRANSACTIONNTFNS_DATA_UNMINED } from "../actions/NotificationActions";
 import { SNACKBAR_DISMISS_MESSAGES } from "../actions/SnackbarActions";
 
 const messages = defineMessages({
@@ -94,6 +95,11 @@ export default function snackbar(state = {}, action) {
   case SNACKBAR_DISMISS_MESSAGES:
     return { state, messages: Array() };
 
+  case TRANSACTIONNTFNS_DATA_UNMINED: {
+    values = { message: action.unminedMessage};
+    type = action.unminedMessage.type;
+    break;
+  }
   // events that generate a snackbar message
   case PUBLISHTX_SUCCESS: {
     const r = action.publishTransactionResponse;

--- a/app/style/Snackbar.less
+++ b/app/style/Snackbar.less
@@ -17,8 +17,9 @@
   background-color: rgba(69, 191, 87, 0.8);
 }
 
-// .snackbar-information {
-// }
+.snackbar-information {
+  padding-top: 25px;
+}
 
 .snackbar-message {
   //word-break: break-all;
@@ -27,8 +28,11 @@
   text-overflow: ellipsis;
 }
 
-// .snackbar-information-row {
-// }
+.snackbar-information-row {
+  width: 100%;
+  float: left;
+  height: 25px;
+}
 
 .snackbar-information-row-type {
   width: 30%;


### PR DESCRIPTION
Also, the publish transaction success message has been removed entirely from the snackbar, since it seems redundant to show that success and the received transaction notification.  