### PR TITLE
Fix overview transaction listing

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -2,7 +2,7 @@
 import * as wallet from "wallet";
 import * as sel from "selectors";
 import { isValidAddress } from "helpers";
-import { getAccountsAttempt, getStakeInfoAttempt, reloadTransactions } from "./ClientActions";
+import { getAccountsAttempt, getStakeInfoAttempt, getMostRecentTransactions } from "./ClientActions";
 import { ChangePassphraseRequest, RenameAccountRequest,  RescanRequest,
   NextAccountRequest, NextAddressRequest, ImportPrivateKeyRequest, ImportScriptRequest,
   ConstructTransactionRequest, SignTransactionRequest,
@@ -82,7 +82,7 @@ export function rescanAttempt(beginHeight) {
       console.log("Rescan done");
       dispatch({ type: RESCAN_COMPLETE });
       setTimeout( () => {dispatch(getAccountsAttempt());}, 1000);
-      setTimeout( () => {dispatch(reloadTransactions());}, 1000);
+      setTimeout( () => {dispatch(getMostRecentTransactions());}, 1000);
     });
     rescanCall.on("status", function(status) {
       console.log("Rescan status:", status);

--- a/app/index.js
+++ b/app/index.js
@@ -153,8 +153,9 @@ var initialState = {
     getAccountsRequestAttempt: false,
     getAccountsResponse: null,
 
-    // PaginateTransactions
-    txPerPage: 8,
+    // Transactions for Overview Page
+    recentTransactionCount: 8,
+    recentTransactions: Array(),
 
     // GetTransactions
     minedTransactions: Array(),

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -9,7 +9,8 @@ import {
   GETTICKETPRICE_ATTEMPT, GETTICKETPRICE_FAILED, GETTICKETPRICE_SUCCESS,
   GETACCOUNTS_ATTEMPT, GETACCOUNTS_FAILED, GETACCOUNTS_SUCCESS,
   GETTRANSACTIONS_ATTEMPT, GETTRANSACTIONS_FAILED,  GETTRANSACTIONS_COMPLETE,
-  NEW_TRANSACTIONS_RECEIVED, CHANGE_TRANSACTIONS_FILTER, CLEAR_CURRENT_TRANSACTIONS,
+  NEW_TRANSACTIONS_RECEIVED, CHANGE_TRANSACTIONS_FILTER,
+  CLEAR_MOSTRECENTTRANSACTIONS,
   UPDATETIMESINCEBLOCK,
   GETTICKETS_ATTEMPT, GETTICKETS_FAILED, GETTICKETS_COMPLETE,
   GETAGENDASERVICE_ATTEMPT, GETAGENDASERVICE_FAILED, GETAGENDASERVICE_SUCCESS,
@@ -255,15 +256,19 @@ export default function grpc(state = {}, action) {
       getTransactionsRequestAttempt: false,
     };
   case GETTRANSACTIONS_COMPLETE:
+    var transactions = [...action.unminedTransactions, ...action.minedTransactions];
     return {
       ...state,
       minedTransactions: action.minedTransactions,
       unminedTransactions: action.unminedTransactions,
-      transactions: [...action.unminedTransactions, ...action.minedTransactions],
+      transactions: transactions,
       noMoreTransactions: action.noMoreTransactions,
       lastTransaction: action.lastTransaction,
       getTransactionsRequestError: "",
       getTransactionsRequestAttempt: false,
+      recentTransactions: state.recentTransactions.length
+        ? state.recentTransactions
+        : transactions.slice(0, state.recentTransactionCount)
     };
   case NEW_TRANSACTIONS_RECEIVED:
     return {
@@ -271,6 +276,7 @@ export default function grpc(state = {}, action) {
       minedTransactions: action.minedTransactions,
       unminedTransactions: action.unminedTransactions,
       transactions: [...action.unminedTransactions, ...action.minedTransactions],
+      recentTransactions: action.recentTransactions,
     };
   case CHANGE_TRANSACTIONS_FILTER:
     return {
@@ -282,14 +288,10 @@ export default function grpc(state = {}, action) {
       lastTransaction: null,
       noMoreTransactions: false
     };
-  case CLEAR_CURRENT_TRANSACTIONS:
+  case CLEAR_MOSTRECENTTRANSACTIONS:
     return {
       ...state,
-      minedTransactions: [],
-      unminedTransactions: [],
-      transactions: [],
-      lastTransaction: null,
-      noMoreTransactions: false
+      recentTransactions: [],
     };
   case UPDATETIMESINCEBLOCK:
     return {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -93,7 +93,6 @@ export const balances = or(get(["grpc", "balances"]), () => []);
 export const walletService = get(["grpc", "walletService"]);
 export const agendaService = get(["grpc", "agendaService"]);
 export const votingService = get(["grpc", "votingService"]);
-export const txPerPage = get(["grpc", "txPerPage"]);
 export const getBalanceRequestAttempt = get(["grpc", "getBalanceRequestAttempt"]);
 export const getAccountsResponse = get(["grpc", "getAccountsResponse"]);
 export const getNetworkResponse = get(["grpc", "getNetworkResponse"]);
@@ -388,11 +387,7 @@ export const rescanPercentFinished = createSelector(
 );
 
 export const homeHistoryTransactions = createSelector(
-  [txPerPage, transactions],
-  (txPerPage, transactions) =>
-    transactions.length >= txPerPage
-      ? transactions.slice(0, txPerPage)
-      : transactions.slice(0, transactions.length)
+  [transactionsNormalizer, get(["grpc", "recentTransactions"])], apply
 );
 
 export const visibleAccounts = createSelector(

--- a/app/style/Loading.less
+++ b/app/style/Loading.less
@@ -32,4 +32,5 @@
   border-radius: 5px;
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
   display: inline-block;
+  margin-top: 2em;
 }


### PR DESCRIPTION
Fix #961 

The transactions for the overview listing are now stored on a separate state and updated after the wallet is loaded, after rescan is completed or when new transactions are received.