### PR TITLE
Update modal buttons to use consistent styling and right justification

### DIFF
--- a/app/components/modals/PassphraseModal/ButtonsToolbar.js
+++ b/app/components/modals/PassphraseModal/ButtonsToolbar.js
@@ -1,5 +1,4 @@
-import { KeyBlueButton } from "buttons";
-import { SlateGrayButton } from "buttons";
+import { KeyBlueButton, InvisibleButton } from "buttons";
 import { FormattedMessage as T } from "react-intl";
 
 const PassphraseModalButtonsToolbar = ({ onSubmit, onCancelModal, submitLabel }) =>
@@ -7,9 +6,9 @@ const PassphraseModalButtonsToolbar = ({ onSubmit, onCancelModal, submitLabel })
     <KeyBlueButton className="passphrase-modal-save-button" onClick={onSubmit}>
       {submitLabel ? submitLabel : <T id="passphraseModal.confirm" m="confirm" />}
     </KeyBlueButton>
-    <SlateGrayButton className="passphrase-modal-close-button" onClick={onCancelModal}>
+    <InvisibleButton className="passphrase-modal-close-button" onClick={onCancelModal}>
       <T id="passphraseModal.btnCancel" m="Cancel" />
-    </SlateGrayButton>
+    </InvisibleButton>
   </div>;
 
 export default PassphraseModalButtonsToolbar;

--- a/app/components/modals/SeedCopyConfirmModal/Modal.js
+++ b/app/components/modals/SeedCopyConfirmModal/Modal.js
@@ -1,5 +1,5 @@
 import DefaultModal from "../Modal";
-import { SlateGrayButton, DangerButton } from "buttons";
+import { InvisibleButton, DangerButton } from "buttons";
 import { FormattedMessage as T } from "react-intl";
 import { TextInput } from "inputs";
 import { ExternalLink } from "shared";
@@ -44,9 +44,9 @@ const Modal = ({ show, onCancelModal, onSubmit, copyConfirmationPhrase,
       <DangerButton className="confirm-modal-confirm-button" onClick={onSubmit} disabled={typedConfirmationPhrase.toLowerCase() !== copyConfirmationPhrase.toLowerCase()}>
         <T id="seedCopyConfirm.btnConfirm" m="Confirm Seed Copy" />
       </DangerButton>
-      <SlateGrayButton className="confirm-modal-close-button" onClick={onCancelModal}>
+      <InvisibleButton className="confirm-modal-close-button" onClick={onCancelModal}>
         <T id="seedCopyConfirm.btnCancel" m="Cancel" />
-      </SlateGrayButton>
+      </InvisibleButton>
     </div>
   </DefaultModal>
 );

--- a/app/style/Modals.less
+++ b/app/style/Modals.less
@@ -188,15 +188,16 @@
 }
 
 .confirm-seed-copy-modal-toolbar {
+  float: right;
   margin-top: 2em;
 }
 
 .confirm-seed-copy-modal-toolbar > .confirm-modal-confirm-button {
-  float: left;
+  float: right;
 }
 
 .confirm-seed-copy-modal-toolbar > .confirm-modal-close-button {
-  float: right;
+  float: left;
 }
 
 .confirm-seed-copy-modal-header {
@@ -243,12 +244,12 @@
 
 .confirm-modal-toolbar {
   position: absolute;
-  left: 20px;
   bottom: 20px;
+  right: 20px;
 }
 
 .confirm-modal-toolbar > .confirm-modal-confirm-button {
-  float: left;
+  float: right;
 }
 
 .confirm-modal-toolbar > .confirm-modal-close-button {

--- a/app/style/Modals.less
+++ b/app/style/Modals.less
@@ -82,7 +82,8 @@
 }
 
 .passphrase-modal-toolbar > .passphrase-modal-close-button {
-  float: right;
+  margin-right: 10px;
+  float: left;
 }
 
 .passphrase-modal-header {
@@ -120,6 +121,7 @@
 .passphrase-modal-toolbar {
   margin-top: 20px;
   height: 44px;
+  float: right;
 }
 
 .info-modal-column {


### PR DESCRIPTION
Closes #1217 

Now all cancel buttons should be InvivisbleButtons.  The pair of cancel/confirm should always be on the right and in that order.