### PR TITLE
Show transactions received while away

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -193,10 +193,11 @@ export const getTransactionsSinceLastOppened = () => async (dispatch, getState) 
   };
   const config = getGlobalCfg();
   const lastBlockHeightSeen = config.get("last_height");
-  const { currentBlockHeight, walletService } = getState().grpc;
+  const { currentBlockHeight, walletService, recentTxSinceLastOpenedCount } = getState().grpc;
 
   try {
-    const { mined, unmined } = await walletGetTransactions(walletService, lastBlockHeightSeen, currentBlockHeight);
+    const { mined, unmined } =
+      await walletGetTransactions(walletService, lastBlockHeightSeen, currentBlockHeight, recentTxSinceLastOpenedCount);
     const transactions = [ ...mined, ...unmined ];
 
     transactions.forEach( tx => {

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -183,42 +183,41 @@ export const GETTRANSACTIONSSINCELASTOPPENED_FAILED = "GETTRANSACTIONSSINCELASTO
 export const GETTRANSACTIONSSINCELASTOPPENED_SUCCESS = "GETTRANSACTIONSSINCELASTOPPENED_SUCCESS";
 
 export const getTransactionsSinceLastOppened = () => async (dispatch, getState) => {
-  dispatch({type: GETTRANSACTIONSSINCELASTOPPENED_ATTEMPT})
-  const transactionsSinceLastOpennedInfo = {
+  dispatch({ type: GETTRANSACTIONSSINCELASTOPPENED_ATTEMPT });
+  const transactionsSinceLastOpenedInfo = {
     transactionsReceived: [],
     ticketsVoted:         [],
     ticketsRevoked:       [],
     totalReward:           0,
     totalDCR:              0,
-  }
+  };
   const config = getGlobalCfg();
   const lastBlockHeightSeen = config.get("last_height");
   const { currentBlockHeight, walletService } = getState().grpc;
-  
+
   try {
-    const { mined, unmined } = await walletGetTransactions(walletService, lastBlockHeightSeen, currentBlockHeight)
-    const transactions = [...mined, ...unmined];
+    const { mined, unmined } = await walletGetTransactions(walletService, lastBlockHeightSeen, currentBlockHeight);
+    const transactions = [ ...mined, ...unmined ];
 
     transactions.forEach( tx => {
       switch (tx.type) {
-        case TransactionDetails.TransactionType.REGULAR:
-          transactionsSinceLastOpennedInfo.totalDCR += tx.amount;
-          transactionsSinceLastOpennedInfo.transactionsReceived.push(tx);
-          break;
-        case TransactionDetails.TransactionType.VOTE:
-          transactionsSinceLastOpennedInfo.totalReward += tx.amount;
-          transactionsSinceLastOpennedInfo.ticketsVoted.push(tx);
-          break;
-        case TransactionDetails.TransactionType.REVOCATION:
-          transactionsSinceLastOpennedInfo.ticketsRevoked.push(tx);
-          break;
-        }
+      case TransactionDetails.TransactionType.REGULAR:
+        transactionsSinceLastOpenedInfo.totalDCR += tx.amount;
+        transactionsSinceLastOpenedInfo.transactionsReceived.push(tx);
+        break;
+      case TransactionDetails.TransactionType.VOTE:
+        transactionsSinceLastOpenedInfo.totalReward += tx.amount;
+        transactionsSinceLastOpenedInfo.ticketsVoted.push(tx);
+        break;
+      case TransactionDetails.TransactionType.REVOCATION:
+        transactionsSinceLastOpenedInfo.ticketsRevoked.push(tx);
+        break;
+      }
     });
-    dispatch({transactionsSinceLastOpenned: transactionsSinceLastOpennedInfo, type: GETTRANSACTIONSSINCELASTOPPENED_SUCCESS})
+    dispatch({ transactionsSinceLastOpened: transactionsSinceLastOpenedInfo, type: GETTRANSACTIONSSINCELASTOPPENED_SUCCESS });
   } catch (error) {
-    dispatch({error, type: GETTRANSACTIONSSINCELASTOPPENED_FAILED})
+    dispatch({ error, type: GETTRANSACTIONSSINCELASTOPPENED_FAILED });
   }
-  
 };
 
 export const GETTICKETBUYERSERVICE_ATTEMPT = "GETTICKETBUYERSERVICE_ATTEMPT";

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -9,7 +9,7 @@ import { updateStakepoolPurchaseInformation, setStakePoolVoteChoices } from "./S
 import { getDecodeMessageServiceAttempt } from "./DecodeMessageActions";
 import { showSidebarMenu, showSidebar } from "./SidebarActions";
 import { push as pushHistory, goBack } from "react-router-redux";
-import { getWalletCfg } from "../config";
+import { getWalletCfg, getGlobalCfg } from "../config";
 import { onAppReloadRequested } from "wallet";
 import { getTransactions as walletGetTransactions } from "wallet/service";
 import { TransactionDetails } from "middleware/walletrpc/api_pb";
@@ -173,7 +173,17 @@ export const getWalletServiceAttempt = () => (dispatch, getState) => {
   const { daemon: { walletName } } = getState();
   dispatch({ type: GETWALLETSERVICE_ATTEMPT });
   wallet.getWalletService(sel.isTestNet(getState()), walletName, address, port)
-    .then(walletService => dispatch(getWalletServiceSuccess(walletService)))
+    .then(async walletService => {
+      dispatch(getWalletServiceSuccess(walletService));
+      const config = getGlobalCfg();
+      const lastBlockHeight = config.get("last_height");
+      const currentBlockHeight = sel.currentBlockHeight(getState());
+      
+      const transactionsSinceLastOppenned = await walletGetTransactions(walletService, lastBlockHeight, currentBlockHeight, 0)
+      console.log(transactionsSinceLastOppenned)
+      console.log("\n\n")
+      
+    })
     .catch(error => dispatch({ error, type: GETWALLETSERVICE_FAILED }));
 };
 

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -3,7 +3,7 @@ import { stopNotifcations } from "./NotificationActions";
 import * as wallet from "wallet";
 import { push as pushHistory, goBack } from "react-router-redux";
 import { ipcRenderer } from "electron";
-import { setMustOpenForm, getWalletCfg, getAppdataPath, getRemoteCredentials, getGlobalCfg } from "../config";
+import { setMustOpenForm, getWalletCfg, getAppdataPath, getRemoteCredentials, getGlobalCfg, setLastHeight } from "../config";
 import { hideSidebarMenu, showSidebar } from "./SidebarActions";
 import { isTestNet } from "selectors";
 import axios from "axios";
@@ -165,9 +165,14 @@ export const deleteDaemonData = () => (dispatch, getState) => {
 
 export const shutdownApp = () => (dispatch, getState) => {
   const { daemon: { walletName } } = getState();
+  const { currentBlockHeight } = getState().grpc;
   const cfg = getWalletCfg(isTestNet(getState()), walletName);
   if (walletName) {
     cfg.set("lastaccess", Date.now());
+  }
+  console.log(currentBlockHeight)
+  if(currentBlockHeight) {
+    setLastHeight(currentBlockHeight);
   }
   dispatch({ type: SHUTDOWN_REQUESTED });
   dispatch(stopNotifcations());

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -170,7 +170,6 @@ export const shutdownApp = () => (dispatch, getState) => {
   if (walletName) {
     cfg.set("lastaccess", Date.now());
   }
-  console.log(currentBlockHeight)
   if(currentBlockHeight) {
     setLastHeight(currentBlockHeight);
   }

--- a/app/config.js
+++ b/app/config.js
@@ -273,6 +273,11 @@ export function setMustOpenForm(openForm) {
   return config.set("must_open_form", openForm);
 }
 
+export function setLastHeight(height) {
+  const config = getGlobalCfg();
+  return config.set("last_height", height);
+}
+
 function makeRandomString(length) {
   var text = "";
   var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";

--- a/app/index.js
+++ b/app/index.js
@@ -147,6 +147,9 @@ var initialState = {
     recentTransactionCount: 8,
     recentTransactions: Array(),
 
+    // Transactions since last opened
+    recentTxSinceLastOpenedCount: 10,
+
     // GetTransactions
     minedTransactions: Array(),
     unminedTransactions: Array(),

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -18,7 +18,8 @@ import {
   GETAGENDAS_ATTEMPT, GETAGENDAS_FAILED, GETAGENDAS_SUCCESS,
   GETVOTECHOICES_ATTEMPT, GETVOTECHOICES_FAILED, GETVOTECHOICES_SUCCESS,
   SETVOTECHOICES_ATTEMPT, SETVOTECHOICES_FAILED, SETVOTECHOICES_SUCCESS,
-  MATURINGHEIGHTS_CHANGED,
+  MATURINGHEIGHTS_CHANGED, GETTRANSACTIONSSINCELASTOPPENED_ATTEMPT, GETTRANSACTIONSSINCELASTOPPENED_FAILED,
+  GETTRANSACTIONSSINCELASTOPPENED_SUCCESS,
 } from "../actions/ClientActions";
 import { STARTUPBLOCK, WALLETREADY } from "../actions/DaemonActions";
 import { NEWBLOCKCONNECTED } from "../actions/NotificationActions";
@@ -88,6 +89,24 @@ export default function grpc(state = {}, action) {
       getTicketBuyerServiceRequestAttempt: false,
       ticketBuyerService: action.ticketBuyerService,
     };
+  case GETTRANSACTIONSSINCELASTOPPENED_ATTEMPT: 
+    return {
+      ...state,
+      getTransactionsSinceLastOpenedError: null,
+      getTransactionsSinceLastOpenedAttempt: true,
+    };
+  case GETTRANSACTIONSSINCELASTOPPENED_SUCCESS:
+    return {
+      ...state,
+      getTransactionsSinceLastOpenedAttempt: false,
+      transactionsSinceLastOpenned: action.transactionsSinceLastOpenned,
+    }
+  case GETTRANSACTIONSSINCELASTOPPENED_FAILED:
+    return {
+      ...state,
+      getTransactionsSinceLastOpenedError: String(action.error),
+      getTransactionsSinceLastOpenedAttempt: false,
+    }
   case GETBALANCE_ATTEMPT:
     return {
       ...state,

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -89,7 +89,7 @@ export default function grpc(state = {}, action) {
       getTicketBuyerServiceRequestAttempt: false,
       ticketBuyerService: action.ticketBuyerService,
     };
-  case GETTRANSACTIONSSINCELASTOPPENED_ATTEMPT: 
+  case GETTRANSACTIONSSINCELASTOPPENED_ATTEMPT:
     return {
       ...state,
       getTransactionsSinceLastOpenedError: null,
@@ -99,14 +99,14 @@ export default function grpc(state = {}, action) {
     return {
       ...state,
       getTransactionsSinceLastOpenedAttempt: false,
-      transactionsSinceLastOpenned: action.transactionsSinceLastOpenned,
-    }
+      transactionsSinceLastOpened: action.transactionsSinceLastOpened,
+    };
   case GETTRANSACTIONSSINCELASTOPPENED_FAILED:
     return {
       ...state,
       getTransactionsSinceLastOpenedError: String(action.error),
       getTransactionsSinceLastOpenedAttempt: false,
-    }
+    };
   case GETBALANCE_ATTEMPT:
     return {
       ...state,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -282,12 +282,12 @@ export const homeHistoryTransactions = createSelector(
   [ transactionsNormalizer, get([ "grpc", "recentRegularTransactions" ]) ], apply
 );
 
-const txSinceLastOpenned = get(["grpc", "transactionsSinceLastOpenned"])
+const txSinceLastOpened = get([ "grpc", "transactionsSinceLastOpened" ]);
 
-export const transactionsSinceLastOpenned = createSelector(
-  [ txSinceLastOpenned ],
-  (txSinceLastOpenned) => txSinceLastOpenned ? txSinceLastOpenned : []
-)
+export const transactionsSinceLastOpened = createSelector(
+  [ txSinceLastOpened ],
+  (txSinceLastOpened) => txSinceLastOpened ? txSinceLastOpened : []
+);
 
 export const dailyBalancesStats = get([ "statistics", "dailyBalances" ]);
 

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -282,6 +282,13 @@ export const homeHistoryTransactions = createSelector(
   [ transactionsNormalizer, get([ "grpc", "recentRegularTransactions" ]) ], apply
 );
 
+const txSinceLastOpenned = get(["grpc", "transactionsSinceLastOpenned"])
+
+export const transactionsSinceLastOpenned = createSelector(
+  [ txSinceLastOpenned ],
+  (txSinceLastOpenned) => txSinceLastOpenned ? txSinceLastOpenned : []
+)
+
 export const dailyBalancesStats = get([ "statistics", "dailyBalances" ]);
 
 export const spendableAndLockedBalance = createSelector(


### PR DESCRIPTION
fixes #911 

I removed the cleanShutdown method from before-quit, because it calls for the second time, which gives a connection error when trying to get the block height.

 Is there a reason for cleanShutdown being called there?

I am just adding these recent transactions to the selector, we still need to show it in a component.