### PR TITLE
Update electron to 1.7.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin/
 .vagrant
 dist/
 app/i18n/extracted/app
+/*.node

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -110,6 +110,9 @@ var cfg = initCfg();
 
 const logger = createLogger(debug);
 logger.log("info", "Using config/data from:" + app.getPath("userData"));
+logger.log("info", "Chrome version: " + process.versions.chrome);
+logger.log("info", "Electron version: " + process.versions.chrome);
+logger.log("info", "Decrediton version: " + app.getVersion());
 
 var createDcrdConf, createDcrwalletConf, createDcrctlConf = false;
 if (!fs.existsSync(dcrdCfg())) {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -110,9 +110,13 @@ var cfg = initCfg();
 
 const logger = createLogger(debug);
 logger.log("info", "Using config/data from:" + app.getPath("userData"));
-logger.log("info", "Chrome version: " + process.versions.chrome);
-logger.log("info", "Electron version: " + process.versions.chrome);
-logger.log("info", "Decrediton version: " + app.getVersion());
+logger.log("info", "Versions: Decrediton: %s, Electron: %s, Chrome: %s",
+  app.getVersion(), process.versions.electron, process.versions.chrome);
+
+process.on("uncaughtException", err => {
+  logger.log("error", "UNCAUGHT EXCEPTION", err);
+  throw err;
+});
 
 var createDcrdConf, createDcrwalletConf, createDcrctlConf = false;
 if (!fs.existsSync(dcrdCfg())) {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "css-loader": "^0.28.4",
     "dateformat": "^2.0.0",
     "devtron": "^1.4.0",
-    "electron": "1.4.15",
+    "electron": "1.8.1",
     "electron-builder": "^19.45.0",
     "electron-devtools-installer": "^2.0.1",
     "enzyme": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "css-loader": "^0.28.4",
     "dateformat": "^2.0.0",
     "devtron": "^1.4.0",
-    "electron": "1.8.1",
+    "electron": "1.7.10",
     "electron-builder": "^19.45.0",
     "electron-devtools-installer": "^2.0.1",
     "enzyme": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,9 +30,9 @@
   version "8.0.58"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.58.tgz#5b3881c0be3a646874803fee3197ea7f1ed6df90"
 
-"@types/node@^8.0.24":
-  version "8.5.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.8.tgz#92509422653f10e9c0ac18d87e0610b39f9821c7"
+"@types/node@^7.0.18":
+  version "7.0.52"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.52.tgz#8990d3350375542b0c21a83cd0331e6a8fc86716"
 
 abab@^1.0.3:
   version "1.0.4"
@@ -2829,11 +2829,11 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.28:
   version "1.3.28"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
 
-electron@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.1.tgz#19b6f39f2013e204a91a60bc3086dc7a4a07ed88"
+electron@1.7.10:
+  version "1.7.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.10.tgz#3a3e83d965fd7fafe473be8ddf8f472561b6253d"
   dependencies:
-    "@types/node" "^8.0.24"
+    "@types/node" "^7.0.18"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,10 @@
   version "8.0.58"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.58.tgz#5b3881c0be3a646874803fee3197ea7f1ed6df90"
 
+"@types/node@^8.0.24":
+  version "8.5.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.8.tgz#92509422653f10e9c0ac18d87e0610b39f9821c7"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -94,9 +98,18 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.3, ajv@^5.5.1:
+ajv@^5.0.0, ajv@^5.1.5, ajv@^5.2.3, ajv@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^5.1.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -2816,10 +2829,11 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.28:
   version "1.3.28"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
 
-electron@1.4.15:
-  version "1.4.15"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.4.15.tgz#eaccafe3f55ade02a746b706ac14b43db6c7ccf8"
+electron@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.1.tgz#19b6f39f2013e204a91a60bc3086dc7a4a07ed88"
   dependencies:
+    "@types/node" "^8.0.24"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 
@@ -2958,8 +2972,8 @@ es6-map@^0.1.3:
     event-emitter "~0.3.5"
 
 es6-promise@^4.0.5:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.2.tgz#f722d7769af88bd33bc13ec6605e1f92966b82d9"
 
 es6-set@~0.1.5:
   version "0.1.5"


### PR DESCRIPTION
Fix #1051 

I tried to update to the 1.8.x release line, but got some undebugable white error screen (electron didn't load the app, didn't throw an exception or gave me anything to indicate where it had errored), so I pulled back to the latest release of the 1.7.x (non-beta) line.

I tested the general functions (seed input, transactions, ticket purchase, simple and advanced mode) on the following platforms:

- Linux (development version with `yarn dev`)
- Linux (locally packaged version with `yarn package`)
- Windows (development version with `yarn dev`)
- Windows (locally packaged version with `yarn package`)

Don't have a macOS computer to test, so could use some help there if available.

I had to delete the `node_modules` and `app/node_modules` and execute `yarn` to rebuild the correct electron/electron-builder packages.

Also, on windows I had to manually install the npm package `windows-build-tools` as an admin, but I don't remember having to do that before (see https://github.com/felixrieseberg/windows-build-tools/issues/56#issuecomment-304404123).

I'm getting an exception on shutdown regarding the grpc module. It's a read error, probably due to trying to execute a service after the wallet process has shutdown, or due to one of the streams getting closed (my guess is the block/transaction notification). I only got this during shutdown, so I guess it can be safely ignored for now, but I can try and better pinpoint the origin if needed.



