### PR TITLE
Fix error message check for already opened wallet

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -113,7 +113,7 @@ export const openWalletAttempt = (pubPass, retryAttempt) => (dispatch, getState)
       dispatch({ type: OPENWALLET_SUCCESS });
     })
     .catch(error => {
-      if (error.message.includes("wallet already loaded")) {
+      if (error.message.includes("wallet already")) {
         dispatch({ response: {}, type: OPENWALLET_SUCCESS });
       } else if (error.message.includes("invalid passphrase") && error.message.includes("public key")) {
         if (retryAttempt) {


### PR DESCRIPTION
There was a slight change in wording (wallet already loaded --> wallet already opened), which made it not catch the error properly on reload.