### PR TITLE
Update lint-fix to properly fix lint issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test-watch": "npm test -- --watch",
     "test-e2e": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --retries 2 --compilers js:babel-register --require ./test/setup.js ./test/e2e.js",
     "lint": "./node_modules/.bin/eslint app scripts && ./node_modules/.bin/stylelint app/style/*.less",
-    "lint-fix": "npm run lint -- --fix && ./node_modules/.bin/stylelint app/style/*.less",
+    "lint-fix": "./node_modules/.bin/eslint app scripts --fix && ./node_modules/.bin/stylelint app/style/*.less --fix",
     "hot-server": "cross-env NODE_ENV=development node --max_old_space_size=4096 -r babel-register server.js",
     "build-main": "cross-env NODE_ENV=production node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.electron.js --progress --profile --colors",
     "build-renderer": "cross-env NODE_ENV=production node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.production.js --progress --profile --colors",


### PR DESCRIPTION
With the added stylelint command to "lint" the --fix was only getting added to the stylelint command with `npm run lint -- --fix`