### PR TITLE
Update MyTickets ticket list

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -262,18 +262,12 @@ export const GETTICKETS_FAILED = "GETTICKETS_FAILED";
 export const GETTICKETS_COMPLETE = "GETTICKETS_COMPLETE";
 
 export const getTicketsInfoAttempt = () => (dispatch, getState) => {
-  const { grpc: { getAccountsResponse, getTicketsRequestAttempt } } = getState();
-  let startRequestHeight, endRequestHeight = 0;
+  const { grpc: { getTicketsRequestAttempt } } = getState();
   if (getTicketsRequestAttempt) return;
-  // Check to make sure getAccountsResponse (which has current block height) is available
-  if (getAccountsResponse !== null) {
-    endRequestHeight = getAccountsResponse.getCurrentBlockHeight();
-    startRequestHeight = -1;
-  } else {
-    // Wait a little then re-dispatch this call since we have no starting height yet
-    setTimeout(() => { dispatch(getTicketsInfoAttempt()); }, 1000);
-    return;
-  }
+
+  // using 0..-1 requests all+unmined tickets
+  let startRequestHeight = 0;
+  let endRequestHeight = -1;
 
   dispatch({ type: GETTICKETS_ATTEMPT });
   wallet.getTickets(sel.walletService(getState()), startRequestHeight, endRequestHeight)

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -2,7 +2,8 @@
 import * as wallet from "wallet";
 import * as sel from "selectors";
 import { isValidAddress } from "helpers";
-import { getAccountsAttempt, getStakeInfoAttempt, getMostRecentTransactions } from "./ClientActions";
+import { getAccountsAttempt, getStakeInfoAttempt, getMostRecentTransactions,
+  getTicketsInfoAttempt } from "./ClientActions";
 import { ChangePassphraseRequest, RenameAccountRequest,  RescanRequest,
   NextAccountRequest, NextAddressRequest, ImportPrivateKeyRequest, ImportScriptRequest,
   ConstructTransactionRequest, SignTransactionRequest,
@@ -82,6 +83,7 @@ export function rescanAttempt(beginHeight) {
       dispatch({ type: RESCAN_COMPLETE });
       setTimeout( () => {dispatch(getAccountsAttempt());}, 1000);
       setTimeout( () => {dispatch(getMostRecentTransactions());}, 1000);
+      setTimeout( () => {dispatch(getTicketsInfoAttempt());}, 1000);
     });
     rescanCall.on("error", function(status) {
       console.error("Rescan error", status);

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -228,7 +228,6 @@ export default function grpc(state = {}, action) {
   case GETTICKETS_ATTEMPT:
     return {
       ...state,
-      tickets: Array(),
       getTicketsRequestAttempt: true,
     };
   case GETTICKETS_FAILED:


### PR DESCRIPTION
Fix #993 
This adds a call to update the tickets list on:
- Rescan Complete
- StakeInfo change (when any of the user's stats changes)

This also loads unmined tickets (weren't being loaded before) and changes the reducer so that tickets are only updated after successfully completing the `getTickets` call.

This is not the perfect solution to #993 as reloading the whole ticket tx set every time is not ideal performance-wise, but should be sufficient until we implement real ticket streaming.

I tested on a testnet wallet with over 2k ticket transactions (among tickets/votes/revokes) and performance was acceptable on my machine. Could use some testing on a bigger wallet.