### PR TITLE
Closes #1260. Add container to prevent overlapping scroll

### DIFF
--- a/app/components/views/GetStartedPage/Logs/Form.js
+++ b/app/components/views/GetStartedPage/Logs/Form.js
@@ -25,7 +25,9 @@ export default ({
         <Tooltip text={ <T id="logs.goBack" m="Go back" /> }><div className="go-back-screen-button" onClick={onHideLogs}/></Tooltip>
         <T id="getStarted.logsTitle" m="Logs" />
       </div>
-      <LogsTab />
+      <div className="log-container">
+        <LogsTab />
+      </div>
       <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft }}  />
     </div>
   </div>

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -73,6 +73,14 @@
   .settings-column-title {
     font-size: 27px;
   }
+
+  .log-container {
+    float: left;
+    margin-top: 10px;
+    max-height: 490px;
+    width: 100%;
+    overflow-y: scroll;
+  }
 }
 
 .getstarted.loader {


### PR DESCRIPTION
I'm uncertain if the div and class code are placed correctly but this is at least an example of how #1260 can be solved.

![scrolling fixed](https://user-images.githubusercontent.com/921390/37564679-1f0f5450-2a9b-11e8-9286-144a57a635a9.png)
