### PR TITLE
Fix issue with transaction details and new menu links

### DIFF
--- a/app/components/SideBar/MenuLinks/index.js
+++ b/app/components/SideBar/MenuLinks/index.js
@@ -24,7 +24,8 @@ class MenuLinks extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const activeLink = getPage(nextProps.routes);
-    const newTop = this._nodes.get(activeLink).offsetTop;
+    const basePage = activeLink.split("/")[0];
+    const newTop = this._nodes.get(basePage).offsetTop;
     this.setState({ top: spring(newTop, theme("springs.sideBar")) });
   }
 

--- a/app/components/TxHistoryRow/index.js
+++ b/app/components/TxHistoryRow/index.js
@@ -36,7 +36,7 @@ class TxRow extends Component {
           ...tx,
           date,
           pending,
-          onClick: () => this.context.router.push(`/transaction/history/${tx.txHash}`),
+          onClick: () => this.context.router.push(`/transactions/history/${tx.txHash}`),
           receiveAddressStr: (tx.txDescription.addressStr || []).join(", "),
         }}
       />

--- a/app/routes.js
+++ b/app/routes.js
@@ -27,7 +27,7 @@ import ShutdownAppPage from "./components/views/ShutdownAppPage";
 export default (
   <Route     path="/"                           component={App}>
     <IndexRoute                                 component={GetStartedPage}/>
-    <Route   path="transaction/history/:txHash" component={TransactionPage}   desc/>
+    <Route   path="transactions/history/:txHash" component={TransactionPage}  desc/>
     <Route   path="home"                        component={HomePage}          noIcon/>
     <Route   path="accounts"                    component={AccountsPage}      desc/>
     <Route   path="transactions"                component={TabbedPage}        tabDesc>


### PR DESCRIPTION
With the changes to MenuLinks, transaction details crashes due to having no corresponding activeLink to use.  This mostly fixes that issue and changes the selected menu to Transactions, but it doesn't highlight the link, because it isn't the "active" route.