### PR TITLE
Clean up account individual updating

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -123,7 +123,6 @@ export const GETBALANCE_SUCCESS = "GETBALANCE_SUCCESS";
 const getBalanceUpdateSuccess = (accountNumber, getBalanceResponse) => (dispatch, getState) => {
   const { grpc: { balances } } = getState();
   let updatedBalance;
-  console.log(accountNumber);
   balances.some(balance => {
     if (balance.accountNumber == accountNumber) {
       updatedBalance = balance;
@@ -257,10 +256,35 @@ export const getAccountsAttempt = (startup) => (dispatch, getState) => {
 };
 
 export const UPDATEHIDDENACCOUNTS = "UPDATEHIDDENACCOUNTS";
+export const UPDATEACCOUNT_SUCCESS = "UPDATEACCOUNT_SUCCESS";
+
+export function updateAccount(account) {
+  return (dispatch, getState) => {
+    const { grpc: { balances } } = getState();
+    let updatedBalance;
+    balances.some(balance => {
+      if (balance.accountNumber == account.accountNumber) {
+        updatedBalance = balance;
+        return balance.accountNumber == account.accountNumber;
+      }
+    });
+
+    if (account.hidden) updatedBalance.hidden = account.hidden;
+    if (account.accountName) updatedBalance.accountName = account.accountName;
+    if (account.externalKeys) updatedBalance.externalKeys = account.externalKeys;
+    if (account.internalKeys) updatedBalance.internalKeys = account.internalKeys;
+    if (account.importedKeys) updatedBalance.importedKeys = account.importedKeys;
+
+    const updatedBalances = balances.map(balance =>
+      (balance.accountNumber === account.accountNumber) ? updatedBalance : balance);
+
+    dispatch({balances: updatedBalances, type: GETBALANCE_SUCCESS });
+  };
+}
 
 export function hideAccount(accountNumber) {
   return (dispatch, getState) => {
-    const {hiddenAccounts} = getState().grpc;
+    const { grpc: { hiddenAccounts } } = getState();
     var updatedHiddenAccounts;
     if (hiddenAccounts.length == 0) {
       updatedHiddenAccounts = Array();
@@ -271,13 +295,13 @@ export function hideAccount(accountNumber) {
     var cfg = getCfg();
     cfg.set("hiddenaccounts", updatedHiddenAccounts);
     dispatch({hiddenAccounts: updatedHiddenAccounts, type: UPDATEHIDDENACCOUNTS});
-    dispatch(getAccountsAttempt());
+    dispatch(updateAccount({accountNumber, hidden: true}));
   };
 }
 
 export function showAccount(accountNumber) {
   return (dispatch, getState) => {
-    const {hiddenAccounts} = getState().grpc;
+    const { grpc: { hiddenAccounts } } = getState();
     var updatedHiddenAccounts = Array();
     for (var i = 0; i < hiddenAccounts.length; i++) {
       if (hiddenAccounts[i] !== accountNumber) {
@@ -287,7 +311,7 @@ export function showAccount(accountNumber) {
     var cfg = getCfg();
     cfg.set("hiddenaccounts", updatedHiddenAccounts);
     dispatch({hiddenAccounts: updatedHiddenAccounts, type: UPDATEHIDDENACCOUNTS});
-    dispatch(getAccountsAttempt());
+    dispatch(updateAccount({accountNumber, hidden: false}));
   };
 }
 

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -71,11 +71,6 @@ export const getTicketBuyerServiceAttempt = () => (dispatch, getState) => {
     .catch(error => dispatch({ error, type: GETTICKETBUYERSERVICE_FAILED }));
 };
 
-
-export const GETACCOUNTSBALANCES_ATTEMPT = "GETACCOUNTSBALANCES_ATTEMPT";
-export const GETACCOUNTSBALANCES_SUCCESS = "GETACCOUNTSBALANCES_SUCCESS";
-export const GETACCOUNTSBALANCES_FAIL = "GETACCOUNTSBALANCES_FAIL";
-
 const getAccountsBalances = (accounts) => (dispatch, getState) => {
   var balances = new Array();
   const { grpc: { network, hiddenAccounts } } = getState();
@@ -136,7 +131,6 @@ const getBalanceUpdateSuccess = (accountNumber, getBalanceResponse) => (dispatch
   updatedBalance.lockedByTickets = getBalanceResponse.getLockedByTickets();
   updatedBalance.votingAuthority = getBalanceResponse.getVotingAuthority();
 
-  console.log("get balance update", accountNumber, updatedBalance);
   const updatedBalances = balances.map(balance =>
     (balance.accountNumber === accountNumber) ? updatedBalance : balance);
 
@@ -421,7 +415,7 @@ export const NEW_TRANSACTIONS_RECEIVED = "NEW_TRANSACTIONS_RECEIVED";
 
 function checkAccountsToUpdate(txs, accountsToUpdate) {
   txs.forEach(tx => {
-    tx.tx.getCreditsList().forEach(credit => {if (accountsToUpdate.find(eq(credit.getAccount()))) accountsToUpdate.push(credit.getAccount());});
+    tx.tx.getCreditsList().forEach(credit => {if (!accountsToUpdate.find(eq(credit.getAccount()))) accountsToUpdate.push(credit.getAccount());});
     tx.tx.getDebitsList().forEach(debit => {if (!accountsToUpdate.find(eq(debit.getPreviousAccount()))) accountsToUpdate.push(debit.getPreviousAccount());});
   });
   return accountsToUpdate;

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -57,7 +57,6 @@ export function renameAccountAttempt(accountNumber, newName) {
           } else {
             var successMsg = "You have successfully updated the account name.";
             setTimeout( () => dispatch({ renameAccountSuccess: successMsg, renameAccountResponse: renameAccountResponse, type: RENAMEACCOUNT_SUCCESS }), 1000);
-            dispatch(getAccountsAttempt());
           }
         });
   };
@@ -81,7 +80,7 @@ export function rescanAttempt(beginHeight) {
     });
     rescanCall.on("end", function() {
       dispatch({ type: RESCAN_COMPLETE });
-      setTimeout( () => {dispatch(getAccountsAttempt());}, 1000);
+      setTimeout( () => {dispatch(getAccountsAttempt(true));}, 1000);
       setTimeout( () => {dispatch(getMostRecentTransactions());}, 1000);
       setTimeout( () => {dispatch(getTicketsInfoAttempt());}, 1000);
     });
@@ -117,7 +116,6 @@ export function getNextAccountAttempt(passphrase, accountName) {
         } else {
           var success = "Account - " + accountName + " - has been successfully created.";
           setTimeout( () => dispatch({getNextAccountResponse: getNextAccountResponse, type: GETNEXTACCOUNT_SUCCESS, successMessage: success }), 1000);
-          dispatch(getAccountsAttempt());
         }
       });
   };
@@ -300,7 +298,6 @@ export function publishTransactionAttempt(tx) {
           dispatch({ error, type: PUBLISHTX_FAILED });
         } else {
           dispatch({ publishTransactionResponse: Buffer.from(publishTransactionResponse.getTransactionHash()), type: PUBLISHTX_SUCCESS });
-          setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
         }
       });
   };
@@ -350,7 +347,6 @@ function purchaseTicketsAction(request) {
           dispatch({ error, type: PURCHASETICKETS_FAILED });
         } else {
           dispatch({ purchaseTicketsResponse: purchaseTicketsResponse, type: PURCHASETICKETS_SUCCESS });
-          setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
           setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 4000);
         }
       });

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -1,7 +1,7 @@
 // @flow
 import * as wallet from "wallet";
-import { getAccountsAttempt, getStakeInfoAttempt,
-  getTicketPriceAttempt, getNetworkAttempt } from "./ClientActions";
+import { getStakeInfoAttempt,
+  getTicketPriceAttempt, getNetworkAttempt, updateAccount } from "./ClientActions";
 import { UPDATETIMESINCEBLOCK, newTransactionsReceived } from "./ClientActions";
 import { TransactionNotificationsRequest, AccountNotificationsRequest } from "middleware/walletrpc/api_pb";
 
@@ -38,7 +38,6 @@ function transactionNtfnsData(response) {
           dispatch({response: response, type: TRANSACTIONNTFNS_DATA });
           setTimeout( () => {dispatch(getStakeInfoAttempt());}, 1000);
           setTimeout( () => {dispatch(getTicketPriceAttempt());}, 1000);
-          //setTimeout( () => {dispatch(getAccountsAttempt());}, 1000);
           setTimeout( () => {dispatch(getNetworkAttempt());}, 1000);
 
           const newlyMined = attachedBlocks.reduce((l, b) => {
@@ -93,7 +92,10 @@ export const accountNtfnsStart = () => (dispatch, getState) => {
   const { walletService } = getState().grpc;
   let accountNtfns = walletService.accountNotifications(request);
   dispatch({ accountNtfns, type: ACCOUNTNTFNS_START });
-  accountNtfns.on("data", data => console.log(data));
+  accountNtfns.on("data", data => {
+    let account = {accountNumber: data.getAccountNumber(), accountName: data.getAccountName(), externalKeys: data.getExternalKeyCount(), internalKeys: data.getInternalKeyCount(), importedKeys: data.getImportedKeyCount()};
+    dispatch(updateAccount(account));
+  });
   accountNtfns.on("end", () => {
     console.log("Account notifications done");
     dispatch({ type: ACCOUNTNTFNS_END });

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -38,7 +38,7 @@ function transactionNtfnsData(response) {
           dispatch({response: response, type: TRANSACTIONNTFNS_DATA });
           setTimeout( () => {dispatch(getStakeInfoAttempt());}, 1000);
           setTimeout( () => {dispatch(getTicketPriceAttempt());}, 1000);
-          setTimeout( () => {dispatch(getAccountsAttempt());}, 1000);
+          //setTimeout( () => {dispatch(getAccountsAttempt());}, 1000);
           setTimeout( () => {dispatch(getNetworkAttempt());}, 1000);
 
           const newlyMined = attachedBlocks.reduce((l, b) => {


### PR DESCRIPTION
Fixes #574 

Now instead of blindly requesting information about all accounts, we only update the account referred to in the transaction or account notification streams. 

I believe more work can be done on streamlining the storing of account information, plus I'm not positive that it's currently Immutable.  

Seems to be making extraneous account update calls, but otherwise appears to be working as expected.