### PR TITLE
Import stakepool create wallet

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -29,8 +29,13 @@ export const GETWALLETSERVICE_FAILED = "GETWALLETSERVICE_FAILED";
 export const GETWALLETSERVICE_SUCCESS = "GETWALLETSERVICE_SUCCESS";
 
 function getWalletServiceSuccess(walletService) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch({ walletService, type: GETWALLETSERVICE_SUCCESS });
+  };
+}
+
+export function startWalletServices() {
+  return (dispatch, getState) => {
     setTimeout(() => { dispatch(loadActiveDataFiltersAttempt()); }, 1000);
     setTimeout(() => { dispatch(getNextAddressAttempt(0)); }, 1000);
     setTimeout(() => { dispatch(getTicketPriceAttempt()); }, 1000);
@@ -40,6 +45,9 @@ function getWalletServiceSuccess(walletService) {
     setTimeout(() => { dispatch(accountNtfnsStart()); }, 1000);
     setTimeout(() => { dispatch(updateStakepoolPurchaseInformation()); }, 1000);
     setTimeout(() => { dispatch(getDecodeMessageServiceAttempt()); }, 1000);
+    setTimeout(() => { dispatch(getTicketBuyerServiceAttempt()); }, 1000);
+    setTimeout(() => { dispatch(getVotingServiceAttempt()); }, 1000);
+    setTimeout(() => { dispatch(getAgendaServiceAttempt()); }, 1000);
 
     var goHomeCb = () => {
       setTimeout(() => { dispatch(pushHistory("/home")); }, 1000);

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -75,7 +75,7 @@ export const updateStakepoolPurchaseInformation = () => (dispatch, getState) =>
     }
   ));
 
-export const setStakePoolInformation = (privpass, poolHost, apiKey, accountNum, internal) =>
+export const setStakePoolInformation = (privpass, poolHost, apiKey, accountNum, internal, creatingWallet) =>
   (dispatch) => {
     wallet.allowStakePoolHost(poolHost);
     if (!internal) dispatch({ type: UPDATESTAKEPOOLCONFIG_ATTEMPT });
@@ -84,7 +84,7 @@ export const setStakePoolInformation = (privpass, poolHost, apiKey, accountNum, 
         if (status === "success") {
           dispatch(
             importScriptAttempt(
-              privpass, data.Script, true, 0, data.TicketAddress,
+              privpass, data.Script, !creatingWallet, 0, data.TicketAddress,
               (error) => error
                 ? dispatch({ error, type: UPDATESTAKEPOOLCONFIG_FAILED })
                 : dispatch(updateSavedConfig(data, poolHost, apiKey, accountNum))

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -210,7 +210,7 @@ export const discoverAddressAttempt = (privPass) => (dispatch, getState) => {
   dispatch({ type: DISCOVERADDRESS_ATTEMPT });
   discoverAddresses(loader, !discoverAccountsComplete, privPass)
     .then(() => {
-      const { subscribeBlockNtfnsResponse } = getState().walletLoader;
+      //const { subscribeBlockNtfnsResponse } = getState().walletLoader;
 
       if (!discoverAccountsComplete) {
         const config = getWalletCfg(isTestNet(getState()), walletName);
@@ -220,7 +220,7 @@ export const discoverAddressAttempt = (privPass) => (dispatch, getState) => {
       }
 
       dispatch({ response: {}, type: DISCOVERADDRESS_SUCCESS });
-      if (subscribeBlockNtfnsResponse !== null) dispatch(fetchHeadersAttempt());
+      //if (subscribeBlockNtfnsResponse !== null) dispatch(fetchHeadersAttempt());
     })
     .catch(error => {
       if (error.message.includes("invalid passphrase") && error.message.includes("private key")) {

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -213,17 +213,18 @@ export const discoverAddressAttempt = (privPass) => (dispatch, getState) => {
   dispatch({ type: DISCOVERADDRESS_ATTEMPT });
   discoverAddresses(loader, !discoverAccountsComplete, privPass)
     .then(() => {
-      //const { subscribeBlockNtfnsResponse } = getState().walletLoader;
 
       if (!discoverAccountsComplete) {
         const config = getWalletCfg(isTestNet(getState()), walletName);
         config.delete("discoveraccounts");
         config.set("discoveraccounts", true);
         dispatch({ complete: true, type: UPDATEDISCOVERACCOUNTS });
+      } else {
+        const { subscribeBlockNtfnsResponse } = getState().walletLoader;
+        if (subscribeBlockNtfnsResponse !== null) dispatch(fetchHeadersAttempt());
       }
 
-      dispatch({ response: {}, type: DISCOVERADDRESS_SUCCESS });
-      //if (subscribeBlockNtfnsResponse !== null) dispatch(fetchHeadersAttempt());
+      dispatch({ response: {}, complete: discoverAccountsComplete, type: DISCOVERADDRESS_SUCCESS });
     })
     .catch(error => {
       if (error.message.includes("invalid passphrase") && error.message.includes("private key")) {

--- a/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
@@ -10,10 +10,11 @@ const CreateForm = ({
   onReturnToWalletSelection,
   onReturnToExistingOrNewScreen,
   onSetCreateWalletFromExisting,
+  onSetWalletPrivatePassphrase,
   getCurrentBlockCount,
   getNeededBlocks,
   getEstimatedTimeLeft,
-  getDaemonSynced
+  getDaemonSynced,
 }) => (
   (availableWallets.length == 0 && existingOrNew) || !createNewWallet ?
     <ExistingOrNewScreen {...{ onSetCreateWalletFromExisting,
@@ -21,7 +22,8 @@ const CreateForm = ({
       getCurrentBlockCount,
       getNeededBlocks,
       getEstimatedTimeLeft,
-      getDaemonSynced }} /> :
+      getDaemonSynced,
+      onSetWalletPrivatePassphrase }} /> :
     <CreateWalletForm {...{
       onReturnToNewSeed,
       onReturnToExistingOrNewScreen,
@@ -29,6 +31,7 @@ const CreateForm = ({
       getCurrentBlockCount,
       getNeededBlocks,
       getEstimatedTimeLeft,
+      onSetWalletPrivatePassphrase
     } }/>
 );
 

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
@@ -149,7 +149,7 @@ class CreateWalletForm extends React.Component {
 
     if (!this.isValid()) return;
     createWalletRequest(pubpass, passPhrase, seed, !!createWalletExisting);
-    onSetWalletPrivatePassphrase && onSetWalletPrivatePassphrase(passPhrase);
+    !!createWalletExisting && onSetWalletPrivatePassphrase && onSetWalletPrivatePassphrase(passPhrase);
   }
 
   isValid() {

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
@@ -141,13 +141,15 @@ class CreateWalletForm extends React.Component {
   onCreateWallet() {
     const {
       createWalletExisting,
-      createWalletRequest
+      createWalletRequest,
+      onSetWalletPrivatePassphrase
     } = this.props;
     const { seed, passPhrase } = this.state;
     const pubpass = ""; // Temporarily disabled?
 
     if (!this.isValid()) return;
     createWalletRequest(pubpass, passPhrase, seed, !!createWalletExisting);
+    onSetWalletPrivatePassphrase && onSetWalletPrivatePassphrase(passPhrase);
   }
 
   isValid() {

--- a/app/components/views/GetStartedPage/DiscoverAddresses/Form.js
+++ b/app/components/views/GetStartedPage/DiscoverAddresses/Form.js
@@ -12,13 +12,13 @@ const messages = defineMessages({
 
 const DiscoverAddressesFormBodyBase = ({
   passPhrase,
-  isInputRequest,
+  isDiscoverAddressAttempt,
   intl,
   onSetPassPhrase,
   onDiscoverAddresses,
   onKeyDown
 }) => (
-  isInputRequest ? (
+  !isDiscoverAddressAttempt ? (
     <Aux>
       <div className="advanced-page-form">
         <div className="advanced-daemon-row">

--- a/app/components/views/GetStartedPage/DiscoverAddresses/index.js
+++ b/app/components/views/GetStartedPage/DiscoverAddresses/index.js
@@ -14,6 +14,14 @@ class DiscoverAddressesBody extends React.Component {
     this.resetState();
   }
 
+  componentDidMount() {
+    if (this.props.walletPrivatePassphrase) {
+      console.log("has private passphrase");
+      // this.state.passPhrase = props.walletPrivatePassphrase;
+      this.props.onDiscoverAddresses(this.props.walletPrivatePassphrase);
+    }
+  }
+
   getInitialState() {
     return {
       passPhrase: "",
@@ -48,11 +56,16 @@ class DiscoverAddressesBody extends React.Component {
   }
 
   onDiscoverAddresses() {
-    if (!this.state.passPhrase) {
+    const { passPhrase } = this.state;
+
+    if (!passPhrase) {
       return this.setState({ hasAttemptedDiscover: true });
     }
 
-    this.props.onDiscoverAddresses(this.state.passPhrase);
+    const { onDiscoverAddresses, onSetWalletPrivatePassphrase } = this.props;
+
+    onSetWalletPrivatePassphrase && onSetWalletPrivatePassphrase(passPhrase);
+    onDiscoverAddresses(passPhrase);
     this.resetState();
   }
 

--- a/app/components/views/GetStartedPage/DiscoverAddresses/index.js
+++ b/app/components/views/GetStartedPage/DiscoverAddresses/index.js
@@ -16,8 +16,6 @@ class DiscoverAddressesBody extends React.Component {
 
   componentDidMount() {
     if (this.props.walletPrivatePassphrase) {
-      console.log("has private passphrase");
-      // this.state.passPhrase = props.walletPrivatePassphrase;
       this.props.onDiscoverAddresses(this.props.walletPrivatePassphrase);
     }
   }

--- a/app/components/views/GetStartedPage/StakePools/Form.js
+++ b/app/components/views/GetStartedPage/StakePools/Form.js
@@ -1,31 +1,69 @@
-import { Tooltip } from "shared";
-import { LoaderBarBottom } from "indicators";
-import { InvisibleButton } from "buttons";
+import { KeyBlueButton, InvisibleButton } from "buttons";
+import { FormattedMessage as T, defineMessages, injectIntl } from "react-intl";
+import { TextInput, StakePoolSelect } from "inputs";
+import { Documentation } from "shared";
 
-export default ({
-  onHideReleaseNotes,
-  onShowSettings,
-  onShowLogs,
-  getCurrentBlockCount,
-  getNeededBlocks,
-  getEstimatedTimeLeft,
-  appVersion
+const messages = defineMessages({
+  apiKeyPlaceholder: {
+    id: "getStartedStake.apiKeyPlaceholder",
+    defaultMessage: "Typically starts with ‘eyJhb…’"
+  }
+});
+
+const Form = ({
+  selectedUnconfigured,
+  unconfiguredStakePools,
+  intl,
+  apiKey,
+  onChangeSelectedUnconfigured,
+  onChangeApiKey,
 }) => (
-  <div className="page-body getstarted">
-    <div className="getstarted loader logs">
-      <div className="content-title">
-        <div className="loader-settings-logs">
-          <InvisibleButton onClick={onShowSettings}>
-            <T id="getStarted.btnSettings" m="Settings" />
-          </InvisibleButton>
-          <InvisibleButton onClick={onShowLogs}>
-            <T id="getStarted.btnLogs" m="Logs" />
+  <Aux>
+    <div className="advanced-page-form">
+      <div className="advanced-daemon-row">
+        <div className="stakepool-add-area-left">
+          <div className="stakepool-field">
+            <div className="stakepool-field-label">
+              <T id="stakepool.label" m="Stakepool" />:
+            </div>
+            <div className="stakepool-field-value">
+              <StakePoolSelect
+                options={unconfiguredStakePools}
+                value={selectedUnconfigured}
+                onChange={onChangeSelectedUnconfigured}
+              />
+            </div>
+          </div>
+          <div className="stakepool-field">
+            <div className="stakepool-field-label">
+              <T id="stakepool.apikey" m="API Key" />:
+            </div>
+            <div className="stakepool-field-value">
+              <TextInput
+                type="text"
+                className="stakepool-add-apikey"
+                placeholder={intl.formatMessage(messages.apiKeyPlaceholder)}
+                value={apiKey}
+                onChange={e => onChangeApiKey(e.target.value)}
+              />
+            </div>
+            <div className="stakepool-field-value-error">
+              {apiKey ? null : <T id="stake.addPool.errors.noApiKey" m="*Please enter your API key" /> }
+            </div>
+          </div>
+          <KeyBlueButton onClick={() => {}}>
+            <T id="getStarted.stakePools.addBtn" m="Add" />
+          </KeyBlueButton>
+          <InvisibleButton onClick={() => {}}>
+            <T id="getStarted.stakePools.continueBtn" m="Continue" />
           </InvisibleButton>
         </div>
-        <Tooltip text={ <T id="logs.goBack" m="Go back" /> }><div className="go-back-screen-button" onClick={onHideReleaseNotes}/></Tooltip>
-        <T id="getStarted.logsTitle" m="Decrediton v{version} Released" values={{ version: (appVersion) }}/>
       </div>
-      <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft }}  />
+      <div className="stakepool-add-area-right">
+        <T id="getStarted.stakePools.info" m="Add your existing stakepools APIs here. You can always add them later if you want." />
+      </div>
     </div>
-  </div>
+  </Aux>
 );
+
+export default injectIntl(Form);

--- a/app/components/views/GetStartedPage/StakePools/Form.js
+++ b/app/components/views/GetStartedPage/StakePools/Form.js
@@ -1,0 +1,31 @@
+import { Tooltip } from "shared";
+import { LoaderBarBottom } from "indicators";
+import { InvisibleButton } from "buttons";
+
+export default ({
+  onHideReleaseNotes,
+  onShowSettings,
+  onShowLogs,
+  getCurrentBlockCount,
+  getNeededBlocks,
+  getEstimatedTimeLeft,
+  appVersion
+}) => (
+  <div className="page-body getstarted">
+    <div className="getstarted loader logs">
+      <div className="content-title">
+        <div className="loader-settings-logs">
+          <InvisibleButton onClick={onShowSettings}>
+            <T id="getStarted.btnSettings" m="Settings" />
+          </InvisibleButton>
+          <InvisibleButton onClick={onShowLogs}>
+            <T id="getStarted.btnLogs" m="Logs" />
+          </InvisibleButton>
+        </div>
+        <Tooltip text={ <T id="logs.goBack" m="Go back" /> }><div className="go-back-screen-button" onClick={onHideReleaseNotes}/></Tooltip>
+        <T id="getStarted.logsTitle" m="Decrediton v{version} Released" values={{ version: (appVersion) }}/>
+      </div>
+      <LoaderBarBottom  {...{ getCurrentBlockCount, getNeededBlocks, getEstimatedTimeLeft }}  />
+    </div>
+  </div>
+);

--- a/app/components/views/GetStartedPage/StakePools/Form.js
+++ b/app/components/views/GetStartedPage/StakePools/Form.js
@@ -23,64 +23,63 @@ const Form = ({
   onChangePassPhrase,
   onContinueCreation,
 }) => (
-  <Aux>
-    <div className="advanced-page-form">
-      <div className="advanced-daemon-row">
-        <div className="stakepool-add-area-left">
-          <div className="stakepool-field">
-            <div className="stakepool-field-label">
-              <T id="stakepool.label" m="Stakepool" />:
-            </div>
-            <div className="stakepool-field-value">
-              <StakePoolSelect
-                options={unconfiguredStakePools}
-                value={selectedUnconfigured}
-                onChange={onChangeSelectedUnconfigured}
-              />
-            </div>
+  <div className="">
+    <div className="getstarted-stakepool-add-row">
+      <div className="getstarted-stakepool-add-col left">
+        <div className="field">
+          <div className="label">
+            <T id="getStarted.stakepool.label" m="Stakepool" />:
           </div>
-          <div className="stakepool-field">
-            <div className="stakepool-field-label">
-              <T id="stakepool.apikey" m="API Key" />:
-            </div>
-            <div className="stakepool-field-value">
-              <TextInput
-                type="text"
-                className="stakepool-add-apikey"
-                placeholder={intl.formatMessage(messages.apiKeyPlaceholder)}
-                value={apiKey}
-                onChange={e => onChangeApiKey(e.target.value)}
-              />
-            </div>
-            <div className="stakepool-field-value-error">
-              {apiKey ? null : <T id="stake.addPool.errors.noApiKey" m="*Please enter your API key" /> }
-            </div>
+          <div className="value">
+            <StakePoolSelect
+              options={unconfiguredStakePools}
+              value={selectedUnconfigured}
+              onChange={onChangeSelectedUnconfigured}
+            />
           </div>
-          { walletPrivatePassphrase ? null :
-            <div className="stakepool-field">
-              <div className="stakepool-field-label">
-                <T id="stakepool.passPhrase" m="Private Passphrase" />:
-              </div>
-              <div className="stakepool-field-value">
-                <PasswordInput
-                  value={passPhrase}
-                  onChange={e => onChangePassPhrase(e.target.value)}
-                />
-              </div>
-            </div> }
-          <KeyBlueButton onClick={onSetStakePoolInfo} loading={isSavingStakePoolConfig} disabled={isSavingStakePoolConfig}>
-            <T id="getStarted.stakePools.addBtn" m="Add" />
-          </KeyBlueButton>
-          <InvisibleButton onClick={onContinueCreation}>
-            <T id="getStarted.stakePools.continueBtn" m="Continue" />
-          </InvisibleButton>
         </div>
+        <div className="field">
+          <div className="label">
+            <T id="stakepool.apikey" m="API Key" />:
+          </div>
+          <div className="value">
+            <TextInput
+              type="text"
+              className="stakepool-add-apikey"
+              placeholder={intl.formatMessage(messages.apiKeyPlaceholder)}
+              value={apiKey}
+              onChange={e => onChangeApiKey(e.target.value)}
+            />
+          </div>
+        </div>
+        { walletPrivatePassphrase ? null :
+          <div className="field">
+            <div className="label">
+              <T id="stakepool.passPhrase" m="Private Passphrase" />:
+            </div>
+            <div className="value">
+              <PasswordInput
+                value={passPhrase}
+                onChange={e => onChangePassPhrase(e.target.value)}
+              />
+            </div>
+          </div> }
       </div>
-      <div className="stakepool-add-area-right">
-        <T id="getStarted.stakePools.info" m="Add your existing stakepools APIs here. You can always add them later if you want." />
+
+      <div className="getstarted-stakepool-add-col right">
+        <T id="getStarted.stakePools.info" m="Add your existing stakepools APIs here. You can always add them later if you want. After you're done, you can press 'continue'." />
       </div>
     </div>
-  </Aux>
+
+    <div className="getstarted-stakepool-add-buttons">
+      <KeyBlueButton onClick={onSetStakePoolInfo} loading={isSavingStakePoolConfig} disabled={isSavingStakePoolConfig}>
+        <T id="getStarted.stakePools.addBtn" m="Add" />
+      </KeyBlueButton>
+      <InvisibleButton onClick={onContinueCreation}>
+        <T id="getStarted.stakePools.continueBtn" m="Continue" />
+      </InvisibleButton>
+    </div>
+  </div>
 );
 
 export default injectIntl(Form);

--- a/app/components/views/GetStartedPage/StakePools/Form.js
+++ b/app/components/views/GetStartedPage/StakePools/Form.js
@@ -1,7 +1,6 @@
 import { KeyBlueButton, InvisibleButton } from "buttons";
 import { FormattedMessage as T, defineMessages, injectIntl } from "react-intl";
-import { TextInput, StakePoolSelect } from "inputs";
-import { Documentation } from "shared";
+import { TextInput, StakePoolSelect, PasswordInput } from "inputs";
 
 const messages = defineMessages({
   apiKeyPlaceholder: {
@@ -15,8 +14,14 @@ const Form = ({
   unconfiguredStakePools,
   intl,
   apiKey,
+  isSavingStakePoolConfig,
+  walletPrivatePassphrase,
+  passPhrase,
   onChangeSelectedUnconfigured,
   onChangeApiKey,
+  onSetStakePoolInfo,
+  onChangePassPhrase,
+  onContinueCreation,
 }) => (
   <Aux>
     <div className="advanced-page-form">
@@ -51,10 +56,22 @@ const Form = ({
               {apiKey ? null : <T id="stake.addPool.errors.noApiKey" m="*Please enter your API key" /> }
             </div>
           </div>
-          <KeyBlueButton onClick={() => {}}>
+          { walletPrivatePassphrase ? null :
+            <div className="stakepool-field">
+              <div className="stakepool-field-label">
+                <T id="stakepool.passPhrase" m="Private Passphrase" />:
+              </div>
+              <div className="stakepool-field-value">
+                <PasswordInput
+                  value={passPhrase}
+                  onChange={e => onChangePassPhrase(e.target.value)}
+                />
+              </div>
+            </div> }
+          <KeyBlueButton onClick={onSetStakePoolInfo} loading={isSavingStakePoolConfig} disabled={isSavingStakePoolConfig}>
             <T id="getStarted.stakePools.addBtn" m="Add" />
           </KeyBlueButton>
-          <InvisibleButton onClick={() => {}}>
+          <InvisibleButton onClick={onContinueCreation}>
             <T id="getStarted.stakePools.continueBtn" m="Continue" />
           </InvisibleButton>
         </div>

--- a/app/components/views/GetStartedPage/StakePools/index.js
+++ b/app/components/views/GetStartedPage/StakePools/index.js
@@ -1,0 +1,3 @@
+import Form from "./Form";
+
+export default Form;

--- a/app/components/views/GetStartedPage/StakePools/index.js
+++ b/app/components/views/GetStartedPage/StakePools/index.js
@@ -11,7 +11,8 @@ class StakePoolsBody extends React.Component {
     this.state = {
       isAdding: false,
       apiKey: "",
-      selectedUnconfigured: this.props.unconfiguredStakePools[0]
+      selectedUnconfigured: this.props.unconfiguredStakePools[0],
+      passPhrase: "",
     };
     if (!props.updatedStakePoolList && this.getStakepoolListingEnabled()) {
       this.props.discoverAvailableStakepools();
@@ -41,10 +42,39 @@ class StakePoolsBody extends React.Component {
     this.setState({ apiKey });
   }
 
-  onSetStakePoolInfo(privpass) {
-    const { apiKey } = this.state;
-    const onSetInfo = this.props.onSetStakePoolInfo;
-    apiKey ? (onSetInfo && onSetInfo(privpass, this.getSelectedUnconfigured().Host, apiKey, 0)) : null;
+  onChangePassPhrase(passPhrase) {
+    this.setState({ passPhrase });
+  }
+
+  onContinueCreation() {
+    if (this.state.passPhrase) {
+      const { onSetWalletPrivatePassphrase } = this.props;
+      onSetWalletPrivatePassphrase && onSetWalletPrivatePassphrase(this.state.passPhrase);
+    }
+    this.props.onFetchHeaders();
+  }
+
+  onSetStakePoolInfo() {
+    const { apiKey, passPhrase } = this.state;
+    if (!apiKey) {
+      return;
+    }
+
+    const pool = this.getSelectedUnconfigured();
+    if (!pool) {
+      return;
+    }
+
+    // walletPrivatePassphrase is filled when this page is loaded immediately
+    // after creating/importing a wallet. On reloads, it will be empty, so we
+    // provide a local option for inputing (passPhrase state var).
+    const { walletPrivatePassphrase } = this.props;
+    const { onSetStakePoolInfo } = this.props;
+    const host = pool.Host;
+    const privPass = passPhrase ? passPhrase : walletPrivatePassphrase;
+
+    onSetStakePoolInfo(privPass, host, apiKey, 0, false, true);
+    this.setState({ apiKey: "" });
   }
 
   render() {
@@ -70,6 +100,8 @@ class StakePoolsBody extends React.Component {
             onSaveStakePool: null,
             onSetStakePoolInfo: null,
             onChangeSelectedUnconfigured: null,
+            onChangePassPhrase: null,
+            onContinueCreation: null,
           }, this),
         }}
       />

--- a/app/components/views/GetStartedPage/StakePools/index.js
+++ b/app/components/views/GetStartedPage/StakePools/index.js
@@ -1,3 +1,80 @@
+import { substruct, compose, eq, get } from "fp";
+import { stakePools } from "connectors";
+import { EnableExternalRequestButton } from "buttons";
+import { EXTERNALREQUEST_STAKEPOOL_LISTING } from "main_dev/externalRequests";
 import Form from "./Form";
 
-export default Form;
+@autobind
+class StakePoolsBody extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isAdding: false,
+      apiKey: "",
+      selectedUnconfigured: this.props.unconfiguredStakePools[0]
+    };
+    if (!props.updatedStakePoolList && this.getStakepoolListingEnabled()) {
+      this.props.discoverAvailableStakepools();
+    }
+  }
+
+  getNoAvailableStakepools() {
+    return (this.props.unconfiguredStakePools.length === 0) && (this.props.configuredStakePools.length === 0);
+  }
+
+  getStakepoolListingEnabled() {
+    return this.props.stakePoolListingEnabled;
+  }
+
+  getSelectedUnconfigured() {
+    const pool = this.state.selectedUnconfigured;
+    return pool
+      ? this.props.unconfiguredStakePools.find(compose(eq(pool.Host), get("Host")))
+      : null;
+  }
+
+  onChangeSelectedUnconfigured(selectedUnconfigured) {
+    this.setState({ selectedUnconfigured });
+  }
+
+  onChangeApiKey(apiKey) {
+    this.setState({ apiKey });
+  }
+
+  onSetStakePoolInfo(privpass) {
+    const { apiKey } = this.state;
+    const onSetInfo = this.props.onSetStakePoolInfo;
+    apiKey ? (onSetInfo && onSetInfo(privpass, this.getSelectedUnconfigured().Host, apiKey, 0)) : null;
+  }
+
+  render() {
+    if (this.getNoAvailableStakepools() && !this.getStakepoolListingEnabled()) {
+      return (
+        <div>
+          <p><T id="stake.enableStakePoolListing.description" m="StakePool listing from external API endpoint is currently disabled. Please enable the access to this third party service or manually configure the stakepool." /></p>
+          <EnableExternalRequestButton requestType={EXTERNALREQUEST_STAKEPOOL_LISTING}>
+            <T id="stake.enableStakePoolListing.button" m="Enable StakePool Listing" />
+          </EnableExternalRequestButton>
+        </div>
+      );
+    }
+
+    return (
+      <Form
+        {...{
+          ...this.props,
+          ...this.state,
+          selectedUnconfigured: this.getSelectedUnconfigured(),
+          ...substruct({
+            onChangeApiKey: null,
+            onSaveStakePool: null,
+            onSetStakePoolInfo: null,
+            onChangeSelectedUnconfigured: null,
+          }, this),
+        }}
+      />
+    );
+  }
+}
+
+export default stakePools(StakePoolsBody);

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -19,7 +19,8 @@ class GetStartedPage extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { showSettings: false, showLogs: false, showReleaseNotes: false };
+    this.state = { showSettings: false, showLogs: false, showReleaseNotes: false,
+      walletPrivatePassphrase: "" };
   }
 
   componentDidMount() {
@@ -45,6 +46,11 @@ class GetStartedPage extends React.Component {
         onRetryStartRPC();
     }
   }
+
+  componentWillUnmount() {
+    this.setState({ walletPrivatePassphrase: "" });
+  }
+
   onShowReleaseNotes() {
     this.setState({ showSettings: false, showLogs: false, showReleaseNotes: true });
   }
@@ -67,6 +73,10 @@ class GetStartedPage extends React.Component {
 
   onHideLogs() {
     this.setState({ showLogs: false });
+  }
+
+  onSetWalletPrivatePassphrase(walletPrivatePassphrase) {
+    this.setState({ walletPrivatePassphrase });
   }
 
   render() {
@@ -95,7 +105,8 @@ class GetStartedPage extends React.Component {
       onShowSettings,
       onHideSettings,
       onShowLogs,
-      onHideLogs
+      onHideLogs,
+      onSetWalletPrivatePassphrase
     } = this;
 
     let text, Form;
@@ -121,7 +132,7 @@ class GetStartedPage extends React.Component {
         if (hasExistingWallet) {
           Form = OpenWallet;
         } else {
-          return <CreateWallet {...props} />;
+          return <CreateWallet {...{ ...props, onSetWalletPrivatePassphrase }} />;
         }
         break;
       case 3:
@@ -164,7 +175,8 @@ class GetStartedPage extends React.Component {
         onShowSettings,
         onHideSettings,
         onShowLogs,
-        onHideLogs
+        onHideLogs,
+        onSetWalletPrivatePassphrase
       }} />;
   }
 }

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -10,6 +10,7 @@ import { DiscoverAddressesBody } from "./DiscoverAddresses";
 import { FetchBlockHeadersBody } from "./FetchBlockHeaders";
 import { AdvancedStartupBody, RemoteAppdataError } from "./AdvancedStartup";
 import { RescanWalletBody } from "./RescanWallet/index";
+import StakePoolsBody from "./StakePools";
 import { walletStartup } from "connectors";
 import { FormattedMessage as T } from "react-intl";
 
@@ -133,10 +134,14 @@ class GetStartedPage extends React.Component {
         Form = DiscoverAddressesBody;
         break;
       case 6:
+        text = <T id="getStarted.header.stakePools.meta" m="Import StakePools" />;
+        Form = StakePoolsBody;
+        break;
+      case 7:
         text = <T id="getStarted.header.fetchingBlockHeaders.meta" m="Fetching block headers" />;
         Form = FetchBlockHeadersBody;
         break;
-      case 7:
+      case 8:
         text = <T id="getStarted.header.rescanWallet.meta" m="Scanning blocks for transactions" />;
         Form = RescanWalletBody;
         break;

--- a/app/connectors/stakePools.js
+++ b/app/connectors/stakePools.js
@@ -11,7 +11,8 @@ const mapStateToProps = selectorMap({
   stakePool: sel.selectedStakePool,
   rescanRequest: sel.rescanRequest,
   stakePoolListingEnabled: sel.stakePoolListingEnabled,
-  updatedStakePoolList: sel.updatedStakePoolList
+  updatedStakePoolList: sel.updatedStakePoolList,
+  isSavingStakePoolConfig: sel.isSavingStakePoolConfig,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -63,6 +63,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onOpenWallet: wla.openWalletAttempt,
   onRetryStartRPC: wla.startRpcRequestFunc,
   doVersionCheck: wla.versionCheckAction,
+  onFetchHeaders: wla.fetchHeadersAttempt,
   onStartDaemon: da.startDaemon,
   onStartWallet: da.startWallet,
   onCreateWallet: da.createWallet,

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -12,6 +12,7 @@ const mapStateToProps = selectorMap({
   showPrivacy: sel.showPrivacy,
   startStepIndex: sel.startStepIndex,
   isInputRequest: sel.isInputRequest,
+  isDiscoverAddressAttempt: sel.isDiscoverAddressAttempt,
   startupError: sel.startupError,
   confirmNewSeed: sel.confirmNewSeed,
   existingOrNew: sel.existingOrNew,

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -214,6 +214,7 @@ export default function walletLoader(state = {}, action) {
   case FETCHHEADERS_ATTEMPT:
     return { ...state,
       fetchHeadersRequestAttempt: true,
+      stepIndex: 7,
     };
   case FETCHHEADERS_FAILED:
     return { ...state,

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -231,11 +231,11 @@ export default function walletLoader(state = {}, action) {
     };
   case RESCAN_ATTEMPT:
     return { ...state,
-      stepIndex: 7
+      stepIndex: 8
     };
   case GETSTARTUPWALLETINFO_ATTEMPT:
     return { ...state,
-      stepIndex: 8
+      stepIndex: 9
     };
   case SUBSCRIBEBLOCKNTFNS_ATTEMPT:
     return { ...state,

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -209,7 +209,7 @@ export default function walletLoader(state = {}, action) {
       discoverAddressError: null,
       discoverAddressRequestAttempt: false,
       discoverAddressResponse: true,
-      stepIndex: 6,
+      stepIndex: action.complete ? 7 : 6, // 6 = stakepool selection, 7 = fetch headers
     };
   case FETCHHEADERS_ATTEMPT:
     return { ...state,

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -191,6 +191,7 @@ export default function walletLoader(state = {}, action) {
     return { ...state,
       discoverAddressInputRequest: true,
       discoverAddressError: String(action.error),
+      discoverAddressRequestAttempt: false,
     };
   case DISCOVERADDRESS_ATTEMPT:
     return { ...state,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -114,6 +114,8 @@ export const isInputRequest = or(
   selectCreateWalletInputRequest
 );
 
+export const isDiscoverAddressAttempt = get([ "walletLoader", "discoverAddressRequestAttempt" ]);
+
 export const balances = or(get([ "grpc", "balances" ]), () => []);
 export const walletService = get([ "grpc", "walletService" ]);
 export const agendaService = get([ "grpc", "agendaService" ]);

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -638,3 +638,39 @@
 .get-started-last-log-lines {
   font-size: 9px;
 }
+
+.getstarted-stakepool-add-row {
+  float: left;
+  width: 100%;
+
+  .getstarted-stakepool-add-col {
+    padding-top: 1em;
+
+    &.left {
+      padding-right: 1em;
+    }
+
+    &.right {
+      float: left;
+      width: 27%;
+      margin-left: 100px;
+      background-color: #eee;
+      padding: 2em;
+    }
+
+    .field {
+      display: grid;
+      min-height: 2em;
+      grid-template-columns: 30% 87%;
+      margin-bottom: 2em;
+
+      .label {
+        text-align: right;
+      }
+    }
+  }
+}
+
+.getstarted-stakepool-add-buttons {
+  float: left;
+}


### PR DESCRIPTION
Fix #384 

This was a bit tricky, due to having to insert this step after discovering accounts and before the rescan, changing the way many different branches of wallet init work (regular/creating new/creating existing/creating existing partially done).

I've also changed the discover account steps to receive the wallet passphrase in case the wallet has just been created, removing the need to ask for the password again in the regular import flow. 