### PR TITLE
Update devtools installer

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -96,7 +96,9 @@ const installExtensions = async () => {
     for (const name of extensions) { // eslint-disable-line
       try {
         await installer.default(installer[name], forceDownload);
-      } catch (e) { } // eslint-disable-line
+      } catch (e) {
+        console.log("Error installing extesion: " + e);
+      }
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "axios": "^0.15.3",
     "css-loader": "^0.28.4",
     "electron-builder": "^19.45.0",
-    "electron-devtools-installer": "^2.0.1",
+    "electron-devtools-installer": "^2.2.4",
     "eslint-import-resolver-webpack": "^0.8.3",
     "ini": "^1.3.4",
     "is-running": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3042,9 +3042,9 @@ electron-chromedriver@~1.7.1:
     electron-download "^4.1.0"
     extract-zip "^1.6.5"
 
-electron-devtools-installer@^2.0.1:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.3.tgz#58b9a4ec507377bc46e091cd43714188e0c369be"
+electron-devtools-installer@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz#261a50337e37121d338b966f07922eb4939a8763"
   dependencies:
     "7zip" "0.0.6"
     cross-unzip "0.0.2"


### PR DESCRIPTION
Required after the bump to electron 2 to install the react/redux dev tools.