### PR TITLE
Create temp dcrd.conf if none is found in expected location

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -78,20 +78,20 @@ export const finishTutorial = () => (dispatch) => {
 };
 
 export const startDaemon = (rpcCreds, appData) => (dispatch, getState) => {
-  const { daemonStarted, walletName } = getState().daemon;
+  const { daemonStarted } = getState().daemon;
   if (daemonStarted) return;
   if (rpcCreds) {
     dispatch({ type: DAEMONSTARTED_REMOTE, credentials: rpcCreds, pid: -1 });
     dispatch(syncDaemon());
   } else if (appData) {
-    wallet.startDaemon(walletName, appData, isTestNet(getState()))
+    wallet.startDaemon(appData, isTestNet(getState()))
       .then(rpcCreds => {
         dispatch({ type: DAEMONSTARTED_APPDATA, appData: appData, credentials: rpcCreds });
         dispatch(syncDaemon(null, appData));
       })
       .catch((err) => dispatch({ err, type: DAEMONSTARTED_ERROR }));
   } else {
-    wallet.startDaemon(walletName, null, isTestNet(getState()))
+    wallet.startDaemon(null, isTestNet(getState()))
       .then(rpcCreds => {
         dispatch({ type: DAEMONSTARTED, credentials: rpcCreds });
         dispatch(syncDaemon());
@@ -221,11 +221,11 @@ export const syncDaemon = () =>
   (dispatch, getState) => {
     const updateBlockCount = () => {
       const { walletLoader: { neededBlocks, stepIndex } } = getState();
-      const { daemon: { daemonSynced, timeStart, blockStart, credentials, walletName } } = getState();
+      const { daemon: { daemonSynced, timeStart, blockStart, credentials } } = getState();
       // check to see if user skipped;
       if (daemonSynced) return;
       return wallet
-        .getBlockCount(walletName, credentials, isTestNet(getState()))
+        .getBlockCount(credentials, isTestNet(getState()))
         .then(updateCurrentBlockCount => {
           if ((neededBlocks == 0 && updateCurrentBlockCount > 0) || (neededBlocks != 0 && updateCurrentBlockCount >= neededBlocks)) {
             dispatch({ type: DAEMONSYNCED });

--- a/app/config.js
+++ b/app/config.js
@@ -131,9 +131,7 @@ export function getWalletCert(certPath) {
 
 export function readDcrdConfig(configPath, testnet) {
   try {
-    console.log(configPath);
     if (!fs.existsSync(dcrdCfg(configPath))) return;
-    console.log("jherere", configPath);
     const readCfg = ini.parse(Buffer.from(fs.readFileSync(dcrdCfg(configPath))).toString());
     let newCfg = {};
     newCfg.rpc_host = "127.0.0.1";

--- a/app/config.js
+++ b/app/config.js
@@ -2,7 +2,7 @@ import fs from "fs";
 import Store from "electron-store";
 import ini from "ini";
 import { stakePoolInfo } from "./middleware/stakepoolapi";
-import { getGlobalCfgPath, dcrdCfg, getWalletPath, dcrctlCfg, dcrwalletCfg, getDcrdRpcCert } from "./main_dev/paths";
+import { appDataDirectory, getGlobalCfgPath, dcrdCfg, getWalletPath, dcrwalletCfg, getDcrdRpcCert } from "./main_dev/paths";
 
 export function getGlobalCfg() {
   const config = new Store();
@@ -131,7 +131,9 @@ export function getWalletCert(certPath) {
 
 export function readDcrdConfig(configPath, testnet) {
   try {
+    console.log(configPath);
     if (!fs.existsSync(dcrdCfg(configPath))) return;
+    console.log("jherere", configPath);
     const readCfg = ini.parse(Buffer.from(fs.readFileSync(dcrdCfg(configPath))).toString());
     let newCfg = {};
     newCfg.rpc_host = "127.0.0.1";
@@ -255,28 +257,36 @@ export function setMustOpenForm(openForm) {
   return config.set("must_open_form", openForm);
 }
 
+function makeRandomString(length) {
+  var text = "";
+  var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  for (var i = 0; i < length; i++)
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+  return text;
+}
+
+export function createTempDcrdConf() {
+  if (!fs.existsSync(dcrdCfg(appDataDirectory()))) {
+    var rpcUser = makeRandomString(10);
+    var rpcPass = makeRandomString(10);
+
+    var dcrdConf = {
+      "Application Options":
+      {
+        rpcuser: rpcUser,
+        rpcpass: rpcPass,
+        rpclisten: "127.0.0.1:9109"
+      }
+    };
+    fs.writeFileSync(dcrdCfg(appDataDirectory()), ini.stringify(dcrdConf));
+  }
+  return appDataDirectory();
+}
+
 export function newWalletConfigCreation(testnet, walletPath) {
   // TODO: set random user/password
-  var dcrdConf = {
-    "Application Options":
-    {
-      rpcuser: "USER",
-      rpcpass: "PASSWORD",
-      rpclisten: "127.0.0.1:9109",
-      testnet: testnet ? "1" : "0"
-    }
-  };
-  fs.writeFileSync(dcrdCfg(getWalletPath(testnet, walletPath)), ini.stringify(dcrdConf));
-  var dcrctlConf = {
-    "Application Options":
-    {
-      rpcuser: "USER",
-      rpcpass: "PASSWORD",
-      rpcserver: "127.0.0.1:9109",
-      testnet: testnet ? "1" : "0"
-    }
-  };
-  fs.writeFileSync(dcrctlCfg(getWalletPath(testnet, walletPath)), ini.stringify(dcrctlConf));
   var dcrwConf = {
     "Application Options":
     {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, Menu, shell, dialog } from "electron";
 import { concat, isString } from "lodash";
 import { initGlobalCfg, validateGlobalCfgFile, setMustOpenForm } from "./config";
-import { initWalletCfg, getWalletCfg, newWalletConfigCreation, readDcrdConfig } from "./config";
+import { initWalletCfg, getWalletCfg, newWalletConfigCreation, readDcrdConfig, createTempDcrdConf } from "./config";
 import fs from "fs-extra";
 import os from "os";
 import path from "path";
@@ -255,7 +255,11 @@ ipcMain.on("start-daemon", (event, walletPath, appData, testnet) => {
     return;
   }
   try {
-    dcrdConfig = launchDCRD(getDcrdPath(), appData, testnet);
+    let dcrdConfPath = getDcrdPath();
+    if (!fs.existsSync(dcrdCfg(dcrdConfPath))) {
+      dcrdConfPath = createTempDcrdConf();
+    }
+    dcrdConfig = launchDCRD(dcrdConfPath, appData, testnet);
     dcrdPID = dcrdConfig.pid;
   } catch (e) {
     logger.log("error", "error launching dcrd: " + e);

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -7,8 +7,8 @@ export const checkDecreditonVersion = log(() => Promise
   .resolve(ipcRenderer.sendSync("check-version"))
   , "Check Decrediton release version");
 
-export const startDaemon = log((walletPath, appData, testnet) => Promise
-  .resolve(ipcRenderer.sendSync("start-daemon", walletPath, appData, testnet))
+export const startDaemon = log((appData, testnet) => Promise
+  .resolve(ipcRenderer.sendSync("start-daemon", appData, testnet))
   .then(pid => {
     if (pid) return pid;
     throw "Error starting daemon";
@@ -60,12 +60,12 @@ export const getPreviousWallet = log(() => Promise
   .resolve(ipcRenderer.sendSync("get-previous-wallet"))
   , "Get Previous Wallet");
 
-export const getBlockCount = log((walletPath, rpcCreds, testnet) => new Promise(resolve => {
+export const getBlockCount = log((rpcCreds, testnet) => new Promise(resolve => {
   ipcRenderer.once("check-daemon-response", (e, block) => {
     const blockCount = isString(block) ? parseInt(block.trim()) : block;
     resolve(blockCount);
   });
-  ipcRenderer.send("check-daemon", walletPath, rpcCreds, testnet);
+  ipcRenderer.send("check-daemon", rpcCreds, testnet);
 }), "Get Block Count");
 
 export const getDcrdLogs = log(() => Promise


### PR DESCRIPTION
Fix #1293 
dcrd does not create a conf file if a conf file is specified in the options (which we do for decrediton).  So we now just create a temp dcrd.conf in appdataDirectory to be used until the user places (or generates) a config file in the default dcrd location.