### PR TITLE
Fix startup actions call procedures

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -21,12 +21,8 @@ export const GETWALLETSERVICE_SUCCESS = "GETWALLETSERVICE_SUCCESS";
 function getWalletServiceSuccess(walletService) {
   return (dispatch, getState) => {
     dispatch({ walletService, type: GETWALLETSERVICE_SUCCESS });
-    setTimeout(() => { dispatch(getAccountsAttempt(true)); }, 10);
-    setTimeout(() => { dispatch(getMostRecentTransactions()); }, 20);
-    setTimeout(() => { dispatch(getTicketsInfoAttempt()); }, 20);
     setTimeout(() => { dispatch(loadActiveDataFiltersAttempt()); }, 1000);
     setTimeout(() => { dispatch(getNextAddressAttempt(0)); }, 1000);
-    setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 1000);
     setTimeout(() => { dispatch(getTicketPriceAttempt()); }, 1000);
     setTimeout(() => { dispatch(getPingAttempt()); }, 1000);
     setTimeout(() => { dispatch(getNetworkAttempt()); }, 1000);
@@ -42,8 +38,12 @@ function getWalletServiceSuccess(walletService) {
     if (walletCreateExisting) {
       setTimeout(() => { dispatch(rescanAttempt(0)); }, 1000);
     } else if (walletCreateResponse == null && fetchHeadersResponse != null && fetchHeadersResponse.getFirstNewBlockHeight() !== 0) {
-
       setTimeout(() => { dispatch(rescanAttempt(fetchHeadersResponse.getFirstNewBlockHeight())); }, 1000);
+    } else {
+      setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 1000);
+      setTimeout(() => { dispatch(getAccountsAttempt(true)); }, 1000);
+      setTimeout(() => { dispatch(getMostRecentTransactions()); }, 1000);
+      setTimeout(() => { dispatch(getTicketsInfoAttempt()); }, 1000);
     }
     setTimeout(() => { dispatch(pushHistory("/home")); }, 1000);
     setTimeout(() => { dispatch(showSidebarMenu()); }, 1000);

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -80,6 +80,7 @@ export function rescanAttempt(beginHeight) {
     });
     rescanCall.on("end", function() {
       dispatch({ type: RESCAN_COMPLETE });
+      setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 1000);
       setTimeout( () => {dispatch(getAccountsAttempt(true));}, 1000);
       setTimeout( () => {dispatch(getMostRecentTransactions());}, 1000);
       setTimeout( () => {dispatch(getTicketsInfoAttempt());}, 1000);


### PR DESCRIPTION
To avoid certain calls being called multiple times, this cleans up the startup actions.  

When there are no new headers, then there is no need to rescan the chain.  Then these calls are explicitly done.  Otherwise if a rescan is required we do the same startup action calls (stakeinfo, gettransactions, ticketinfo, account balances) on that success as well.