### PR TITLE
Show account name in votes and received txs

### DIFF
--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -141,7 +141,7 @@ const TxDetails = ({ routes, router,
                 </div>
                 {txOutputs.map(({ accountName, address, amount }, idx) => (
                   <div key={idx} className="txdetails-row">
-                    <div className="txdetails-address">{txDirection === "out" ? "change" : txDirection === "transfer" ? addSpacingAroundText(accountName) : addSpacingAroundText(address)}</div>
+                    <div className="txdetails-address">{txDirection === "out" ? "change" : accountName ? addSpacingAroundText(accountName) : addSpacingAroundText(address)}</div>
                     <div className="txdetails-amount"><Balance amount={amount} /></div>
                   </div>
                 ))}


### PR DESCRIPTION
Fix #1103 

Besides votes, this also changes the txdetail page to show the account name on received transactions.