### PR TITLE
Capture invalid seed pasting and display error

### DIFF
--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ExistingSeed/Form.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ExistingSeed/Form.js
@@ -94,7 +94,7 @@ class ExistingSeedForm extends React.Component{
                 <T id="confirmSeed.warnings.pasteExistingSeed" m="*Please make sure you also have a physical, written down copy of your seed." />
               </div>}
               {this.state.showPasteError &&
-              <div className="red-error">
+              <div className="error">
                 <T id="confirmSeed.warnings.pasteExistingError" m="* Please paste a valid 33 word seed."/>
               </div>}
               {seedWords.map((seedWord) => {

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ExistingSeed/Form.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ExistingSeed/Form.js
@@ -13,6 +13,7 @@ class ExistingSeedForm extends React.Component{
     super(props);
     this.state = {
       showPasteWarning : false,
+      showPasteError: false,
       seedType: "words",
     };
   }
@@ -26,11 +27,19 @@ class ExistingSeedForm extends React.Component{
       .filter(w => /^[\w]+$/.test(w))
       .filter(w => lowercaseSeedWords.indexOf(w.toLowerCase()) > -1)
       .map((w, i) => ({ index: i, word: w }));
-    this.props.setSeedWords(words);
+    if (words.length == 33) {
+      this.props.setSeedWords(words);
+      this.setState({
+        showPasteWarning : true,
+        showPasteError: false
+      });
+    } else {
+      this.setState({
+        showPasteWarning : false,
+        showPasteError : true
+      });
 
-    this.setState({
-      showPasteWarning : true
-    });
+    }
   }
 
   handleToggle = (side) => {
@@ -58,7 +67,7 @@ class ExistingSeedForm extends React.Component{
   }
 
   render(){
-    const { onChangeSeedWord, seedWords, setSeedWords,  } = this.props;
+    const { onChangeSeedWord, seedWords, setSeedWords } = this.props;
     const { seedType } = this.state;
     const errors = this.mountSeedErrors();
     return (
@@ -80,8 +89,13 @@ class ExistingSeedForm extends React.Component{
           </div>
           {seedType == "words" && Array.isArray(seedWords) ?
             <div className="seedArea">
-              {!this.state.showPasteWarning ? null : <div className="orange-warning">
+              {this.state.showPasteWarning &&
+              <div className="orange-warning">
                 <T id="confirmSeed.warnings.pasteExistingSeed" m="*Please make sure you also have a physical, written down copy of your seed." />
+              </div>}
+              {this.state.showPasteError &&
+              <div className="red-error">
+                <T id="confirmSeed.warnings.pasteExistingError" m="* Please paste a valid 33 word seed."/>
               </div>}
               {seedWords.map((seedWord) => {
                 const className = seedWord.word ? seedWord.error ? "seedWord error" : "seedWord populated" : "seedWord restore";

--- a/app/style/CreateWalletForm.less
+++ b/app/style/CreateWalletForm.less
@@ -51,7 +51,7 @@
   top: 122px;
 }
 
-.red-error {
+.seedArea > .error {
   color: red;
   position: fixed;
   top: 122px;

--- a/app/style/CreateWalletForm.less
+++ b/app/style/CreateWalletForm.less
@@ -51,6 +51,12 @@
   top: 122px;
 }
 
+.red-error {
+  color: red;
+  position: fixed;
+  top: 122px;
+}
+
 .wallet-key-blue-button {
   margin-top: 12px;
   float: left;


### PR DESCRIPTION
Close #1339 

Way to replicate error: C-V any bad words into any box in the restore seed area.  Previously, it would make the seed words disappear, now it determines whether a valid 33 mnenomic seed so it will display correctly.