### PR TITLE
Remove revoke div from Overview

### DIFF
--- a/app/components/views/HomePage/Page.js
+++ b/app/components/views/HomePage/Page.js
@@ -1,7 +1,6 @@
 // @flow
 import { rescan, home } from "connectors";
 import { DecredLoading } from "indicators";
-import { PassphraseModalButton } from "buttons";
 import { Balance, TabbedHeader } from "shared";
 import TxHistory from "TxHistory";
 import { FormattedMessage as T } from "react-intl";
@@ -11,11 +10,9 @@ import "style/HomePage.less";
 const HomePage = ({
   routes,
   spendableTotalBalance,
-  hasTicketsToRevoke,
   transactions,
   getTransactionsRequestAttempt,
   getAccountsResponse,
-  onRevokeTickets
 }) => {
   return (
     <Aux>
@@ -26,17 +23,6 @@ const HomePage = ({
       </TabbedHeader>
       { getTransactionsRequestAttempt ? <div className="page-content"><DecredLoading /></div> :
       <div className="page-content">
-        { hasTicketsToRevoke &&
-        <div className="tickets-to-revoke-warning">
-          <T id="home.revokeTicketMessage" m="You have outstanding missed or expired tickets, please revoke them to unlock your funds" />
-          <PassphraseModalButton
-              modalTitle={<T id="tickets.revokeConfirmations" m="Revoke Tickets Confirmation" />}
-              className="stakepool-content-revoke-button"
-              onSubmit={onRevokeTickets}
-          >
-            <T id="purchaseTickets.revokeBtn" m="Revoke" />
-          </PassphraseModalButton>
-        </div> }
         <div className="home-content-title">
           <div className="home-content-title-text">
             <T id="home.recentTransactionsTitle" m="Recent Transactions" />


### PR DESCRIPTION
Due to false positive notifications of needing to revoke, we've decided to remove the "Revoke tickets ..." div on the overview.  The revoke button will still appear on the Purchase Tickets page when hasTicketsToRevoke is true.  We'll be figuring out better ways of letting decrediton know that it needs to revoke tickets.