### PR TITLE
[launcher] Remove network toggle and autoload daemon

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -177,8 +177,11 @@ export const prepStartDaemon = () => (dispatch, getState) => {
     dispatch(startDaemon());
     return;
   }
+  if (!walletName) {
+    return;
+  }
   const { rpc_password, rpc_user, rpc_cert, rpc_host, rpc_port } = getRemoteCredentials(isTestNet(getState()), walletName);
-  const hasAllCredentials = rpc_password.length > 0 && rpc_user.length > 0 && rpc_cert.length > 0 && rpc_host.length > 0 && rpc_port.length > 0;
+  const hasAllCredentials = rpc_password && rpc_user && rpc_password.length > 0 && rpc_user.length > 0 && rpc_cert.length > 0 && rpc_host.length > 0 && rpc_port.length > 0;
   const hasAppData = getAppdataPath(isTestNet(getState()), walletName) && getAppdataPath(isTestNet(getState()), walletName).length > 0;
 
 

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -1,4 +1,4 @@
-import { versionCheckAction, startRpcRequestFunc, determineNeededBlocks } from "./WalletLoaderActions";
+import { versionCheckAction } from "./WalletLoaderActions";
 import { stopNotifcations } from "./NotificationActions";
 import * as wallet from "wallet";
 import { push as pushHistory } from "react-router-redux";
@@ -164,7 +164,6 @@ export const startWallet = (selectedWallet) => (dispatch, getState) => {
       dispatch({ type: WALLET_STAKEPOOL_SETTINGS, activeStakePoolConfig, selectedStakePool, currentStakePoolConfig });
       dispatch({ type: WALLET_LOADER_SETTINGS, discoverAccountsComplete });
       setTimeout(()=>dispatch(versionCheckAction()), 2000);
-      setTimeout(()=>dispatch(determineNeededBlocks()), 2000);
     })
     .catch((err) => {
       console.log(err);
@@ -181,6 +180,7 @@ export const prepStartDaemon = () => (dispatch, getState) => {
   const { rpc_password, rpc_user, rpc_cert, rpc_host, rpc_port } = getRemoteCredentials(isTestNet(getState()), walletName);
   const hasAllCredentials = rpc_password.length > 0 && rpc_user.length > 0 && rpc_cert.length > 0 && rpc_host.length > 0 && rpc_port.length > 0;
   const hasAppData = getAppdataPath(isTestNet(getState()), walletName) && getAppdataPath(isTestNet(getState()), walletName).length > 0;
+
 
   if(hasAllCredentials && hasAppData)
     this.props.setCredentialsAppdataError();
@@ -207,7 +207,6 @@ export const syncDaemon = () =>
             dispatch({ type: DAEMONSYNCED });
             dispatch({ currentBlockHeight: updateCurrentBlockCount, type: STARTUPBLOCK });
             setMustOpenForm(false);
-            dispatch(startRpcRequestFunc());
             return;
           } else if (updateCurrentBlockCount !== 0) {
             const blocksLeft = neededBlocks - updateCurrentBlockCount;

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -1,4 +1,4 @@
-import { versionCheckAction } from "./WalletLoaderActions";
+import { versionCheckAction, startRpcRequestFunc } from "./WalletLoaderActions";
 import { stopNotifcations } from "./NotificationActions";
 import * as wallet from "wallet";
 import { push as pushHistory } from "react-router-redux";
@@ -197,7 +197,7 @@ export const syncDaemon = () =>
   (dispatch, getState) => {
     const updateBlockCount = () => {
       const { walletLoader: { neededBlocks } } = getState();
-      const { daemon: { daemonSynced, timeStart, blockStart, credentials, walletName } } = getState();
+      const { daemon: { daemonSynced, timeStart, blockStart, credentials, walletName, walletReady } } = getState();
       // check to see if user skipped;
       if (daemonSynced) return;
       return wallet
@@ -207,6 +207,9 @@ export const syncDaemon = () =>
             dispatch({ type: DAEMONSYNCED });
             dispatch({ currentBlockHeight: updateCurrentBlockCount, type: STARTUPBLOCK });
             setMustOpenForm(false);
+            if (walletReady) {
+              dispatch(startRpcRequestFunc());
+            }
             return;
           } else if (updateCurrentBlockCount !== 0) {
             const blocksLeft = neededBlocks - updateCurrentBlockCount;

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -199,8 +199,8 @@ export const STARTUPBLOCK = "STARTUPBLOCK";
 export const syncDaemon = () =>
   (dispatch, getState) => {
     const updateBlockCount = () => {
-      const { walletLoader: { neededBlocks } } = getState();
-      const { daemon: { daemonSynced, timeStart, blockStart, credentials, walletName, walletReady } } = getState();
+      const { walletLoader: { neededBlocks, stepIndex } } = getState();
+      const { daemon: { daemonSynced, timeStart, blockStart, credentials, walletName } } = getState();
       // check to see if user skipped;
       if (daemonSynced) return;
       return wallet
@@ -210,7 +210,8 @@ export const syncDaemon = () =>
             dispatch({ type: DAEMONSYNCED });
             dispatch({ currentBlockHeight: updateCurrentBlockCount, type: STARTUPBLOCK });
             setMustOpenForm(false);
-            if (walletReady) {
+            // stepIndex 3 means either successfully opened or created.
+            if (stepIndex == 3) {
               dispatch(startRpcRequestFunc());
             }
             return;

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -5,7 +5,6 @@ import {
 } from "wallet";
 import * as wallet from "wallet";
 import { getWalletServiceAttempt, getTicketBuyerServiceAttempt, getAgendaServiceAttempt, getVotingServiceAttempt } from "./ClientActions";
-import { prepStartDaemon } from "./DaemonActions";
 import { getVersionServiceAttempt } from "./VersionActions";
 import { getWalletCfg, getDcrdCert } from "config";
 import { getWalletPath } from "main_dev/paths";
@@ -80,7 +79,7 @@ export const createWalletRequest = (pubPass, privPass, seed, existing) =>
         dispatch(clearStakePoolConfigNewWallet());
         dispatch({ complete: !existing, type: UPDATEDISCOVERACCOUNTS });
         config.set("discoveraccounts", !existing);
-        dispatch(prepStartDaemon());
+        dispatch(startRpcRequestFunc());
       })
       .catch(error => dispatch({ error, type: CREATEWALLET_FAILED }));
   };
@@ -96,12 +95,12 @@ export const openWalletAttempt = (pubPass, retryAttempt) => (dispatch, getState)
   return openWallet(getState().walletLoader.loader, pubPass)
     .then(() => {
       dispatch({ type: OPENWALLET_SUCCESS });
-      dispatch(prepStartDaemon());
+      dispatch(startRpcRequestFunc());
     })
     .catch(error => {
       if (error.message.includes("wallet already loaded")) {
         dispatch({ response: {}, type: OPENWALLET_SUCCESS });
-        dispatch(prepStartDaemon());
+        dispatch(startRpcRequestFunc());
       } else if (error.message.includes("invalid passphrase") && error.message.includes("public key")) {
         if (retryAttempt) {
           dispatch({ error, type: OPENWALLET_FAILED_INPUT });

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -69,6 +69,7 @@ export const CREATEWALLET_SUCCESS = "CREATEWALLET_SUCCESS";
 
 export const createWalletRequest = (pubPass, privPass, seed, existing) =>
   (dispatch, getState) => {
+    const { daemonSynced } = getState().daemon;
     dispatch({ existing: existing, type: CREATEWALLET_ATTEMPT });
     return createWallet(getState().walletLoader.loader, pubPass, privPass, seed)
       .then(() => {
@@ -79,7 +80,7 @@ export const createWalletRequest = (pubPass, privPass, seed, existing) =>
         dispatch(clearStakePoolConfigNewWallet());
         dispatch({ complete: !existing, type: UPDATEDISCOVERACCOUNTS });
         config.set("discoveraccounts", !existing);
-        dispatch(startRpcRequestFunc());
+        if (daemonSynced) dispatch(startRpcRequestFunc());
       })
       .catch(error => dispatch({ error, type: CREATEWALLET_FAILED }));
   };
@@ -91,16 +92,17 @@ export const OPENWALLET_FAILED = "OPENWALLET_FAILED";
 export const OPENWALLET_SUCCESS = "OPENWALLET_SUCCESS";
 
 export const openWalletAttempt = (pubPass, retryAttempt) => (dispatch, getState) => {
+  const { daemonSynced } = getState().daemon;
   dispatch({ type: OPENWALLET_ATTEMPT });
   return openWallet(getState().walletLoader.loader, pubPass)
     .then(() => {
       dispatch({ type: OPENWALLET_SUCCESS });
-      dispatch(startRpcRequestFunc());
+      if (daemonSynced) dispatch(startRpcRequestFunc());
     })
     .catch(error => {
       if (error.message.includes("wallet already loaded")) {
         dispatch({ response: {}, type: OPENWALLET_SUCCESS });
-        dispatch(startRpcRequestFunc());
+        if (daemonSynced) dispatch(startRpcRequestFunc());
       } else if (error.message.includes("invalid passphrase") && error.message.includes("public key")) {
         if (retryAttempt) {
           dispatch({ error, type: OPENWALLET_FAILED_INPUT });

--- a/app/components/indicators/LoaderBarBottom.js
+++ b/app/components/indicators/LoaderBarBottom.js
@@ -1,6 +1,5 @@
 import { FormattedMessage as T, FormattedRelative } from "react-intl";
 import { LinearProgressSmall } from "indicators";
-import { getDaemonSynced } from "../../selectors";
 
 @autobind
 class LoaderBarBottom extends React.Component {

--- a/app/components/indicators/LoaderBarBottom.js
+++ b/app/components/indicators/LoaderBarBottom.js
@@ -1,5 +1,6 @@
 import { FormattedMessage as T, FormattedRelative } from "react-intl";
 import { LinearProgressSmall } from "indicators";
+import { getDaemonSynced } from "../../selectors";
 
 @autobind
 class LoaderBarBottom extends React.Component {
@@ -20,13 +21,13 @@ class LoaderBarBottom extends React.Component {
   }
 
   render() {
-    const { getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft } = this.props;
+    const { getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft, getDaemonSynced } = this.props;
     let finishDateEstimation = null;
     if (getEstimatedTimeLeft !== null) {
       finishDateEstimation = new Date();
       finishDateEstimation.setSeconds(finishDateEstimation.getSeconds() + getEstimatedTimeLeft);
     }
-    return ( getCurrentBlockCount &&
+    return ( getCurrentBlockCount && !getDaemonSynced &&
       <div className="loader-bar-bottom">
         <div className="loader-bar-estimation">
           <span className="normal"><T id="getStarted.chainLoading.syncEstimation.small" m="Loading Decred blockchain, estimated time left"/></span>

--- a/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
@@ -9,17 +9,20 @@ const CreateForm = ({
   onSetCreateWalletFromExisting,
   getCurrentBlockCount,
   getNeededBlocks,
-  getEstimatedTimeLeft
+  getEstimatedTimeLeft,
+  getDaemonSynced
 }) => (
   existingOrNew ?
     <ExistingOrNewScreen {...{ onSetCreateWalletFromExisting,
       getCurrentBlockCount,
       getNeededBlocks,
-      getEstimatedTimeLeft }} /> :
+      getEstimatedTimeLeft,
+      getDaemonSynced }} /> :
     <CreateWalletForm {...{ onReturnToNewSeed, onReturnToExistingOrNewScreen,
       getCurrentBlockCount,
       getNeededBlocks,
-      getEstimatedTimeLeft } }/>
+      getEstimatedTimeLeft,
+    } }/>
 );
 
 export default CreateForm;

--- a/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
@@ -6,11 +6,20 @@ const CreateForm = ({
   existingOrNew,
   onReturnToNewSeed,
   onReturnToExistingOrNewScreen,
-  onSetCreateWalletFromExisting
+  onSetCreateWalletFromExisting,
+  getCurrentBlockCount,
+  getNeededBlocks,
+  getEstimatedTimeLeft
 }) => (
   existingOrNew ?
-    <ExistingOrNewScreen {...{ onSetCreateWalletFromExisting }} /> :
-    <CreateWalletForm {...{ onReturnToNewSeed, onReturnToExistingOrNewScreen } }/>
+    <ExistingOrNewScreen {...{ onSetCreateWalletFromExisting,
+      getCurrentBlockCount,
+      getNeededBlocks,
+      getEstimatedTimeLeft }} /> :
+    <CreateWalletForm {...{ onReturnToNewSeed, onReturnToExistingOrNewScreen,
+      getCurrentBlockCount,
+      getNeededBlocks,
+      getEstimatedTimeLeft } }/>
 );
 
 export default CreateForm;

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ContinueWalletCreation.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ContinueWalletCreation.js
@@ -2,6 +2,7 @@ import ExistingSeed from "./ExistingSeed";
 import ConfirmSeed from "./ConfirmSeed";
 import CreatePassPhrase from "./CreatePassPhrase";
 import { FormattedMessage as T } from "react-intl";
+import { LoaderBarBottom } from "indicators";
 import { KeyBlueButton, InvisibleButton } from "buttons";
 import "style/CreateWalletForm.less";
 
@@ -14,6 +15,9 @@ const ContinueWalletCreation = ({
   createWalletExisting,
   onReturnToNewSeed,
   onReturnToExistingOrNewScreen,
+  getCurrentBlockCount,
+  getNeededBlocks,
+  getEstimatedTimeLeft,
   ...props
 }) => (
   <div className="getstarted content">
@@ -39,6 +43,7 @@ const ContinueWalletCreation = ({
         ><T id="getStarted.backBtn" m="Cancel" /> </InvisibleButton>
       </div>
     </div>
+    <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft }}  />
   </div>
 );
 

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ContinueWalletCreation.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ContinueWalletCreation.js
@@ -18,6 +18,7 @@ const ContinueWalletCreation = ({
   getCurrentBlockCount,
   getNeededBlocks,
   getEstimatedTimeLeft,
+  getDaemonSynced,
   ...props
 }) => (
   <div className="getstarted content">
@@ -43,7 +44,7 @@ const ContinueWalletCreation = ({
         ><T id="getStarted.backBtn" m="Cancel" /> </InvisibleButton>
       </div>
     </div>
-    <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft }}  />
+    <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft, getDaemonSynced }}  />
   </div>
 );
 

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/CreateWallet.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/CreateWallet.js
@@ -15,7 +15,8 @@ const CreateWallet = ({
   onReturnToExistingOrNewScreen,
   getCurrentBlockCount,
   getNeededBlocks,
-  getEstimatedTimeLeft
+  getEstimatedTimeLeft,
+  getDaemonSynced,
 }) => (
   <Aux>
     <div className="getstarted content">
@@ -70,7 +71,7 @@ const CreateWallet = ({
           <T id="createWallet.continueBtn" m="Continue" />
         </KeyBlueButton>
       </div>
-      <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft }}  />
+      <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft, getDaemonSynced }}  />
     </div>
     <SeedCopyConfirmModal
       show={showCopySeedConfirm}

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/CreateWallet.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/CreateWallet.js
@@ -2,6 +2,7 @@ import { KeyBlueButton } from "buttons";
 import { FormattedMessage as T } from "react-intl";
 import { SeedCopyConfirmModal } from "modals";
 import { Tooltip } from "shared";
+import { LoaderBarBottom } from "indicators";
 import "style/CreateWalletForm.less";
 
 const CreateWallet = ({
@@ -11,7 +12,10 @@ const CreateWallet = ({
   showCopySeedConfirm,
   onCancelCopySeedConfirm,
   onSubmitCopySeedConfirm,
-  onReturnToExistingOrNewScreen
+  onReturnToExistingOrNewScreen,
+  getCurrentBlockCount,
+  getNeededBlocks,
+  getEstimatedTimeLeft
 }) => (
   <Aux>
     <div className="getstarted content">
@@ -66,6 +70,7 @@ const CreateWallet = ({
           <T id="createWallet.continueBtn" m="Continue" />
         </KeyBlueButton>
       </div>
+      <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft }}  />
     </div>
     <SeedCopyConfirmModal
       show={showCopySeedConfirm}

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
@@ -56,7 +56,8 @@ class CreateWalletForm extends React.Component {
       isCreatingWallet,
       getCurrentBlockCount,
       getNeededBlocks,
-      getEstimatedTimeLeft
+      getEstimatedTimeLeft,
+      getDaemonSynced,
     } = this.props;
     const {
       setSeed,
@@ -85,8 +86,8 @@ class CreateWalletForm extends React.Component {
             isCreatingWallet,
             getCurrentBlockCount,
             getNeededBlocks,
-            getEstimatedTimeLeft
-
+            getEstimatedTimeLeft,
+            getDaemonSynced
           }}
         />
       ) : (
@@ -102,7 +103,8 @@ class CreateWalletForm extends React.Component {
             onReturnToExistingOrNewScreen,
             getCurrentBlockCount,
             getNeededBlocks,
-            getEstimatedTimeLeft
+            getEstimatedTimeLeft,
+            getDaemonSynced
           }}
         />
       );

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
@@ -54,6 +54,9 @@ class CreateWalletForm extends React.Component {
       onReturnToNewSeed,
       onReturnToExistingOrNewScreen,
       isCreatingWallet,
+      getCurrentBlockCount,
+      getNeededBlocks,
+      getEstimatedTimeLeft
     } = this.props;
     const {
       setSeed,
@@ -79,7 +82,10 @@ class CreateWalletForm extends React.Component {
             isValid,
             onReturnToNewSeed,
             onReturnToExistingOrNewScreen,
-            isCreatingWallet
+            isCreatingWallet,
+            getCurrentBlockCount,
+            getNeededBlocks,
+            getEstimatedTimeLeft
 
           }}
         />
@@ -94,6 +100,9 @@ class CreateWalletForm extends React.Component {
             onSubmitCopySeedConfirm,
             onCancelCopySeedConfirm,
             onReturnToExistingOrNewScreen,
+            getCurrentBlockCount,
+            getNeededBlocks,
+            getEstimatedTimeLeft
           }}
         />
       );

--- a/app/components/views/GetStartedPage/CreateWallet/ExistingOrNewScreen.js
+++ b/app/components/views/GetStartedPage/CreateWallet/ExistingOrNewScreen.js
@@ -6,7 +6,8 @@ const ExistingOrNewScreen = ({
   onSetCreateWalletFromExisting,
   getCurrentBlockCount,
   getNeededBlocks,
-  getEstimatedTimeLeft
+  getEstimatedTimeLeft,
+  getDaemonSynced
 }) => (
   <div className="getstarted content">
     <div className="createwallet-button-area">
@@ -21,7 +22,7 @@ const ExistingOrNewScreen = ({
         </div>
       </div>
     </div>
-    <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft }}  />
+    <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft, getDaemonSynced }}  />
   </div>
 );
 

--- a/app/components/views/GetStartedPage/CreateWallet/ExistingOrNewScreen.js
+++ b/app/components/views/GetStartedPage/CreateWallet/ExistingOrNewScreen.js
@@ -1,8 +1,12 @@
 import { FormattedMessage as T } from "react-intl";
+import { LoaderBarBottom } from "indicators";
 import "style/CreateWalletForm.less";
 
 const ExistingOrNewScreen = ({
-  onSetCreateWalletFromExisting
+  onSetCreateWalletFromExisting,
+  getCurrentBlockCount,
+  getNeededBlocks,
+  getEstimatedTimeLeft
 }) => (
   <div className="getstarted content">
     <div className="createwallet-button-area">
@@ -17,6 +21,7 @@ const ExistingOrNewScreen = ({
         </div>
       </div>
     </div>
+    <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft }}  />
   </div>
 );
 

--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -9,6 +9,7 @@ export default ({
   barText,
   isInputRequest,
   getCurrentBlockCount,
+  getWalletReady,
   getDaemonStarted,
   getDaemonSynced,
   getNeededBlocks,
@@ -24,6 +25,7 @@ export default ({
     <div className="getstarted loader">
       <Aux>
         <div className="content-title">
+          {getWalletReady &&
           <div className="loader-settings-logs">
             <InvisibleButton onClick={onShowSettings}>
               <T id="getStarted.btnSettings" m="Settings" />
@@ -32,6 +34,7 @@ export default ({
               <T id="getStarted.btnLogs" m="Logs" />
             </InvisibleButton>
           </div>
+          }
           <T id="loader.title" m={"Welcome to Decrediton Wallet"}/>
         </div>
         <div className="loader-buttons">

--- a/app/components/views/GetStartedPage/WalletSelection/CreateWalletForm.js
+++ b/app/components/views/GetStartedPage/WalletSelection/CreateWalletForm.js
@@ -10,10 +10,8 @@ const messages = defineMessages({
 });
 
 const CreateWalletForm = ({
-  networkSelected,
   newWalletName,
   onChangeCreateWalletName,
-  onChangeCreateWalletNetwork,
   intl
 }) => {
   return (
@@ -31,21 +29,6 @@ const CreateWalletForm = ({
             placeholder={intl.formatMessage(messages.messageWalletNamePlaceholder)}
             showErrors
           />
-        </div>
-      </div>
-      <div className="advanced-daemon-row">
-        <div className="advanced-daemon-label">
-          <T id="advanced.toggle.network" m="Network" />
-        </div>
-        <div className="advanced-daemon-input">
-          <div className="text-toggle network">
-            <div className={"text-toggle-button-left " + (networkSelected && "text-toggle-button-active")} onClick={!networkSelected ? onChangeCreateWalletNetwork : null}>
-              <T id="advancedDaemon.toggle.mainnet" m="Mainnet" />
-            </div>
-            <div className={"text-toggle-button-right " + (!networkSelected && "text-toggle-button-active")} onClick={networkSelected ? onChangeCreateWalletNetwork : null}>
-              <T id="advancedDaemon.toggle.testnet" m="Testnet" />
-            </div>
-          </div>
         </div>
       </div>
     </Aux>

--- a/app/components/views/GetStartedPage/WalletSelection/index.js
+++ b/app/components/views/GetStartedPage/WalletSelection/index.js
@@ -79,26 +79,14 @@ class WalletSelectionBody extends React.Component {
   onChangeCreateWalletName(newWalletName) {
     this.setState({ newWalletName });
   }
-  onChangeCreateWalletNetwork() {
-    const { newWalletNetwork } = this.state;
-    var updatedNetwork = newWalletNetwork;
-    if (newWalletNetwork == "mainnet") {
-      updatedNetwork = "testnet";
-    } else if (newWalletNetwork == "testnet") {
-      updatedNetwork = "mainnet";
-    }
-    this.setState({ newWalletNetwork: updatedNetwork });
-  }
   createWallet() {
-    const { newWalletName, newWalletNetwork } = this.state;
-    if (newWalletName == "" || (newWalletNetwork !== "mainnet" && newWalletNetwork !== "testnet")) {
+    const { newWalletName } = this.state;
+    if (newWalletName == "" ) {
       return;
     }
     this.props.onCreateWallet({
-      label: newWalletName + " (" + newWalletNetwork + ")",
-      network: newWalletNetwork,
-      value: { wallet: newWalletName, network: newWalletNetwork
-      } });
+      label: newWalletName,
+      value: { wallet: newWalletName } });
   }
   startWallet() {
     this.props.onStartWallet(this.state.selectedWallet);

--- a/app/components/views/GetStartedPage/WalletSelection/index.js
+++ b/app/components/views/GetStartedPage/WalletSelection/index.js
@@ -13,7 +13,6 @@ class WalletSelectionBody extends React.Component {
     return {
       createWalletForm: false,
       newWalletName: "",
-      newWalletNetwork: "mainnet",
       selectedWallet: this.props.availableWallets ? this.props.availableWallets[0] : null
     };
   }
@@ -33,7 +32,6 @@ class WalletSelectionBody extends React.Component {
       startWallet,
       createWallet,
       onChangeCreateWalletName,
-      onChangeCreateWalletNetwork,
       showCreateWalletForm,
       hideCreateWalletForm
     } = this;
@@ -50,7 +48,6 @@ class WalletSelectionBody extends React.Component {
           sideActive,
           onChangeAvailableWallets,
           onChangeCreateWalletName,
-          onChangeCreateWalletNetwork,
           startWallet,
           createWallet,
           createWalletForm,

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -143,6 +143,7 @@ class GetStartedPage extends React.Component {
         ...props,
         ...state,
         text,
+        getWalletReady,
         startupError,
         showSettings,
         showLogs,

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -26,6 +26,8 @@ class GetStartedPage extends React.Component {
       .then(({ previousWallet }) => {
         previousWallet && this.props.onStartWallet(previousWallet);
       });
+    this.props.determineNeededBlocks();
+    setTimeout(()=>this.props.prepStartDaemon(), 1000);
   }
 
   onShowReleaseNotes() {

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -97,9 +97,14 @@ class GetStartedPage extends React.Component {
       return <Logs {...{ onShowSettings, onHideLogs, ...props }} />;
     } else if (showReleaseNotes) {
       return <ReleaseNotes {...{ onShowSettings, onShowLogs, onHideReleaseNotes, ...props }} />;
-    } else if (getWalletReady && !isPrepared) {
+    } else if (isAdvancedDaemon && openForm && !remoteAppdataError && !isPrepared) {
+      Form = AdvancedStartupBody;
+    } else if (remoteAppdataError && !isPrepared) {
+      Form = RemoteAppdataError;
+    } else if (!getWalletReady) {
+      Form = WalletSelectionBody;
+    } else {
       switch (startStepIndex || 0) {
-      case 0:
       case 1:
         text = startupError ? startupError :
           <T id="getStarted.header.checkingWalletState.meta" m="Checking wallet state" />;
@@ -111,17 +116,6 @@ class GetStartedPage extends React.Component {
           return <CreateWallet {...props} />;
         }
         break;
-      default:
-        if (isAdvancedDaemon && openForm && !remoteAppdataError) {
-          Form = AdvancedStartupBody;
-        } else if (remoteAppdataError) {
-          Form = RemoteAppdataError;
-        }
-      }
-    } else if (!getWalletReady) {
-      Form = WalletSelectionBody;
-    } else if (isPrepared) {
-      switch (startStepIndex || 0) {
       case 3:
       case 4:
         text = <T id="getStarted.header.startrpc.meta" m="Establishing RPC connection" />;

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -22,12 +22,19 @@ class GetStartedPage extends React.Component {
   }
 
   componentDidMount() {
-    this.props.onGetAvailableWallets()
-      .then(({ previousWallet }) => {
-        previousWallet && this.props.onStartWallet(previousWallet);
-      });
-    this.props.determineNeededBlocks();
-    setTimeout(()=>this.props.prepStartDaemon(), 1000);
+    const { getWalletReady, getDaemonStarted, getNeededBlocks, onGetAvailableWallets, onStartWallet, prepStartDaemon, determineNeededBlocks } = this.props;
+    if (!getWalletReady) {
+      onGetAvailableWallets()
+        .then(({ previousWallet }) => {
+          previousWallet && onStartWallet(previousWallet);
+        });
+    }
+    if (!getNeededBlocks) {
+      determineNeededBlocks();
+    }
+    if (!getDaemonStarted) {
+      setTimeout(()=>prepStartDaemon(), 1000);
+    }
   }
 
   onShowReleaseNotes() {

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -97,9 +97,9 @@ class GetStartedPage extends React.Component {
       return <Logs {...{ onShowSettings, onHideLogs, ...props }} />;
     } else if (showReleaseNotes) {
       return <ReleaseNotes {...{ onShowSettings, onShowLogs, onHideReleaseNotes, ...props }} />;
-    } else if (isAdvancedDaemon && openForm && !remoteAppdataError && !isPrepared) {
+    } else if (isAdvancedDaemon && openForm && !remoteAppdataError && !isPrepared && getWalletReady) {
       Form = AdvancedStartupBody;
-    } else if (remoteAppdataError && !isPrepared) {
+    } else if (remoteAppdataError && !isPrepared && getWalletReady) {
       Form = RemoteAppdataError;
     } else if (!getWalletReady) {
       Form = WalletSelectionBody;

--- a/app/config.js
+++ b/app/config.js
@@ -79,6 +79,9 @@ export function initGlobalCfg() {
   if (!config.has("locale")) {
     config.set("locale","");
   }
+  if (!config.has("network")) {
+    config.set("network","mainnet");
+  }
   if (!config.has("set_language")) {
     config.set("set_language","true");
   }

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -39,6 +39,8 @@ const mapStateToProps = selectorMap({
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({
+  determineNeededBlocks: wla.determineNeededBlocks,
+  prepStartDaemon: da.prepStartDaemon,
   onShowTutorial: da.showTutorial,
   onShowLanguage: da.showLanguage,
   onShowGetStarted: da.showGetStarted,

--- a/app/index.js
+++ b/app/index.js
@@ -37,6 +37,7 @@ var initialState = {
     selectedStakePool: null,
   },
   daemon: {
+    network: globalCfg.get("network"),
     locale: locale,
     tutorial: globalCfg.get("show_tutorial"),
     setLanguage: globalCfg.get("set_language"),

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -208,20 +208,22 @@ const installExtensions = async () => {
 
 const { ipcMain } = require("electron");
 
-ipcMain.on("get-available-wallets", (event) => {// Attempt to find all currently available wallet.db's in the respective network direction in each wallets data dir
+ipcMain.on("get-available-wallets", (event, network) => {// Attempt to find all currently available wallet.db's in the respective network direction in each wallets data dir
   var availableWallets = [];
-  var mainnetWalletDirectories = fs.readdirSync(getWalletPath(false));
 
-  for (var i in mainnetWalletDirectories) {
-    if (fs.pathExistsSync(getWalletDBPathFromWallets(false, mainnetWalletDirectories[i].toString()))) {
-      availableWallets.push({ network: "mainnet", wallet: mainnetWalletDirectories[i] });
+  if (network == "mainnet") {
+    var mainnetWalletDirectories = fs.readdirSync(getWalletPath(false));
+    for (var i in mainnetWalletDirectories) {
+      if (fs.pathExistsSync(getWalletDBPathFromWallets(false, mainnetWalletDirectories[i].toString()))) {
+        availableWallets.push({ network: "mainnet", wallet: mainnetWalletDirectories[i] });
+      }
     }
-  }
-  var testnetWalletDirectories = fs.readdirSync(getWalletPath(true));
-
-  for (var j in testnetWalletDirectories) {
-    if (fs.pathExistsSync(getWalletDBPathFromWallets(true, testnetWalletDirectories[j].toString()))) {
-      availableWallets.push({ network: "testnet", wallet: testnetWalletDirectories[j] });
+  } else {
+    var testnetWalletDirectories = fs.readdirSync(getWalletPath(true));
+    for (var j in testnetWalletDirectories) {
+      if (fs.pathExistsSync(getWalletDBPathFromWallets(true, testnetWalletDirectories[j].toString()))) {
+        availableWallets.push({ network: "testnet", wallet: testnetWalletDirectories[j] });
+      }
     }
   }
   event.returnValue = availableWallets;

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -418,15 +418,14 @@ const launchDCRD = (daemonPath, appdata, testnet) => {
     args = [ `--appdata=${appdata}` ];
     newConfig = readDcrdConfig(appdata, testnet);
     newConfig.rpc_cert = getDcrdRpcCert(appdata);
-    if (testnet) {
-      args.push("--testnet");
-    }
   } else {
     args = [ `--configfile=${dcrdCfg(daemonPath)}` ];
     newConfig = readDcrdConfig(daemonPath, testnet);
     newConfig.rpc_cert = getDcrdRpcCert();
   }
-
+  if (testnet) {
+    args.push("--testnet");
+  }
   // Check to make sure that the rpcuser and rpcpass were set in the config
   if (!newConfig.rpc_user || !newConfig.rpc_password) {
     const errorMessage =  "No " + `${!newConfig.rpc_user ? "rpcuser " : "" }` + `${!newConfig.rpc_user && !newConfig.rpc_password ? "and " : "" }` + `${!newConfig.rpc_password ? "rpcpass " : "" }` + "set in " + `${appdata ? appdata : getDcrdPath()}` + "/dcrd.conf.  Please set them and restart.";

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -245,14 +245,14 @@ ipcMain.on("start-daemon", (event, walletPath, appData, testnet) => {
   }
   if (!daemonIsAdvanced && !primaryInstance) {
     logger.log("info", "Running on secondary instance. Assuming dcrd is already running.");
-    dcrdConfig = readDcrdConfig(getWalletPath(testnet, walletPath), testnet);
+    dcrdConfig = readDcrdConfig(getDcrdPath(), testnet);
     dcrdConfig.rpc_cert = getDcrdRpcCert();
     dcrdConfig.pid = -1;
     event.returnValue = dcrdConfig;
     return;
   }
   try {
-    dcrdConfig = launchDCRD(walletPath, appData, testnet);
+    dcrdConfig = launchDCRD(getDcrdPath(), appData, testnet);
     dcrdPID = dcrdConfig.pid;
   } catch (e) {
     logger.log("error", "error launching dcrd: " + e);
@@ -299,7 +299,7 @@ ipcMain.on("check-daemon", (event, walletPath, rpcCreds, testnet) => {
   let args = [ "getblockcount" ];
   let host, port;
   if (!rpcCreds){
-    args.push(`--configfile=${dcrctlCfg(getWalletPath(testnet, walletPath))}`);
+    args.push(`--configfile=${dcrctlCfg(appDataDirectory())}`);
   } else if (rpcCreds) {
     if (rpcCreds.rpc_user) {
       args.push(`--rpcuser=${rpcCreds.rpc_user}`);
@@ -410,7 +410,7 @@ const DecodeDaemonIPCData = (data, cb) => {
   }
 };
 
-const launchDCRD = (walletPath, appdata, testnet) => {
+const launchDCRD = (daemonPath, appdata, testnet) => {
   var spawn = require("child_process").spawn;
   let args = [];
   let newConfig = {};
@@ -422,14 +422,14 @@ const launchDCRD = (walletPath, appdata, testnet) => {
       args.push("--testnet");
     }
   } else {
-    args = [ `--configfile=${dcrdCfg(getWalletPath(testnet, walletPath))}` ];
-    newConfig = readDcrdConfig(getWalletPath(testnet, walletPath), testnet);
+    args = [ `--configfile=${dcrdCfg(daemonPath)}` ];
+    newConfig = readDcrdConfig(daemonPath, testnet);
     newConfig.rpc_cert = getDcrdRpcCert();
   }
 
   // Check to make sure that the rpcuser and rpcpass were set in the config
   if (!newConfig.rpc_user || !newConfig.rpc_password) {
-    const errorMessage =  "No " + `${!newConfig.rpc_user ? "rpcuser " : "" }` + `${!newConfig.rpc_user && !newConfig.rpc_password ? "and " : "" }` + `${!newConfig.rpc_password ? "rpcpass " : "" }` + "set in " + `${appdata ? appdata : getWalletPath(testnet, walletPath)}` + "/dcrd.conf.  Please set them and restart.";
+    const errorMessage =  "No " + `${!newConfig.rpc_user ? "rpcuser " : "" }` + `${!newConfig.rpc_user && !newConfig.rpc_password ? "and " : "" }` + `${!newConfig.rpc_password ? "rpcpass " : "" }` + "set in " + `${appdata ? appdata : getDcrdPath()}` + "/dcrd.conf.  Please set them and restart.";
     logger.log("error", errorMessage);
     mainWindow.webContents.executeJavaScript("alert(\"" + `${errorMessage}` + "\");");
     mainWindow.webContents.executeJavaScript("window.close();");

--- a/app/reducers/daemon.js
+++ b/app/reducers/daemon.js
@@ -68,7 +68,6 @@ export default function version(state = {}, action) {
       selectCreateWalletInputRequest: false,
       walletReady: true,
       walletName: action.walletName,
-      network: action.network,
       hiddenAccounts: action.hiddenAccounts,
     };
   case WALLETCREATED:

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -157,21 +157,6 @@
     }
   }
 
-  .loader-bar-bottom {
-    float: left;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-
-    .loader-bar-estimation {
-      float: left;
-      font-size: 11px;
-      margin-left: 82px;
-      margin-bottom: 20px;
-    }
-  }
-
   .go-back-screen-button {
     height: 12px;
     width: 12px;
@@ -185,6 +170,21 @@
 
   .go-back-screen-button:hover {
     opacity: 0.7;
+  }
+}
+
+.loader-bar-bottom {
+  float: left;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+
+  .loader-bar-estimation {
+    float: left;
+    font-size: 11px;
+    margin-left: 82px;
+    margin-bottom: 20px;
   }
 }
 

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -82,8 +82,8 @@ export const getDecreditonLogs = log(() => Promise
     throw "Error getting decrediton logs";
   }), "Get Decrediton Logs", logOptionNoResponseData());
 
-export const getAvailableWallets = log(() => Promise
-  .resolve(ipcRenderer.sendSync("get-available-wallets"))
+export const getAvailableWallets = log((network) => Promise
+  .resolve(ipcRenderer.sendSync("get-available-wallets", network))
   .then(availableWallets => {
     if (availableWallets) return availableWallets;
     throw "Error getting avaiable wallets logs";


### PR DESCRIPTION
This PR is an attempt to have the UX be more like what @linnutee had suggested in the docks.  Which network that the wallet will be using will be determined by the config instead of chosen on startup.  This now allows us to auto-load the daemon (if not in advanced mode) so the user can have the daemon syncing while they create/select their wallet.  