### PR TITLE
[config] Add nospreadticketpurchases option for wallet  start up

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -504,6 +504,7 @@ const launchDCRWallet = (walletPath, testnet) => {
 
   const cfg = getWalletCfg(testnet, walletPath);
 
+  args.push("--ticketbuyer.nospreadticketpurchases");
   args.push("--ticketbuyer.balancetomaintainabsolute=" + cfg.get("balancetomaintain"));
   args.push("--ticketbuyer.maxfee=" + cfg.get("maxfee"));
   args.push("--ticketbuyer.maxpricerelative=" + cfg.get("maxpricerelative"));


### PR DESCRIPTION
Due to constant user confusion and reports, we will now enable immediate ticket purchasing for auto buyer.  This should be totally fine with only a slight bump in fees for the first block of a down ticket price window.   