### PR TITLE
Fix for menulinks not being highlighted

### DIFF
--- a/app/components/SideBar/MenuLinks/index.js
+++ b/app/components/SideBar/MenuLinks/index.js
@@ -5,13 +5,13 @@ import { spring, Motion } from "react-motion";
 import theme from "theme";
 
 const linkList = [
-  { path: "/home/balance",       link: <T id="sidebar.link.home" m="Overview" />,             icon:"overview" },
-  { path: "/transactions/send",  link: <T id="sidebar.link.transactions" m="Transactions" />, icon:"transactions" },
-  { path: "/tickets/purchase",   link: <T id="sidebar.link.tickets" m="Tickets" /> ,          icon:"tickets" },
-  { path: "/accounts",           link: <T id="sidebar.link.accounts" m="Accounts" />,         icon:"accounts" },
-  { path: "/security/sign",      link: <T id="activesidebar.link.security" m="Security" />,   icon:"securitycntr" },
-  { path: "/settings",           link: <T id="sidebar.link.settings" m="Settings" />,         icon:"settings" },
-  { path: "/help/links",         link: <T id="sidebar.link.help" m="Help" />,                 icon:"help" },
+  { path: "/home",          link: <T id="sidebar.link.home" m="Overview" />,             icon:"overview" },
+  { path: "/transactions",  link: <T id="sidebar.link.transactions" m="Transactions" />, icon:"transactions" },
+  { path: "/tickets",       link: <T id="sidebar.link.tickets" m="Tickets" /> ,          icon:"tickets" },
+  { path: "/accounts",      link: <T id="sidebar.link.accounts" m="Accounts" />,         icon:"accounts" },
+  { path: "/security",      link: <T id="activesidebar.link.security" m="Security" />,   icon:"securitycntr" },
+  { path: "/settings",      link: <T id="sidebar.link.settings" m="Settings" />,         icon:"settings" },
+  { path: "/help",          link: <T id="sidebar.link.help" m="Help" />,                 icon:"help" },
 ];
 
 @autobind

--- a/app/components/views/HelpPage/index.js
+++ b/app/components/views/HelpPage/index.js
@@ -2,6 +2,7 @@ import { LinksTab, LinksTabHeader } from "./LinksTab";
 import { LogsTab, LogsTabHeader } from "./LogsTab";
 import { TabbedPage, TabbedPageTab as Tab, TitleHeader } from "layout";
 import { FormattedMessage as T } from "react-intl";
+import { Switch, Route, Redirect } from "react-router-dom";
 
 const HelpPageHeader = () =>
   <TitleHeader
@@ -9,9 +10,15 @@ const HelpPageHeader = () =>
     title={<T id="help.title" m="Help" />}
   />;
 
-export default () => (
+const Tabs = () =>
   <TabbedPage header={<HelpPageHeader />}>
     <Tab path="/help/links" component={LinksTab} header={LinksTabHeader} link={<T id="help.tab.links" m="Links"/>}/>
     <Tab path="/help/logs" component={LogsTab} header={LogsTabHeader} link={<T id="help.tab.logs" m="Logs"/>}/>
-  </TabbedPage>
+  </TabbedPage>;
+
+export default () => (
+  <Switch>
+    <Redirect from="/help" exact to="/help/links" />
+    <Route path="/help" component={Tabs} />
+  </Switch>
 );

--- a/app/components/views/HelpPage/index.js
+++ b/app/components/views/HelpPage/index.js
@@ -2,7 +2,7 @@ import { LinksTab, LinksTabHeader } from "./LinksTab";
 import { LogsTab, LogsTabHeader } from "./LogsTab";
 import { TabbedPage, TabbedPageTab as Tab, TitleHeader } from "layout";
 import { FormattedMessage as T } from "react-intl";
-import { Switch, Route, Redirect } from "react-router-dom";
+import { Switch, Redirect } from "react-router-dom";
 
 const HelpPageHeader = () =>
   <TitleHeader
@@ -10,15 +10,9 @@ const HelpPageHeader = () =>
     title={<T id="help.title" m="Help" />}
   />;
 
-const Tabs = () =>
+export default () =>
   <TabbedPage header={<HelpPageHeader />}>
+    <Switch><Redirect from="/help" exact to="/help/links" /></Switch>
     <Tab path="/help/links" component={LinksTab} header={LinksTabHeader} link={<T id="help.tab.links" m="Links"/>}/>
     <Tab path="/help/logs" component={LogsTab} header={LogsTabHeader} link={<T id="help.tab.logs" m="Logs"/>}/>
   </TabbedPage>;
-
-export default () => (
-  <Switch>
-    <Redirect from="/help" exact to="/help/links" />
-    <Route path="/help" component={Tabs} />
-  </Switch>
-);

--- a/app/components/views/SecurityPage/index.js
+++ b/app/components/views/SecurityPage/index.js
@@ -1,6 +1,6 @@
 import { TabbedPage, TabbedPageTab as Tab, TitleHeader, DescriptionHeader } from "layout";
 import { FormattedMessage as T } from "react-intl";
-import { Switch, Route, Redirect } from "react-router-dom";
+import { Switch, Redirect } from "react-router-dom";
 import { default as SignTab } from "./SignMessage";
 import { default as ValidateAddressTab } from "./ValidateAddress";
 import { default as VerifyMessageTab } from "./VerifyMessage";
@@ -16,17 +16,11 @@ const TabHeader = () =>
     description={<T id="security.description" m="Various tools that help in different aspects of crypto currency security will be located here." />}
   />;
 
-const Tabs = () => (
+export default () => (
   <TabbedPage header={<PageHeader />} >
+    <Switch><Redirect from="/security" exact to="/security/sign" /></Switch>
     <Tab path="/security/sign" component={SignTab} header={TabHeader} link={<T id="security.tab.sign" m="Sign Message"/>}/>
     <Tab path="/security/verify" component={VerifyMessageTab} header={TabHeader} link={<T id="security.tab.verify" m="Verify Message"/>}/>
     <Tab path="/security/validate" component={ValidateAddressTab} header={TabHeader} link={<T id="security.tab.validate" m="Validate Address"/>}/>
   </TabbedPage>
-);
-
-export default () => (
-  <Switch>
-    <Redirect from="/security" exact to="/security/sign" />
-    <Route path="/security" component={Tabs} />
-  </Switch>
 );

--- a/app/components/views/SecurityPage/index.js
+++ b/app/components/views/SecurityPage/index.js
@@ -1,5 +1,6 @@
 import { TabbedPage, TabbedPageTab as Tab, TitleHeader, DescriptionHeader } from "layout";
 import { FormattedMessage as T } from "react-intl";
+import { Switch, Route, Redirect } from "react-router-dom";
 import { default as SignTab } from "./SignMessage";
 import { default as ValidateAddressTab } from "./ValidateAddress";
 import { default as VerifyMessageTab } from "./VerifyMessage";
@@ -15,10 +16,17 @@ const TabHeader = () =>
     description={<T id="security.description" m="Various tools that help in different aspects of crypto currency security will be located here." />}
   />;
 
-export default () => (
+const Tabs = () => (
   <TabbedPage header={<PageHeader />} >
     <Tab path="/security/sign" component={SignTab} header={TabHeader} link={<T id="security.tab.sign" m="Sign Message"/>}/>
     <Tab path="/security/verify" component={VerifyMessageTab} header={TabHeader} link={<T id="security.tab.verify" m="Verify Message"/>}/>
     <Tab path="/security/validate" component={ValidateAddressTab} header={TabHeader} link={<T id="security.tab.validate" m="Validate Address"/>}/>
   </TabbedPage>
+);
+
+export default () => (
+  <Switch>
+    <Redirect from="/security" exact to="/security/sign" />
+    <Route path="/security" component={Tabs} />
+  </Switch>
 );

--- a/app/components/views/TicketsPage/index.js
+++ b/app/components/views/TicketsPage/index.js
@@ -1,5 +1,5 @@
 import { TabbedPage, TabbedPageTab as Tab, TitleHeader, DescriptionHeader } from "layout";
-import { Switch, Route, Redirect } from "react-router-dom";
+import { Switch, Redirect } from "react-router-dom";
 import { FormattedMessage as T } from "react-intl";
 import { purchaseTickets } from "connectors";
 import { Balance } from "shared";
@@ -23,18 +23,12 @@ const TabHeader = purchaseTickets(({ ticketPrice }) =>
   />
 );
 
-const Tabs = () => (
+export default () => (
   <TabbedPage header={<PageHeader />} >
+    <Switch><Redirect from="/tickets" exact to="/tickets/purchase" /></Switch>
     <Tab path="/tickets/purchase" component={PurchaseTab} header={TabHeader} link={<T id="tickets.tab.purchase" m="Purchase"/>}/>
     <Tab path="/tickets/mytickets" component={MyTicketsTab} header={TabHeader} link={<T id="tickets.tab.mytickets" m="My Tickets"/>}/>
     <Tab path="/tickets/governance" component={GovernanceTab} header={TabHeader} link={<T id="tickets.tab.governance" m="Governance"/>}/>
     <Tab path="/tickets/statistics" component={StatisticsTab} header={TabHeader} link={<T id="tickets.tab.statistics" m="Statistics"/>}/>
   </TabbedPage>
-);
-
-export default () => (
-  <Switch>
-    <Redirect from="/tickets" exact to="/tickets/purchase" />
-    <Route path="/tickets" component={Tabs} />
-  </Switch>
 );

--- a/app/components/views/TicketsPage/index.js
+++ b/app/components/views/TicketsPage/index.js
@@ -1,4 +1,5 @@
 import { TabbedPage, TabbedPageTab as Tab, TitleHeader, DescriptionHeader } from "layout";
+import { Switch, Route, Redirect } from "react-router-dom";
 import { FormattedMessage as T } from "react-intl";
 import { purchaseTickets } from "connectors";
 import { Balance } from "shared";
@@ -22,11 +23,18 @@ const TabHeader = purchaseTickets(({ ticketPrice }) =>
   />
 );
 
-export default () => (
+const Tabs = () => (
   <TabbedPage header={<PageHeader />} >
     <Tab path="/tickets/purchase" component={PurchaseTab} header={TabHeader} link={<T id="tickets.tab.purchase" m="Purchase"/>}/>
     <Tab path="/tickets/mytickets" component={MyTicketsTab} header={TabHeader} link={<T id="tickets.tab.mytickets" m="My Tickets"/>}/>
     <Tab path="/tickets/governance" component={GovernanceTab} header={TabHeader} link={<T id="tickets.tab.governance" m="Governance"/>}/>
     <Tab path="/tickets/statistics" component={StatisticsTab} header={TabHeader} link={<T id="tickets.tab.statistics" m="Statistics"/>}/>
   </TabbedPage>
+);
+
+export default () => (
+  <Switch>
+    <Redirect from="/tickets" exact to="/tickets/purchase" />
+    <Route path="/tickets" component={Tabs} />
+  </Switch>
 );

--- a/app/components/views/TransactionsPage/index.js
+++ b/app/components/views/TransactionsPage/index.js
@@ -1,4 +1,5 @@
 import { TabbedPage, TabbedPageTab as Tab, TitleHeader } from "layout";
+import { Switch, Route, Redirect } from "react-router-dom";
 import { FormattedMessage as T } from "react-intl";
 import { default as SendTab, SendTabHeader } from "./SendTab";
 import { default as ReceiveTab, ReceiveTabHeader } from "./ReceiveTab";
@@ -11,11 +12,18 @@ const PageHeader = () =>
     title={<T id="transactions.title" m="Transactions" />}
   />;
 
-export default () => (
+const Tabs = () => (
   <TabbedPage header={<PageHeader />} >
     <Tab path="/transactions/send" component={SendTab} header={SendTabHeader} link={<T id="transactions.tab.send" m="Send"/>}/>
     <Tab path="/transactions/receive" component={ReceiveTab} header={ReceiveTabHeader} link={<T id="transactions.tab.receive" m="Receive"/>}/>
     <Tab path="/transactions/history" component={HistoryTab} header={HistoryTabHeader} link={<T id="transactions.tab.history" m="History"/>}/>
     <Tab path="/transactions/export" component={ExportTab} header={ExportTabHeader} link={<T id="transactions.tab.export" m="Export"/>}/>
   </TabbedPage>
+);
+
+export default () => (
+  <Switch>
+    <Redirect from="/transactions" exact to="/transactions/send" />
+    <Route path="/transactions" component={Tabs} />
+  </Switch>
 );

--- a/app/components/views/TransactionsPage/index.js
+++ b/app/components/views/TransactionsPage/index.js
@@ -1,5 +1,5 @@
 import { TabbedPage, TabbedPageTab as Tab, TitleHeader } from "layout";
-import { Switch, Route, Redirect } from "react-router-dom";
+import { Switch, Redirect } from "react-router-dom";
 import { FormattedMessage as T } from "react-intl";
 import { default as SendTab, SendTabHeader } from "./SendTab";
 import { default as ReceiveTab, ReceiveTabHeader } from "./ReceiveTab";
@@ -12,18 +12,12 @@ const PageHeader = () =>
     title={<T id="transactions.title" m="Transactions" />}
   />;
 
-const Tabs = () => (
+export default () => (
   <TabbedPage header={<PageHeader />} >
+    <Switch><Redirect from="/transactions" exact to="/transactions/send" /></Switch>
     <Tab path="/transactions/send" component={SendTab} header={SendTabHeader} link={<T id="transactions.tab.send" m="Send"/>}/>
     <Tab path="/transactions/receive" component={ReceiveTab} header={ReceiveTabHeader} link={<T id="transactions.tab.receive" m="Receive"/>}/>
     <Tab path="/transactions/history" component={HistoryTab} header={HistoryTabHeader} link={<T id="transactions.tab.history" m="History"/>}/>
     <Tab path="/transactions/export" component={ExportTab} header={ExportTabHeader} link={<T id="transactions.tab.export" m="Export"/>}/>
   </TabbedPage>
-);
-
-export default () => (
-  <Switch>
-    <Redirect from="/transactions" exact to="/transactions/send" />
-    <Route path="/transactions" component={Tabs} />
-  </Switch>
 );


### PR DESCRIPTION
Previously, whenever you went to a tab that wasn't first (or specifically the one in the links path) it grey out the active menu link