### PR TITLE
Show last log lines while starting RPC

### DIFF
--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -86,7 +86,7 @@ export default ({
           }
           <DecredLoading hidden={startupError || isInputRequest} />
         </div>
-        { Form && <Form {...{ ...props, isInputRequest, startupError }}/> }
+        { Form && <Form {...{ ...props, isInputRequest, startupError, getCurrentBlockCount }}/> }
       </Aux>
     </div>
   </div>

--- a/app/components/views/GetStartedPage/StartRPC.js
+++ b/app/components/views/GetStartedPage/StartRPC.js
@@ -1,13 +1,23 @@
 import { KeyBlueButton } from "buttons";
 import { ShowError } from "shared";
 import { FormattedMessage as T } from "react-intl";
+import { getDcrdLastLogLine, getDcrwalletLastLogLine } from "wallet";
+import ReactTimeout from "react-timeout";
 import "style/GetStarted.less";
 
-export const StartRPCBody = ({
-  startupError,
-  onRetryStartRPC
-}) => (
-  startupError &&
+function parseLogLine(line) {
+  const res = /^[\d :\-\.]+ \[...\] (.+)$/.exec(line);
+  return res ? res[1] : "";
+}
+
+const LastLogLinesFragment = ({ lastDcrdLogLine, lastDcrwalletLogLine }) => (
+  <div className="get-started-last-log-lines">
+    <div className="last-dcrd-log-line">{lastDcrdLogLine}</div>
+    <div className="last-dcrwallet-log-line">{lastDcrwalletLogLine}</div>
+  </div>
+);
+
+const StartupErrorFragment = ({ onRetryStartRPC }) => (
   <div className="advanced-page-form">
     <div className="advanced-daemon-row">
       <ShowError className="get-started-error" error="Connection to dcrd failed, please try and reconnect." />
@@ -19,3 +29,41 @@ export const StartRPCBody = ({
     </div>
   </div>
 );
+
+@autobind
+class StartRPCBody extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { lastDcrdLogLine: "", lastDcrwalletLogLine: "" };
+  }
+
+  componentDidMount() {
+    this.props.setInterval(() => {
+      Promise
+        .all([ getDcrdLastLogLine(), getDcrwalletLastLogLine() ])
+        .then(([ dcrdLine, dcrwalletLine ]) => {
+          const lastDcrdLogLine = parseLogLine(dcrdLine);
+          const lastDcrwalletLogLine = parseLogLine(dcrwalletLine);
+          if ( lastDcrdLogLine !== this.state.lastDcrdLogLine ||
+              lastDcrwalletLogLine !== this.state.lastDcrwalletLogLine)
+          {
+            this.setState({ lastDcrdLogLine, lastDcrwalletLogLine });
+          }
+        });
+    }, 2000);
+  }
+
+  render () {
+    const { startupError, getCurrentBlockCount } = this.props;
+
+    return (
+      <Aux>
+        {!getCurrentBlockCount && <LastLogLinesFragment {...this.state} />}
+        {startupError && <StartupErrorFragment {...this.props} />}
+      </Aux>
+    );
+  }
+}
+
+export default ReactTimeout(StartRPCBody);

--- a/app/components/views/GetStartedPage/StartRPC.js
+++ b/app/components/views/GetStartedPage/StartRPC.js
@@ -6,7 +6,7 @@ import ReactTimeout from "react-timeout";
 import "style/GetStarted.less";
 
 function parseLogLine(line) {
-  const res = /^[\d :\-\.]+ \[...\] (.+)$/.exec(line);
+  const res = /^[\d :\-.]+ \[...\] (.+)$/.exec(line);
   return res ? res[1] : "";
 }
 

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -5,7 +5,7 @@ import Logs from "./Logs";
 import Settings from "./Settings";
 import ReleaseNotes from "./ReleaseNotes";
 import { WalletSelectionBody } from "./WalletSelection";
-import { StartRPCBody } from "./StartRPC";
+import StartRPCBody from "./StartRPC";
 import { DiscoverAddressesBody } from "./DiscoverAddresses";
 import { FetchBlockHeadersBody } from "./FetchBlockHeaders";
 import { AdvancedStartupBody, RemoteAppdataError } from "./AdvancedStartup";

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -388,6 +388,20 @@ ipcMain.on("get-decrediton-logs", (event) => {
   event.returnValue = "decrediton logs!";
 });
 
+function lastLogLine(log) {
+  let lastLineIdx = log.lastIndexOf(os.EOL, log.length - os.EOL.length -1);
+  let lastLineBuff = log.slice(lastLineIdx).toString("utf-8");
+  return lastLineBuff.trim();
+}
+
+ipcMain.on("get-last-log-line-dcrd", event => {
+  event.returnValue = lastLogLine(dcrdLogs);
+});
+
+ipcMain.on("get-last-log-line-dcrwallet", event => {
+  event.returnValue = lastLogLine(dcrwalletLogs);
+});
+
 ipcMain.on("get-previous-wallet", (event) => {
   event.returnValue = previousWallet;
 });

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -556,3 +556,7 @@
 .privacy-option-icon.custom {
   background-image: @stakey-privacy-custom;
 }
+
+.get-started-last-log-lines {
+  font-size: 9px;
+}

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -103,3 +103,9 @@ export const reloadAllowedExternalRequests = log(() => Promise
 export const allowStakePoolHost = log(host => Promise
   .resolve(ipcRenderer.sendSync("allow-stakepool-host", host))
   , "Allow StakePool Host");
+
+export const getDcrdLastLogLine = () => Promise
+  .resolve(ipcRenderer.sendSync("get-last-log-line-dcrd"));
+
+export const getDcrwalletLastLogLine = () => Promise
+  .resolve(ipcRenderer.sendSync("get-last-log-line-dcrwallet"));


### PR DESCRIPTION
Fix #1333 

This shows the last log lines of dcrd and dcrwallet during the "Stablishing RPC Connections..." stage of startup. This is the stage where migrations in the daemon/wallet databases happen, so it should be slightly clearer for users what is going on.