### PR TITLE
Switch DcrInput to atoms

### DIFF
--- a/app/components/inputs/DcrInput.js
+++ b/app/components/inputs/DcrInput.js
@@ -1,7 +1,67 @@
+import FloatInput from "./FloatInput";
 import NumericInput from "./NumericInput";
+import { strToDcrAtoms } from "helpers/strings";
 import balanceConnector from "connectors/balance";
 
-const DcrInput = ({...props, currencyDisplay}) =>
-  <NumericInput {...{...props, unit: currencyDisplay}} />;
+/**
+ * DcrInput provides a way to receive decred amount inputs. Instead of the usual
+ * value/onChange pair, it uses amount/onChangeAmount to track values in decred
+ * atoms, correctly accounting for the currently used currencyDisplay, floating
+ * convertions, etc.
+ *
+ * It tracks 2 different values: the typed input in the text box (which may
+ * contain decimal and eventually thousands separator) and the actual input
+ * amount in **ATOMS** (as required by various wallet operations).
+ */
+@autobind
+class DcrInput extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {value: this.amountToDisplayStr(props.amount)};
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!nextProps.amount && !this.state.value) {
+      //ignore when emptying or setting to 0
+      return;
+    }
+
+    if (nextProps.amount !== this.props.amount) {
+      this.setState({value: this.amountToDisplayStr(nextProps.amount)});
+    }
+  }
+
+  amountToDisplayStr(amount) {
+    if (!amount) return amount;
+    const { unitDivisor } = this.props;
+    return amount / unitDivisor;
+  }
+
+  changeAmount(value) {
+    const { unitDivisor } = this.props;
+    const amount = !value ? 0 : strToDcrAtoms(value, unitDivisor);
+    if (amount !== this.props.amount) {
+      this.props.onChangeAmount && this.props.onChangeAmount(amount);
+    }
+  }
+
+  onChange(e) {
+    const value = e.target.value;
+    if (value !== this.state.value) {
+      this.setState({value}, () => this.changeAmount(value));
+    }
+  }
+
+  render() {
+    const { unitDivisor, currencyDisplay } = this.props;
+    const { value } = this.state;
+    const { onChange } = this;
+
+    return unitDivisor !== 1
+    ? <FloatInput {...this.props} unit={currencyDisplay} value={value} onChange={onChange} />
+    : <NumericInput {...this.props} unit={currencyDisplay} onChange={onChange} />;
+  }
+}
 
 export default balanceConnector(DcrInput);

--- a/app/components/inputs/DcrInput.js
+++ b/app/components/inputs/DcrInput.js
@@ -61,6 +61,14 @@ class DcrInput extends React.Component {
 
   onChange(e) {
     const value = e.target.value;
+    if (value) {
+      // pre-validate if <= max supply
+      const { unitDivisor } = this.props;
+      const amount = strToDcrAtoms(value, unitDivisor);
+      // TODO: move to a global constant
+      if (amount > 21e14) return;
+    }
+
     if (value !== this.state.value) {
       this.setState({value}, () => this.changeAmount(value));
     }

--- a/app/components/inputs/DcrInput.js
+++ b/app/components/inputs/DcrInput.js
@@ -1,5 +1,5 @@
 import FloatInput from "./FloatInput";
-import NumericInput from "./NumericInput";
+import IntegerInput from "./IntegerInput";
 import { strToDcrAtoms } from "helpers/strings";
 import balanceConnector from "connectors/balance";
 
@@ -59,14 +59,14 @@ class DcrInput extends React.Component {
     const { onChange } = this;
     const maxFracDigits = Math.log10(unitDivisor);
 
-    return unitDivisor !== 1
-    ? <FloatInput
+    const Comp = unitDivisor !== 1 ? FloatInput : IntegerInput;
+    return <Comp
         {...this.props}
         unit={currencyDisplay}
         value={value}
-        onChange={onChange} maxFracDigits={maxFracDigits}
-      />
-    : <NumericInput {...this.props} unit={currencyDisplay} onChange={onChange} />;
+        onChange={onChange}
+        maxFracDigits={maxFracDigits}
+      />;
   }
 }
 

--- a/app/components/inputs/DcrInput.js
+++ b/app/components/inputs/DcrInput.js
@@ -4,6 +4,19 @@ import { strToDcrAtoms } from "helpers/strings";
 import balanceConnector from "connectors/balance";
 
 /**
+ * FixedDcrInput is a simple numeric input that is assumed to **always** hold
+ * a floating point number representing a DCR amount (ie, an amount that
+ * will be mutiplied by 1e8 to get to the actual atoms value).
+ *
+ * This is **not** affected by the global currencyDisplay state.
+ *
+ * Whenever possible, use the DcrInput component, as it is more flexible and
+ * already manages the underlying input value in atoms.
+ */
+export const FixedDcrInput = ({...props, currencyDisplay}) =>
+  <FloatInput {...{...props, unit: currencyDisplay, maxFracDigits: 8}} />;
+
+/**
  * DcrInput provides a way to receive decred amount inputs. Instead of the usual
  * value/onChange pair, it uses amount/onChangeAmount to track values in decred
  * atoms, correctly accounting for the currently used currencyDisplay, floating

--- a/app/components/inputs/DcrInput.js
+++ b/app/components/inputs/DcrInput.js
@@ -57,9 +57,15 @@ class DcrInput extends React.Component {
     const { unitDivisor, currencyDisplay } = this.props;
     const { value } = this.state;
     const { onChange } = this;
+    const maxFracDigits = Math.log10(unitDivisor);
 
     return unitDivisor !== 1
-    ? <FloatInput {...this.props} unit={currencyDisplay} value={value} onChange={onChange} />
+    ? <FloatInput
+        {...this.props}
+        unit={currencyDisplay}
+        value={value}
+        onChange={onChange} maxFracDigits={maxFracDigits}
+      />
     : <NumericInput {...this.props} unit={currencyDisplay} onChange={onChange} />;
   }
 }

--- a/app/components/inputs/FloatInput.js
+++ b/app/components/inputs/FloatInput.js
@@ -1,0 +1,20 @@
+import NumericInput from "./NumericInput";
+import { restrictToStdDecimalNumber } from "helpers/strings";
+
+const FloatInput = ({...props}) => {
+
+  var value = props.value;
+
+  const onChange = (e) => {
+    const newValue = restrictToStdDecimalNumber(e.target.value);
+    if (value !== newValue) {
+      value = newValue;
+      e.target.value = newValue;
+      props.onChange && props.onChange(e);
+    }
+  };
+
+  return <NumericInput {...props} onChange={onChange} value={value}/>;
+};
+
+export default FloatInput;

--- a/app/components/inputs/FloatInput.js
+++ b/app/components/inputs/FloatInput.js
@@ -1,12 +1,13 @@
 import NumericInput from "./NumericInput";
-import { restrictToStdDecimalNumber } from "helpers/strings";
+import { restrictToStdDecimalNumber, limitFractionalDigits } from "helpers/strings";
 
-const FloatInput = ({...props}) => {
+const FloatInput = ({...props, maxFracDigits}) => {
 
   var value = props.value;
 
   const onChange = (e) => {
-    const newValue = restrictToStdDecimalNumber(e.target.value);
+    let newValue = restrictToStdDecimalNumber(e.target.value);
+    newValue = maxFracDigits ? limitFractionalDigits(newValue, maxFracDigits) : newValue;
     if (value !== newValue) {
       value = newValue;
       e.target.value = newValue;

--- a/app/components/inputs/Input.js
+++ b/app/components/inputs/Input.js
@@ -1,5 +1,6 @@
 import { FormattedMessage as T } from "react-intl";
 import "style/Input.less";
+import { isNullOrUndefined } from "util";
 
 class Input extends React.Component{
   constructor(props) {
@@ -65,7 +66,7 @@ class Input extends React.Component{
             disabled={disabled ? disabled : null}
             readOnly={readOnly ? readOnly : null}
             placeholder={placeholder}
-            value={value}
+            value={isNullOrUndefined(value) ? "" : value}
             onChange={onChange}
             onFocus={this.onInputFocus}
             onBlur={this.onInputBlur}

--- a/app/components/inputs/IntegerInput.js
+++ b/app/components/inputs/IntegerInput.js
@@ -1,0 +1,19 @@
+import NumericInput from "./NumericInput";
+
+const IntegerInput = ({...props}) => {
+
+  var value = props.value;
+
+  const onChange = (e) => {
+    let newValue = e.target.value.replace(/[^0-9]/g, "");
+    if (value !== newValue) {
+      value = newValue;
+      e.target.value = newValue;
+      props.onChange && props.onChange(e);
+    }
+  };
+
+  return <NumericInput {...props} onChange={onChange} value={value}/>;
+};
+
+export default IntegerInput;

--- a/app/components/inputs/index.js
+++ b/app/components/inputs/index.js
@@ -14,3 +14,4 @@ export { default as SettingsInput } from "./SettingsInput";
 export { default as StakePoolSelect } from "./StakePoolSelect";
 export { default as TextInput } from "./TextInput";
 export { default as PassphraseModalField } from "./PassphraseModalField";
+export { FixedDcrInput } from "./DcrInput";

--- a/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/Details.js
+++ b/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/Details.js
@@ -1,4 +1,4 @@
-import { FeeInput, DcrInput, PercentInput, BlocksInput } from "inputs";
+import { FeeInput, FixedDcrInput, PercentInput, BlocksInput } from "inputs";
 import { KeyBlueButton } from "buttons";
 import { FormattedMessage as T, defineMessages } from "react-intl";
 
@@ -58,7 +58,7 @@ const Details = ({
       </div></div>
           <div className="stakepool-purchase-ticket-num-input">
             <div className="stakepool-input-form-purchase-ticket">
-              <DcrInput
+              <FixedDcrInput
                 placeholder={formatMessage(messages.balanceToMaintain)}
                 value={balanceToMaintain}
                 onChange={onChangeBalanceToMaintain}
@@ -97,7 +97,7 @@ const Details = ({
       </div></div>
           <div className="stakepool-purchase-ticket-num-input">
             <div className="stakepool-input-form-purchase-ticket">
-              <DcrInput
+              <FixedDcrInput
                 placeholder={formatMessage(messages.maxPriceAbsolute)}
                 value={maxPriceAbsolute}
                 onChange={onChangeMaxPriceAbsolute}

--- a/app/components/views/TransactionsPage/SendTab/OutputAccountRow.js
+++ b/app/components/views/TransactionsPage/SendTab/OutputAccountRow.js
@@ -1,4 +1,3 @@
-import { compose } from "fp";
 import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
 import { DcrInput, ReceiveAccountsSelect } from "inputs";
 import "style/SendPage.less";
@@ -12,12 +11,11 @@ const messages = defineMessages({
 
 const SendOutputAccountRow = ({
   index,
-  amountStr,
+  amount,
   amountError,
   getOnChangeOutputAmount,
   isSendAll,
   totalSpent,
-  unitDivisor,
   intl,
 }) => (
   <div className="send-row">
@@ -38,17 +36,17 @@ const SendOutputAccountRow = ({
             hidden={!isSendAll}
             className="send-address-input-amount"
             disabled={true}
-            value={totalSpent !== null ? totalSpent / unitDivisor : ""}
+            amount={totalSpent}
           />
           <DcrInput
             showErrors={true}
             invalid={!!amountError}
             invalidMessage={amountError}
             hidden={isSendAll}
-            value={amountStr}
+            amount={amount}
             className="send-address-input-amount"
             placeholder={intl.formatMessage(messages.amountPlaceholder)}
-            onChange={compose(getOnChangeOutputAmount(index), e => e.target.value)}
+            onChangeAmount={getOnChangeOutputAmount(index)}
           />
         </div>
       </div>

--- a/app/components/views/TransactionsPage/SendTab/OutputRow.js
+++ b/app/components/views/TransactionsPage/SendTab/OutputRow.js
@@ -18,7 +18,7 @@ const SendOutputRow = ({
   index,
   outputs,
   destination,
-  amountStr,
+  amount,
   addressError,
   amountError,
   onAddOutput,
@@ -26,6 +26,7 @@ const SendOutputRow = ({
   getOnChangeOutputDestination,
   getOnChangeOutputAmount,
   isSendAll,
+  totalSpent,
   intl
 }) => (
   <div className="send-row">
@@ -62,17 +63,17 @@ const SendOutputRow = ({
             hidden={!isSendAll}
             className="send-address-input-amount"
             disabled={true}
-            value={amountStr}
+            amount={totalSpent}
           />
           <DcrInput
             showErrors={true}
             invalid={!!amountError}
             invalidMessage={amountError}
             hidden={isSendAll}
-            value={amountStr}
+            amount={amount}
             className="send-address-input-amount"
             placeholder={intl.formatMessage(messages.amountPlaceholder)}
-            onChange={compose(getOnChangeOutputAmount(index), e => e.target.value)}
+            onChangeAmount={getOnChangeOutputAmount(index)}
           />
         </div>
       </div>

--- a/app/connectors/balance.js
+++ b/app/connectors/balance.js
@@ -3,7 +3,8 @@ import { selectorMap } from "../fp";
 import * as sel from "../selectors";
 
 const mapStateToProps = selectorMap({
-  currencyDisplay: sel.currencyDisplay
+  currencyDisplay: sel.currencyDisplay,
+  unitDivisor: sel.unitDivisor,
 });
 
 export default connect(mapStateToProps);

--- a/app/helpers/strings.js
+++ b/app/helpers/strings.js
@@ -18,3 +18,22 @@ export function restrictToStdDecimalNumber(s) {
     .replace(/^\.(.*)$/, "0.$1")              // prepend 0 when starting with period
     .replace(/^([\d]*)(\.?[\d]*).*/, "$1$2"); // use only the first run of numbers
 }
+
+// Converts a string encoded as stdDecimalString (ie, a string protected by
+// restrictToStdDecimalNumber) into a decred atom amount. This performs a
+// conversion from a string into a JS number and then scales the number
+// according to unitDivisor so the value represents an atom amount.
+//
+// Due to floating point inacuracies, a rounding function compatible to dcrutil
+// `round` is used (see:
+// https://github.com/decred/dcrd/blob/v1.1.2/dcrutil/amount.go#L77)
+//
+// Note that, since JS doesn't actually have an integer type (all numbers
+// are floating-point numbers), the Math.trunc function is used to simulate
+// the float64 -> int64 conversion.
+//
+// This is fine for representing numbers within the range of the total decred
+// supply (up to 21e14) but may not be arbitrarily applicable.
+export function strToDcrAtoms(s, unitDivisor) {
+  return Math.trunc(parseFloat(s) * unitDivisor + 0.5);
+}

--- a/app/helpers/strings.js
+++ b/app/helpers/strings.js
@@ -1,3 +1,5 @@
+import { isString } from "util";
+
 // @flow
 
 // This function adds spaces around text to fix an issue with double-clicking to select it
@@ -36,4 +38,20 @@ export function restrictToStdDecimalNumber(s) {
 // supply (up to 21e14) but may not be arbitrarily applicable.
 export function strToDcrAtoms(s, unitDivisor) {
   return Math.trunc(parseFloat(s) * unitDivisor + 0.5);
+}
+
+// Restricts the given stdDecimalString (ie, a string projected by
+// restrictToStdDecimalNumber) to the given amount of fractional digits (ie,
+// digits after the decimal point).
+//
+// This function does **not** pad the string if less than maxFracDigits are
+// present.
+export function limitFractionalDigits(s, maxFracDigits) {
+  if (!isString(s)) return s;
+
+  const match = s.match(/(\d+)\.(\d*)/);
+  if (!match) return s;
+  if (!maxFracDigits) return s[1]; // no fractional digits, return just the int part
+  if (match[2].length <= maxFracDigits) return s;
+  return match[1] + "." + match[2].substr(0, maxFracDigits);
 }


### PR DESCRIPTION
Fix #1110 

This changes the `DcrInput` component to manage the input amount in atoms instead of as string, implementing rounding for floating values following the same procedure as dcrd/dcrwallet (https://github.com/decred/dcrd/blob/v1.1.2/dcrutil/amount.go#L77).

It also adds `FloatInput`, `IntegerInput` (behave as expected) and `FixedDcrInput` (which behaves as the old `DcrInput`, meant for inputs that are *always* assumed to be in DCR amounts).
