### PR TITLE
[tickets] Set all currently shown agendas to finished

### DIFF
--- a/app/components/views/TicketsPage/GovernanceTab/AgendaCard.js
+++ b/app/components/views/TicketsPage/GovernanceTab/AgendaCard.js
@@ -1,4 +1,5 @@
 import { FormattedMessage as T } from "react-intl";
+import { Tooltip } from "shared";
 import "style/AgendaCard.less";
 
 // Currently removing percent progress until a solution to populate is found
@@ -13,15 +14,11 @@ const AgendaCard = ({
       : ({ className: "agenda-card", onClick })
   )}>
     <div className="agenda-card-bottom">
-      {agenda.finished ? (
+      <Tooltip text={<T id="agenda.card.finishedTooltip" m="This agenda has finished voting and PASSED.  You may still toggle your vote choices, but they will no longer be tallied." />}>
         <div className="agenda-card-indicator-finished">
           <T id="agenda.card.finishedIndicator" m="Finished" />
         </div>
-      ) : (
-        <div className="agenda-card-indicator-pending">
-          <T id="agenda.card.inProgressIndicator" m="In Progress" />
-        </div>
-      )}
+      </Tooltip>
       <div className="agenda-card-bottom-cfg">
         {agenda.getDescription()} <span className="agenda-card-bottom-cfg-last">
           <T id="agenda.overview.idLabel" m="Agenda ID" />:
@@ -38,3 +35,17 @@ const AgendaCard = ({
 );
 
 export default AgendaCard;
+/*
+  XXX We are currently going to automatically set the agendas to finished to avoid confusion
+  Once we have figured a more graceful way to determine whether an agenda is still active we can just leave this.
+
+{agenda.finished ? (
+  <div className="agenda-card-indicator-finished">
+    <T id="agenda.card.finishedIndicator" m="Finished" />
+  </div>
+) : (
+  <div className="agenda-card-indicator-pending">
+    <T id="agenda.card.inProgressIndicator" m="In Progress" />
+  </div>
+)}
+*/

--- a/app/components/views/TicketsPage/GovernanceTab/AgendaOverview/Overview.js
+++ b/app/components/views/TicketsPage/GovernanceTab/AgendaOverview/Overview.js
@@ -1,4 +1,5 @@
 import { KeyBlueButton } from "buttons";
+import { Tooltip } from "shared";
 import { FormattedMessage as T } from "react-intl";
 import "style/AgendaOverview.less";
 
@@ -60,9 +61,11 @@ const Overview = ({
     </div>
     <div className="agenda-bottom">
       <div className="agenda-bottom-overview">
-        <div className="agenda-indicator-pending">
-          <T id="agenda.overview.inProgressIndicator" m="In Progress" />
-        </div>
+        <Tooltip text={<T id="agenda.card.finishedTooltip" m="This agenda has finished voting and PASSED.  You may still toggle your vote choices, but they will no longer be tallied." />}>
+          <div className="agenda-indicator-finished">
+            <T id="agenda.card.finishedIndicator" m="Finished" />
+          </div>
+        </Tooltip>
       </div>
       <div className="agenda-bottom-options">
         <KeyBlueButton

--- a/app/style/AgendaOverview.less
+++ b/app/style/AgendaOverview.less
@@ -158,3 +158,21 @@
   background-repeat: no-repeat;
   color: #2971ff;
 }
+
+.agenda-indicator-finished {
+  float: right;
+  padding: 5px 8px 5px 20px;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 3px;
+  font-size: 12px;
+  line-height: 8px;
+  text-align: right;
+  text-transform: capitalize;
+  border-color: #8997a5;
+  background-image: @agenda-indicator-finished;
+  background-position: 6px 50%;
+  background-size: 10px;
+  background-repeat: no-repeat;
+  color: #8997a5;
+}


### PR DESCRIPTION
Due to various reasons, we currently don't have a graceful way of notifying dcrwallet (and thereby decrediton) of an agenda's state at any given moment.  Until that solution is in place, we will simply show the user that the agenda voting has finished and passed.

I will be opening an issue describing various solutions that can be implemented in the future.