### PR TITLE
Rollback electron-store version and conf version

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,9 +11,12 @@
   },
   "license": "ISC",
   "dependencies": {
-    "electron-store": "^1.0.0",
+    "electron-store": "1.2.0",
     "grpc": "1.6.0",
     "minimist": "^1.2.0"
+  },
+  "devDependencies": {
+    "conf": "1.1.2"
   },
   "optionalDependencies": {
     "win32ipc": "./modules/win32ipc"

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
     "grpc": "1.6.0",
     "minimist": "^1.2.0"
   },
-  "devDependencies": {
+  "resolutions": {
     "conf": "1.1.2"
   },
   "optionalDependencies": {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -140,7 +140,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-conf@1.1.2:
+conf@1.1.2, conf@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/conf/-/conf-1.1.2.tgz#a164003022dd1643cd5abd9653071bd3b0a19f50"
   dependencies:
@@ -148,16 +148,6 @@ conf@1.1.2:
     env-paths "^1.0.0"
     make-dir "^1.0.0"
     pkg-up "^2.0.0"
-
-conf@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/conf/-/conf-1.3.1.tgz#829a82b081bb355129992333be1598f797a56f58"
-  dependencies:
-    dot-prop "^4.1.0"
-    env-paths "^1.0.0"
-    make-dir "^1.0.0"
-    pkg-up "^2.0.0"
-    write-file-atomic "^2.3.0"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -300,7 +290,7 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -349,10 +339,6 @@ http-signature@~1.1.0:
     assert-plus "^0.2.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
-
-imurmurhash@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -684,7 +670,7 @@ set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -818,14 +804,6 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-
-write-file-atomic@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
-  dependencies:
-    graceful-fs "^4.1.11"
-    imurmurhash "^0.1.4"
-    signal-exit "^3.0.2"
 
 y18n@^3.2.0:
   version "3.2.1"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -140,7 +140,16 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-conf@^1.3.0:
+conf@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-1.1.2.tgz#a164003022dd1643cd5abd9653071bd3b0a19f50"
+  dependencies:
+    dot-prop "^4.1.0"
+    env-paths "^1.0.0"
+    make-dir "^1.0.0"
+    pkg-up "^2.0.0"
+
+conf@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/conf/-/conf-1.3.1.tgz#829a82b081bb355129992333be1598f797a56f58"
   dependencies:
@@ -204,11 +213,11 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-electron-store@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-1.3.0.tgz#ee488a28a61fb982fd35b658fb9cb6331eb201f8"
+electron-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-1.2.0.tgz#96f708f0188c7708907e9f9b7cba790bed6b989f"
   dependencies:
-    conf "^1.3.0"
+    conf "^1.0.0"
 
 env-paths@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Due to an error in electron/asar below, some windows users have encountered this issue.  Until the underlying issue is resolved we will roll back to a known working version.

Fixes #995 