### PR TITLE
Store previousWallet as var instead of config

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -96,14 +96,11 @@ export const shutdownApp = () => (dispatch) => {
 
 export const cleanShutdown = () => () => wallet.cleanShutdown();
 
-export const getAvailableWallets = () => (dispatch) => {
-  wallet.getAvailableWallets()
-    .then(availableWallets => {
-      dispatch({ availableWallets, type: AVAILABLE_WALLETS });
-    })
-    .catch((err) => {
-      console.log(err);
-    });
+export const getAvailableWallets = () => async (dispatch) => {
+  const availableWallets = await wallet.getAvailableWallets();
+  const previousWallet = await wallet.getPreviousWallet();
+  dispatch({ availableWallets, previousWallet, type: AVAILABLE_WALLETS });
+  return { availableWallets, previousWallet };
 };
 
 export const removeWallet = (selectedWallet) => (dispatch) => {
@@ -134,8 +131,7 @@ export const startWallet = (selectedWallet) => (dispatch) => {
   wallet.startWallet(selectedWallet.value.wallet, selectedWallet.network == "testnet")
     .then(({ port }) => {
       const walletCfg = getWalletCfg(selectedWallet.network == "testnet", selectedWallet.value.wallet);
-      const globalCfg = getGlobalCfg();
-      globalCfg.set("previouswallet", selectedWallet);
+      wallet.setPreviousWallet(selectedWallet);
 
       var currentStakePoolConfig = walletCfg.get("stakepools");
       var foundStakePoolConfig = false;

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -22,11 +22,10 @@ class GetStartedPage extends React.Component {
   }
 
   componentDidMount() {
-    if (!this.props.getWalletReady && !this.props.previousWallet) {
-      this.props.onGetAvailableWallets();
-    } else if (this.props.previousWallet) {
-      this.props.onStartWallet(this.props.previousWallet);
-    }
+    this.props.onGetAvailableWallets()
+      .then(({ previousWallet }) => {
+        previousWallet && this.props.onStartWallet(previousWallet);
+      });
   }
 
   onShowReleaseNotes() {

--- a/app/config.js
+++ b/app/config.js
@@ -297,11 +297,6 @@ export function setMustOpenForm(openForm) {
   return config.set("must_open_form", openForm);
 }
 
-export function clearPreviousWallet() {
-  const config = getGlobalCfg();
-  return config.set("previouswallet", null);
-}
-
 export function newWalletConfigCreation(testnet, walletPath) {
   // TODO: set random user/password
   var dcrdConf = {

--- a/app/index.js
+++ b/app/index.js
@@ -54,8 +54,8 @@ var initialState = {
     shutdownRequested: false,
     openForm: globalCfg.get("must_open_form"),
     remoteAppdataError: false,
-    previousWallet: globalCfg.get("previouswallet"),
-    selectCreateWalletInputRequest: globalCfg.get("previouswallet") ? false : true
+    previousWallet: null,
+    selectCreateWalletInputRequest: true
   },
   version: {
     // RequiredVersion

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, Menu, shell, dialog } from "electron";
 import { concat, isString } from "lodash";
-import { initGlobalCfg, appDataDirectory, getDcrdPath, validateGlobalCfgFile, setMustOpenForm, clearPreviousWallet } from "./config.js";
+import { initGlobalCfg, appDataDirectory, getDcrdPath, validateGlobalCfgFile, setMustOpenForm } from "./config.js";
 import { dcrctlCfg, dcrdCfg, dcrwalletCfg, initWalletCfg, getWalletCfg, newWalletConfigCreation, readDcrdConfig, getWalletPath } from "./config.js";
 import path from "path";
 import fs from "fs-extra";
@@ -20,6 +20,7 @@ let debug = false;
 let dcrdPID;
 let dcrwPID;
 let dcrwPort;
+let previousWallet = null;
 let dcrdConfig = {};
 let currentBlockCount;
 let primaryInstance;
@@ -412,6 +413,15 @@ ipcMain.on("get-dcrwallet-logs", (event) => {
 
 ipcMain.on("get-decrediton-logs", (event) => {
   event.returnValue = "decrediton logs!";
+});
+
+ipcMain.on("get-previous-wallet", (event) => {
+  event.returnValue = previousWallet;
+});
+
+ipcMain.on("set-previous-wallet", (event, cfg) => {
+  previousWallet = cfg;
+  event.returnValue = true;
 });
 
 const AddToLog = (destIO, destLogBuffer, data) => {
@@ -920,6 +930,5 @@ app.on("before-quit", (event) => {
   event.preventDefault();
   cleanShutdown();
   setMustOpenForm(true);
-  clearPreviousWallet();
   app.exit(0);
 });

--- a/app/reducers/daemon.js
+++ b/app/reducers/daemon.js
@@ -90,7 +90,9 @@ export default function version(state = {}, action) {
     };
   case AVAILABLE_WALLETS:
     return { ...state,
-      availableWallets: action.availableWallets
+      availableWallets: action.availableWallets,
+      previousWallet: action.previousWallet,
+      selectCreateWalletInputRequest: !action.previousWallet,
     };
   default:
     return state;

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -48,6 +48,14 @@ export const startWallet = log((walletPath, testnet) => new Promise((resolve, re
   resolveCheck();
 }), "Start Wallet");
 
+export const setPreviousWallet = log((cfg) => Promise
+  .resolve(ipcRenderer.sendSync("set-previous-wallet", cfg))
+  , "Set Previous Wallet");
+
+export const getPreviousWallet = log(() => Promise
+  .resolve(ipcRenderer.sendSync("get-previous-wallet"))
+  , "Get Previous Wallet");
+
 export const getBlockCount = log((walletPath, rpcCreds, testnet) => Promise
   .resolve(ipcRenderer.sendSync("check-daemon", walletPath, rpcCreds, testnet))
   .then(block => isString(block) ? parseInt(block.trim()) : block)


### PR DESCRIPTION
This switches the previous wallet to be saved as a var on main.development instead of a config. This enables running multiple wallets simultaneously, connecting to the same daemon (when running in advanced daemon mode).

Last step to supporting multiple concurrent wallets is managing a single dcrd instance when not running in advanced daemon mode.