### PR TITLE
Rollback react-select to 1.0.0-rc.10

### DIFF
--- a/app/components/views/GetStartedPage/OpenWallet/CreateWalletForm/ConfirmSeed/SeedEntry.js
+++ b/app/components/views/GetStartedPage/OpenWallet/CreateWalletForm/ConfirmSeed/SeedEntry.js
@@ -35,7 +35,7 @@ class SeedEntry extends React.Component {
         onPaste={this.props.onPaste}
       >
         <Select.Async
-          autofocus
+          autoFocus
           clearable={false}
           placeholder={formatMessage(messages.enterSeedPlaceholder)}
           multi={true}

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "react-redux": "^4.4.5",
     "react-router": "^3.2.0",
     "react-router-redux": "^4.0.8",
-    "react-select": "^1.0.0-rc.5",
+    "react-select": "1.0.0-rc.10",
     "react-timeout": "^1.0.1",
     "redux": "^3.6.0",
     "redux-form": "^7.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6899,7 +6899,7 @@ react-infinite-scroller@^1.1.1:
   dependencies:
     prop-types "^15.5.8"
 
-react-input-autosize@^2.1.0:
+react-input-autosize@^2.0.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.1.2.tgz#a3dc11a5517c434db25229925541309de3f7a8f5"
   dependencies:
@@ -6976,13 +6976,13 @@ react-router@^3.2.0:
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-react-select@^1.0.0-rc.5:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.1.0.tgz#626a2de839fdea2ade74dd1b143a9bde34be6c82"
+react-select@1.0.0-rc.10:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.0.0-rc.10.tgz#f137346250f9255c979fbfa21860899928772350"
   dependencies:
     classnames "^2.2.4"
     prop-types "^15.5.8"
-    react-input-autosize "^2.1.0"
+    react-input-autosize "^2.0.1"
 
 react-timeout@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Due to an issue with repeated words being deleted, we have rolled back to a working version of react-select while we can investigate the problem and ways to properly fix.