### PR TITLE
Overview stats bugs

### DIFF
--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -293,7 +293,10 @@ export const balancesStats = (opts) => (dispatch, getState) => {
       var spenderInputs = decodedSpender.getTransaction().getInputsList();
       var ticketHash = reverseRawHash(spenderInputs[spenderInputs.length-1].getPreviousTransactionHash());
       var ticket = liveTickets[ticketHash];
-      if (!ticket) throw "Previous live ticket not found: " + ticketHash;
+      if (!ticket) {
+        console.log("live tickets", liveTickets);
+        throw "Previous live ticket not found: " + ticketHash;
+      }
       var returnAmount = tx.tx.getCreditsList().reduce((s, c) => s + c.getAmount(), 0);
       var wasWallet = ticket.isWallet;
       return { spendable: +returnAmount, locked: wasWallet ? -ticket.commitAmount : 0,

--- a/app/components/charts/ChartTooltip.js
+++ b/app/components/charts/ChartTooltip.js
@@ -4,7 +4,11 @@ import "style/Chart.less";
 
 const ChartLegend = (props) => {
   const { payload } = props;
-  const rowLegend = payload[0] && payload[0].payload.legendName;
+  if (!payload || payload.length === 0 || !payload[0] || !payload[0].payload || !payload[0].payload.legendName) {
+    return null;
+  }
+
+  const rowLegend = payload[0].payload.legendName;
 
   return (
     <div className="chart-tooltip">

--- a/app/components/shared/Balance.js
+++ b/app/components/shared/Balance.js
@@ -8,7 +8,7 @@ export const Balance = ({ currencyDisplay, amount, onClick, bold, large,
   const secondary = large ? "balance-tiny" : flat ? "balance-base" : title ? "balance-title" : "balance-small";
   if (currencyDisplay === "DCR") {
     var totalDcr = 0;
-    if (typeof amount !== "undefined" && amount !== 0) {
+    if (typeof amount !== "undefined" && amount !== 0 && !isNaN(amount)) {
       totalDcr = preScaled ? parseFloat(amount) : parseInt(amount) / 100000000;
     }
     const split = totalDcr.toFixed(8).toString().split(".");

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -312,6 +312,7 @@ export const totalValueOfLiveTickets = createSelector(
   (balances) => {
     if (!balances) return 0;
     const lastBalance = balances[balances.length-1];
+    if (!lastBalance) return 0;
     return lastBalance.series.locked + lastBalance.series.lockedNonWallet;
   }
 );

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -375,7 +375,8 @@
 }
 
 @keyframes spin {
-  100% { transform: rotate(0deg); }
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
 .rescan-button.spin {


### PR DESCRIPTION
Fixes three small bugs related to recent refactors:

- Returns the spin animation to the rescan button
- Prevents hover bug on charts on empty wallets
- Prevents hover bug on charts on an errored wallet (I had a wallet with a vote but not the related ticket, which was causing a BSOD; a rescan fixes the issue, but I couldn't easily trigger the rescan due to the BSOD).