### PR TITLE
Add first pass action logging in WalletLoader

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -21,13 +21,18 @@ export const LOADER_SUCCESS = "LOADER_SUCCESS";
 
 export const loaderRequest = ( address, port) => (dispatch) => {
   const request = { address, port };
+  wallet.log("debug", "Wallet loader request at: " + address +":" + port);
   dispatch({ request, type: LOADER_ATTEMPT });
   return getLoader(request)
     .then(loader => {
       dispatch({ loader, type: LOADER_SUCCESS });
       dispatch(walletExistRequest());
+      wallet.log("debug", "Wallet loader successfully started");
     })
-    .catch(error => dispatch({ error, type: LOADER_FAILED }));
+    .catch(error => {
+      dispatch({ error, type: LOADER_FAILED });
+      wallet.log("error", "Wallet loader request failed:", error);
+    });
 };
 
 export const WALLETEXIST_ATTEMPT = "WALLETEXIST_ATTEMPT";
@@ -41,12 +46,16 @@ export const walletExistRequest = () =>
         dispatch({response: response, type: WALLETEXIST_SUCCESS });
         if (response.getExists()) {
           dispatch(openWalletAttempt("public", false));
-        }
-        else {
+          wallet.log("debug", "Existing wallet found.");
+        } else {
           dispatch({ type: CREATEWALLET_NEWSEED_INPUT });
+          wallet.log("debug", "No existing wallet found.");
         }
       })
-      .catch(error => dispatch({ error, type: WALLETEXIST_FAILED }));
+      .catch(error => {
+        dispatch({ error, type: WALLETEXIST_FAILED });
+        wallet.log("error", "Wallet exists failed:", error);
+      });
 
 export const CREATEWALLET_NEWSEED_CONFIRM_INPUT = "CREATEWALLET_NEWSEED_CONFIRM_INPUT";
 export const CREATEWALLET_NEWSEED_BACK_INPUT = "CREATEWALLET_NEWSEED_BACK_INPUT";
@@ -67,8 +76,10 @@ export const CREATEWALLET_SUCCESS = "CREATEWALLET_SUCCESS";
 export const createWalletRequest = (pubPass, privPass, seed, existing) =>
   (dispatch, getState) => {
     dispatch({ existing: existing, type: CREATEWALLET_ATTEMPT });
+    wallet.log("info", "Create wallet request, from existing? " + existing);
     return createWallet(getState().walletLoader.loader, pubPass, privPass, seed)
       .then(() => {
+        wallet.log("debug", "Created wallet successfully");
         const config = getCfg();
         config.delete("discoveraccounts");
         dispatch({response: {}, type: CREATEWALLET_SUCCESS });
@@ -77,7 +88,10 @@ export const createWalletRequest = (pubPass, privPass, seed, existing) =>
         config.set("discoveraccounts", !existing);
         dispatch(startRpcRequestFunc());
       })
-      .catch(error => dispatch({ error, type: CREATEWALLET_FAILED }));
+      .catch(error => {
+        dispatch({ error, type: CREATEWALLET_FAILED });
+        wallet.log("error", "Create wallet failed:", error);
+      });
   };
 
 export const OPENWALLET_INPUT = "OPENWALLET_INPUT";
@@ -87,9 +101,11 @@ export const OPENWALLET_FAILED = "OPENWALLET_FAILED";
 export const OPENWALLET_SUCCESS = "OPENWALLET_SUCCESS";
 
 export const openWalletAttempt = (pubPass, retryAttempt) => (dispatch, getState) => {
+  wallet.log("info", "Open wallet request");
   dispatch({ type: OPENWALLET_ATTEMPT });
   return openWallet(getState().walletLoader.loader, pubPass)
     .then(() => {
+      wallet.log("debug", "Opened wallet successfully");
       dispatch({ type: OPENWALLET_SUCCESS });
       dispatch(startRpcRequestFunc(false));
     })
@@ -106,6 +122,7 @@ export const openWalletAttempt = (pubPass, retryAttempt) => (dispatch, getState)
       } else {
         dispatch({ error, type: OPENWALLET_FAILED });
       }
+      wallet.log("error", "Open wallet failed:", error);
     });
 };
 
@@ -114,10 +131,17 @@ export const CLOSEWALLET_FAILED = "CLOSEWALLET_FAILED";
 export const CLOSEWALLET_SUCCESS = "CLOSEWALLET_SUCCESS";
 
 export const closeWalletRequest = () => (dispatch, getState) => {
+  wallet.log("info", "Close wallet request");
   dispatch({ type: CLOSEWALLET_ATTEMPT });
   return closeWallet(getState().walletLoader.loader)
-    .then(() => dispatch({ type: CLOSEWALLET_SUCCESS }))
-    .catch(error => dispatch({ error, type: CLOSEWALLET_FAILED }));
+    .then(() => {
+      dispatch({ type: CLOSEWALLET_SUCCESS });
+      wallet.log("debug", "Closed wallet successfully");
+    })
+    .catch(error => {
+      dispatch({ error, type: CLOSEWALLET_FAILED });
+      wallet.log("error", "Close wallet failed:", error);
+    });
 };
 
 export const STARTRPC_ATTEMPT = "STARTRPC_ATTEMPT";
@@ -153,12 +177,14 @@ export const startRpcRequestFunc = (isRetry) =>
   const loader = getState().walletLoader.loader;
 
   const cert = getDcrdCert(rpccertPath);
-
+  const rpcLog = "user: " + rpcuser + " pass: " + rpcpass + " rpccertPath: " + rpccertPath + " rpchost:" + daemonhost + " rpcport:" + rpcport;
+  wallet.log("info", "Start RPC attempt " + rpcLog);
   if (!isRetry) dispatch({type: STARTRPC_ATTEMPT});
   return startRpc(loader, daemonhost, rpcport, rpcuser, rpcpass, cert)
     .then(() => {
       dispatch({ type: STARTRPC_SUCCESS});
       dispatch(subscribeBlockAttempt());
+      wallet.log("debug", "Connected RPC daemon successfully");
     })
     .catch(error => {
       if (error.message.includes("RPC client already created")) {
@@ -178,6 +204,7 @@ export const startRpcRequestFunc = (isRetry) =>
       } else {
         dispatch(startRpcRequestFunc(true));
       }
+      wallet.log("error", "Start RPC Client failed:", error);
     });
 };
 
@@ -189,6 +216,7 @@ export const DISCOVERADDRESS_SUCCESS = "DISCOVERADDRESS_SUCCESS";
 
 export const discoverAddressAttempt = (privPass) => (dispatch, getState) => {
   const { loader, discoverAccountsComplete } = getState().walletLoader;
+  wallet.log("info", "Discovering addresses request, accounts? " + !discoverAccountsComplete);
   dispatch({ type: DISCOVERADDRESS_ATTEMPT });
   discoverAddresses(loader, !discoverAccountsComplete, privPass)
     .then(() => {
@@ -202,6 +230,7 @@ export const discoverAddressAttempt = (privPass) => (dispatch, getState) => {
       }
 
       dispatch({response: {}, type: DISCOVERADDRESS_SUCCESS});
+      wallet.log("debug", "Discovered addresses successfully");
       if (subscribeBlockNtfnsResponse !== null) dispatch(fetchHeadersAttempt());
     })
     .catch(error => {
@@ -210,6 +239,7 @@ export const discoverAddressAttempt = (privPass) => (dispatch, getState) => {
       } else {
         dispatch({ error, type: DISCOVERADDRESS_FAILED });
       }
+      wallet.log("error", "Discover addresses failed:", error);
     });
 };
 
@@ -219,19 +249,24 @@ export const SUBSCRIBEBLOCKNTFNS_SUCCESS = "SUBSCRIBEBLOCKNTFNS_SUCCESS";
 
 const subscribeBlockAttempt = () => (dispatch, getState) => {
   const { loader, discoverAccountsComplete } = getState().walletLoader;
-
+  wallet.log("info", "Subscribe to block notifications request");
   dispatch({request: {}, type: SUBSCRIBEBLOCKNTFNS_ATTEMPT});
   return subscribeToBlockNotifications(loader)
     .then(() => {
+      wallet.log("debug", "Subscribed to block notifications successfully");
       dispatch({response: {}, type: SUBSCRIBEBLOCKNTFNS_SUCCESS});
       if (discoverAccountsComplete) {
         dispatch(discoverAddressAttempt());
       } else {
+        wallet.log("info", "Need to ask user for private passphrase for account discovery.");
         // This is dispatched to indicate we should wait for user input to discover addresses.
         dispatch({response: {}, type: DISCOVERADDRESS_INPUT});
       }
     })
-    .catch(error => dispatch({ error, type: SUBSCRIBEBLOCKNTFNS_FAILED }));
+    .catch(error => {
+      dispatch({ error, type: SUBSCRIBEBLOCKNTFNS_FAILED });
+      wallet.log("error", "Subscribe to block notifications:", error);
+    });
 };
 
 export const FETCHHEADERS_ATTEMPT = "FETCHHEADER_ATTEMPT";
@@ -240,22 +275,28 @@ export const FETCHHEADERS_SUCCESS = "FETCHHEADERS_SUCCESS";
 export const FETCHHEADERS_PROGRESS = "FETCHHEADERS_PROGRESS";
 
 export const fetchHeadersAttempt = () => (dispatch, getState) => {
+  wallet.log("info", "Fetch headers request");
   dispatch({request: {}, type: FETCHHEADERS_ATTEMPT});
   return fetchHeaders(getState().walletLoader.loader)
     .then(response => {
+      wallet.log("debug", "New fetched headers received");
       dispatch({response, type: FETCHHEADERS_SUCCESS});
       dispatch(getWalletServiceAttempt());
       dispatch(getTicketBuyerServiceAttempt());
       dispatch(getVotingServiceAttempt());
       dispatch(getAgendaServiceAttempt());
     })
-    .catch(error => dispatch({ error, type: FETCHHEADERS_FAILED }));
+    .catch(error => {
+      dispatch({ error, type: FETCHHEADERS_FAILED });
+      wallet.log("error", "Fetch headers failed:", error);
+    });
 };
 
 export const UPDATEDISCOVERACCOUNTS = "UPDATEDISCOVERACCOUNTS";
 export const CLEARSTAKEPOOLCONFIG = "CLEARSTAKEPOOLCONFIG";
 
 export function clearStakePoolConfigNewWallet() {
+  wallet.log("info", "Clearing stakepool configuration due to new wallet.");
   return (dispatch) => {
     let config = getCfg();
     config.delete("stakepools");
@@ -282,8 +323,8 @@ export function determineNeededBlocks() {
       wallet.log("info", `Determined needed block height as ${neededBlocks}`);
       dispatch({ neededBlocks, type: NEEDED_BLOCKS_DETERMINED});
     })
-    .catch(function (error) {
-      console.log("Unable to obtain latest block number.", error);
+    .catch(error => {
+      wallet.log("error", "Unable to obtain latest block number.", error);
     });
   };
 }


### PR DESCRIPTION
First swing at adding logging to decrediton actions.

The thought is to log each action attempt as "info", successes as "debug" and errors as such.  I'm open to input to try and find a nice equilibrium that isn't too spammy.

Once we settle on general outline for these, I will apply the same to the rest of the actions.  After that we can debate how much logging we want above in the components, but I'm thinking we shouldn't really have any logging up above (unless some error situation).