### PR TITLE
Remove references to getAccountsResponse.getCurrentBlockCount

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -475,13 +475,12 @@ function filterTransactions(transactions, filter) {
 // When no more transactions are available given the current filter,
 // `grpc.noMoreTransactions` is set to true.
 export const getTransactions = () => async (dispatch, getState) => {
-  const { getAccountsResponse, getTransactionsRequestAttempt,
+  const { currentBlockHeight, getTransactionsRequestAttempt,
     transactionsFilter, walletService, maximumTransactionCount, recentTransactionCount } = getState().grpc;
   let { noMoreTransactions, lastTransaction, minedTransactions, recentRegularTransactions, recentStakeTransactions } = getState().grpc;
   if (getTransactionsRequestAttempt || noMoreTransactions) return;
 
-  // Check to make sure getAccountsResponse (which has current block height) is available
-  if (getAccountsResponse === null) {
+  if (!currentBlockHeight) {
     // Wait a little then re-dispatch this call since we have no starting height yet
     setTimeout(() => { dispatch(getTransactions()); }, 1000);
     return;
@@ -504,11 +503,11 @@ export const getTransactions = () => async (dispatch, getState) => {
     let startRequestHeight, endRequestHeight;
 
     if ( transactionsFilter.listDirection === "desc" ) {
-      startRequestHeight = lastTransaction ? lastTransaction.height -1 : getAccountsResponse.getCurrentBlockHeight();
+      startRequestHeight = lastTransaction ? lastTransaction.height -1 : currentBlockHeight;
       endRequestHeight = 1;
     } else {
       startRequestHeight = lastTransaction ? lastTransaction.height +1 : 1;
-      endRequestHeight = getAccountsResponse.getCurrentBlockHeight();
+      endRequestHeight = currentBlockHeight;
     }
 
     try {

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -318,7 +318,7 @@ export function purchaseTicketsAttempt(passphrase, accountNum, spendLimit, requi
     wallet.log("info", "Purchasing tickets", accountNum, spendLimit, requiredConf,
       numTickets, expiry, ticketFee, txFee, stakepool.TicketAddress,
       stakepool.PoolAddress, stakepool.PoolFees);
-    const { getAccountsResponse } = getState().grpc;
+    const { currentBlockHeight } = getState().grpc;
     var request = new PurchaseTicketsRequest();
     request.setPassphrase(new Uint8Array(Buffer.from(passphrase)));
     request.setAccount(accountNum);
@@ -329,7 +329,7 @@ export function purchaseTicketsAttempt(passphrase, accountNum, spendLimit, requi
     request.setPoolAddress(stakepool.PoolAddress);
     request.setPoolFees(stakepool.PoolFees);
     if (expiry !== 0) {
-      request.setExpiry(getAccountsResponse.getCurrentBlockHeight() + expiry);
+      request.setExpiry(currentBlockHeight + expiry);
     } else {
       request.setExpiry(expiry);
     }

--- a/app/index.js
+++ b/app/index.js
@@ -82,6 +82,7 @@ var initialState = {
     walletService: null,
     requiredStakepoolAPIVersion: 2,
     recentBlockTimestamp: null,
+    currentBlockHeight: 0,
 
     // ints for mainnet and testnet protocol hex
     // TestNet2 CurrencyNet = 0x48e7a065


### PR DESCRIPTION
Found this while leaving decrediton open for a long time, then trying to purchase a ticket. Since we moved away from requesting the accounts balances on every block, the block height of `getAccountsResponse` would get outdated. 

This switches the remaining instances of where `getAccountsResponse` was being used to grab the block height to the `grpc.currentBlockHeight` state var.