### PR TITLE
Change log format to dcrd/dcrwallet

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -3,6 +3,7 @@ import {
   getLoader, startRpc, getWalletExists, createWallet, openWallet, closeWallet, discoverAddresses,
   subscribeToBlockNotifications, fetchHeaders, getStakePoolInfo
 } from "wallet";
+import * as wallet from "wallet";
 import { getWalletServiceAttempt, getTicketBuyerServiceAttempt, getAgendaServiceAttempt, getVotingServiceAttempt } from "./ClientActions";
 import { getVersionServiceAttempt } from "./VersionActions";
 import { getCfg, getCfgPath, getDcrdCert,RPCDaemonPort, RPCDaemonHost } from "config";
@@ -277,7 +278,9 @@ export function determineNeededBlocks() {
     const explorerInfoURL = `https://${network}.decred.org/api/status`;
     axios.get(explorerInfoURL, {timeout: 5000})
     .then(function (response) {
-      dispatch({ neededBlocks: response.data.info.blocks, type: NEEDED_BLOCKS_DETERMINED});
+      const neededBlocks = response.data.info.blocks;
+      wallet.log("info", `Determined needed block height as ${neededBlocks}`);
+      dispatch({ neededBlocks, type: NEEDED_BLOCKS_DETERMINED});
     })
     .catch(function (error) {
       console.log("Unable to obtain latest block number.", error);

--- a/app/logging.js
+++ b/app/logging.js
@@ -1,0 +1,74 @@
+import { app } from "electron";
+import winston from "winston";
+import path from "path";
+
+const pad = (s, n) => {
+  n = n || 2;
+  s = Array(n).join("0") + s;
+  return s.substring(s.length - n);
+};
+
+// logTimestamp is a function to format current time as a string using a
+// format compatible to dcrd/dcrwallet logs. This function is meant to be
+// installed in the winston loggers.
+const logTimestamp = () => {
+  let date = new Date();
+  let y = date.getFullYear();
+  let mo = pad(date.getMonth() + 1);
+  let d = pad(date.getDate());
+  let h = pad(date.getHours());
+  let mi = pad(date.getMinutes());
+  let s = pad(date.getSeconds());
+  let ms = pad(date.getMilliseconds(), 3);
+  return `${y}-${mo}-${d} ${h}:${mi}:${s}.${ms}`;
+};
+
+// logLevelsPrintable are the printable strings for each log level, compatible
+// with the dcrd/dcrwallet logs.
+const logLevelsPrintable = {
+  "error": "ERR",
+  "warn": "WRN",
+  "info": "INF",
+  "verbose": "VBS",
+  "debug": "DBG",
+  "silly": "TRC",
+};
+
+const logFormatter = (opts) => {
+  //console.log(opts);
+  const lvl = logLevelsPrintable[opts.level]||"UNK";
+  const time = opts.timestamp();
+  const msg = opts.message;
+  const subsys = "DCTN";
+  return `${time} [${lvl}] ${subsys}: ${msg}`;
+};
+
+const logFormatterColorized = (opts) => {
+  const config = winston.config;
+  return config.colorize(opts.level, logFormatter(opts));
+};
+
+// createLogger creates the main app logger. This stores all logs into the
+// decrediton app data dir and sends to the console when debug == true.
+// This is meant to be called from the ipcMain thread.
+export function createLogger(debug) {
+  const logger = new (winston.Logger)({
+    transports: [
+      new (winston.transports.File)({
+        json: false,
+        filename: path.join(app.getPath("userData"), "decrediton.log"),
+        timestamp: logTimestamp,
+        formatter: logFormatter,
+      })
+    ]
+  });
+
+  if (debug) {
+    logger.add(winston.transports.Console, {
+      timestamp: logTimestamp,
+      formatter: logFormatterColorized,
+    });
+  }
+
+  return logger;
+}

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -107,35 +107,61 @@ if (err !== null) {
 }
 var cfg = initCfg();
 
+const logTimestamp = () => {
+  // Format the timestamp in local time like the dcrd and dcrwallet logs.
+  let pad = (s, n) => {
+    n = n || 2;
+    s = Array(n).join("0") + s;
+    return s.substring(s.length - n);
+  };
+
+  let date = new Date();
+  let y = date.getFullYear();
+  let mo = pad(date.getMonth() + 1);
+  let d = pad(date.getDate());
+  let h = pad(date.getHours());
+  let mi = pad(date.getMinutes());
+  let s = pad(date.getSeconds());
+  let ms = pad(date.getMilliseconds(), 3);
+  return `${y}-${mo}-${d} ${h}:${mi}:${s}.${ms}`;
+};
+const logLevelsPrintable = {
+  "error": "ERR",
+  "warn": "WRN",
+  "info": "INF",
+  "verbose": "VBS",
+  "debug": "DBG",
+  "silly": "TRC",
+};
+const logFormatter = (opts) => {
+  //console.log(opts);
+  const lvl = logLevelsPrintable[opts.level]||"UNK";
+  const time = opts.timestamp();
+  const msg = opts.message;
+  const subsys = "DCTN";
+  return `${time} [${lvl}] ${subsys}: ${msg}`;
+};
+const logFormatterColorized = (opts) => {
+  const config = winston.config;
+  return config.colorize(opts.level, logFormatter(opts));
+};
+
 var logger = new (winston.Logger)({
   transports: [
     new (winston.transports.File)({
       json: false,
       filename: path.join(app.getPath("userData"), "decrediton.log"),
-      timestamp: function () {
-        // Format the timestamp in local time like the dcrd and dcrwallet logs.
-        let pad = (s, n) => {
-          n = n || 2;
-          s = Array(n).join("0") + s;
-          return s.substring(s.length - n);
-        };
-
-        let date = new Date();
-        let y = date.getFullYear();
-        let mo = pad(date.getMonth() + 1);
-        let d = pad(date.getDate());
-        let h = pad(date.getHours());
-        let mi = pad(date.getMinutes());
-        let s = pad(date.getSeconds());
-        let ms = pad(date.getMilliseconds(), 3);
-        return `${y}-${mo}-${d} ${h}:${mi}:${s}.${ms}`;
-      }
+      timestamp: logTimestamp,
+      formatter: logFormatter,
     })
   ]
 });
 
 if (debug) {
-  logger.add(winston.transports.Console, { colorize: "all" });
+  logger.add(winston.transports.Console, {
+    timestamp: logTimestamp,
+    formatter: logFormatterColorized,
+  });
 }
 
 logger.log("info", "Using config/data from:" + app.getPath("userData"));

--- a/app/wallet/app.js
+++ b/app/wallet/app.js
@@ -1,3 +1,7 @@
 import { ipcRenderer } from "electron";
 
 export const onAppReloadRequested = cb => ipcRenderer.on("app-reload-requested", cb);
+
+export const log = (level, ...args) => {
+  ipcRenderer.send("main-log", ...[level, ...args]);
+};


### PR DESCRIPTION
Fix #541 

Log format generated by the main logger now follows the dcrd/dcrwallet convention. Currently, it is using a single fixed subsystem (DCTN = DeCrediToN) as we don't have many logging messages.

This also moves all logging init logic into a separate file to improve readability.

It also adds the ability to send log messages to the main logger from the react app, by adding a `wallet.log()` function. These log messages will be persisted to the decrediton.log file, so we can start to add logging throughout the app to improve debugging.
