### PR TITLE
Fix observed issues with unit and fees

### DIFF
--- a/app/connectors/send.js
+++ b/app/connectors/send.js
@@ -14,7 +14,8 @@ const mapStateToProps = selectorMap({
   isSendingTransaction: sel.isSendingTransaction,
   isConstructingTransaction: sel.isConstructingTransaction,
   nextAddress: sel.nextAddress,
-  nextAddressAccount: sel.nextAddressAccount
+  nextAddressAccount: sel.nextAddressAccount,
+  unitDivisor: sel.unitDivisor
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -478,7 +478,7 @@ export const unsignedTransaction = createSelector(
 );
 
 export const estimatedFee = compose(
-  bytes => (bytes / 1000) * 0.001 * 100000000, estimatedSignedSize
+  bytes => (bytes / 1000) * (0.001 * 100000000), estimatedSignedSize
 );
 
 export const totalSpent = createSelector(


### PR DESCRIPTION
The fix to estimated fees is especially strange.  On master, when you have "atoms" currency display selected and an output of 1 atom transaction entered it will show 25300.000000000004 for estimated fees.  With the extra parenthesis it appears to not cause the slight float accuracy oddity.