### PR TITLE
Add --ia32 win packaging, and fix win path for executables

### DIFF
--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -82,7 +82,10 @@ export function getExecutablePath(name, customBinPath) {
     process.env.NODE_ENV === "development"
       ? path.join(__dirname, "..", "..", "bin")
       : path.join(process.resourcesPath, "bin");
-  let execName = os.platform() !== "win32" ? name : name + ".exe";
+  let execName = os.platform() !== "win32" ? name :
+    os.arch() == "x64" ? name + "64.exe" :
+      os.arch() == "ia32" ? name + "32.exe" :
+        name + ".exe";
 
   return path.join(binPath, execName);
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "postinstall": "concurrently \"electron-builder install-app-deps\" \"node node_modules/fbjs-scripts/node/check-dev-engines.js package.json\"",
     "dev": "npm run hot-server -- --start-hot",
     "package": "npm run build && build --publish never",
-    "package-win": "npm run build && build --win --x64",
+    "package-win": "npm run build && build --win --x64 --ia32",
     "package-linux": "npm run build && build --linux",
     "package-mac": "npm run build && build --mac",
     "package-all": "npm run build && build -mwl",


### PR DESCRIPTION
This will allow for a 32bit version of decrediton to be launched.

NOTE: To have decrediton properly build on windows we now will need to add dcr*32 and dcr*64 versions of the binaries in the /bin directory. 