### PR TITLE
Prevent stakepools getting removed when not returned from api

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -324,10 +324,12 @@ export function updateStakePoolConfig(config, foundStakePoolConfigs) {
 
   if (foundStakePoolConfigs !== null) {
     let newStakePoolConfigs = foundStakePoolConfigs.map(s => {
-      return currentConfigsByHost[s.Host]
-          ? { ...currentConfigsByHost[s.Host], ...s }
-          : s;
+      const current = currentConfigsByHost[s.Host];
+      delete currentConfigsByHost[s.Host];
+      return current ? { ...current, ...s } : s;
     });
+    Object.keys(currentConfigsByHost)
+      .forEach(v => newStakePoolConfigs.push(currentConfigsByHost[v]));
     config.set("stakepools", newStakePoolConfigs);
   }
 }


### PR DESCRIPTION
Fix #1026 

This prevents stakepools that are not currently returned from the decred api (due to timeout between api and stakepool or any other reason) from being removed from the users config.

This also opens up the possibility of manually configured stakepools by editing config.json and adding the necessary stakepool fields.