### PR TITLE
Dynamic scrollbar

### DIFF
--- a/app/components/layout/TabbedPage.js
+++ b/app/components/layout/TabbedPage.js
@@ -56,18 +56,32 @@ class TabbedPage extends React.Component {
     return [ {
       key: matchedTab.tab.props.path,
       data: { matchedTab, element },
-      style: { left: spring(0, theme("springs.tab")) }
+      style: { left: spring(0, theme("springs.tab")), sbarTop: spring(800, theme("springs.tab")) }
     } ];
   }
 
   willLeave() {
     const pos = this.state.dir === "l2r" ? -1000 : +1000;
-    return { left: spring(pos, spring(theme("springs.tab"))) };
+    return { left: spring(pos, spring(theme("springs.tab"))), sbarTop: spring(0, theme("springs.tab")) };
   }
 
   willEnter() {
     const pos = this.state.dir === "l2r" ? +1000 : -1000;
-    return { left: pos };
+    return { left: pos, sbarTop: 800 };
+  }
+
+  scrollbarOverlayGetStyles(showScroll) {
+    if (!showScroll) return [];
+
+    return [ {
+      key: "scrollbar",
+      data: {},
+      style: { opacity: spring(1, theme("springs.tab")) }
+    } ];
+  }
+
+  scrollbarOverlayWillLeave() {
+    return { opacity: spring(0, theme("springs.tab")) };
   }
 
   render() {
@@ -97,13 +111,33 @@ class TabbedPage extends React.Component {
             willLeave={this.willLeave}
             willEnter={this.willEnter}
           >
-            {interpolatedStyles => <Aux>
-              {interpolatedStyles.map(s =>
-                <div className="tab-content" style={{ left: s.style.left, right: -s.style.left }} key={s.key}>
-                  {s.data.element}
-                </div>
-              )}
-            </Aux>}
+            {interpolatedStyles => {
+              return (<Aux>
+                {interpolatedStyles.map(s => {
+                  return (
+                    <div
+                      className={[ "tab-content", Math.abs(s.style.left) < 0.1 ? "visible" : "" ].join(" ")}
+                      style={{ left: s.style.left, right: -s.style.left }}
+                      key={s.key}
+                    >
+                      {s.data.element}
+                    </div>
+                  );
+                })}
+                <TransitionMotion
+                  styles={this.scrollbarOverlayGetStyles(interpolatedStyles.length !== 1)}
+                  willLeave={this.scrollbarOverlayWillLeave}
+                >
+                  {sbStyle => {
+                    return <Aux>
+                      {sbStyle.map(s =>
+                        <div className="scrollbar-overlay" key={s.key} style={{ opacity: s.style.opacity }} />
+                      )}
+                    </Aux>;
+                  }}
+                </TransitionMotion>
+              </Aux>);
+            }}
           </TransitionMotion>
 
           {nonTabs}

--- a/app/components/layout/TabbedPage.js
+++ b/app/components/layout/TabbedPage.js
@@ -67,7 +67,7 @@ class TabbedPage extends React.Component {
 
   willEnter() {
     const pos = this.state.dir === "l2r" ? +1000 : -1000;
-    return { left: pos, sbarTop: 800 };
+    return { left: pos };
   }
 
   scrollbarOverlayGetStyles(showScroll) {

--- a/app/components/layout/TabbedPage.js
+++ b/app/components/layout/TabbedPage.js
@@ -56,13 +56,13 @@ class TabbedPage extends React.Component {
     return [ {
       key: matchedTab.tab.props.path,
       data: { matchedTab, element },
-      style: { left: spring(0, theme("springs.tab")), sbarTop: spring(800, theme("springs.tab")) }
+      style: { left: spring(0, theme("springs.tab")) }
     } ];
   }
 
   willLeave() {
     const pos = this.state.dir === "l2r" ? -1000 : +1000;
-    return { left: spring(pos, spring(theme("springs.tab"))), sbarTop: spring(0, theme("springs.tab")) };
+    return { left: spring(pos, spring(theme("springs.tab"))) };
   }
 
   willEnter() {

--- a/app/style/Layout.less
+++ b/app/style/Layout.less
@@ -13,7 +13,7 @@
   width: calc(100% - @sidebar-width);
   position: absolute;
   right: 0px;
-  background-color: #f3f6f6;
+  background-color: @background-container;
   overflow-x: hidden;
 }
 
@@ -22,7 +22,7 @@
 .page-content-mixin {
   position: relative;
   padding: 54px 60px 0px 80px;
-  background-color: #f3f6f6;
+  background-color: @background-container;
   overflow-y: scroll;
   height: calc(100% - 214px);
 }
@@ -48,14 +48,23 @@
 }
 
 .page-content::-webkit-scrollbar,
-.tab-content::-webkit-scrollbar {
+.tab-content.visible::-webkit-scrollbar {
   width: 5px;
   background-color: #e7eaed;
 }
 
+.tab-content::-webkit-scrollbar {
+  width: 5px;
+  background-color: transparent;
+}
+
 .page-content::-webkit-scrollbar-thumb,
-.tab-content::-webkit-scrollbar-thumb {
+.tab-content.visible::-webkit-scrollbar-thumb {
   background-color: #8797a5;
+}
+
+.tab-content::-webkit-scrollbar-thumb {
+  background-color: transparent;
 }
 
 .inverted-colors {
@@ -80,7 +89,7 @@
   top: 173px;
   bottom: 0px;
   left: 0px;
-  background-color: #f3f6f6;
+  background-color: @background-container;
 }
 
 .standalone-page-body {
@@ -92,7 +101,7 @@
   bottom: 0px;
   left: 0px;
   padding: 60px 60px 30px 60px;
-  background-color: #f3f6f6;
+  background-color: @background-container;
 }
 
 .tabbed-page-header > .title-header-title,
@@ -151,7 +160,7 @@
   bottom: 0px;
   left: 0px;
   padding: 60px 60px 30px 60px;
-  background-color: #f3f6f6;
+  background-color: @background-container;
 }
 
 .component-tab-content {
@@ -178,4 +187,13 @@
   right: 0;
   top: 0;
   bottom: 0;
+}
+
+.scrollbar-overlay {
+  position: absolute;
+  right: 0px;
+  top: 0px;
+  bottom: 0px;
+  width: 20px;
+  background-color: @background-container;
 }

--- a/app/style/main.less
+++ b/app/style/main.less
@@ -27,6 +27,7 @@
 @stroke-color-focused: #2970ff;
 
 @background-hovered: #e9f8fe;
+@background-container: #f3f6f6;
 
 @input-transition-time: 230ms;
 @input-timing-function: ease-in-out;


### PR DESCRIPTION
Fix #1189 

Due to various limitations, the simplest way (least amount of changes to overall app structure) to fix this was to add an overlay over the scrollbar during tab switching, which gets shown after the tab is fully in view.