### PR TITLE
Call publishUnminedTransactions on startup

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -40,7 +40,6 @@ function getWalletServiceSuccess(walletService) {
     setTimeout(() => { dispatch(accountNtfnsStart()); }, 1000);
     setTimeout(() => { dispatch(updateStakepoolPurchaseInformation()); }, 1000);
     setTimeout(() => { dispatch(getDecodeMessageServiceAttempt()); }, 1000);
-    setTimeout(() => { dispatch(publishUnminedTransactionsAttempt()); }, 1000);
 
     var goHomeCb = () => {
       setTimeout(() => { dispatch(pushHistory("/home")); }, 1000);
@@ -78,6 +77,7 @@ export const getStartupWalletInfo = () => (dispatch) => {
         await dispatch(getMostRecentRegularTransactions());
         await dispatch(getMostRecentStakeTransactions());
         await dispatch(getMostRecentTransactions());
+        await dispatch(publishUnminedTransactionsAttempt());
         await dispatch(getStartupStats());
         dispatch(findImmatureTransactions());
         dispatch({ type: GETSTARTUPWALLETINFO_SUCCESS });

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -3,7 +3,7 @@ import * as wallet from "wallet";
 import * as sel from "selectors";
 import eq from "lodash/fp/eq";
 import { getNextAddressAttempt, loadActiveDataFiltersAttempt, rescanAttempt,
-  stopAutoBuyerAttempt, getTicketBuyerConfigAttempt } from "./ControlActions";
+  stopAutoBuyerAttempt, getTicketBuyerConfigAttempt, publishUnminedTransactionsAttempt } from "./ControlActions";
 import { transactionNtfnsStart, accountNtfnsStart } from "./NotificationActions";
 import { updateStakepoolPurchaseInformation, setStakePoolVoteChoices } from "./StakePoolActions";
 import { getDecodeMessageServiceAttempt } from "./DecodeMessageActions";
@@ -40,6 +40,7 @@ function getWalletServiceSuccess(walletService) {
     setTimeout(() => { dispatch(accountNtfnsStart()); }, 1000);
     setTimeout(() => { dispatch(updateStakepoolPurchaseInformation()); }, 1000);
     setTimeout(() => { dispatch(getDecodeMessageServiceAttempt()); }, 1000);
+    setTimeout(() => { dispatch(publishUnminedTransactionsAttempt()); }, 1000);
 
     var goHomeCb = () => {
       setTimeout(() => { dispatch(pushHistory("/home")); }, 1000);

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -499,10 +499,12 @@ export const PUBLISHUNMINEDTRANSACTIONS_FAILED = "PUBLISHUNMINEDTRANSACTIONS_FAI
 
 export const publishUnminedTransactionsAttempt = () => (dispatch, getState) => {
   dispatch({ type: PUBLISHUNMINEDTRANSACTIONS_ATTEMPT });
-
-  wallet.publishUnminedTransactions(sel.walletService(getState()))
-    .then(() => dispatch({ type: PUBLISHUNMINEDTRANSACTIONS_SUCCESS }))
-    .catch(error => dispatch({ error, type: PUBLISHUNMINEDTRANSACTIONS_FAILED }));
+  const { grpc: { unminedTransactions } } = getState();
+  if (unminedTransactions && unminedTransactions.length > 0) {
+    wallet.publishUnminedTransactions(sel.walletService(getState()))
+      .then(() => dispatch({ type: PUBLISHUNMINEDTRANSACTIONS_SUCCESS }))
+      .catch(error => dispatch({ error, type: PUBLISHUNMINEDTRANSACTIONS_FAILED }));
+  }
 };
 
 export const MODAL_SHOWN = "MODAL_SHOWN";

--- a/app/main_dev/templates.js
+++ b/app/main_dev/templates.js
@@ -1,13 +1,9 @@
 import { app, shell, BrowserWindow } from "electron";
-import { getGlobalCfg } from "../config";
-import { createLogger } from "./logging";
 import { cleanShutdown, GetDcrdPID, GetDcrwPID, readExesVersion } from "./launch";
 import { getDirectoryLogs, getDcrwalletPath, getDcrdPath } from "./paths";
 
 let versionWin = null;
 let grpcVersions = { requiredVersion: null, walletVersion: null };
-
-const logger = createLogger();
 
 const darwinTemplate = (mainWindow, locale) => [
   {


### PR DESCRIPTION
To avoid users having to manually click the button to rebroadcast, I've added a check on startup to see if there are any unmined then issue publishUnminedTransactions if so.

Also includes a small lint-fix that was merged to master.