### PR TITLE
Maintain selected stakepool state and remove stakepool

### DIFF
--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -24,8 +24,9 @@ const updateSavedConfig = (newPoolInfo, poolHost, apiKey, accountNum) =>
         : config);
     if (!stakePoolConfigs.find((conf, idx) => conf !== currentStakePoolConfig[idx])) return;
     getCfg().set("stakepools", stakePoolConfigs);
+    let selectedStakePool = stakePoolConfigs.filter(p => p.Host === poolHost)[0] || null;
     dispatch({
-      successMessage: `You have successfully configured ${poolHost}`,
+      selectedStakePool,
       currentStakePoolConfig: stakePoolConfigs,
       type: UPDATESTAKEPOOLCONFIG_SUCCESS
     });
@@ -102,7 +103,7 @@ export const SETSTAKEPOOLVOTECHOICES_ATTEMPT = "SETSTAKEPOOLVOTECHOICES_ATTEMPT"
 export const SETSTAKEPOOLVOTECHOICES_FAILED = "SETSTAKEPOOLVOTECHOICES_FAILED";
 export const SETSTAKEPOOLVOTECHOICES_SUCCESS = "SETSTAKEPOOLVOTECHOICES_SUCCESS";
 
-const updateStakePoolVoteChoicesConfig = (stakePool, voteChoices) => (dispatch) => {
+const updateStakePoolVoteChoicesConfig = (stakePool, voteChoices) => (dispatch, getState) => {
   const config = getCfg();
   const voteChoicesConfig = voteChoices.getChoicesList().map(choice => ({
     agendaId: choice.getAgendaId(),
@@ -113,10 +114,11 @@ const updateStakePoolVoteChoicesConfig = (stakePool, voteChoices) => (dispatch) 
       ? ({ ...config, VoteBits: voteChoices.getVotebits(), VoteChoices: voteChoicesConfig })
       : config
   );
+  const selectedStakePool = sel.selectedStakePool(getState());
 
   config.set("stakepools", stakePoolConfigs);
   dispatch({
-    successMessage: "You have successfully updated your vote choices.",
+    selectedStakePool,
     currentStakePoolConfig: stakePoolConfigs,
     type: UPDATESTAKEPOOLCONFIG_SUCCESS
   });
@@ -150,3 +152,31 @@ export const discoverAvailableStakepools = () => (dispatch) =>
 export const CHANGESELECTEDSTAKEPOOL = "CHANGESELECTEDSTAKEPOOL";
 export const changeSelectedStakePool = (selectedStakePool) => (dispatch) =>
   dispatch({selectedStakePool, type: CHANGESELECTEDSTAKEPOOL});
+
+export const REMOVESTAKEPOOLCONFIG = "REMOVESTAKEPOOLCONFIG";
+export const removeStakePoolConfig = (host) => (dispatch, getState) => {
+  let config = getCfg();
+  let existingPools = config.get("stakepools");
+  let pool = existingPools.filter(p => p.Host === host)[0];
+  if (!pool) { return; }
+
+  // Instead of simply deleting from exstingPools we blank all non-default
+  // fields so the stakepool can be reconfigured without needing to re-fetch
+  // the stakepool list from the remote api.
+
+  const propsToMaintain = ["Host", "Network", "APIVersionsSupported"];
+  let newPool = {};
+  propsToMaintain.forEach(p => newPool[p] = pool[p]); // **not** a deep copy
+  let newPools = existingPools.map(p => p.Host === host ? newPool : p);
+  config.set("stakepools", newPools);
+
+  let selectedStakePool = sel.selectedStakePool(getState());
+  if (selectedStakePool && selectedStakePool.Host === host) {
+    selectedStakePool = newPools.filter(p => p.ApiKey)[0] || null;
+  }
+
+  dispatch({
+    selectedStakePool,
+    currentStakePoolConfig: newPools,
+    type: REMOVESTAKEPOOLCONFIG});
+};

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -146,3 +146,7 @@ export const discoverAvailableStakepools = () => (dispatch) =>
         dispatch({ type: DISCOVERAVAILABLESTAKEPOOLS_SUCCESS, currentStakePoolConfig: config.get("stakepools")});
       } // TODO: add error notification after global snackbar is merged
     });
+
+export const CHANGESELECTEDSTAKEPOOL = "CHANGESELECTEDSTAKEPOOL";
+export const changeSelectedStakePool = (selectedStakePool) => (dispatch) =>
+  dispatch({selectedStakePool, type: CHANGESELECTEDSTAKEPOOL});

--- a/app/components/buttons/DangerButton.js
+++ b/app/components/buttons/DangerButton.js
@@ -1,0 +1,9 @@
+const DangerButton = ({ className, style, block, type, disabled, onClick, children }) => (
+  <div
+    className={"danger-button" + (className ? (" " + className) : "")}
+    style={({...style, display: block ? "block" : undefined })}
+    {...{ type, disabled, onClick }}
+  >{children}</div>
+);
+
+export default DangerButton;

--- a/app/components/buttons/index.js
+++ b/app/components/buttons/index.js
@@ -10,12 +10,14 @@ export { default as TransactionLink } from "./TransactionLink";
 import ModalButton from "./ModalButton";
 import KeyBlueButton from "./KeyBlueButton";
 import AutoBuyerSwitch from "./AutoBuyerSwitch";
-export { ModalButton, AutoBuyerSwitch, KeyBlueButton };
+import DangerButton from "./DangerButton";
+export { ModalButton, AutoBuyerSwitch, KeyBlueButton, DangerButton };
 
 /***************************************************
  * Custom Modal Buttons
  ***************************************************/
-import { InfoModal, PassphraseModal, ChangePassphraseModal } from "modals";
+import { InfoModal, PassphraseModal, ChangePassphraseModal,
+  ConfirmModal } from "modals";
 
 // mbb = ModalButtonBuilder (func to build a functional ModalButton component
 // with extra fixed props)
@@ -37,3 +39,4 @@ export const InfoModalButton = mbb("purchase-tickets-info-button", InfoModal);
 export const ChangePassphraseButton = mbb("change-password-default-icon", ChangePassphraseModal);
 export const PassphraseModalButton = mbb(null, PassphraseModal, KeyBlueButton);
 export const PassphraseModalSwitch = mbb(null, PassphraseModal, AutoBuyerSwitch);
+export const RemoveStakePoolButton = mbb(null, ConfirmModal, DangerButton);

--- a/app/components/modals/ConfirmModal/index.js
+++ b/app/components/modals/ConfirmModal/index.js
@@ -1,0 +1,37 @@
+import Modal from "../Modal";
+import { SlateGrayButton, KeyBlueButton } from "buttons";
+import { FormattedMessage as T } from "react-intl";
+
+const propTypes = {
+  modalTitle: PropTypes.object.isRequired,
+  show: PropTypes.bool.isRequired,
+  modalContent: PropTypes.object.isRequired,
+  onCancelModal: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired
+};
+
+const ConfirmModal = ({modalTitle, modalContent, show, onCancelModal, onSubmit,
+  confirmLabel}) => (
+  <Modal className="confirm-modal" {...{ show }}>
+    <div className="confirm-modal-header">
+      <div className="confirm-modal-header-title">
+        {modalTitle}
+      </div>
+    </div>
+    <div className="confirm-modal-content">
+      {modalContent}
+    </div>
+    <div className="confirm-modal-toolbar">
+      <KeyBlueButton className="confirm-modal-confirm-button" onClick={onSubmit}>
+        {confirmLabel || <T id="infoModal.btnConfirm" m="Confirm" />}
+      </KeyBlueButton>
+      <SlateGrayButton className="confirm-modal-close-button" onClick={onCancelModal}>
+        <T id="confirmModal.btnCancel" m="Cancel" />
+      </SlateGrayButton>
+    </div>
+  </Modal>
+);
+
+ConfirmModal.propTypes = propTypes;
+
+export default ConfirmModal;

--- a/app/components/modals/index.js
+++ b/app/components/modals/index.js
@@ -12,3 +12,4 @@ export { default as AddAccountModal } from "./AddAccountModal";
 export { default as ChangePassphraseModal } from "./ChangePassphraseModal";
 export { default as InfoModal } from "./InfoModal/Modal";
 export { default as PassphraseModal } from "./PassphraseModal/PassphraseModal";
+export { default as ConfirmModal } from "./ConfirmModal";

--- a/app/components/views/TicketsPage/GovernanceTab/index.js
+++ b/app/components/views/TicketsPage/GovernanceTab/index.js
@@ -7,7 +7,7 @@ class VotingPrefs extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      stakePool: props.defaultStakePool,
+      stakePool: props.stakePool,
       selectedAgenda: null,
       isShowingDetails: false
     };

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/index.js
@@ -149,12 +149,6 @@ class PurchaseTickets extends React.Component {
     this.state.isShowingAdvanced ? this.onHideAdvanced() : this.onShowAdvanced();
   }
 
-  onChangeStakePool(stakePool) {
-    const { onChangeStakePool } = this.props;
-    this.setState({ stakePool });
-    onChangeStakePool && onChangeStakePool(stakePool);
-  }
-
   onChangeAccount(account) {
     const { onChangeAccount } = this.props;
     this.setState({ account });

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/List.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/List.js
@@ -1,5 +1,5 @@
 import { FormattedMessage as T } from "react-intl";
-import { KeyBlueButton, SlateGrayButton }from "buttons";
+import { KeyBlueButton, SlateGrayButton, RemoveStakePoolButton }from "buttons";
 import "style/Layout.less";
 import "style/StakePool.less";
 
@@ -8,7 +8,8 @@ const StakePoolsList = ({
   unconfiguredStakePools,
   onShowAddStakePool,
   onHideStakePoolConfig,
-  rescanRequest
+  onRemoveStakePool,
+  rescanRequest,
 }) => (
   <div className="tab-card">
     <div className="stakepool-flex-height">
@@ -32,9 +33,22 @@ const StakePoolsList = ({
               <div className="stakepool-content-nest-prefix-settings"><T id="stakepools.list.form.field.script" m="Script:" /></div>
               <textarea disabled value={Script} className="stakepool-content-nest-content-settings"/>
             </div>
-            <div className="stakepool-content-nest-settings-bottom">
+            <div className="stakepool-content-nest-settings">
               <div className="stakepool-content-nest-prefix-settings"><T id="stakepools.list.form.field.poolfees" m="Pool Fees:" /></div>
               <div className="stakepool-content-nest-content-settings">{PoolFees}</div>
+            </div>
+            <div className="stakepool-content-nest-settings-bottom">
+              <div className="stakepool-content-nest-prefix-settings"></div>
+              <div className="stakepool-content-nest-content-settings">
+                <RemoveStakePoolButton
+                  modalTitle={<T id="stakepools.list.removeConfirmTitle" m="Remove StakePool" />}
+                  buttonLabel={<T id="stakepools.list.btnRemove" m="Remove"/>}
+                  modalContent={
+                    <T id="stakepools.list.confirmRemove" m="Do you confirm removal of stakepool {stakepool}?"
+                      values={{stakepool: (<span className="mono">{Host}</span>)}}/>}
+                  onSubmit={() => onRemoveStakePool(Host)}
+                />
+              </div>
             </div>
           </div>
         ))}

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
@@ -45,7 +45,8 @@ class StakePools extends React.Component {
             onSetStakePoolInfo: null,
             onChangeSelectedUnconfigured: null,
             onCancelPassphraseRequest: null,
-            onCancelAddStakePool: null
+            onCancelAddStakePool: null,
+            onRemoveStakePool: null
           }, this),
         }}
       />
@@ -98,6 +99,11 @@ class StakePools extends React.Component {
     const { apiKey } = this.state;
     const onSetInfo = this.props.onSetStakePoolInfo;
     apiKey ? (onSetInfo && onSetInfo(privpass, this.getSelectedUnconfigured().Host, apiKey, 0)) : null;
+  }
+
+  onRemoveStakePool(host) {
+    const { onRemoveStakePool } = this.props;
+    onRemoveStakePool && onRemoveStakePool(host);
   }
 }
 

--- a/app/components/views/TicketsPage/PurchaseTab/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/index.js
@@ -14,16 +14,16 @@ class Purchase extends React.Component {
   getInitialState() {
     return {
       account: this.props.defaultSpendingAccount,
-      stakePool: this.props.defaultStakePool,
-      isShowingStakePools: !this.props.defaultStakePool,
+      stakePool: this.props.stakePool,
+      isShowingStakePools: !this.props.stakePool,
       isShowingVotingPrefs: false,
       isShowingImportScript: false,
     };
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!this.props.defaultStakePool && nextProps.defaultStakePool) {
-      this.setState({stakePool: nextProps.defaultStakePool});
+    if (!this.props.stakePool && nextProps.stakePool) {
+      this.setState({stakePool: nextProps.stakePool});
     }
   }
 

--- a/app/connectors/stakePools.js
+++ b/app/connectors/stakePools.js
@@ -8,6 +8,7 @@ const mapStateToProps = selectorMap({
   configuredStakePools: sel.configuredStakePools,
   unconfiguredStakePools: sel.unconfiguredStakePools,
   defaultStakePool: sel.defaultStakePool,
+  stakePool: sel.selectedStakePool,
   rescanRequest: sel.rescanRequest
 });
 

--- a/app/connectors/stakePools.js
+++ b/app/connectors/stakePools.js
@@ -14,6 +14,7 @@ const mapStateToProps = selectorMap({
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   onSetStakePoolInfo: spa.setStakePoolInformation,
+  onRemoveStakePool: spa.removeStakePoolConfig,
   discoverAvailableStakepools: spa.discoverAvailableStakepools
 }, dispatch);
 

--- a/app/connectors/ticketsPage.js
+++ b/app/connectors/ticketsPage.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from "redux";
 import { selectorMap } from "fp";
 import * as sel from "selectors";
 import * as ca from "actions/ControlActions";
-import * as sta from "actions/StakePoolActions";
+import * as spa from "actions/StakePoolActions";
 
 const mapStateToProps = selectorMap({
   spendingAccounts: sel.spendingAccounts,
@@ -38,7 +38,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onClearRevokeTicketsSuccess: ca.clearRevokeTicketsSuccess,
   onClearImportScriptError: ca.clearImportScriptError,
   onClearImportScriptSuccess: ca.clearImportScriptSuccess,
-  onChangeStakePool: sta.changeSelectedStakePool,
+  onChangeStakePool: spa.changeSelectedStakePool,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/connectors/ticketsPage.js
+++ b/app/connectors/ticketsPage.js
@@ -1,8 +1,9 @@
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-import { selectorMap } from "../fp";
-import * as sel from "../selectors";
-import * as ca from "../actions/ControlActions";
+import { selectorMap } from "fp";
+import * as sel from "selectors";
+import * as ca from "actions/ControlActions";
+import * as sta from "actions/StakePoolActions";
 
 const mapStateToProps = selectorMap({
   spendingAccounts: sel.spendingAccounts,
@@ -10,6 +11,7 @@ const mapStateToProps = selectorMap({
   unconfiguredStakePools: sel.unconfiguredStakePools,
   defaultSpendingAccount: sel.defaultSpendingAccount,
   defaultStakePool: sel.defaultStakePool,
+  stakePool: sel.selectedStakePool,
   ticketPrice: sel.ticketPrice,
   currentStakePoolConfigError: sel.currentStakePoolConfigError,
   currentStakePoolConfigSuccessMessage: sel.currentStakePoolConfigSuccessMessage,
@@ -35,7 +37,8 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onClearRevokeTicketsError: ca.clearRevokeTicketsError,
   onClearRevokeTicketsSuccess: ca.clearRevokeTicketsSuccess,
   onClearImportScriptError: ca.clearImportScriptError,
-  onClearImportScriptSuccess: ca.clearImportScriptSuccess
+  onClearImportScriptSuccess: ca.clearImportScriptSuccess,
+  onChangeStakePool: sta.changeSelectedStakePool,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/connectors/votingPrefs.js
+++ b/app/connectors/votingPrefs.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from "redux";
 import { selectorMap } from "fp";
 import * as sel from "selectors";
 import * as ca from "actions/ClientActions";
-import * as sta from "actions/StakePoolActions";
+import * as spa from "actions/StakePoolActions";
 
 const mapStateToProps = selectorMap({
   configuredStakePools: sel.configuredStakePools,
@@ -14,7 +14,7 @@ const mapStateToProps = selectorMap({
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   onUpdateVotePreference: ca.setVoteChoicesAttempt,
-  onChangeStakePool: sta.changeSelectedStakePool,
+  onChangeStakePool: spa.changeSelectedStakePool,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/connectors/votingPrefs.js
+++ b/app/connectors/votingPrefs.js
@@ -1,17 +1,20 @@
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-import { selectorMap } from "../fp";
-import * as sel from "../selectors";
-import * as ca from "../actions/ClientActions";
+import { selectorMap } from "fp";
+import * as sel from "selectors";
+import * as ca from "actions/ClientActions";
+import * as sta from "actions/StakePoolActions";
 
 const mapStateToProps = selectorMap({
   configuredStakePools: sel.configuredStakePools,
   defaultStakePool: sel.defaultStakePool,
+  stakePool: sel.selectedStakePool,
   agendas: sel.agendas
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({
-  onUpdateVotePreference: ca.setVoteChoicesAttempt
+  onUpdateVotePreference: ca.setVoteChoicesAttempt,
+  onChangeStakePool: sta.changeSelectedStakePool,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/index.js
+++ b/app/index.js
@@ -22,10 +22,12 @@ var foundStakePoolConfig = false;
 var currentStakePoolConfig = cfg.get("stakepools");
 var network = cfg.get("network");
 var hiddenAccounts = cfg.get("hiddenaccounts");
+var firstConfiguredStakePool = null;
 if (currentStakePoolConfig !== undefined) {
   for (var i = 0; i < currentStakePoolConfig.length; i++) {
     if (currentStakePoolConfig[i].ApiKey && currentStakePoolConfig[i].Network == network) {
       foundStakePoolConfig = true;
+      firstConfiguredStakePool = currentStakePoolConfig[i];
       break;
     }
   }
@@ -68,6 +70,7 @@ var initialState = {
     currentStakePoolConfigError: null,
     currentStakePoolConfigSuccessMessage: "",
     activeStakePoolConfig: foundStakePoolConfig,
+    selectedStakePool: firstConfiguredStakePool,
   },
   daemon: {
     daemonStarted: false,

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -19,7 +19,8 @@ import {
 } from "../actions/ControlActions";
 import {
   UPDATESTAKEPOOLCONFIG_SUCCESS, UPDATESTAKEPOOLCONFIG_FAILED,
-  SETSTAKEPOOLVOTECHOICES_SUCCESS, SETSTAKEPOOLVOTECHOICES_FAILED
+  SETSTAKEPOOLVOTECHOICES_SUCCESS, SETSTAKEPOOLVOTECHOICES_FAILED,
+  REMOVESTAKEPOOLCONFIG
 } from "../actions/StakePoolActions";
 import {
   NEW_TRANSACTIONS_RECEIVED
@@ -135,6 +136,10 @@ const messages = defineMessages({
   DECODERAWTXS_FAILED: {
     id: "decodeRawTx.errors.decodeFailed",
     defaultMessage: "{originalError}"
+  },
+  REMOVESTAKEPOOLCONFIG: {
+    id: "stakepools.removedStakePoolConfig",
+    defaultMessage: "Successfully removed StakePool config"
   }
 });
 
@@ -172,6 +177,7 @@ export default function snackbar(state = {}, action) {
   case STARTAUTOBUYER_SUCCESS:
   case UPDATESTAKEPOOLCONFIG_SUCCESS:
   case SETSTAKEPOOLVOTECHOICES_SUCCESS:
+  case REMOVESTAKEPOOLCONFIG:
     type = "Success";
     message = messages[action.type] || messages.defaultSuccessMessage;
     break;

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -1,6 +1,7 @@
 import {
     UPDATESTAKEPOOLCONFIG_ATTEMPT, UPDATESTAKEPOOLCONFIG_FAILED, UPDATESTAKEPOOLCONFIG_SUCCESS,
     DISCOVERAVAILABLESTAKEPOOLS_SUCCESS, CHANGESELECTEDSTAKEPOOL,
+    REMOVESTAKEPOOLCONFIG,
 } from "../actions/StakePoolActions";
 import { CLEARSTAKEPOOLCONFIG } from "../actions/WalletLoaderActions";
 
@@ -22,6 +23,7 @@ export default function stakepool(state = {}, action) {
       currentStakePoolConfigRequest: false,
       currentStakePoolConfig: action.currentStakePoolConfig,
       activeStakePoolConfig: true,
+      selectedStakePool: action.selectedStakePool,
     };
   case CLEARSTAKEPOOLCONFIG:
     return {...state,
@@ -33,6 +35,12 @@ export default function stakepool(state = {}, action) {
   case CHANGESELECTEDSTAKEPOOL:
     return {...state,
       selectedStakePool: action.selectedStakePool
+    };
+  case REMOVESTAKEPOOLCONFIG:
+    return {...state,
+      currentStakePoolConfig: action.currentStakePoolConfig,
+      selectedStakePool: action.selectedStakePool,
+      activeStakePoolConfig: !!action.selectedStakePool,
     };
   default:
     return state;

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -1,6 +1,6 @@
 import {
     UPDATESTAKEPOOLCONFIG_ATTEMPT, UPDATESTAKEPOOLCONFIG_FAILED, UPDATESTAKEPOOLCONFIG_SUCCESS,
-    DISCOVERAVAILABLESTAKEPOOLS_SUCCESS
+    DISCOVERAVAILABLESTAKEPOOLS_SUCCESS, CHANGESELECTEDSTAKEPOOL,
 } from "../actions/StakePoolActions";
 import { CLEARSTAKEPOOLCONFIG } from "../actions/WalletLoaderActions";
 
@@ -30,6 +30,10 @@ export default function stakepool(state = {}, action) {
     };
   case DISCOVERAVAILABLESTAKEPOOLS_SUCCESS:
     return {...state, currentStakePoolConfig: action.currentStakePoolConfig };
+  case CHANGESELECTEDSTAKEPOOL:
+    return {...state,
+      selectedStakePool: action.selectedStakePool
+    };
   default:
     return state;
   }

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -606,6 +606,7 @@ export const unconfiguredStakePools = createSelector(
 );
 
 export const defaultStakePool = compose(get(0), configuredStakePools);
+export const selectedStakePool = get(["stakepool", "selectedStakePool"]);
 
 const currentStakePoolConfigRequest = get(["stakepool", "currentStakePoolConfigRequest"]);
 

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -121,6 +121,27 @@
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.22);
 }
 
+.danger-button {
+  cursor: pointer;
+  display: inline-block;
+  padding: 17px 18px 18px;
+  border-radius: 5px;
+  background-color: #b12d2d;
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+  color: #fff;
+  font-size: 13px;
+  line-height: 9px;
+  font-weight: 600;
+  text-align: center;
+  text-decoration: none;
+  text-transform: capitalize;
+  transition: all 100ms cubic-bezier(0.86, 0, 0.07, 1) 0s;
+}
+
+.danger-button:hover {
+  background-color: #c73434;
+}
+
 .manage-pools-button {
   float: left;
   background-color: #2971ff;

--- a/app/style/Modals.less
+++ b/app/style/Modals.less
@@ -13,6 +13,7 @@
 .app-modal {
   position: fixed;
   background-color: #fff;
+  z-index: 200;
 }
 
 .app-modal.info-modal {
@@ -156,3 +157,54 @@
   width: 75%;
   text-align: left;
 }
+
+.app-modal.confirm-modal {
+  left: 10%;
+  right: 10%;
+  top: 20%;
+  border-radius: 5px;
+  overflow-y: auto;
+  padding: 2em;
+  color: rgba(12, 30, 62, 1);
+  line-height: normal;
+  text-align: left;
+}
+
+@media screen and (min-width: 768px) {
+  .app-modal.confirm-modal {
+    left: 20%;
+    right: 20%;
+  }
+}
+
+@media screen and (max-height: 420px) {
+  .app-modal.confirm-modal {
+    top: 10%;
+    max-height: 60%;
+  }
+}
+
+.confirm-modal-toolbar {
+  margin-top: 2em;
+}
+
+.confirm-modal-toolbar > .confirm-modal-close-button {
+  float: right;
+}
+
+.confirm-modal-header {
+  margin-bottom: 1em;
+}
+
+.confirm-modal-header-title {
+  font-weight: 600;
+  font-size: 19px;
+  text-transform: capitalize;
+}
+
+
+
+
+// .passphrase-modal-header-description {
+//   font-size: 15px;
+// }

--- a/app/style/Modals.less
+++ b/app/style/Modals.less
@@ -201,10 +201,3 @@
   font-size: 19px;
   text-transform: capitalize;
 }
-
-
-
-
-// .passphrase-modal-header-description {
-//   font-size: 15px;
-// }


### PR DESCRIPTION
Fix #1058 

This adds the following changes:
- Move selected stakepool into global state so it is maintained between tab/page changes
- Add a remove stakepool button into the the stakepool list
- Add a DangerButton to be used in remove operations
- Add ConfirmModal to be used in operations that need confirmation but not necessarily the passphrase

Only thing I'm not 100% sure is if I need to dispatch a rescan after removing a stakepool from the configured ones.