### PR TITLE
Add cursor pointer to rescan-button and rescan-cancel-button

### DIFF
--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -344,6 +344,7 @@
   background-color: transparent;
   background-image: @menu-rescan-icon;
   background-size: 16px 16px;
+  cursor: pointer;
 }
 
 .rescan-button:hover {
@@ -375,6 +376,7 @@
   background-color: transparent;
   background-image: @menu-cancel-rescan-icon;
   background-size: 16px 16px;
+  cursor: pointer;
 }
 
 .rescan-cancel-button:hover {


### PR DESCRIPTION
Fix mouse hover on macOS. Similar as #1038 and #436.

<img width="308" alt="cancel button" src="https://user-images.githubusercontent.com/921390/35881225-73156e20-0b80-11e8-8517-07e4eaa2101e.png">
