### PR TITLE
Update tutorial copy and styles

### DIFF
--- a/app/components/views/HomePage/tables/NoTicketsLinks.js
+++ b/app/components/views/HomePage/tables/NoTicketsLinks.js
@@ -3,9 +3,9 @@ import { FormattedMessage as T } from "react-intl";
 
 export default () => (
   <div className="overview-no-tickets">
-    <Link to="/mytickets/purchase" className="purchaseTickets">
+    {/* <Link to="/mytickets/purchase" className="purchaseTickets">
       <T id="home.noTickets.purchase" m="Stake Your Idle DCR and Earn Rewards" /> →
-    </Link>
+    </Link> */}
     <Link to="/tutorial/staking" className="whatIsStaking">
       <T id="home.noTickets.staking" m="What is Staking (Proof-of-Stake)?" /> →
     </Link>

--- a/app/components/views/TutorialsPage/Staking/index.js
+++ b/app/components/views/TutorialsPage/Staking/index.js
@@ -4,17 +4,24 @@ import { MakeStandardPage as StandardPage } from "../StandardPage";
 
 const Page1 = StandardPage(
   "staking-01",
-  <T id="tutorial.staking.page1" m={`This is Stakey, our mascot!
+  <T id="tutorial.staking.page1" m={`Decred holders can participate in the Staking (Proof-of Stake) process by purchasing tickets. These tickets are used to vote on miners’ Proof-of-Work in order to validate changes to the Decred blockchain, or on governance proposals within the Politeia system.
 
-He represents the best aspects of the Decred network and shows up on all staking-related activities.
+  Staking to verify PoW is rewarding, as each cast vote receives part of the Decred Block Reward. Typically, five tickets are included in each block, meaning each ticket holder receives 6% of the total block reward.
+`}/>);
 
-Once you stake your coins, you have a say on the continued evolution of the Decred network. You become a stakeholder and can vote on agendas, participate on Politeia and help keep the PoW miners in check.
+const Page2 = StandardPage(
+  "staking-01",
+  <T id="tutorial.staking.page2" m={`When a ticket is purchased, the cost of the ticket is locked in your wallet until the ticket is used to vote, or is revoked. Tickets enter the mempool, then the ticketpool where they are drawn at random to vote. There is a 99.5% probability that a ticket will vote. The average ticket will vote in 28 days, but tickets still in the pool that have not been drawn after 142 days will be revoked. The DCR used to purchase the ticket is released from lockup when it votes or when the ticket is revoked.
+
+  When a proposal is set for a vote in Politeia, a snapshot of the ticket pool will be taken at the time of voting. All tickets will have the right to vote on the proposal in an off chain process.
+
+  As block validation is immutable, decisions made on all voted tickets can be publicly tracked. Active participation in staking helps secure Decred network’s, network, ensure quality Proof-of-Work, and determine the future direction of Decred.
 `} />);
 
 export default (props) => (
   <PagedTutorial
     {...props}
     title={<T id="tutorial.ticketLifecycle.title" m="Ticket Lifecycle" />}
-    pages={[ Page1 ]}
+    pages={[ Page1, Page2 ]}
   />
 );

--- a/app/components/views/TutorialsPage/TicketLifecycle/index.js
+++ b/app/components/views/TutorialsPage/TicketLifecycle/index.js
@@ -9,35 +9,38 @@ const Page1 = StandardPage(
 
 const Page2 = StandardPage(
   "lifecycle-02",
-  <T id="tutorial.ticketLifecycle.page2" m={`1. When a Ticket is purchased, the total cost is it’s Ticket Fee + Ticket Price.
+  <T id="tutorial.ticketLifecycle.page2" m={`When a Ticket is purchased, the total cost is its Ticket Fee + Ticket Price. The price is dynamic in order to yield a ticket pool of approximately 40,960 tickets.
 
-  2. Your ticket enters the mempool. This is where your ticket waits to be mined by PoW miners. Only 20 fresh tickets are mined into each block.
+  Your ticket enters the mempool. Up to 20 tickets are mined into each block, prioritized by the ticket fee.
 `} />);
 
 const Page3 = StandardPage(
   "lifecycle-03",
-  <T id="tutorial.ticketLifecycle.page3" m={`2.A - If your ticket is mined into a block, it becomes an immature ticket. This state lasts for 256 blocks (about 20 hours). During this time the ticket cannot vote. At this point, the ticket fee is non-refundable.
+  <T id="tutorial.ticketLifecycle.page3" m={`Two things might happen next:
 
-  2.B - If your ticket is not mined, both the Ticket Price and Ticket Fee are returned to the purchasing account.
+  A - Your ticket is mined into a block and it becomes an immature ticket. This state lasts for 256 blocks (about 20 hours). During this time, the ticket cannot vote and the ticket fee becomes non-refundable.
+
+  B - If your ticket is not mined, it will stay in the mempool until the ticket price increases or the block height hits your ticket expiration date. At this point, both the Ticket Price and Ticket Fee are returned.
 `} />);
 
 const Page4 = StandardPage(
   "lifecycle-04",
-  <T id="tutorial.ticketLifecycle.page4" m={`3. After your ticket matures (256 blocks), it enters the Ticket Pool and is eligible for voting. Average time for most tickets to vote is about 28 days. Any ticket has a 99.5% chance of voting within ~142 days. If, after this time, a ticket has not voted, it expires. You receive a refund on the original Ticket Price.
+  <T id="tutorial.ticketLifecycle.page4" m={`When your ticket matures (256 blocks), it enters the Ticket Pool and can be selected to vote. For each new block, five tickets are deterministically and pseudorandomly selected to vote on the newly mined block. The average ticket is selected to vote in approximately 28 days, and any ticket has a 99.5% chance of voting within ~142 days. If, after this time a ticket has not voted, it expires and the original Ticket Price is refunded.
 `}/>);
 
 const Page5 = StandardPage(
   "lifecycle-05",
-  <T id="tutorial.ticketLifecycle.page5" m={`4. A ticket may miss its call to vote if the voting wallet does not respond or two valid blocks are found within close proximity of each other. If this happens, you receive a refund on the original Ticket Price.
+  <T id="tutorial.ticketLifecycle.page5" m={`You must be connected to the network to cast a vote, which is why many people use stakepools. If your ticket is called and it misses the vote, you receive a refund on the original Ticket Price.
 
-  5. After a ticket has voted, missed, or expired, the funds (ticket price and subsidy if applicable, minus the fee) will enter immature status for another 256 blocks, after which they are released. If a ticket is missed or expired, a ticket revocation transaction is submitted by the wallet which then frees up the locked ticket price.
+  After a ticket has voted, missed, or expired, the funds (ticket price minus the fee) will enter immature status for another 256 blocks, after which they are released from lockup in the wallet. If a ticket is missed or expired, a ticket revocation transaction is submitted by the wallet to free up the locked ticket price.
 
   NOTE: Revocations can only be submitted for a corresponding missed ticket. You cannot revoke a ticket until it is missed.
 `}/>);
 
 const Page6 = StandardPage(
   "lifecycle-06",
-  null);
+  <T id="tutorial.ticketLifecycle.page6" m={`You should now understand a bit better the lifecycle of a ticket, so start staking your Decred and participate on the community!
+`}/>);
 
 export default (props) => (
   <PagedTutorial

--- a/app/style/Tutorial.less
+++ b/app/style/Tutorial.less
@@ -189,6 +189,10 @@
     white-space: pre-line;
   }
 
+  .tutorial-page-indicator a {
+    cursor: pointer;
+  }
+
   .tutorial-image-and-indicator {
     text-align: center;
     height: 35vw;


### PR DESCRIPTION
I've also hidden the "purchase tickets" tutorial that was listed on the original tutorial design, since we don't have copy and images for it.