### PR TITLE
Activate Eslint Rule no-useless-escape

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
       "error",
       2
     ],
-    "no-useless-escape": ["off"],
     "linebreak-style": [
       "error",
       "unix"

--- a/app/helpers/strings.js
+++ b/app/helpers/strings.js
@@ -16,7 +16,7 @@ export function restrictToStdDecimalNumber(s) {
   return s
     .replace(/,/g, ".")                       // comma to period
     .replace(/[^\d.]/g, "")                   // remove non-numbers
-    .replace(/\.[\.]+/g, ".")                 // remove repetitive periods
+    .replace(/\.[.]+/g, ".")                  // remove repetitive periods
     .replace(/^\.(.*)$/, "0.$1")              // prepend 0 when starting with period
     .replace(/^([\d]*)(\.?[\d]*).*/, "$1$2"); // use only the first run of numbers
 }


### PR DESCRIPTION
We should try to activate default eslint rules.

The dot operator doesn't need to be escaped inside brackets.
For reference see
https://stackoverflow.com/questions/10397968/escape-dot-in-a-regex-range
https://stackoverflow.com/questions/19976018/does-a-dot-have-to-be-escaped-in-a-character-class-square-brackets-of-a-regula
or directly https://www.regular-expressions.info/refcharclass.html