### PR TITLE
Add logging to all wallet methods

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -311,6 +311,9 @@ export const PURCHASETICKETS_SUCCESS = "PURCHASETICKETS_SUCCESS";
 export function purchaseTicketsAttempt(passphrase, accountNum, spendLimit, requiredConf,
   numTickets, expiry, ticketFee, txFee, stakepool) {
   return (dispatch, getState) => {
+    wallet.log("info", "Purchasing tickets", accountNum, spendLimit, requiredConf,
+      numTickets, expiry, ticketFee, txFee, stakepool.TicketAddress,
+      stakepool.PoolAddress, stakepool.PoolFees);
     const {getAccountsResponse} = getState().grpc;
     var request = new PurchaseTicketsRequest();
     request.setPassphrase(new Uint8Array(Buffer.from(passphrase)));

--- a/app/wallet/app.js
+++ b/app/wallet/app.js
@@ -9,6 +9,7 @@ export const log = (level, ...args) => {
 };
 
 export const logOptionNoArgs = (opts) => ({...opts, noArguments: true});
+export const logOptionNoResponseData = (opts) => ({...opts, noResponseData: true});
 
 // Formats a dynamic list of log arguments
 const formatLogArgs = (msg, args) => {
@@ -48,8 +49,12 @@ export const withLog = (f, msg, opts={}) => (...args) => {
         if (res.length === 1 && res[0] === undefined) {
           log("debug", "%s returned without data", msg);
         } else {
-          const { logMsg, logArgs } = formatLogArgs(`${msg} returned `, res);
-          log("debug", logMsg, ...logArgs);
+          if (opts.noResponseData) {
+            log("debug", `${msg} returned [response data omitted]`);
+          } else {
+            const { logMsg, logArgs } = formatLogArgs(`${msg} returned `, res);
+            log("debug", logMsg, ...logArgs);
+          }
         }
 
         resolve(...res);
@@ -65,3 +70,9 @@ export const withLog = (f, msg, opts={}) => (...args) => {
 
 export const withLogNoArgs = (f, msg, opts={}) =>
   withLog(f, msg, logOptionNoArgs(opts));
+
+export const withLogNoResponseData = (f, msg, opts={}) =>
+  withLog(f, msg, logOptionNoResponseData(opts));
+
+export const withLogNoData = (f, msg, opts={}) =>
+  withLog(f, msg, logOptionNoArgs(logOptionNoResponseData(opts)));

--- a/app/wallet/client.js
+++ b/app/wallet/client.js
@@ -5,7 +5,7 @@ import {
   BalanceRequest, TicketPriceRequest, StakeInfoRequest,
   AgendasRequest, VoteChoicesRequest, SetVoteChoicesRequest, GetTicketsRequest,
 } from "middleware/walletrpc/api_pb";
-import { withLog as log, logOptionNoResponseData, withLogNoData } from "./app";
+import { withLog as log, logOptionNoResponseData, withLogNoData, withLogNoResponseData } from "./app";
 
 const promisifyReq = (fnName, Req) => log((service, ...args) => new Promise((ok, fail) =>
   service[fnName](new Req(), ...args, (err, res) => err ? fail(err) : ok(res))), fnName);
@@ -21,7 +21,7 @@ export const getAgendas = promisifyReq("agendas", AgendasRequest);
 export const getVoteChoices = promisifyReq("voteChoices", VoteChoicesRequest);
 export const doPing = promisifyReq("ping", PingRequest);
 
-export const getBalance = withLogNoData((walletService, accountNum, requiredConfs) => new Promise((ok, fail) => {
+export const getBalance = withLogNoResponseData((walletService, accountNum, requiredConfs) => new Promise((ok, fail) => {
   const request = new BalanceRequest();
   request.setAccountNumber(accountNum);
   request.setRequiredConfirmations(requiredConfs);

--- a/app/wallet/client.js
+++ b/app/wallet/client.js
@@ -5,33 +5,36 @@ import {
   BalanceRequest, TicketPriceRequest, StakeInfoRequest,
   AgendasRequest, VoteChoicesRequest, SetVoteChoicesRequest, GetTicketsRequest,
 } from "middleware/walletrpc/api_pb";
-import { withLog as log } from "./app";
+import { withLog as log, logOptionNoResponseData, withLogNoData } from "./app";
 
-const promisifyReq = (fnName, Req) => (service, ...args) => new Promise((ok, fail) =>
-  service[fnName](new Req(), ...args, (err, res) => err ? fail(err) : ok(res)));
+const promisifyReq = (fnName, Req) => log((service, ...args) => new Promise((ok, fail) =>
+  service[fnName](new Req(), ...args, (err, res) => err ? fail(err) : ok(res))), fnName);
+
+const promisifyReqLogNoData = (fnName, Req) => withLogNoData((service, ...args) => new Promise((ok, fail) =>
+service[fnName](new Req(), ...args, (err, res) => err ? fail(err) : ok(res))), fnName);
 
 export const getNetwork = promisifyReq("network", NetworkRequest);
-export const getStakeInfo = promisifyReq("stakeInfo", StakeInfoRequest);
+export const getStakeInfo = promisifyReqLogNoData("stakeInfo", StakeInfoRequest);
 export const getTicketPrice = promisifyReq("ticketPrice", TicketPriceRequest);
-export const getAccounts = promisifyReq("accounts", AccountsRequest);
+export const getAccounts = promisifyReqLogNoData("accounts", AccountsRequest);
 export const getAgendas = promisifyReq("agendas", AgendasRequest);
 export const getVoteChoices = promisifyReq("voteChoices", VoteChoicesRequest);
 export const doPing = promisifyReq("ping", PingRequest);
 
-export const getBalance = (walletService, accountNum, requiredConfs) => new Promise((ok, fail) => {
+export const getBalance = withLogNoData((walletService, accountNum, requiredConfs) => new Promise((ok, fail) => {
   const request = new BalanceRequest();
   request.setAccountNumber(accountNum);
   request.setRequiredConfirmations(requiredConfs);
   walletService.balance(request, (err, res) => err ? fail(err) : ok(res));
-});
+}), "Get Balance");
 
-export const getAccountNumber = (walletService, accountName) => new Promise((ok, fail) => {
+export const getAccountNumber = log((walletService, accountName) => new Promise((ok, fail) => {
   const request = new AccountNumberRequest();
   request.setAccountName(accountName);
   walletService.accountNumber(request, (err, res) => err ? fail(err) : ok(res));
-});
+}), "Get Account Number");
 
-export const getTickets = (walletService, startHeight, endHeight) => new Promise((ok, fail) => {
+export const getTickets = log((walletService, startHeight, endHeight) => new Promise((ok, fail) => {
   const tickets = [];
   const request = new GetTicketsRequest();
   request.setStartingBlockHeight(startHeight);
@@ -44,7 +47,7 @@ export const getTickets = (walletService, startHeight, endHeight) => new Promise
   }));
   getTx.on("end", () => ok(tickets));
   getTx.on("error", fail);
-});
+}), "Get Tickets", logOptionNoResponseData());
 
 export const setAgendaVote = log((votingService, agendaId, choiceId) =>
   new Promise((ok, fail) => {

--- a/app/wallet/config.js
+++ b/app/wallet/config.js
@@ -1,6 +1,8 @@
 import Promise from "promise";
 import { stakePoolInfo } from "middleware/stakepoolapi";
+import { withLogNoData  } from "./index";
 
-export const getStakePoolInfo = () =>
+export const getStakePoolInfo = withLogNoData(() =>
   new Promise((resolve, reject) =>
-    stakePoolInfo((response, error) => !response ? reject(error) : resolve(response)));
+    stakePoolInfo((response, error) => !response ? reject(error) : resolve(response))),
+    "Get Stakepool Info");

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -1,49 +1,51 @@
 import Promise from "promise";
 import { ipcRenderer } from "electron";
 import { isString } from "util";
+import { withLog as log, logOptionNoResponseData } from "./app";
 
-export const startDaemon = (appData) => Promise
+export const startDaemon = log((appData) => Promise
   .resolve(ipcRenderer.sendSync("start-daemon", appData))
   .then(pid => {
     if (pid) return pid;
     throw "Error starting daemon";
-  });
+  }), "Start Daemon");
 
-export const cleanShutdown = () => Promise
+export const cleanShutdown = log(() => Promise
   .resolve(ipcRenderer.send("clean-shutdown"))
   .then(stopped => {
     if (!stopped) throw "Error shutting down app";
-  });
+  }), "Clean Shutdown");
 
-export const startWallet = () => Promise
+export const startWallet = log(() => Promise
   .resolve(ipcRenderer
     .sendSync("start-wallet"))
   .then(pid => {
     if (pid) return pid;
     throw "Error starting wallet";
-  });
+  }), "Start Wallet");
 
-export const getBlockCount = (rpcCreds, appData) => Promise
+export const getBlockCount = log((rpcCreds, appData) => Promise
   .resolve(ipcRenderer.sendSync("check-daemon", rpcCreds, appData))
-  .then(block => isString(block) ? parseInt(block.trim()) : block);
+  .then(block => isString(block) ? parseInt(block.trim()) : block)
+  , "Get Block Count");
 
-export const getDcrdLogs = () => Promise
+export const getDcrdLogs = log(() => Promise
   .resolve(ipcRenderer.sendSync("get-dcrd-logs"))
   .then(logs => {
     if (logs) return logs;
     throw "Error getting dcrd logs";
-  });
+  }), "Get Dcrd Logs", logOptionNoResponseData());
 
-export const getDcrwalletLogs = () => Promise
+export const getDcrwalletLogs = log(() => Promise
   .resolve(ipcRenderer.sendSync("get-dcrwallet-logs"))
   .then(logs => {
     if (logs) return logs;
     throw "Error getting dcrwallet logs";
-  });
+  }), "Get Dcrwallet Logs", logOptionNoResponseData());
 
-export const getDecreditonLogs = () => Promise
+export const getDecreditonLogs = log(() => Promise
     .resolve(ipcRenderer.sendSync("get-decrediton-logs"))
     .then(logs => {
       if (logs) return logs;
       throw "Error getting decrediton logs";
-    });
+    }), "Get Decrediton Logs", logOptionNoResponseData());

--- a/app/wallet/loader.js
+++ b/app/wallet/loader.js
@@ -5,12 +5,12 @@ import { WalletExistsRequest, CreateWalletRequest, OpenWalletRequest,
   CloseWalletRequest, StartConsensusRpcRequest, DiscoverAddressesRequest,
   SubscribeToBlockNotificationsRequest, FetchHeadersRequest } from "middleware/walletrpc/api_pb";
 
-export const getLoader = ({ address, port }) =>
+export const getLoader = log(({ address, port }) =>
   new Promise((resolve, reject) =>
     rpcLoader(address, port, (loader, error) =>
-      error ? reject(error) : resolve(loader)));
+      error ? reject(error) : resolve(loader))), "Get Loader");
 
-export const startRpc = (loader, daemonhost, rpcport, rpcuser, rpcpass, cert) =>
+export const startRpc = log((loader, daemonhost, rpcport, rpcuser, rpcpass, cert) =>
   new Promise((resolve, reject) => {
     const request = new StartConsensusRpcRequest();
     request.setNetworkAddress(daemonhost + ":" + rpcport);
@@ -18,12 +18,12 @@ export const startRpc = (loader, daemonhost, rpcport, rpcuser, rpcpass, cert) =>
     request.setPassword(new Uint8Array(Buffer.from(rpcpass)));
     request.setCertificate(new Uint8Array(cert));
     loader.startConsensusRpc(request, error => error ? reject(error) : resolve());
-  });
+  }), "Start RPC", logOptionNoArgs());
 
-export const getWalletExists = (loader) =>
+export const getWalletExists = log((loader) =>
   new Promise((resolve, reject) =>
     loader.walletExists(new WalletExistsRequest(), (error, response) =>
-      error ? reject(error) : resolve(response)));
+      error ? reject(error) : resolve(response))), "Get Wallet Exists");
 
 export const createWallet = log((loader, pubPass, privPass, seed) =>
   new Promise((resolve, reject) => {

--- a/app/wallet/message.js
+++ b/app/wallet/message.js
@@ -1,6 +1,6 @@
 import Promise from "promise";
 import { SignMessageRequest, VerifyMessageRequest }  from "middleware/walletrpc/api_pb";
-import { withLogNoArgs as log } from "./app";
+import { withLogNoData as log } from "./app";
 
 export const signMessage = log((walletService, address, message, passphrase) => {
   const request = new SignMessageRequest();

--- a/app/wallet/notifications.js
+++ b/app/wallet/notifications.js
@@ -1,11 +1,14 @@
 import Promise from "promise";
 import { TransactionNotificationsRequest, AccountNotificationsRequest} from "middleware/walletrpc/api_pb";
 import { transactionNtfs, accountNtfs } from "middleware/grpc/client";
+import { withLog as log } from "./index";
 
-export const getTransactionNotifications = (walletService) =>
+export const getTransactionNotifications = log((walletService) =>
   new Promise((resolve) =>
-    transactionNtfs(walletService, new TransactionNotificationsRequest(), (data) => resolve(data)));
+    transactionNtfs(walletService, new TransactionNotificationsRequest(), (data) => resolve(data))),
+  "Get Transaction Notifications");
 
-export const getAccountNotifications = (walletService) =>
+export const getAccountNotifications = log((walletService) =>
   new Promise((resolve) =>
-    accountNtfs(walletService, new AccountNotificationsRequest(), (data) => resolve(data)));
+    accountNtfs(walletService, new AccountNotificationsRequest(), (data) => resolve(data))),
+  "Get Account Notifications");

--- a/app/wallet/stakePool.js
+++ b/app/wallet/stakePool.js
@@ -1,21 +1,22 @@
 import Promise from "promise";
 import * as api from "../middleware/stakepoolapi";
+import { withLog as log, logOptionNoArgs } from "./index";
 
 export const getPurchaseInfo = (poolHost, apiKey) =>
   new Promise((resolve, reject) =>
     api.getPurchaseInfo(poolHost, apiKey, (response, error, poolHost) =>
       error ? reject(error) : resolve({ response, poolHost })));
 
-export const setStakePoolAddress = (poolHost, apiKey, addressPubKey) =>
+export const setStakePoolAddress = log((poolHost, apiKey, addressPubKey) =>
   new Promise((resolve, reject) =>
     api.setStakePoolAddress(
       poolHost, apiKey, addressPubKey,
       (response, error) => error ? reject(error) : resolve(response)
-    ));
+    )), "Set Stakepool Address", logOptionNoArgs());
 
-export const setVoteChoices = (poolHost, apiKey, voteBits) =>
+export const setVoteChoices = log((poolHost, apiKey, voteBits) =>
   new Promise((resolve, reject) =>
     api.setVoteChoices(
       poolHost, apiKey, voteBits,
       (response, error) => error ? reject(error) : resolve(response)
-    ));
+    )), "Set Vote Choices", logOptionNoArgs());

--- a/app/wallet/version.js
+++ b/app/wallet/version.js
@@ -1,16 +1,17 @@
 import Promise from "promise";
 import { getVersionService as getService } from "../middleware/grpc/client";
 const messages = require("../middleware/walletrpc/api_pb");
+import { withLog as log } from "./index";
 
-export const getVersionService = (address, port) =>
+export const getVersionService = log((address, port) =>
   new Promise((resolve, reject) =>
     getService(address, port, (versionService, error) =>
-      error ? reject(error) : resolve(versionService)));
+      error ? reject(error) : resolve(versionService))), "Get Version Service");
 
-export const getVersionResponse = (versionService) =>
+export const getVersionResponse = log((versionService) =>
   new Promise((resolve, reject) =>
     versionService.version(
       new messages.VersionRequest(),
       (error, response) => error ? reject(error) : resolve(response)
     )
-  );
+  ), "Get Version Response");


### PR DESCRIPTION
Part of #1042 

This adds logging to all wallet actions. I tried to track down and omit private information leaking (such as balance amounts, transaction data, etc) but it should be double checked to see if I missed any.

I also added logging to the `purchaseTicketAttempt`, due to the recent #1084 issue, but before adding more logging we should see if the action refactors (#907 & future PRs) will continue, as it is easier to add logging to the normalized wallet functions rather then on each react action.

Also didn't add logging to config yet as there is work being done on that to refactor it for multiple wallet support.