### PR TITLE
[launcher] Remove unnecessary text and move to wallet loading area

### DIFF
--- a/app/components/indicators/LinearProgressFull.js
+++ b/app/components/indicators/LinearProgressFull.js
@@ -1,10 +1,10 @@
 import "style/Loading.less";
+import { FormattedMessage as T } from "react-intl";
 
 @autobind
 class LinearProgressFull extends React.Component {
-
   render() {
-    const { barText, value, min, max, error, disabled, getDaemonSynced } = this.props;
+    const { value, min, max, error, disabled, getDaemonSynced } = this.props;
     const perComplete = value/max-min;
     const leftStartingPoint = perComplete*95 + "%";
     return (
@@ -24,7 +24,10 @@ class LinearProgressFull extends React.Component {
           </div>
         }
         <div className={(getDaemonSynced || !disabled) ? "linear-progress-text loading" : "linear-progress-text"}>
-          {barText}
+          {disabled && !getDaemonSynced ?
+            <T id="loaderBar.Waiting" m="Waiting for daemon connection..." /> :
+            getDaemonSynced ? <T id="loaderBar.Loaded" m="Blockchain loaded" /> :
+              <T id="loaderBar.Loading" m="Blockchain syncing" />}
         </div>
       </div>
     );

--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -6,6 +6,8 @@ import "style/GetStarted.less";
 export default ({
   Form,
   text,
+  barText,
+  isInputRequest,
   getCurrentBlockCount,
   getDaemonStarted,
   getDaemonSynced,
@@ -41,7 +43,7 @@ export default ({
             error={startupError}
             getDaemonSynced={getDaemonSynced}
             disabled={!getDaemonStarted || getCurrentBlockCount == null}
-            barText={text}
+            barText={barText}
             min={0}
             max={getNeededBlocks}
             value={getCurrentBlockCount}
@@ -54,9 +56,19 @@ export default ({
           }
         </div>
         <div className="loader-bar-icon">
-          <DecredLoading hidden={startupError || props.isInputRequest} />
+          {text && !startupError &&
+            <div className="loader-bar-icon-text">
+              {text}...
+            </div>
+          }
+          {startupError &&
+            <div className="loader-bar-icon-text error">
+              {startupError}
+            </div>
+          }
+          <DecredLoading hidden={startupError || isInputRequest} />
         </div>
-        { Form && <Form {...{ ...props, startupError }}/> }
+        { Form && <Form {...{ ...props, isInputRequest, startupError }}/> }
       </Aux>
     </div>
   </div>

--- a/app/components/views/GetStartedPage/OpenWallet/DecryptForm.js
+++ b/app/components/views/GetStartedPage/OpenWallet/DecryptForm.js
@@ -21,6 +21,9 @@ const OpenWalletDecryptFormBodyBase = ({
   isInputRequest &&
   <div className="advanced-page-form">
     <div className="advanced-daemon-row">
+      <T id="getStarted.decrypt.info" m="This wallet is encrypted, please enter the public passphrase to decrypt it." />
+    </div>
+    <div className="advanced-daemon-row">
       <div className="advanced-daemon-label">
         <T id="getStarted.decrypt.label" m="Decrypt Wallet" />
       </div>

--- a/app/components/views/GetStartedPage/OpenWallet/index.js
+++ b/app/components/views/GetStartedPage/OpenWallet/index.js
@@ -24,12 +24,10 @@ class OpenWallet extends React.Component {
       onSetPublicPassPhrase,
       onOpenWallet
     } = this;
-    const { isInputRequest } = this.props;
     return (
       <OpenWalletDecryptFormBody
         {...{
           ...this.props,
-          isInputRequest,
           publicPassPhrase,
           hasAttemptedOpen,
           onSetPublicPassPhrase,

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -84,14 +84,12 @@ class GetStartedPage extends React.Component {
         break;
       case 2:
         if (hasExistingWallet) {
-          text = <T id="getStarted.decrypt.info" m="This wallet is encrypted, please enter the public passphrase to decrypt it." />;
           Form = OpenWallet;
         } else {
           return <CreateWallet {...props} />;
         }
         break;
       default:
-        text = <T id="getStarted.advanced.title" m="Advanced Daemon Set Up" />;
         if (isAdvancedDaemon && openForm && !remoteAppdataError) {
           Form = AdvancedStartupBody;
         } else if (remoteAppdataError) {
@@ -99,7 +97,6 @@ class GetStartedPage extends React.Component {
         }
       }
     } else if (!getWalletReady) {
-      text = <T id="getStarted.walletSelect.title" m="Select the Wallet to Load" />;
       Form = WalletSelectionBody;
     } else if (isPrepared) {
       switch (startStepIndex || 0) {

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -120,13 +120,23 @@
     margin-bottom: 20px;
   }
 
-  .loader-bar-icon .new-logo-animation {
+  .loader-bar-icon {
     position: absolute;
-    right: 50px;
-    top: 165px;
-    height: 50px;
-    width: 50px;
-    background-size: 50px;
+    right: 37px;
+    top: 286px;
+    .loader-bar-icon-text {
+      float: left;
+      margin-top: 14px;
+      margin-right: 20px;
+    }
+
+    .new-logo-animation {
+      float: right;
+      margin: 0;
+      height: 50px;
+      width: 50px;
+      background-size: 50px;
+    }
   }
 
   .loader-bar-estimation {

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -124,6 +124,7 @@
     position: absolute;
     right: 37px;
     top: 286px;
+
     .loader-bar-icon-text {
       float: left;
       margin-top: 14px;


### PR DESCRIPTION
This PR is an attempt to offer more clear information about what decrediton is doing for the loading.  It removes most text out of the loading bar except for Waiting/Loading/Synced Blockchain text.  All other states or information about it is doing is now located next to the loading icon upper right of the loading bar.