### PR TITLE
Move initial rescan to GetStarted stage

### DIFF
--- a/app/components/views/GetStartedPage/RescanWallet/Form.js
+++ b/app/components/views/GetStartedPage/RescanWallet/Form.js
@@ -1,6 +1,6 @@
 import Header from "../DefaultHeader";
 import LinearProgress from "material-ui/LinearProgress";
-import { FormattedMessage as T, FormattedRelative } from "react-intl";
+import { FormattedMessage as T } from "react-intl";
 import { SlateGrayButton } from "buttons";
 import "style/GetStarted.less";
 

--- a/app/components/views/GetStartedPage/RescanWallet/Form.js
+++ b/app/components/views/GetStartedPage/RescanWallet/Form.js
@@ -1,0 +1,55 @@
+import Header from "../DefaultHeader";
+import LinearProgress from "material-ui/LinearProgress";
+import { FormattedMessage as T, FormattedRelative } from "react-intl";
+import { SlateGrayButton } from "buttons";
+import "style/GetStarted.less";
+
+const RescanWalletFormHeader = ({
+  startupError,
+}) => (
+  <Header
+    headerMetaOverview={<T id="getStarted.header.rescanWallet.meta" m="Scanning blocks for transactions" />}
+    headerTop={startupError
+      ? <div key="pubError" className="get-started-view-notification-error">{startupError}</div>
+      : <div key="pubError" ></div>}
+  />
+);
+
+const RescanWalletFormBody = ({
+    onShowLogs,
+    rescanEndBlock,
+    rescanStartBlock,
+    rescanCurrentBlock,
+  }) => (
+    <div className="get-started-content-new-seed">
+      <div className="get-started-content-instructions">
+        <LinearProgress
+          mode="determinate"
+          min={rescanStartBlock}
+          max={rescanEndBlock}
+          value={rescanCurrentBlock}
+        />
+
+        <p>
+          <T
+            id="getStarted.walletRescan.progress"
+            m="Rescan Progress ({rescanCurrentBlock} / {rescanEndBlock})"
+            values={{
+              rescanCurrentBlock: rescanCurrentBlock > rescanStartBlock
+                ? rescanCurrentBlock
+                : rescanStartBlock,
+              rescanEndBlock: rescanEndBlock
+            }}
+            />
+        </p>
+      </div>
+
+      <div className="get-started-bottom-buttons">
+        <SlateGrayButton onClick={onShowLogs}>
+          <T id="getStarted.btnLogs" m="Logs" />
+        </SlateGrayButton>
+      </div>
+    </div>
+  );
+
+export { RescanWalletFormHeader, RescanWalletFormBody };

--- a/app/components/views/GetStartedPage/RescanWallet/index.js
+++ b/app/components/views/GetStartedPage/RescanWallet/index.js
@@ -1,0 +1,6 @@
+import {
+  RescanWalletFormHeader as RescanWalletHeader,
+  RescanWalletFormBody as RescanWalletBody
+} from "./Form";
+
+export { RescanWalletHeader, RescanWalletBody };

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -9,6 +9,7 @@ import { DaemonLoadingHeader, DaemonLoadingBody } from "./DaemonLoading";
 import { AdvancedStartupHeader, AdvancedStartupBody, RemoteAppdataError } from "./AdvancedStartup";
 import { SettingsBody, SettingsHeader } from "./Settings";
 import { LogsBody, LogsHeader } from "./Logs";
+import { RescanWalletHeader, RescanWalletBody } from "./RescanWallet/index";
 import { walletStartup } from "connectors";
 import { getAppdataPath, getRemoteCredentials } from "config.js";
 
@@ -111,6 +112,10 @@ class GetStartedPage extends React.Component {
       case 6:
         Header = FetchBlockHeadersHeader;
         Body = FetchBlockHeadersBody;
+        break;
+      case 7:
+        Header = RescanWalletHeader;
+        Body = RescanWalletBody;
         break;
       default:
         Header = FinalStartUpHeader;

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -23,6 +23,9 @@ const mapStateToProps = selectorMap({
   isAdvancedDaemon: sel.isAdvancedDaemon,
   openForm: sel.openForm,
   remoteAppdataError: sel.getRemoteAppdataError,
+  rescanEndBlock: sel.rescanEndBlock,
+  rescanStartBlock: sel.rescanStartBlock,
+  rescanCurrentBlock: sel.rescanCurrentBlock,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -24,7 +24,8 @@ import {
   REMOVESTAKEPOOLCONFIG
 } from "../actions/StakePoolActions";
 import {
-  NEW_TRANSACTIONS_RECEIVED
+  NEW_TRANSACTIONS_RECEIVED,
+  GETSTARTUPWALLETINFO_FAILED
 } from "../actions/ClientActions";
 import { SNACKBAR_DISMISS_MESSAGES } from "../actions/SnackbarActions";
 
@@ -208,6 +209,7 @@ export default function snackbar(state = {}, action) {
   case DECODERAWTXS_FAILED:
   case SIGNMESSAGE_FAILED:
   case VERIFYMESSAGE_FAILED:
+  case GETSTARTUPWALLETINFO_FAILED:
     type = "Error";
     message = messages[action.type] || messages.defaultErrorMessage;
     values = { originalError: String(action.error) };

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -10,7 +10,14 @@ import {
   FETCHHEADERS_ATTEMPT, FETCHHEADERS_FAILED, FETCHHEADERS_PROGRESS, FETCHHEADERS_SUCCESS,
   CREATEWALLET_EXISTINGSEED_INPUT, CREATEWALLET_NEWSEED_INPUT, CREATEWALLET_NEWSEED_CONFIRM_INPUT, CREATEWALLET_NEWSEED_BACK_INPUT,
   UPDATEDISCOVERACCOUNTS, NEEDED_BLOCKS_DETERMINED
-} from "../actions/WalletLoaderActions";
+} from "actions/WalletLoaderActions";
+import {
+  GETSTARTUPWALLETINFO_ATTEMPT
+} from "actions/ClientActions";
+import {
+  RESCAN_ATTEMPT
+} from "actions/ControlActions";
+
 export default function walletLoader(state = {}, action) {
   switch (action.type) {
   case LOADER_ATTEMPT:
@@ -195,7 +202,14 @@ export default function walletLoader(state = {}, action) {
       fetchHeadersError: null,
       fetchHeadersRequestAttempt: false,
       fetchHeadersResponse: action.response,
-      stepIndex: 7,
+    };
+  case RESCAN_ATTEMPT:
+    return {...state,
+      stepIndex: 7
+    };
+  case GETSTARTUPWALLETINFO_ATTEMPT:
+    return {...state,
+      stepIndex: 8
     };
   case SUBSCRIBEBLOCKNTFNS_ATTEMPT:
     return {...state,

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -23,8 +23,8 @@ export const startWallet = () => Promise
   });
 
 export const getBlockCount = (rpcCreds, appData) => Promise
-  .resolve(ipcRenderer
-    .sendSync("check-daemon", rpcCreds, appData));
+  .resolve(ipcRenderer.sendSync("check-daemon", rpcCreds, appData))
+  .then(block => parseInt(block.trim()));
 
 export const getDcrdLogs = () => Promise
   .resolve(ipcRenderer.sendSync("get-dcrd-logs"))


### PR DESCRIPTION
Fix #1089 

This moves the initial rescan and wallet info gathering (balances & latest transactions) to the GetStarted stage. This way, the main wallet UI is only shown after all needed data is already on the state, preventing flashes of zero or a mutating balance.

This commit accomplishes this by:

- Promisifying a few wallet startup actions
- Unifying the logic for the different branches of wallet info gathering (brand new wallet from seed, existing wallet from seed, existing wallet with no new block headers, existing wallet with new block headers available) into the `getStartupWalletInfo` action
- Modifying the startup logic to wait for the balances before requesting the transactions (as it is needed)
- Modifying the GetStarted stages to add a rescan step (triggered as needed) before going to the final wallet setup
- Only going to the main wallet UI after `getStartupWalletInfo` completes
