### PR TITLE
[getstarted] Load wallet before daemon

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -1,4 +1,4 @@
-import { versionCheckAction } from "./WalletLoaderActions";
+import { versionCheckAction, startRpcRequestFunc } from "./WalletLoaderActions";
 import { stopNotifcations } from "./NotificationActions";
 import * as wallet from "wallet";
 import { push as pushHistory } from "react-router-redux";
@@ -119,7 +119,8 @@ export const syncDaemon = () =>
             dispatch({type: DAEMONSYNCED});
             dispatch({currentBlockHeight: updateCurrentBlockCount, type: STARTUPBLOCK});
             setMustOpenForm(false);
-            dispatch(startWallet());
+            //dispatch(start());
+            dispatch(startRpcRequestFunc());
             return;
           } else if (updateCurrentBlockCount !== 0) {
             const blocksLeft = neededBlocks - updateCurrentBlockCount;

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -82,13 +82,12 @@ export const startWallet = () => (dispatch, getState) => {
   });
 };
 
-export const prepStartDaemon = (dispatch, getState) => {
-  const { daemone: { isAdvancedDaemon } } = getState();
-  //if (!isAdvancedDaemon) {
-  dispatch(startDaemon());
-  //  return;
- // }
-/*
+export const prepStartDaemon = () => (dispatch, getState) => {
+  const { daemon: { daemonAdvanced, openForm } } = getState();
+  if (!daemonAdvanced) {
+    dispatch(startDaemon());
+    return;
+  }
   const {rpc_password, rpc_user, rpc_cert, rpc_host, rpc_port} = getRemoteCredentials(isTestNet(getState()));
   const hasAllCredentials = rpc_password.length > 0 && rpc_user.length > 0 && rpc_cert.length > 0 && rpc_host.length > 0 && rpc_port.length > 0;
   const hasAppData = getAppdataPath(isTestNet(getState())) && getAppdataPath(isTestNet(getState())).length > 0;
@@ -96,12 +95,11 @@ export const prepStartDaemon = (dispatch, getState) => {
   if(hasAllCredentials && hasAppData)
     this.props.setCredentialsAppdataError();
 
-  if (!this.props.openForm && hasAppData) {
+  if (!openForm && hasAppData) {
     dispatch(startDaemon(null, getAppdataPath(isTestNet(getState()))));
-  } else if (!this.props.openForm && hasAllCredentials) {
+  } else if (!openForm && hasAllCredentials) {
     dispatch(startDaemon(getRemoteCredentials(isTestNet(getState()))));
   }
-  */
 };
 
 export const STARTUPBLOCK = "STARTUPBLOCK";
@@ -119,7 +117,6 @@ export const syncDaemon = () =>
             dispatch({type: DAEMONSYNCED});
             dispatch({currentBlockHeight: updateCurrentBlockCount, type: STARTUPBLOCK});
             setMustOpenForm(false);
-            //dispatch(start());
             dispatch(startRpcRequestFunc());
             return;
           } else if (updateCurrentBlockCount !== 0) {

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -6,6 +6,7 @@ import { ipcRenderer } from "electron";
 import { setMustOpenForm } from "config";
 import { hideSidebarMenu } from "./SidebarActions";
 import { isTestNet } from "selectors";
+import { getAppdataPath, getRemoteCredentials } from "config.js";
 
 export const DAEMONSTARTED = "DAEMONSTARTED";
 export const DAEMONSTARTED_APPDATA = "DAEMONSTARTED_APPDATA";
@@ -79,6 +80,28 @@ export const startWallet = () => (dispatch, getState) => {
     console.log(err);
     dispatch({type: DAEMONSTARTED_ERROR});
   });
+};
+
+export const prepStartDaemon = (dispatch, getState) => {
+  const { daemone: { isAdvancedDaemon } } = getState();
+  //if (!isAdvancedDaemon) {
+  dispatch(startDaemon());
+  //  return;
+ // }
+/*
+  const {rpc_password, rpc_user, rpc_cert, rpc_host, rpc_port} = getRemoteCredentials(isTestNet(getState()));
+  const hasAllCredentials = rpc_password.length > 0 && rpc_user.length > 0 && rpc_cert.length > 0 && rpc_host.length > 0 && rpc_port.length > 0;
+  const hasAppData = getAppdataPath(isTestNet(getState())) && getAppdataPath(isTestNet(getState())).length > 0;
+
+  if(hasAllCredentials && hasAppData)
+    this.props.setCredentialsAppdataError();
+
+  if (!this.props.openForm && hasAppData) {
+    dispatch(startDaemon(null, getAppdataPath(isTestNet(getState()))));
+  } else if (!this.props.openForm && hasAllCredentials) {
+    dispatch(startDaemon(getRemoteCredentials(isTestNet(getState()))));
+  }
+  */
 };
 
 export const STARTUPBLOCK = "STARTUPBLOCK";

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -5,6 +5,7 @@ import {
 } from "wallet";
 import * as wallet from "wallet";
 import { getWalletServiceAttempt, getTicketBuyerServiceAttempt, getAgendaServiceAttempt, getVotingServiceAttempt } from "./ClientActions";
+import { startDaemon } from "./DaemonActions";
 import { getVersionServiceAttempt } from "./VersionActions";
 import { getWalletCfg, getWalletCfgPath, getDcrdCert } from "config";
 import { isTestNet } from "selectors";
@@ -77,7 +78,8 @@ export const createWalletRequest = (pubPass, privPass, seed, existing) =>
         dispatch(clearStakePoolConfigNewWallet());
         dispatch({complete: !existing, type: UPDATEDISCOVERACCOUNTS});
         config.set("discoveraccounts", !existing);
-        dispatch(startRpcRequestFunc());
+        //dispatch(startRpcRequestFunc());
+        dispatch(startDaemon());
       })
       .catch(error => dispatch({ error, type: CREATEWALLET_FAILED }));
   };
@@ -93,12 +95,14 @@ export const openWalletAttempt = (pubPass, retryAttempt) => (dispatch, getState)
   return openWallet(getState().walletLoader.loader, pubPass)
     .then(() => {
       dispatch({ type: OPENWALLET_SUCCESS });
-      dispatch(startRpcRequestFunc(false));
+      dispatch(startDaemon());
+      //dispatch(startRpcRequestFunc(false));
     })
     .catch(error => {
       if (error.message.includes("wallet already loaded")) {
         dispatch({response: {}, type: OPENWALLET_SUCCESS});
-        dispatch(startRpcRequestFunc(false));
+        dispatch(startDaemon());
+        //dispatch(startRpcRequestFunc(false));
       } else if (error.message.includes("invalid passphrase") && error.message.includes("public key")) {
         if (retryAttempt) {
           dispatch({ error, type: OPENWALLET_FAILED_INPUT });

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -5,7 +5,7 @@ import {
 } from "wallet";
 import * as wallet from "wallet";
 import { getWalletServiceAttempt, getTicketBuyerServiceAttempt, getAgendaServiceAttempt, getVotingServiceAttempt } from "./ClientActions";
-import { startDaemon } from "./DaemonActions";
+import { prepStartDaemon } from "./DaemonActions";
 import { getVersionServiceAttempt } from "./VersionActions";
 import { getWalletCfg, getWalletCfgPath, getDcrdCert } from "config";
 import { isTestNet } from "selectors";
@@ -78,8 +78,7 @@ export const createWalletRequest = (pubPass, privPass, seed, existing) =>
         dispatch(clearStakePoolConfigNewWallet());
         dispatch({complete: !existing, type: UPDATEDISCOVERACCOUNTS});
         config.set("discoveraccounts", !existing);
-        //dispatch(startRpcRequestFunc());
-        dispatch(startDaemon());
+        dispatch(prepStartDaemon());
       })
       .catch(error => dispatch({ error, type: CREATEWALLET_FAILED }));
   };
@@ -95,14 +94,12 @@ export const openWalletAttempt = (pubPass, retryAttempt) => (dispatch, getState)
   return openWallet(getState().walletLoader.loader, pubPass)
     .then(() => {
       dispatch({ type: OPENWALLET_SUCCESS });
-      dispatch(startDaemon());
-      //dispatch(startRpcRequestFunc(false));
+      dispatch(prepStartDaemon());
     })
     .catch(error => {
       if (error.message.includes("wallet already loaded")) {
         dispatch({response: {}, type: OPENWALLET_SUCCESS});
-        dispatch(startDaemon());
-        //dispatch(startRpcRequestFunc(false));
+        dispatch(prepStartDaemon());
       } else if (error.message.includes("invalid passphrase") && error.message.includes("public key")) {
         if (retryAttempt) {
           dispatch({ error, type: OPENWALLET_FAILED_INPUT });

--- a/app/components/views/GetStartedPage/FetchBlockHeaders/Form.js
+++ b/app/components/views/GetStartedPage/FetchBlockHeaders/Form.js
@@ -13,10 +13,9 @@ const FetchBlockHeadersFormHeader = ({
 );
 
 const FetchBlockHeadersFormBody = ({
-  isProcessing,
   showLongWaitMessage
 }) => {
-  return isProcessing && showLongWaitMessage ? (
+  return showLongWaitMessage ? (
     <div className="get-started-fetch-headers-message">
       <T id="getStarted.firstTimeSyncDelayReminder" m="If you are syncing the blockchain for the first time, this may take a while." />
     </div>

--- a/app/components/views/GetStartedPage/Page.js
+++ b/app/components/views/GetStartedPage/Page.js
@@ -8,7 +8,7 @@ const Page = ({ Header, Body, ...props }) => {
       <Header {...props} />
       <div className="page-content-fixed">
         <DecredLoading
-          hidden={!props.isProcessing || props.showSettings || props.showLogs}
+          hidden={props.startupError || props.isInputRequest || props.showSettings || props.showLogs}
           className="get-started-loading"
         />
         <Body {...props} />

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -69,7 +69,7 @@ class GetStartedPage extends React.Component {
     } = this;
 
     let Header, Body;
-
+    console.log(getWalletReady, startStepIndex, isPrepared);
     if (showSettings) {
       Header = SettingsHeader;
       Body = SettingsBody;
@@ -87,6 +87,17 @@ class GetStartedPage extends React.Component {
         Header = OpenWalletHeader;
         Body = OpenWalletBody;
         break;
+      default:
+        if (isAdvancedDaemon && openForm && !remoteAppdataError) {
+          Header = AdvancedStartupHeader;
+          Body = AdvancedStartupBody;
+        } else if (remoteAppdataError) {
+          Header = AdvancedStartupHeader;
+          Body = RemoteAppdataError;
+        } else {
+          Header = DaemonLoadingHeader;
+          Body = DaemonLoadingBody;
+        }
       }
     } else if (isPrepared) {
       switch (startStepIndex || 0) {

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -11,7 +11,6 @@ import { SettingsBody, SettingsHeader } from "./Settings";
 import { LogsBody, LogsHeader } from "./Logs";
 import { RescanWalletHeader, RescanWalletBody } from "./RescanWallet/index";
 import { walletStartup } from "connectors";
-import { getAppdataPath, getRemoteCredentials } from "config.js";
 
 @autobind
 class GetStartedPage extends React.Component {
@@ -23,22 +22,9 @@ class GetStartedPage extends React.Component {
   }
 
   componentDidMount() {
-    if (!this.props.isAdvancedDaemon) {
-      this.props.onStartDaemon();
+    if (!this.props.getWalletReady) {
+      this.props.onStartWallet();
       return;
-    }
-
-    const {rpc_password, rpc_user, rpc_cert, rpc_host, rpc_port} = getRemoteCredentials(this.props.isTestNet);
-    const hasAllCredentials = rpc_password.length > 0 && rpc_user.length > 0 && rpc_cert.length > 0 && rpc_host.length > 0 && rpc_port.length > 0;
-    const hasAppData = getAppdataPath(this.props.isTestNet) && getAppdataPath(this.props.isTestNet).length > 0;
-
-    if(hasAllCredentials && hasAppData)
-      this.props.setCredentialsAppdataError();
-
-    if (!this.props.openForm && hasAppData) {
-      this.props.onStartDaemon(null, getAppdataPath(this.props.isTestNet));
-    } else if (!this.props.openForm && hasAllCredentials) {
-      this.props.onStartDaemon(getRemoteCredentials(this.props.isTestNet));
     }
   }
 
@@ -64,6 +50,7 @@ class GetStartedPage extends React.Component {
       isPrepared,
       isAdvancedDaemon,
       openForm,
+      getWalletReady,
       remoteAppdataError,
       ...props
     } = this.props;
@@ -89,7 +76,7 @@ class GetStartedPage extends React.Component {
     } else if (showLogs) {
       Header = LogsHeader;
       Body = LogsBody;
-    } else if (isPrepared) {
+    } else if (getWalletReady) {
       switch (startStepIndex || 0) {
       case 0:
       case 1:
@@ -100,6 +87,9 @@ class GetStartedPage extends React.Component {
         Header = OpenWalletHeader;
         Body = OpenWalletBody;
         break;
+      }
+    } else if (isPrepared) {
+      switch (startStepIndex || 0) {
       case 3:
       case 4:
         Header = StartRPCHeader;

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -67,16 +67,14 @@ class GetStartedPage extends React.Component {
       onShowLogs,
       onHideLogs
     } = this;
-
     let Header, Body;
-    console.log(getWalletReady, startStepIndex, isPrepared);
     if (showSettings) {
       Header = SettingsHeader;
       Body = SettingsBody;
     } else if (showLogs) {
       Header = LogsHeader;
       Body = LogsBody;
-    } else if (getWalletReady) {
+    } else if (getWalletReady && !isPrepared) {
       switch (startStepIndex || 0) {
       case 0:
       case 1:
@@ -123,16 +121,8 @@ class GetStartedPage extends React.Component {
         Body = FinalStartUpBody;
       }
     } else {
-      if (isAdvancedDaemon && openForm && !remoteAppdataError) {
-        Header = AdvancedStartupHeader;
-        Body = AdvancedStartupBody;
-      } else if (remoteAppdataError) {
-        Header = AdvancedStartupHeader;
-        Body = RemoteAppdataError;
-      } else {
-        Header = DaemonLoadingHeader;
-        Body = DaemonLoadingBody;
-      }
+      Header = DaemonLoadingHeader;
+      Body = DaemonLoadingBody;
     }
 
     return <Page Header={Header} Body={Body}

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -36,7 +36,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onOpenWallet: wla.openWalletAttempt,
   onRetryStartRPC: wla.startRpcRequestFunc,
   doVersionCheck: wla.versionCheckAction,
-  onStartDaemon: da.startDaemon,
+  onStartWallet: da.startWallet,
   determineNeededBlocks: wla.determineNeededBlocks,
   setCredentialsAppdataError: da.setCredentialsAppdataError
 }, dispatch);

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -11,7 +11,6 @@ const mapStateToProps = selectorMap({
   startupError: sel.startupError,
   confirmNewSeed: sel.confirmNewSeed,
   hasExistingWallet: sel.hasExistingWallet,
-  isProcessing: sel.isStartupProcessing,
   getDaemonStarted: sel.getDaemonStarted,
   getDaemonSynced: sel.getDaemonSynced,
   getCurrentBlockCount: sel.getCurrentBlockCount,

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -36,6 +36,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onOpenWallet: wla.openWalletAttempt,
   onRetryStartRPC: wla.startRpcRequestFunc,
   doVersionCheck: wla.versionCheckAction,
+  onStartDaemon: da.startDaemon,
   onStartWallet: da.startWallet,
   determineNeededBlocks: wla.determineNeededBlocks,
   setCredentialsAppdataError: da.setCredentialsAppdataError

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -118,6 +118,7 @@ export default function walletLoader(state = {}, action) {
       walletOpenError: null,
       walletOpenRequestAttempt: false,
       walletOpenResponse: action.response,
+      advancedDaemonInputRequest: true,
       stepIndex: 3,
     };
   case CLOSEWALLET_ATTEMPT:

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -21,7 +21,6 @@ export const getWalletReady = get(["daemon", "walletReady"]);
 export const isPrepared = and(
   getDaemonStarted,
   getDaemonSynced,
-  getWalletReady,
 );
 export const getCredentials = get(["daemon", "credentials"]);
 

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -78,16 +78,7 @@ export const isInputRequest = or(
   openWalletInputRequest,
   createWalletInputRequest,
   discoverAddressInputRequest,
-);
-export const isStartupProcessing = and(
-  not(isAdvancedDaemon),
-  or(
-    not(isPrepared),
-    and(
-      not(isInputRequest),
-      not(startupError)
-    )
-  )
+  and(openForm, isAdvancedDaemon)
 );
 
 export const balances = or(get(["grpc", "balances"]), () => []);

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -73,12 +73,14 @@ export const startupError = or(
 const openWalletInputRequest = get(["walletLoader", "openWalletInputRequest"]);
 const createWalletInputRequest = get(["walletLoader", "createWalletInputRequest"]);
 const discoverAddressInputRequest = get(["walletLoader", "discoverAddressInputRequest"]);
+const advancedDaemonInputRequest = get(["walletLoader", "advancedDaemonInputRequest"]);
+const openWalletRequestAttempt = get(["walletLoader", "walletOpenRequestAttempt"]);
 
 export const isInputRequest = or(
-  openWalletInputRequest,
+  and(openWalletInputRequest, not(openWalletRequestAttempt)),
   createWalletInputRequest,
   discoverAddressInputRequest,
-  and(openForm, isAdvancedDaemon)
+  and(openForm, isAdvancedDaemon, advancedDaemonInputRequest)
 );
 
 export const balances = or(get(["grpc", "balances"]), () => []);


### PR DESCRIPTION
Due to the upcoming onboarding/get started changes, it is required that wallet is loaded before the daemon is attempted to load.  

This offers a much more intuitive onboarding flow, so users can do all of the wallet creation prior to spinning up the daemon.  In a future PR we can parallelize the process as well, so the daemon can be syncing in the background while the user creates the wallet.  