### PR TITLE
Add additional cleanShutdown request in before-quit for mac shutdown

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -815,6 +815,7 @@ app.on("ready", async () => {
 app.on("before-quit", (event) => {
   logger.log("info","Caught before-quit. Set decredition as was closed");
   event.preventDefault();
+  cleanShutdown();
   setMustOpenForm(true);
   app.exit(0);
 });


### PR DESCRIPTION
Fix #859 

Due to ctrl-q or issuing a Quit request from the dock on macOs windows are closed immediately and we need to ensure that the daemon and wallet are requested for shutdown before-quit.