### PR TITLE
Change to only request stakeInfo when new stake transactions are noticed

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -454,8 +454,9 @@ export const newTransactionsReceived = (newlyMinedTransactions, newlyUnminedTran
   var accountsToUpdate = new Array();
   accountsToUpdate = checkAccountsToUpdate(unminedDupeCheck, accountsToUpdate);
   accountsToUpdate = checkAccountsToUpdate(newlyMinedTransactions, accountsToUpdate);
+  accountsToUpdate = Array.from(new Set(accountsToUpdate));
   accountsToUpdate.forEach(v => dispatch(getBalanceUpdateAttempt(v, 0)));
-  console.log(accountsToUpdate);
+  
   if (checkForStakeTransactions(unminedDupeCheck) || checkForStakeTransactions(newlyMinedTransactions)) dispatch(getStakeInfoAttempt());
 
   unminedTransactions = filterTransactions([

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -444,6 +444,8 @@ export const newTransactionsReceived = (newlyMinedTransactions, newlyUnminedTran
   accountsToUpdate = checkAccountsToUpdate(newlyUnminedTransactions, accountsToUpdate);
   accountsToUpdate.forEach(v => dispatch(getBalanceUpdateAttempt(v, 0)));
 
+  if (checkForStakeTransactions(newlyUnminedTransactions) || checkForStakeTransactions(newlyMinedTransactions)) dispatch(getStakeInfoAttempt());
+
   let { unminedTransactions, minedTransactions, recentTransactions } = getState().grpc;
   const { transactionsFilter, recentTransactionCount } = getState().grpc;
 

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -456,7 +456,7 @@ export const newTransactionsReceived = (newlyMinedTransactions, newlyUnminedTran
   accountsToUpdate = checkAccountsToUpdate(newlyMinedTransactions, accountsToUpdate);
   accountsToUpdate = Array.from(new Set(accountsToUpdate));
   accountsToUpdate.forEach(v => dispatch(getBalanceUpdateAttempt(v, 0)));
-  
+
   if (checkForStakeTransactions(unminedDupeCheck) || checkForStakeTransactions(newlyMinedTransactions)) dispatch(getStakeInfoAttempt());
 
   unminedTransactions = filterTransactions([

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -11,6 +11,8 @@ import { push as pushHistory } from "react-router-redux";
 import { getCfg } from "../config.js";
 import { onAppReloadRequested } from "wallet";
 import { getTransactions as walletGetTransactions } from "wallet/service";
+import { TransactionDetails } from "middleware/walletrpc/api_pb";
+
 
 export const GETWALLETSERVICE_ATTEMPT = "GETWALLETSERVICE_ATTEMPT";
 export const GETWALLETSERVICE_FAILED = "GETWALLETSERVICE_FAILED";
@@ -419,6 +421,18 @@ function checkAccountsToUpdate(txs, accountsToUpdate) {
     tx.tx.getDebitsList().forEach(debit => {if (!accountsToUpdate.find(eq(debit.getPreviousAccount()))) accountsToUpdate.push(debit.getPreviousAccount());});
   });
   return accountsToUpdate;
+}
+
+function checkForStakeTransactions(txs) {
+  var stakeTxsFound = false;
+  txs.forEach(tx => {
+    if (tx.type == TransactionDetails.TransactionType.VOTE ||
+      tx.type == TransactionDetails.TransactionType.TICKET_PURCHASE ||
+      tx.type == TransactionDetails.TransactionType.REVOCATION) {
+      stakeTxsFound = true;
+    }
+  });
+  return stakeTxsFound;
 }
 // newTransactionsReceived should be called when a new set of transactions has
 // been received from the wallet (through a notification).

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -347,7 +347,6 @@ function purchaseTicketsAction(request) {
           dispatch({ error, type: PURCHASETICKETS_FAILED });
         } else {
           dispatch({ purchaseTicketsResponse: purchaseTicketsResponse, type: PURCHASETICKETS_SUCCESS });
-          setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 4000);
         }
       });
   };
@@ -368,7 +367,6 @@ export function revokeTicketsAttempt(passphrase) {
         if (error) {
           dispatch({ error, type: REVOKETICKETS_FAILED });
         } else {
-          setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 4000);
           dispatch({ revokeTicketsResponse: revokeTicketsResponse, type: REVOKETICKETS_SUCCESS });
         }
       });

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -1,6 +1,6 @@
 // @flow
 import * as wallet from "wallet";
-import { getStakeInfoAttempt, getTicketPriceAttempt, updateAccount } from "./ClientActions";
+import { getTicketPriceAttempt, updateAccount } from "./ClientActions";
 import { newTransactionsReceived } from "./ClientActions";
 import { TransactionNotificationsRequest, AccountNotificationsRequest } from "middleware/walletrpc/api_pb";
 
@@ -20,7 +20,6 @@ function transactionNtfnsData(response) {
       var currentBlockTimestamp = attachedBlocks[attachedBlocks.length-1].getTimestamp();
       var currentBlockHeight = attachedBlocks[attachedBlocks.length-1].getHeight();
       dispatch({currentBlockHeight, currentBlockTimestamp, type: NEWBLOCKCONNECTED });
-      setTimeout( () => {dispatch(getStakeInfoAttempt());}, 1000);
       setTimeout( () => {dispatch(getTicketPriceAttempt());}, 1000);
 
       const newlyMined = attachedBlocks.reduce((l, b) => {


### PR DESCRIPTION
Further streamlining of new block connecting.  Now we should only request stake info updates when we receive a new stake transaction (ticket, vote, revoke).  This is especially important since StakeInfo is a very expensive request for dcrwallet to process.