### PR TITLE
Bump electron version due to critical security fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "cross-env": "^3.1.3",
     "dateformat": "^2.0.0",
     "devtron": "^1.4.0",
-    "electron": "1.7.10",
+    "electron": "1.7.11",
     "enzyme": "^3.1.0",
     "eslint": "^3.12.1",
     "eslint-config-airbnb": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2824,9 +2824,9 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   dependencies:
     electron-releases "^2.1.0"
 
-electron@1.7.10:
-  version "1.7.10"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.10.tgz#3a3e83d965fd7fafe473be8ddf8f472561b6253d"
+electron@1.7.11:
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.11.tgz#993b6aa79e0e79a7cfcc369f4c813fbd9a0b08d9"
   dependencies:
     "@types/node" "^7.0.18"
     electron-download "^3.0.1"


### PR DESCRIPTION
https://electronjs.org/blog/protocol-handler-fix

Appears that the vulnerability doesn't effect us, but better bump to be sure.