### PR TITLE
Fix seed and rename account inputs

### DIFF
--- a/app/components/modals/SeedCopyConfirmModal/Modal.js
+++ b/app/components/modals/SeedCopyConfirmModal/Modal.js
@@ -35,7 +35,10 @@ const Modal = ({show, onCancelModal, onSubmit, copyConfirmationPhrase,
           confirmationPhrase: <span className="mono confirm-seed-copy-phrase">'{copyConfirmationPhrase}'</span>,
         }}/>
       </p>
-      <TextInput autoFocus onChange={(e) => onTypedConfirmationPhraseChanged(e.target.value)}/>
+      <TextInput
+        autoFocus
+        value={typedConfirmationPhrase}
+        onChange={(e) => onTypedConfirmationPhraseChanged(e.target.value)}/>
     </div>
     <div className="confirm-modal-toolbar">
       <DangerButton className="confirm-modal-confirm-button" onClick={onSubmit} disabled={typedConfirmationPhrase.toLowerCase() !== copyConfirmationPhrase.toLowerCase()}>

--- a/app/components/views/AccountsPage/Accounts/AccountRow/RenameAccount.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/RenameAccount.js
@@ -12,6 +12,7 @@ const messages = defineMessages({
 const RenameAccount = ({
   account,
   updateRenameAccountName,
+  renameAccountName,
   renameAccount,
   hideRenameAccount,
   intl,
@@ -36,7 +37,8 @@ const RenameAccount = ({
               className="address-content-nest-address-hash-to"
               placeholder={intl.formatMessage(messages.newNamePlaceholder)}
               maxLength="50"
-              onBlur={(e) => updateRenameAccountName(e.target.value)}
+              value={renameAccountName}
+              onChange={(e) => updateRenameAccountName(e.target.value)}
             />
           </div>
         </div>

--- a/app/components/views/AccountsPage/Accounts/AccountRow/index.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/index.js
@@ -77,12 +77,13 @@ class AccountRow extends React.Component {
       renameAccount,
       hideRenameAccount,
     } = this;
-    const { renameAccountNameError } = this.state;
+    const { renameAccountNameError, renameAccountName } = this.state;
     return [{
       data: <RenameAccount
         {...{
           account,
           updateRenameAccountName,
+          renameAccountName,
           renameAccount,
           hideRenameAccount,
           intl,


### PR DESCRIPTION
Fix #1127 

The rename account input was also broken.

I checked all `<\w+Input` components and all of them (except the rename account and the seed input) were using the `onChange={...}/value={...}` style for storing the inputs, ao only those two got broken.