### PR TITLE
Support dynamic dcrwallet port

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -21,7 +21,6 @@ export const AVAILABLE_WALLETS = "AVAILABLE_WALLETS";
 export const SHUTDOWN_REQUESTED = "SHUTDOWN_REQUESTED";
 export const SET_CREDENTIALS_APPDATA_ERROR = "SET_CREDENTIALS_APPDATA_ERROR";
 
-
 export const WALLETCREATED = "WALLETCREATED";
 export const WALLET_AUTOBUYER_SETTINGS = "WALLET_AUTOBUYER_SETTINGS";
 export const WALLET_STAKEPOOL_SETTINGS = "WALLET_STAKEPOOL_SETTINGS";
@@ -103,7 +102,7 @@ export const createWallet = (selectedWallet) => (dispatch) => {
 
 export const startWallet = (selectedWallet) => (dispatch) => {
   wallet.startWallet(selectedWallet.value.wallet, selectedWallet.network == "testnet")
-    .then(() => {
+    .then(({port}) => {
       const walletCfg = getWalletCfg(selectedWallet.network == "testnet", selectedWallet.value.wallet);
       const globalCfg = getGlobalCfg();
       globalCfg.set("previouswallet", selectedWallet);
@@ -130,7 +129,7 @@ export const startWallet = (selectedWallet) => (dispatch) => {
       var discoverAccountsComplete = walletCfg.get("discoveraccounts");
       var activeStakePoolConfig = foundStakePoolConfig;
       var selectedStakePool = firstConfiguredStakePool;
-      dispatch({type: WALLETREADY, walletName: selectedWallet.value.wallet, network: selectedWallet.network, hiddenAccounts});
+      dispatch({type: WALLETREADY, walletName: selectedWallet.value.wallet, network: selectedWallet.network, hiddenAccounts, port});
       dispatch({type: WALLET_AUTOBUYER_SETTINGS, balanceToMaintain, maxFee, maxPriceAbsolute, maxPriceRelative, maxPerBlock});
       dispatch({type: WALLET_SETTINGS, currencyDisplay});
       dispatch({type: WALLET_STAKEPOOL_SETTINGS, activeStakePoolConfig, selectedStakePool, currentStakePoolConfig});

--- a/app/config.js
+++ b/app/config.js
@@ -324,7 +324,7 @@ export function newWalletConfigCreation(testnet, walletPath) {
       tlscurve: "P-256",
       noinitialload: "1",
       onetimetlskey: "1",
-      grpclisten: "127.0.0.1:9121",
+      grpclisten: "127.0.0.1:0",
       appdata: getWalletPath(testnet, walletPath),
       testnet: testnet ? "1" : "0",
       nolegacyrpc: "1",

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -19,6 +19,7 @@ let grpcVersions = {requiredVersion: null, walletVersion: null};
 let debug = false;
 let dcrdPID;
 let dcrwPID;
+let dcrwPort;
 let dcrdConfig = {};
 let currentBlockCount;
 
@@ -312,6 +313,7 @@ ipcMain.on("remove-wallet", (event, walletPath, testnet) => {
 ipcMain.on("start-wallet", (event, walletPath, testnet) => {
   if (dcrwPID) {
     logger.log("info", "dcrwallet already started " + dcrwPID);
+    mainWindow.webContents.send("dcrwallet-port", dcrwPort);
     event.returnValue = dcrwPID;
     return;
   }
@@ -550,6 +552,7 @@ const launchDCRWallet = (walletPath, testnet) => {
   });
 
   const notifyGrpcPort = (port) => {
+    dcrwPort = port;
     logger.log("info", "wallet grpc running on port", port);
     mainWindow.webContents.send("dcrwallet-port", port);
   };

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -21,7 +21,7 @@ import {
   SETVOTECHOICES_ATTEMPT, SETVOTECHOICES_FAILED, SETVOTECHOICES_SUCCESS,
   UPDATEHIDDENACCOUNTS, MATURINGHEIGHTS_CHANGED,
 } from "../actions/ClientActions";
-import { STARTUPBLOCK } from "../actions/DaemonActions";
+import { STARTUPBLOCK, WALLETREADY } from "../actions/DaemonActions";
 import { NEWBLOCKCONNECTED } from "../actions/NotificationActions";
 import {
   GETDECODEMESSAGESERVICE_ATTEMPT, GETDECODEMESSAGESERVICE_FAILED, GETDECODEMESSAGESERVICE_SUCCESS,
@@ -489,6 +489,11 @@ export default function grpc(state = {}, action) {
     return {
       ...state,
       maturingBlockHeights: action.maturingBlockHeights,
+    };
+  case WALLETREADY:
+    return {
+      ...state,
+      port: action.port
     };
   default:
     return state;

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -30,12 +30,18 @@ export const removeWallet = log((walletPath, testnet) => Promise
     throw "Error creating wallet";
   }), "Remove Wallet");
 
-export const startWallet = log((walletPath, testnet) => Promise
-  .resolve(ipcRenderer.sendSync("start-wallet", walletPath, testnet))
-  .then(pid => {
-    if (pid) return pid;
-    throw "Error starting wallet";
-  }), "Start Wallet");
+export const startWallet = log((walletPath, testnet) => new Promise((resolve, reject) => {
+  let pid, port;
+
+  // resolveCheck must be done both on the dcrwallet-port event and on the
+  // return of the sendSync call because we can't be certain which will happen first
+  const resolveCheck = () => pid && port ? resolve({pid, port}) : null;
+
+  ipcRenderer.once("dcrwallet-port", (e, p) => { port = p; resolveCheck(); });
+  pid = ipcRenderer.sendSync("start-wallet", walletPath, testnet);
+  if (!pid) reject("Error starting wallet");
+  resolveCheck();
+}), "Start Wallet");
 
 export const getBlockCount = log((walletPath, rpcCreds, testnet) => Promise
   .resolve(ipcRenderer.sendSync("check-daemon", walletPath, rpcCreds, testnet))


### PR DESCRIPTION
Fix #852 

This opens up the possibility of running multiple wallet instances at the same time (not yet implemented).

On non-windows platforms, the `--rpclistenerevents --pipetx` dcrwallet arguments are used to pipe the events from the wallet daemon into decrediton. The grpc port is found when the appropriate IPC message is received.

On windows, due to various node/golang incompatibilities it's not possible to do that, so for the moment we resort to parsing the stdout output, looking for the appropriate log string. This is an ugly hack, so hopefully, we can have a better IPC mechanism on windows in the future.

Tested on linux and windows (needs testing on macOS).

To test this on an existing configured wallet, you'll need to edit the corresponding `dcrwallet.conf` (usually `.config/decrediton/wallets/testnet/default-wallet/dcrwallet.conf` or similar), modifying the grpc listen port to 0, eg: `grpclisten=127.0.0.1:0`).

Creating a new wallet and importing from an old install should automatically set the grpc port as 0.