### PR TITLE
[poc] Update balance on maturing coin blocks

### DIFF
--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -1,6 +1,6 @@
 // @flow
 import * as wallet from "wallet";
-import { getTicketPriceAttempt, updateAccount, getAllAccountsBalances, MATURINGHEIGHTS_CHANGED } from "./ClientActions";
+import { getTicketPriceAttempt, updateAccount, getAccountNumbersBalances } from "./ClientActions";
 import { newTransactionsReceived } from "./ClientActions";
 import { TransactionNotificationsRequest, AccountNotificationsRequest } from "middleware/walletrpc/api_pb";
 
@@ -23,11 +23,14 @@ function transactionNtfnsData(response) {
       dispatch({currentBlockHeight, currentBlockTimestamp, type: NEWBLOCKCONNECTED });
       setTimeout( () => {dispatch(getTicketPriceAttempt());}, 1000);
 
-      const maturedHeights = maturingBlockHeights.filter(h => h <= currentBlockHeight);
-      console.log("testing on new block", maturedHeights, maturingBlockHeights, currentBlockHeight);
+      const maturedHeights = Object.keys(maturingBlockHeights).filter(h => h <= currentBlockHeight);
       if (maturedHeights.length > 0) {
-        console.log("matured");
-        dispatch(getAllAccountsBalances());
+        const accountNumbers = maturedHeights.reduce((l, h) => {
+          maturingBlockHeights[h].forEach(an => l.indexOf(an) === -1 ? l.push(an) : null);
+          return l;
+        }, []);
+        console.log("gonna update accounts", accountNumbers);
+        dispatch(getAccountNumbersBalances(accountNumbers));
       }
 
       const newlyMined = attachedBlocks.reduce((l, b) => {

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -1,6 +1,6 @@
 // @flow
 import * as wallet from "wallet";
-import { getTicketPriceAttempt, updateAccount } from "./ClientActions";
+import { getTicketPriceAttempt, updateAccount, getAllAccountsBalances, MATURINGHEIGHTS_CHANGED } from "./ClientActions";
 import { newTransactionsReceived } from "./ClientActions";
 import { TransactionNotificationsRequest, AccountNotificationsRequest } from "middleware/walletrpc/api_pb";
 
@@ -11,7 +11,7 @@ export const TRANSACTIONNTFNS_END = "TRANSACTIONNTFNS_END";
 export const NEWBLOCKCONNECTED = "NEWBLOCKCONNECTED";
 
 function transactionNtfnsData(response) {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     const attachedBlocks = response.getAttachedBlocksList();
     const unminedTxList = response.getUnminedTransactionsList();
 
@@ -19,8 +19,16 @@ function transactionNtfnsData(response) {
     if (attachedBlocks.length > 0) {
       var currentBlockTimestamp = attachedBlocks[attachedBlocks.length-1].getTimestamp();
       var currentBlockHeight = attachedBlocks[attachedBlocks.length-1].getHeight();
+      const { maturingBlockHeights } = getState().grpc;
       dispatch({currentBlockHeight, currentBlockTimestamp, type: NEWBLOCKCONNECTED });
       setTimeout( () => {dispatch(getTicketPriceAttempt());}, 1000);
+
+      const maturedHeights = maturingBlockHeights.filter(h => h <= currentBlockHeight);
+      console.log("testing on new block", maturedHeights, maturingBlockHeights, currentBlockHeight);
+      if (maturedHeights.length > 0) {
+        console.log("matured");
+        dispatch(getAllAccountsBalances());
+      }
 
       const newlyMined = attachedBlocks.reduce((l, b) => {
         b.getTransactionsList().forEach((t, i) => {

--- a/app/index.js
+++ b/app/index.js
@@ -183,6 +183,9 @@ var initialState = {
     // map from (reversed) transaction hash to fully decoded transaction
     decodedTransactions: {},
 
+    // list of block heights where balance update should occur due to maturing
+    // tickets/votes/
+    maturingBlockHeights: [],
   },
   walletLoader: {
     rpcRetryAttempts: 0,

--- a/app/index.js
+++ b/app/index.js
@@ -183,9 +183,10 @@ var initialState = {
     // map from (reversed) transaction hash to fully decoded transaction
     decodedTransactions: {},
 
-    // list of block heights where balance update should occur due to maturing
-    // tickets/votes/
-    maturingBlockHeights: [],
+    // Map that stores the accounts that should be updated at future block
+    // heights, due to maturing stake transactions. Keys are the heights,
+    // values are arrays of account numbers.
+    maturingBlockHeights: {},
   },
   walletLoader: {
     rpcRetryAttempts: 0,

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -19,7 +19,7 @@ import {
   GETAGENDAS_ATTEMPT, GETAGENDAS_FAILED, GETAGENDAS_SUCCESS,
   GETVOTECHOICES_ATTEMPT, GETVOTECHOICES_FAILED, GETVOTECHOICES_SUCCESS,
   SETVOTECHOICES_ATTEMPT, SETVOTECHOICES_FAILED, SETVOTECHOICES_SUCCESS,
-  UPDATEHIDDENACCOUNTS,
+  UPDATEHIDDENACCOUNTS, MATURINGHEIGHTS_CHANGED,
 } from "../actions/ClientActions";
 import { STARTUPBLOCK } from "../actions/DaemonActions";
 import { NEWBLOCKCONNECTED } from "../actions/NotificationActions";
@@ -305,10 +305,13 @@ export default function grpc(state = {}, action) {
       currentBlockHeight: action.currentBlockHeight,
     };
   case NEWBLOCKCONNECTED:
+    var newMaturingBlockHeights = [...state.maturingBlockHeights]
+      .filter(h => h > action.currentBlockHeight);
     return {
       ...state,
       recentBlockTimestamp: action.currentBlockTimestamp,
       currentBlockHeight: action.currentBlockHeight,
+      maturingBlockHeights: newMaturingBlockHeights,
     };
   case GETAGENDASERVICE_ATTEMPT:
     return {
@@ -478,6 +481,11 @@ export default function grpc(state = {}, action) {
         ...state.decodedTransactions,
         ...action.transactions
       }
+    };
+  case MATURINGHEIGHTS_CHANGED:
+    return {
+      ...state,
+      maturingBlockHeights: action.maturingBlockHeights,
     };
   default:
     return state;

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -305,8 +305,11 @@ export default function grpc(state = {}, action) {
       currentBlockHeight: action.currentBlockHeight,
     };
   case NEWBLOCKCONNECTED:
-    var newMaturingBlockHeights = [...state.maturingBlockHeights]
-      .filter(h => h > action.currentBlockHeight);
+    var newMaturingBlockHeights = Object.keys(state.maturingBlockHeights)
+      .reduce((o, h) => {
+        h > action.currentBlockHeight ? o[h] = state.maturingBlockHeights[h] : null;
+        return o;
+      }, {});
     return {
       ...state,
       recentBlockTimestamp: action.currentBlockTimestamp,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -4,6 +4,7 @@ import {
 } from "./fp";
 import { reverseHash } from "./helpers/byteActions";
 import { TRANSACTION_TYPES }  from "wallet/service";
+import { MainNetParams, TestNetParams } from "wallet/constants";
 import { TicketTypes, decodeVoteScript } from "./helpers/tickets";
 
 const EMPTY_ARRAY = [];  // Maintaining identity (will) improve performance;
@@ -636,3 +637,5 @@ export const mainWindow = () => window;
 
 export const shutdownRequested = get(["daemon", "shutdownRequested"]);
 export const daemonStopped = get(["daemon", "daemonStopped"]);
+
+export const chainParams = compose(isTestNet => isTestNet ? TestNetParams : MainNetParams, isTestNet);

--- a/app/wallet/constants.js
+++ b/app/wallet/constants.js
@@ -1,0 +1,15 @@
+// Constants copied from dcrd/chaincfg/params.go
+
+export const TestNetParams = {
+  TicketMaturity:          16,
+  TicketExpiry:            6144, // 6*TicketPoolSize
+  CoinbaseMaturity:        16,
+  SStxChangeMaturity:      1,
+};
+
+export const MainNetParams = {
+  TicketMaturity:          256,
+  TicketExpiry:            40960, // 5*TicketPoolSize
+  CoinbaseMaturity:        256,
+  SStxChangeMaturity:      1,
+};

--- a/app/wallet/index.js
+++ b/app/wallet/index.js
@@ -3,6 +3,7 @@ import { TransactionDetails } from "../middleware/walletrpc/api_pb";
 export * from "./app";
 export * from "./config";
 export * from "./client";
+export * from "./constants";
 export * from "./daemon";
 export * from "./loader";
 export * from "./message";


### PR DESCRIPTION
Fix #1085 

I left some instrumentation for now, to help test/debug. Will remove it and the [poc] title after review.

This is basically following the proposal in the issue (tracking the blocks where coins are maturing) with a slight change to also track the related accounts (so only the accounts related to the maturing coins are updated).

Transactions are checked on startup, rescan and after new transactions are mined.

I'm checking both for votes/revokes coinbase maturing and ticket expiry (though maybe I should ignore that?)

Also, I've created a new constants file in the wallet dir, so we should later on move all "magic" numbers spread throughout the app into this single file for better organization. It is following the same convention as the dcrd go code (one chainParam object for each network).