### PR TITLE
Fixes for startup crashing

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -81,7 +81,7 @@ export const syncDaemon = () =>
       return wallet
         .getBlockCount(credentials, appData)
         .then(updateCurrentBlockCount => {
-          if (neededBlocks > 0 && updateCurrentBlockCount >= neededBlocks) {
+          if ((neededBlocks == 0 && updateCurrentBlockCount > 0) || updateCurrentBlockCount >= neededBlocks) {
             dispatch({type: DAEMONSYNCED});
             dispatch({currentBlockHeight: updateCurrentBlockCount, type: STARTUPBLOCK});
             setMustOpenForm(false);

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -81,7 +81,8 @@ export const syncDaemon = () =>
       return wallet
         .getBlockCount(credentials, appData)
         .then(updateCurrentBlockCount => {
-          if ((neededBlocks == 0 && updateCurrentBlockCount > 0) || updateCurrentBlockCount >= neededBlocks) {
+          if ((neededBlocks == 0 && updateCurrentBlockCount > 0) || (neededBlocks != 0 && updateCurrentBlockCount >= neededBlocks)) {
+            console.log(updateCurrentBlockCount);
             dispatch({type: DAEMONSYNCED});
             dispatch({currentBlockHeight: updateCurrentBlockCount, type: STARTUPBLOCK});
             setMustOpenForm(false);

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -82,7 +82,6 @@ export const syncDaemon = () =>
         .getBlockCount(credentials, appData)
         .then(updateCurrentBlockCount => {
           if ((neededBlocks == 0 && updateCurrentBlockCount > 0) || (neededBlocks != 0 && updateCurrentBlockCount >= neededBlocks)) {
-            console.log(updateCurrentBlockCount);
             dispatch({type: DAEMONSYNCED});
             dispatch({currentBlockHeight: updateCurrentBlockCount, type: STARTUPBLOCK});
             setMustOpenForm(false);

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -81,7 +81,7 @@ export const syncDaemon = () =>
       return wallet
         .getBlockCount(credentials, appData)
         .then(updateCurrentBlockCount => {
-          if (updateCurrentBlockCount >= neededBlocks) {
+          if (neededBlocks > 0 && updateCurrentBlockCount >= neededBlocks) {
             dispatch({type: DAEMONSYNCED});
             dispatch({currentBlockHeight: updateCurrentBlockCount, type: STARTUPBLOCK});
             setMustOpenForm(false);

--- a/app/components/views/GetStartedPage/StartRPC.js
+++ b/app/components/views/GetStartedPage/StartRPC.js
@@ -1,5 +1,6 @@
 import Header from "./DefaultHeader";
-import { KeyBlueButton, ShowError } from "buttons";
+import { KeyBlueButton } from "buttons";
+import { ShowError } from "shared";
 import { FormattedMessage as T } from "react-intl";
 import "style/GetStarted.less";
 
@@ -12,12 +13,11 @@ export const StartRPCBody = ({
   startupError,
   onRetryStartRPC
 }) => (
-  startupError ? (
+  startupError &&
     <div className="get-started-content-new-seed page-content">
       <ShowError className="get-started-error" error="Connection to dcrd failed, please try and reconnect." />
       <KeyBlueButton className="get-started-rpc-retry-button" onClick={onRetryStartRPC}>
         <T id="getStarted.retryBtn" m="Retry" />
       </KeyBlueButton>
     </div>
-  ) : null
 );


### PR DESCRIPTION
NeededBlocks was not being checked whether it was greater than 0, so it was bypassing the daemon syncing check.  This also exposed an incorrect component being imported for ShowErrors on the StartRPC screen.