### PR TITLE
Add development binary linux target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
 script:
   - yarn lint
   - yarn test
-  - yarn package-linux
+  - yarn package-dev-linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   yarn: true
   directories:
     - node_modules
-    - "app/node_modules"
+    - app/node_modules
 
 install:
   - yarn

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "package-linux": "npm run build && build --linux",
     "package-mac": "npm run build && build --mac",
     "package-all": "npm run build && build -mwl",
+    "package-dev-linux": "npm run build && build --linux tar.gz",
     "cleanup": "mop -v",
     "flow": "flow",
     "i18n-prepare-untranslated": "node ./scripts/prepareUntranslated.js && ./node_modules/.bin/rip json2pot 'app/i18n/extracted/**/*.json' -c id -o app/i18n/pot/decrediton.pot",


### PR DESCRIPTION
This adds a yarn script to generate binaries for linux, without generating the .rpm and .deb packages.

I'm mainly using this to generate the development binaries for periodic testing.