### PR TITLE
[launcher] Fix disabled Restore Wallet button box shadow

### DIFF
--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -284,7 +284,7 @@
     float: left;
   }
 
-  .wallet-key-blue-button {
+  .wallet-key-blue-button:not(.key-blue-button-disabled) {
     float: left;
     box-shadow: 0px 5px 13px rgba(0, 0, 0, 0.21);
   }


### PR DESCRIPTION
On restore wallet from seed when the button turns disabled and loading, on hover it would remove the button's box-shadow.  This was due to the special wallet creation button style that overrides the disabled button style.  

This is a quick fix until we can do a full overhaul to make buttons consistent everywhere.