### PR TITLE
Change tx scroll threshold on large height

### DIFF
--- a/app/components/views/TransactionsPage/HistoryTab/Page.js
+++ b/app/components/views/TransactionsPage/HistoryTab/Page.js
@@ -12,6 +12,7 @@ const Page = ({
                 transactions,
                 selectedSortOrderKey,
                 selectedTxTypeKey,
+                loadMoreThreshold,
                 noMoreTransactions,
                 onChangeSelectedType,
                 onChangeSortType,
@@ -20,9 +21,9 @@ const Page = ({
   <InfiniteScroll
     hasMore={!noMoreTransactions}
     loadMore={onLoadMoreTransactions}
-    initialLoad={false}
+    initialLoad={loadMoreThreshold > 90}
     useWindow={false}
-    threshold={90}
+    threshold={loadMoreThreshold}
   >
     <div className="tab-card">
       <div className="history-content-title">

--- a/app/components/views/TransactionsPage/HistoryTab/index.js
+++ b/app/components/views/TransactionsPage/HistoryTab/index.js
@@ -20,11 +20,16 @@ class History extends React.Component {
   }
 
   render() {
+    // empirically defined to load 1 page of transactions in default height
+    // and an additional page when window.innerHeight > default
+    const loadMoreThreshold = 90 + Math.max(0, this.props.window.innerHeight - 765);
+
     return  !this.props.walletService ? <ErrorScreen /> : (
       <HistoryPage
         {...{
           ...this.props,
           ...this.state,
+          loadMoreThreshold,
           txTypes: this.getTxTypes(),
           sortTypes: this.getSortTypes(),
           transactions: this.getTransactions(),

--- a/app/connectors/historyPage.js
+++ b/app/connectors/historyPage.js
@@ -10,6 +10,7 @@ const mapStateToProps = selectorMap({
   transactions: sel.transactions,
   transactionsFilter: sel.transactionsFilter,
   noMoreTransactions: sel.noMoreTransactions,
+  window: sel.mainWindow,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({


### PR DESCRIPTION
Fix #1044 

The new threshold is empirically defined (meaning: in a hacky way), but I think it should suffice for now.

Tested with a window height up to 1280 px.

I didn't hook to the window.resize listener, so the only outstanding possible bug is if the window is resized while the transaction list is opened (currently the user can just go to another page and come back and it will list correctly). If you think that is a relevant thing to fix, let me know and I'll work on a further fix.