### PR TITLE
Renamed "purchase-tickets-info-button" and added some margin

### DIFF
--- a/app/components/buttons/index.js
+++ b/app/components/buttons/index.js
@@ -35,7 +35,7 @@ const helpLinkButton = ({className, onClick, buttonLabel}) =>
   <div className={className} onClick={onClick}>{buttonLabel}</div>;
 
 export const HelpLinkInfoModal = mbb("help-icon", InfoModal, helpLinkButton);
-export const InfoModalButton = mbb("purchase-tickets-info-button", InfoModal);
+export const InfoModalButton = mbb("info-modal-button", InfoModal);
 export const ChangePassphraseButton = mbb("change-password-default-icon", ChangePassphraseModal);
 export const PassphraseModalButton = mbb(null, PassphraseModal, KeyBlueButton);
 export const PassphraseModalSwitch = mbb(null, PassphraseModal, AutoBuyerSwitch);

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -212,7 +212,7 @@
   background-color: #8997a6;
 }
 
-.purchase-tickets-info-button {
+.info-modal-button {
   border-radius: 0px;
   background-image: @tickets-info-icon;
   background-position: 50% 50%;
@@ -233,7 +233,7 @@
   cursor: pointer;
 }
 
-.purchase-tickets-info-button:hover {
+.info-modal-button:hover {
   opacity: 0.7;
 }
 

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -231,6 +231,7 @@
   line-height: inherit;
   text-decoration: none;
   cursor: pointer;
+  margin-left: 4px;
 }
 
 .info-modal-button:hover {


### PR DESCRIPTION
Renamed "purchase-tickets-info-button" to "info-modal-button". That name made more sense.

Added some margin to the left. I found it too close to the on the left hand side. 
Before
![before](https://user-images.githubusercontent.com/921390/35199242-d37c9306-fefb-11e7-9da2-a0c341c064f0.png)
After
![after](https://user-images.githubusercontent.com/921390/35199241-d364fe6c-fefb-11e7-8069-ac3ba11f9650.png)

