### PR TITLE
Ignore non-dirs when listing available wallets

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -208,27 +208,20 @@ const installExtensions = async () => {
 const { ipcMain } = require("electron");
 
 ipcMain.on("get-available-wallets", (event, network) => {// Attempt to find all currently available wallet.db's in the respective network direction in each wallets data dir
-  var availableWallets = [];
+  const availableWallets = [];
+  const isTestNet = network !== "mainnet";
 
-  if (network == "mainnet") {
-    var mainnetWalletDirectories = fs.readdirSync(getWalletPath(false));
-    for (var i in mainnetWalletDirectories) {
-      if (fs.pathExistsSync(getWalletDBPathFromWallets(false, mainnetWalletDirectories[i].toString()))) {
-        availableWallets.push({ network: "mainnet", wallet: mainnetWalletDirectories[i], finished: true });
-      } else {
-        availableWallets.push({ network: "mainnet", wallet: mainnetWalletDirectories[i], finished: false });
-      }
-    }
-  } else {
-    var testnetWalletDirectories = fs.readdirSync(getWalletPath(true));
-    for (var j in testnetWalletDirectories) {
-      if (fs.pathExistsSync(getWalletDBPathFromWallets(true, testnetWalletDirectories[j].toString()))) {
-        availableWallets.push({ network: "testnet", wallet: testnetWalletDirectories[j], finished: true });
-      } else {
-        availableWallets.push({ network: "testnet", wallet: testnetWalletDirectories[j], finished: false });
-      }
-    }
-  }
+  const walletsBasePath = getWalletPath(isTestNet);
+  const walletDirs = fs.readdirSync(walletsBasePath);
+  walletDirs.forEach(wallet => {
+    const walletDirStat = fs.statSync(path.join(walletsBasePath, wallet));
+    if (!walletDirStat.isDirectory()) return;
+
+    const walletDbFilePath = getWalletDBPathFromWallets(isTestNet, wallet);
+    const finished = fs.pathExistsSync(walletDbFilePath);
+    availableWallets.push({ network, wallet, finished });
+  });
+
   event.returnValue = availableWallets;
 });
 


### PR DESCRIPTION
I had the extraneous `config.json` on my wallets dir as well, but I couldn't track why it was there. I tested several combinations of the migration code, but couldn't reproduce the creation of the config.json file inside ~/.config/decrediton/wallets. Maybe this was happening on a development test or an earlier version?

Anyway, I simplified the code that lists available wallets a bit and added a check to only list if it's a dir.