### PR TITLE
Fix misc lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "cross-env NODE_ENV=test jest",
     "test-watch": "npm test -- --watch",
     "test-e2e": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --retries 2 --compilers js:babel-register --require ./test/setup.js ./test/e2e.js",
-    "lint": "./node_modules/.bin/eslint --ignore-path .eslintignore *.js app && ./node_modules/.bin/stylelint app/style/*.less",
+    "lint": "./node_modules/.bin/eslint --ignore-path .eslintignore *.js app scripts && ./node_modules/.bin/stylelint app/style/*.less",
     "lint-fix": "npm run lint -- --fix && ./node_modules/.bin/stylelint app/style/*.less",
     "hot-server": "cross-env NODE_ENV=development node --max_old_space_size=4096 -r babel-register server.js",
     "build-main": "cross-env NODE_ENV=production node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.electron.js --progress --profile --colors",

--- a/scripts/aliasDefaultMessage.js
+++ b/scripts/aliasDefaultMessage.js
@@ -49,7 +49,7 @@ function aliasDefaultMessagePlugin({types: t}) {
   }
 
   function createMessageDescriptor(propPaths) {
-    return propPaths.reduce((hash, [keyPath, valuePath]) => {
+    return propPaths.reduce((hash, [keyPath]) => {
       const key = getMessageDescriptorKey(keyPath);
 
       if (DESCRIPTOR_PROPS.has(key)) {
@@ -63,7 +63,7 @@ function aliasDefaultMessagePlugin({types: t}) {
   return {
     visitor: {
       JSXOpeningElement(path, state) {
-        const {file, opts} = state;
+        const {opts} = state;
         const moduleSourceName = getModuleSourceName(opts);
         const name = path.get("name");
 

--- a/scripts/aliasDefaultMessage.js
+++ b/scripts/aliasDefaultMessage.js
@@ -10,82 +10,82 @@
  *
  */
 const COMPONENT_NAMES = [
-    "FormattedMessage",
+  "FormattedMessage",
 ];
 
 const DESCRIPTOR_PROPS = new Set(["m"]);
 
 function aliasDefaultMessagePlugin({types: t}) {
 
-    function referencesImport(path, mod, importedNames) {
-        if (!(path.isIdentifier() || path.isJSXIdentifier())) {
-            return false;
-        }
-
-        return importedNames.some((name) => path.referencesImport(mod, name));
+  function referencesImport(path, mod, importedNames) {
+    if (!(path.isIdentifier() || path.isJSXIdentifier())) {
+      return false;
     }
 
-    function getModuleSourceName(opts) {
-        return opts.moduleSourceName || "react-intl";
+    return importedNames.some((name) => path.referencesImport(mod, name));
+  }
+
+  function getModuleSourceName(opts) {
+    return opts.moduleSourceName || "react-intl";
+  }
+
+  function evaluatePath(path) {
+    const evaluated = path.evaluate();
+    if (evaluated.confident) {
+      return evaluated.value;
     }
 
-    function evaluatePath(path) {
-        const evaluated = path.evaluate();
-        if (evaluated.confident) {
-            return evaluated.value;
-        }
-
-        throw path.buildCodeFrameError(
+    throw path.buildCodeFrameError(
             "[React Intl] Messages must be statically evaluate-able for extraction."
         );
+  }
+
+  function getMessageDescriptorKey(path) {
+    if (path.isIdentifier() || path.isJSXIdentifier()) {
+      return path.node.name;
     }
 
-    function getMessageDescriptorKey(path) {
-        if (path.isIdentifier() || path.isJSXIdentifier()) {
-            return path.node.name;
-        }
+    return evaluatePath(path);
+  }
 
-        return evaluatePath(path);
-    }
+  function createMessageDescriptor(propPaths) {
+    return propPaths.reduce((hash, [keyPath, valuePath]) => {
+      const key = getMessageDescriptorKey(keyPath);
 
-    function createMessageDescriptor(propPaths) {
-        return propPaths.reduce((hash, [keyPath, valuePath]) => {
-            const key = getMessageDescriptorKey(keyPath);
+      if (DESCRIPTOR_PROPS.has(key)) {
+        hash[key] = keyPath;
+      }
 
-            if (DESCRIPTOR_PROPS.has(key)) {
-                hash[key] = keyPath;
-            }
+      return hash;
+    }, {});
+  }
 
-            return hash;
-        }, {});
-    }
+  return {
+    visitor: {
+      JSXOpeningElement(path, state) {
+        const {file, opts} = state;
+        const moduleSourceName = getModuleSourceName(opts);
+        const name = path.get("name");
 
-    return {
-        visitor: {
-            JSXOpeningElement(path, state) {
-                const {file, opts} = state;
-                const moduleSourceName = getModuleSourceName(opts);
-                const name = path.get("name");
-
-                if (referencesImport(name, moduleSourceName, COMPONENT_NAMES)) {
-                    const attributes = path.get("attributes")
+        if (referencesImport(name, moduleSourceName, COMPONENT_NAMES)) {
+          const attributes = path.get("attributes")
                         .filter((attr) => attr.isJSXAttribute());
 
-                    let descriptor = createMessageDescriptor(
+          let descriptor = createMessageDescriptor(
                         attributes.map((attr) => [
-                            attr.get("name"),
-                            attr.get("value"),
+                          attr.get("name"),
+                          attr.get("value"),
                         ])
                     );
 
-                    if (descriptor.m) {
-                        descriptor.m.replaceWith(t.JSXIdentifier("defaultMessage"));
-                    }
-                }
-
-            }
+          if (descriptor.m) {
+            descriptor.m.replaceWith(t.JSXIdentifier("defaultMessage"));
+          }
         }
-    };
+
+      }
+    }
+  };
 }
 
 module.exports = aliasDefaultMessagePlugin;

--- a/scripts/aliasDefaultMessage.js
+++ b/scripts/aliasDefaultMessage.js
@@ -10,10 +10,10 @@
  *
  */
 const COMPONENT_NAMES = [
-    'FormattedMessage',
+    "FormattedMessage",
 ];
 
-const DESCRIPTOR_PROPS = new Set(['m']);
+const DESCRIPTOR_PROPS = new Set(["m"]);
 
 function aliasDefaultMessagePlugin({types: t}) {
 
@@ -26,7 +26,7 @@ function aliasDefaultMessagePlugin({types: t}) {
     }
 
     function getModuleSourceName(opts) {
-        return opts.moduleSourceName || 'react-intl';
+        return opts.moduleSourceName || "react-intl";
     }
 
     function evaluatePath(path) {
@@ -36,7 +36,7 @@ function aliasDefaultMessagePlugin({types: t}) {
         }
 
         throw path.buildCodeFrameError(
-            '[React Intl] Messages must be statically evaluate-able for extraction.'
+            "[React Intl] Messages must be statically evaluate-able for extraction."
         );
     }
 
@@ -65,16 +65,16 @@ function aliasDefaultMessagePlugin({types: t}) {
             JSXOpeningElement(path, state) {
                 const {file, opts} = state;
                 const moduleSourceName = getModuleSourceName(opts);
-                const name = path.get('name');
+                const name = path.get("name");
 
                 if (referencesImport(name, moduleSourceName, COMPONENT_NAMES)) {
-                    const attributes = path.get('attributes')
+                    const attributes = path.get("attributes")
                         .filter((attr) => attr.isJSXAttribute());
 
                     let descriptor = createMessageDescriptor(
                         attributes.map((attr) => [
-                            attr.get('name'),
-                            attr.get('value'),
+                            attr.get("name"),
+                            attr.get("value"),
                         ])
                     );
 
@@ -85,7 +85,7 @@ function aliasDefaultMessagePlugin({types: t}) {
 
             }
         }
-    }
+    };
 }
 
 module.exports = aliasDefaultMessagePlugin;

--- a/scripts/prepareUntranslated.js
+++ b/scripts/prepareUntranslated.js
@@ -1,5 +1,5 @@
 // translationRunner.js
-const manageTranslations = require('react-intl-translations-manager').default;
+const manageTranslations = require("react-intl-translations-manager").default;
 
 manageTranslations({
   messagesDirectory: "app/i18n/extracted",


### PR DESCRIPTION
Running eslint gives:

```
.../decrediton/scripts/aliasDefaultMessage.js
  13:5   error  Expected indentation of 2 spaces but found 4    indent
  13:5   error  Strings must use doublequote                    quotes
  16:35  error  Strings must use doublequote                    quotes
  20:5   error  Expected indentation of 2 spaces but found 4    indent
  21:9   error  Expected indentation of 6 spaces but found 8    indent
  22:13  error  Expected indentation of 10 spaces but found 12  Vindent
  25:9   error  Expected indentation of 6 spaces but found 8    indent
  28:5   error  Expected indentation of 2 spaces but found 4    indent
  29:9   error  Expected indentation of 6 spaces but found 8    indent
  29:41  error  Strings must use doublequote                    quotes
  32:5   error  Expected indentation of 2 spaces but found 4    indent
  33:9   error  Expected indentation of 6 spaces but found 8    indent
  34:9   error  Expected indentation of 6 spaces but found 8    indent
  35:13  error  Expected indentation of 10 spaces but found 12  indent
  38:9   error  Expected indentation of 6 spaces but found 8    indent
  39:13  error  Strings must use doublequote                    quotes
  43:5   error  Expected indentation of 2 spaces but found 4    indent
  44:9   error  Expected indentation of 6 spaces but found 8    indent
  45:13  error  Expected indentation of 10 spaces but found 12  indent
  48:9   error  Expected indentation of 6 spaces but found 8    indent
  51:5   error  Expected indentation of 2 spaces but found 4    indent
  52:9   error  Expected indentation of 6 spaces but found 8    indent
  52:50  error  'valuePath' is defined but never used           no-unused-vars
  53:13  error  Expected indentation of 10 spaces but found 12  indent
  55:13  error  Expected indentation of 10 spaces but found 12  indent
  56:17  error  Expected indentation of 14 spaces but found 16  indent
  59:13  error  Expected indentation of 10 spaces but found 12  indent
  63:5   error  Expected indentation of 2 spaces but found 4    indent
  64:9   error  Expected indentation of 6 spaces but found 8    indent
  65:13  error  Expected indentation of 10 spaces but found 12  indent
  66:17  error  Expected indentation of 14 spaces but found 16  indent
  66:24  error  'file' is assigned a value but never used       no-unused-vars
  67:17  error  Expected indentation of 14 spaces but found 16  indent
  68:17  error  Expected indentation of 14 spaces but found 16  indent
  68:39  error  Strings must use doublequote                    quotes
  70:17  error  Expected indentation of 14 spaces but found 16  indent
  71:21  error  Expected indentation of 18 spaces but found 20  indent
  71:49  error  Strings must use doublequote                    quotes
  74:21  error  Expected indentation of 18 spaces but found 20  indent
  76:29  error  Expected indentation of 26 spaces but found 28  indent
  76:38  error  Strings must use doublequote                    quotes
  77:29  error  Expected indentation of 26 spaces but found 28  indent
  77:38  error  Strings must use doublequote                    quotes
  81:21  error  Expected indentation of 18 spaces but found 20  indent
  82:25  error  Expected indentation of 22 spaces but found 24  indent
  88:6   error  Missing semicolon                               semi

.../decrediton/scripts/prepareUntranslated.js
  2:36  error  Strings must use doublequote  quotes

✖ 47 problems (47 errors, 0 warnings)
```
This PR corrects that.