### PR TITLE
Add log viewing to GetStarted stage

### DIFF
--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -27,13 +27,19 @@ const DaemonLoadingFormBody = ({
     getNeededBlocks,
     showLongWaitMessage,
     finishDateEstimation,
-    onShowSettings
+    onShowSettings,
+    onShowLogs,
   }) => (
     <div className="get-started-content-new-seed">
     {getDaemonStarted ? getCurrentBlockCount == null ?
       showLongWaitMessage ?
       <div className="get-started-fetch-headers-message">
         <T id="getStarted.chainLoading" m="The Decred chain is currently loading and may take a few minutes." />
+        <div style={{marginTop: "1em"}}>
+          <SlateGrayButton onClick={onShowLogs}>
+            <T id="getStarted.btnLogs" m="Logs" />
+          </SlateGrayButton>
+        </div>
       </div> :
       <div></div> :
       <Aux>
@@ -66,6 +72,9 @@ const DaemonLoadingFormBody = ({
         <div className="get-started-bottom-buttons">
           <SlateGrayButton onClick={onShowSettings}>
             <T id="getStarted.btnSettings" m="Application Settings" />
+          </SlateGrayButton>
+          <SlateGrayButton onClick={onShowLogs}>
+            <T id="getStarted.btnLogs" m="Logs" />
           </SlateGrayButton>
         </div>
       </Aux> :

--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -33,14 +33,16 @@ const DaemonLoadingFormBody = ({
     <div className="get-started-content-new-seed">
     {getDaemonStarted ? getCurrentBlockCount == null ?
       showLongWaitMessage ?
-      <div className="get-started-fetch-headers-message">
-        <T id="getStarted.chainLoading" m="The Decred chain is currently loading and may take a few minutes." />
-        <div style={{marginTop: "1em"}}>
+      <Aux>
+        <div className="get-started-fetch-headers-message">
+          <T id="getStarted.chainLoading" m="The Decred chain is currently loading and may take a few minutes." />
+        </div>
+        <div className="get-started-bottom-buttons">
           <SlateGrayButton onClick={onShowLogs}>
             <T id="getStarted.btnLogs" m="Logs" />
           </SlateGrayButton>
         </div>
-      </div> :
+      </Aux> :
       <div></div> :
       <Aux>
         <div className="get-started-content-instructions">

--- a/app/components/views/GetStartedPage/Logs/Form.js
+++ b/app/components/views/GetStartedPage/Logs/Form.js
@@ -1,0 +1,7 @@
+import LogsTab from "views/HelpPage/LogsTab";
+
+export default () => (
+  <div className="get-started-content-new-seed get-started-logs">
+    <LogsTab />
+  </div>
+);

--- a/app/components/views/GetStartedPage/Logs/Header.js
+++ b/app/components/views/GetStartedPage/Logs/Header.js
@@ -1,0 +1,27 @@
+import Header from "../DefaultHeader";
+import { SlateGrayButton } from "buttons";
+import { FormattedMessage as T } from "react-intl";
+
+export default ({
+  startupError,
+  onHideLogs
+}) => (
+  <Header
+  headerTop={startupError
+    ? <div key="pubError" className="get-started-view-notification-error">{startupError}</div>
+    : <div key="pubError" ></div>}
+    headerMetaOverview={(
+      <div className="get-started-create-wallet-header">
+        <div className="get-started-subheader">
+          <T id="getStarted.header.logs.meta" m="Logs" />
+        </div>
+        <div className="get-started-button-toolbar">
+            <SlateGrayButton
+              className="get-started-view-button-go-back"
+              onClick={onHideLogs}
+            ><T id="getStarted.logs.backBtn" m="Back" /> </SlateGrayButton>
+        </div>
+      </div>
+    )}
+  />
+);

--- a/app/components/views/GetStartedPage/Logs/index.js
+++ b/app/components/views/GetStartedPage/Logs/index.js
@@ -1,0 +1,2 @@
+export { default as LogsHeader } from "./Header";
+export { default as LogsBody } from "./Form";

--- a/app/components/views/GetStartedPage/Page.js
+++ b/app/components/views/GetStartedPage/Page.js
@@ -8,7 +8,7 @@ const Page = ({ Header, Body, ...props }) => {
       <Header {...props} />
       <div className="page-content-fixed">
         <DecredLoading
-          hidden={!props.isProcessing || props.showSettings}
+          hidden={!props.isProcessing || props.showSettings || props.showLogs}
           className="get-started-loading"
         />
         <Body {...props} />

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -8,6 +8,7 @@ import { FinalStartUpHeader, FinalStartUpBody } from "./FinalStartUp";
 import { DaemonLoadingHeader, DaemonLoadingBody } from "./DaemonLoading";
 import { AdvancedStartupHeader, AdvancedStartupBody, RemoteAppdataError } from "./AdvancedStartup";
 import { SettingsBody, SettingsHeader } from "./Settings";
+import { LogsBody, LogsHeader } from "./Logs";
 import { walletStartup } from "connectors";
 import { getAppdataPath, getRemoteCredentials } from "config.js";
 
@@ -16,7 +17,7 @@ class GetStartedPage extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { showSettings: false };
+    this.state = { showSettings: false, showLogs: false };
     props.determineNeededBlocks();
   }
 
@@ -48,6 +49,14 @@ class GetStartedPage extends React.Component {
     this.setState({ showSettings: false });
   }
 
+  onShowLogs() {
+    this.setState({ showLogs: true });
+  }
+
+  onHideLogs() {
+    this.setState({ showLogs: false });
+  }
+
   render() {
     const {
       startStepIndex,
@@ -60,12 +69,15 @@ class GetStartedPage extends React.Component {
 
     const {
       showSettings,
+      showLogs,
       ...state
     } = this.state;
 
     const {
       onShowSettings,
-      onHideSettings
+      onHideSettings,
+      onShowLogs,
+      onHideLogs
     } = this;
 
     let Header, Body;
@@ -73,6 +85,9 @@ class GetStartedPage extends React.Component {
     if (showSettings) {
       Header = SettingsHeader;
       Body = SettingsBody;
+    } else if (showLogs) {
+      Header = LogsHeader;
+      Body = LogsBody;
     } else if (isPrepared) {
       switch (startStepIndex || 0) {
       case 0:
@@ -119,8 +134,11 @@ class GetStartedPage extends React.Component {
         ...props,
         ...state,
         showSettings,
+        showLogs,
         onShowSettings,
-        onHideSettings}} />;
+        onHideSettings,
+        onShowLogs,
+        onHideLogs}} />;
   }
 }
 

--- a/app/components/views/HelpPage/LogsTab/Page.js
+++ b/app/components/views/HelpPage/LogsTab/Page.js
@@ -8,6 +8,7 @@ const Logs = ({
   dcrdLogs,
   dcrwalletLogs,
   remoteDcrd,
+  walletReady,
   }
 ) => (
   <Aux>
@@ -27,7 +28,7 @@ const Logs = ({
           </div> :
           <div/>
       }
-      {!dcrwalletLogs ?
+      {!walletReady ? null : !dcrwalletLogs ?
         <div className="log-area-hidden" onClick={showDcrwalletLogs}>
           <T id="help.logs.show.dcrwallet" m="Show dcrwallet logs" />
         </div>:

--- a/app/connectors/logging.js
+++ b/app/connectors/logging.js
@@ -5,6 +5,7 @@ import * as sel from "../selectors";
 
 const mapStateToProps = selectorMap({
   getCredentials: sel.getCredentials,
+  walletReady: sel.getWalletReady,
 });
 
 export default connect(mapStateToProps);

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -304,3 +304,7 @@
     margin-right: 1em;
   }
 }
+
+.get-started-logs {
+  color: #eee;
+}


### PR DESCRIPTION
Fix #1049 

Besides during blockchain downloading, I also added the log button on daemon loading (before starting the blockchain download) as that seems to be the step most people get stuck.

Let me know if you think it should be added to more places.