### PR TITLE
Add customBinPath cmdline arg

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -28,9 +28,12 @@ function unknownFn(arg) {
 }
 
 function getExecutablePath(name) {
-  let binPath = process.env.NODE_ENV === "development"
-    ? path.join(__dirname, "..", "bin")
-    : path.join(process.resourcesPath, "bin");
+  let customBinPath = argv.customBinPath;
+
+  let binPath = customBinPath ? customBinPath :
+    process.env.NODE_ENV === "development"
+      ? path.join(__dirname, "..", "bin")
+      : path.join(process.resourcesPath, "bin");
   let execName = os.platform() !== "win32" ? name : name + ".exe";
 
   return path.join(binPath, execName);
@@ -49,13 +52,14 @@ Options
   --testnet          Connect to testnet
   --mainnet          Connect to mainnet
   --extrawalletargs  Pass extra arguments to dcrwallet
+  --customBinPath    Custom path for dcrd/dcrwallet/dcrctl binaries
 `);
 }
 
 // Allowed cmd line options are defined here.
 var opts = {
   boolean: ["debug", "testnet", "mainnet", "help", "version"],
-  string: ["extrawalletargs"],
+  string: ["extrawalletargs", "customBinPath"],
   default: { debug: false },
   alias: { d: "debug" },
   unknown: unknownFn
@@ -394,7 +398,7 @@ const launchDCRD = (appdata) => {
     }
   }
 
-  logger.log("info", `Starting dcrd with ${args}`);
+  logger.log("info", `Starting ${dcrdExe} with ${args}`);
 
   var dcrd = spawn(dcrdExe, args, {
     detached: os.platform() == "win32",
@@ -478,7 +482,7 @@ const launchDCRWallet = () => {
     args = concat(args, stringArgv(argv.extrawalletargs));
   }
 
-  logger.log("info", `Starting dcrwallet with ${args}`);
+  logger.log("info", `Starting ${dcrwExe} with ${args}`);
 
   var dcrwallet = spawn(dcrwExe, args, {
     detached: os.platform() == "win32",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-main": "cross-env NODE_ENV=production node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.electron.js --progress --profile --colors",
     "build-renderer": "cross-env NODE_ENV=production node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.production.js --progress --profile --colors",
     "build": "npm run build-main && npm run build-renderer",
-    "start": "cross-env NODE_ENV=production electron ./app/",
+    "start": "cross-env NODE_ENV=production electron ./app/ --debug --customBinPath=./bin",
     "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r babel-register -r babel-polyfill ./app/main.development",
     "postinstall": "concurrently \"electron-builder install-app-deps\" \"node node_modules/fbjs-scripts/node/check-dev-engines.js package.json\"",
     "dev": "npm run hot-server -- --start-hot",


### PR DESCRIPTION
Fix #1025.

I believe the point of `yarn start` is to simulate a production run on a development machine, so I added a `customBinPath` command line arg to pass the fix the problem and added `--debug` to help check out any errors.

I also modified the logging of the launchXXXX functions to show the path to the executable being run.

Tested in development and on a packaged version on Linux.