### PR TITLE
Add config option to disable animations

### DIFF
--- a/app/components/SideBar/MenuLinks/index.js
+++ b/app/components/SideBar/MenuLinks/index.js
@@ -65,7 +65,7 @@ class MenuLinks extends React.Component {
   }
 
   render () {
-    const caret = this.props.uiAnimations ? this.getAnimatedCaret : this.getStaticCaret();
+    const caret = this.props.uiAnimations ? this.getAnimatedCaret() : this.getStaticCaret();
 
     return (
       <Aux>

--- a/app/components/SideBar/MenuLinks/index.js
+++ b/app/components/SideBar/MenuLinks/index.js
@@ -1,5 +1,5 @@
 import MenuLink from "./MenuLink";
-import { routing } from "connectors";
+import { routing, theming } from "connectors";
 import { FormattedMessage as T } from "react-intl";
 import { spring, Motion } from "react-motion";
 import theme from "theme";
@@ -52,7 +52,21 @@ class MenuLinks extends React.Component {
     return { top: spring(newTop, theme("springs.sideBar")) };
   }
 
+  getAnimatedCaret() {
+    return (
+      <Motion style={ { top: this.state.top } }>
+        { style => <div className="menu-caret" {...{ style }}/> }
+      </Motion>
+    );
+  }
+
+  getStaticCaret() {
+    return <div className="menu-caret" style={ { top: this.state.top.val } } />;
+  }
+
   render () {
+    const caret = this.props.uiAnimations ? this.getAnimatedCaret : this.getStaticCaret();
+
     return (
       <Aux>
         { linkList.map(({ path, link, icon }) =>
@@ -60,12 +74,10 @@ class MenuLinks extends React.Component {
             {link}
           </MenuLink>
         )}
-        <Motion style={ { top: this.state.top } }>
-          { style => <div className="menu-caret" {...{ style }}/> }
-        </Motion>
+        {caret}
       </Aux>
     );
   }
 }
 
-export default routing(MenuLinks);
+export default routing(theming(MenuLinks));

--- a/app/components/shared/RoutedTabsHeader.js
+++ b/app/components/shared/RoutedTabsHeader.js
@@ -1,4 +1,4 @@
-import { routing } from "connectors";
+import { routing, theming } from "connectors";
 import { NavLink as Link } from "react-router-dom";
 import { spring, Motion } from "react-motion";
 import theme from "theme";
@@ -43,6 +43,28 @@ class RoutedTabsHeader extends React.Component {
     return { caretLeft, caretWidth };
   }
 
+  getAnimatedCaret() {
+    const caretStyle = {
+      left: spring(this.state.caretLeft, theme("springs.tab")),
+      width: spring(this.state.caretWidth, theme("springs.tab")),
+    };
+
+    return (
+      <Motion style={caretStyle}>
+        { style => <div className="tabs-caret"><div className="active" style={style}></div></div> }
+      </Motion>
+    );
+  }
+
+  getStaticCaret() {
+    const style = {
+      left: this.state.caretLeft,
+      width: this.state.caretWidth,
+    };
+
+    return <div className="tabs-caret"><div className="active" style={style}></div></div>;
+  }
+
   render() {
     const { tabs } = this.props;
 
@@ -54,17 +76,12 @@ class RoutedTabsHeader extends React.Component {
       </span>
     );
 
-    const caretStyle = {
-      left: spring(this.state.caretLeft, theme("springs.tab")),
-      width: spring(this.state.caretWidth, theme("springs.tab")),
-    };
+    const caret = this.props.uiAnimations ? this.getAnimatedCaret() : this.getStaticCaret();
 
     return (
       <div className="tabs">
         {tabLinks}
-        <Motion style={caretStyle}>
-          { style => <div className="tabs-caret"><div className="active" style={style}></div></div> }
-        </Motion>
+        {caret}
       </div>
     );
   }
@@ -74,4 +91,4 @@ RoutedTabsHeader.propTypes = {
   tabs: PropTypes.array.isRequired,
 };
 
-export default routing(RoutedTabsHeader);
+export default routing(theming(RoutedTabsHeader));

--- a/app/components/shared/StaticSwitch.js
+++ b/app/components/shared/StaticSwitch.js
@@ -1,0 +1,9 @@
+import { Switch } from "react-router-dom";
+
+export default ({ className, children }) => (
+  <div className={className}>
+    <div>
+      <Switch>{children}</Switch>
+    </div>
+  </div>
+);

--- a/app/components/shared/TransitionMotionWrapper.js
+++ b/app/components/shared/TransitionMotionWrapper.js
@@ -1,11 +1,14 @@
 import { cloneElement as k, createElement as h } from "react";
 import { TransitionMotion } from "react-motion";
+import { theming } from "connectors";
+import { isFunction } from "util";
 
 const TransitionMotionWrapper = ({
   willEnter,
   willLeave,
   defaultStyles,
   styles,
+  uiAnimations,
   ...props
 }) => {
   const tmProps = { willEnter, willLeave, defaultStyles, styles };
@@ -16,6 +19,11 @@ const TransitionMotionWrapper = ({
       h("div", childProps, k(data));
   };
   const children = children => h("div", { className: props.className }, children.map(child));
+  if (!uiAnimations) {
+    const actual = isFunction(styles) ? styles(props) : styles;
+    return h(Aux, {}, children(actual));
+  }
+
   return h(TransitionMotion, tmProps, children);
 };
 
@@ -23,4 +31,4 @@ TransitionMotionWrapper.defaultProps = {
   mapStyles: val => val,
 };
 
-export default TransitionMotionWrapper;
+export default theming(TransitionMotionWrapper);

--- a/app/components/shared/index.js
+++ b/app/components/shared/index.js
@@ -8,4 +8,5 @@ export { default as ExternalLink } from "./ExternalLink";
 export { default as UnselectableText } from "./UnselectableText";
 export { default as RoutedTabsHeader } from "./RoutedTabsHeader";
 export { default as Documentation } from "./Documentation";
+export { default as StaticSwitch } from "./StaticSwitch";
 export * from "./RoutedTabsHeader";

--- a/app/config.js
+++ b/app/config.js
@@ -78,6 +78,9 @@ export function initGlobalCfg() {
   if (!config.has("set_language")) {
     config.set("set_language","true");
   }
+  if (!config.has("ui_animations")) {
+    config.set("ui_animations", true);
+  }
   if (!config.has("show_tutorial")) {
     config.set("show_tutorial","true");
   }

--- a/app/connectors/index.js
+++ b/app/connectors/index.js
@@ -43,3 +43,4 @@ export { default as modal } from "./modal";
 export { default as modalVisible } from "./modalVisible";
 export { default as locale } from "./locale";
 export { default as fatalErrorPage } from "./fatalErrorPage";
+export { default as theming } from "./theming";

--- a/app/connectors/theming.js
+++ b/app/connectors/theming.js
@@ -1,0 +1,9 @@
+import { connect } from "react-redux";
+import * as sel from "../selectors";
+import { selectorMap } from "../fp";
+
+const mapStateToProps = selectorMap({
+  uiAnimations: sel.uiAnimations,
+});
+
+export default connect(mapStateToProps);

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -2,9 +2,10 @@ import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
 import { IntlProvider } from "react-intl";
 import MUItheme from "materialUITheme";
 import { defaultFormats } from "i18n/locales";
-import app from "connectors/app";
+import { app, theming } from "connectors";
 import { Redirect, Route, Switch } from "react-router-dom";
 import { AnimatedSwitch } from "react-router-transition";
+import { StaticSwitch } from "shared";
 import GetStartedContainer from "./GetStarted";
 import WalletContainer from "./Wallet";
 import ShutdownAppPage from "components/views/ShutdownAppPage";
@@ -78,6 +79,8 @@ class App extends React.Component {
 
   render() {
     const { locale } = this.props;
+    const MainSwitch = this.props.uiAnimations ? AnimatedSwitch : StaticSwitch;
+
     return (
       <MuiThemeProvider muiTheme={MUItheme}>
         <IntlProvider
@@ -89,12 +92,12 @@ class App extends React.Component {
           <Aux>
             <Switch><Redirect from="/" exact to="/getStarted" /></Switch>
             <Snackbar/>
-            <AnimatedSwitch {...topLevelAnimation} className="top-level-container">
+            <MainSwitch {...topLevelAnimation} className="top-level-container">
               <Route path="/getStarted"  component={GetStartedContainer} />
               <Route path="/shutdown"    component={ShutdownAppPage} />
               <Route path="/error"       component={FatalErrorPage} />
               <Route path="/"            component={WalletContainer} />
-            </AnimatedSwitch>
+            </MainSwitch>
             <div id="modal-portal" />
           </Aux>
         </IntlProvider>
@@ -103,4 +106,4 @@ class App extends React.Component {
   }
 }
 
-export default app(App);
+export default app(theming(App));

--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -1,5 +1,6 @@
 import { Route } from "react-router-dom";
 import { AnimatedSwitch } from "react-router-transition";
+import { StaticSwitch } from "shared";
 import HomePage from "components/views/HomePage";
 import SettingsPage from "components/views/SettingsPage";
 import AccountsPage from "components/views/AccountsPage";
@@ -14,7 +15,7 @@ import TicketsPage from "components/views/TicketsPage";
 import TutorialsPage from "components/views/TutorialsPage";
 import SideBar from "components/SideBar";
 import { BlurableContainer } from "layout";
-import { walletContainer } from "connectors";
+import { walletContainer, theming } from "connectors";
 
 const pageAnimation = { atEnter: { opacity: 0 }, atLeave: { opacity: 0 }, atActive: { opacity: 1 } };
 
@@ -22,10 +23,12 @@ const pageAnimation = { atEnter: { opacity: 0 }, atLeave: { opacity: 0 }, atActi
 class Wallet extends React.Component {
   render() {
     const { expandSideBar } = this.props;
+    const MainSwitch = this.props.uiAnimations ? AnimatedSwitch : StaticSwitch;
+
     return (
       <BlurableContainer className="page-body">
         <SideBar />
-        <AnimatedSwitch {...pageAnimation} className={expandSideBar ? "page-view" : "page-view-reduced-bar"}>
+        <MainSwitch {...pageAnimation} className={expandSideBar ? "page-view" : "page-view-reduced-bar"}>
           <Route path="/home"                           component={HomePage} />
           <Route path="/accounts"                       component={AccountsPage} />
           <Route path="/settings"                       component={SettingsPage} />
@@ -38,10 +41,10 @@ class Wallet extends React.Component {
           <Route path="/transactions"                   component={TransactionsPage} />
           <Route path="/tickets"                        component={TicketsPage} />
           <Route path="/tutorial"                       component={TutorialsPage} />
-        </AnimatedSwitch>
+        </MainSwitch>
       </BlurableContainer>
     );
   }
 }
 
-export default walletContainer(Wallet);
+export default walletContainer(theming(Wallet));

--- a/app/index.js
+++ b/app/index.js
@@ -37,6 +37,7 @@ var initialState = {
       proxyLocation: globalCfg.get("proxy_location"),
     },
     settingsChanged: false,
+    uiAnimations: globalCfg.get("ui_animations"),
   },
   stakepool: {
     currentStakePoolConfig: null,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -623,6 +623,7 @@ export const isConstructingTransaction = bool(constructTxRequestAttempt);
 
 export const tempSettings = get([ "settings", "tempSettings" ]);
 export const settingsChanged = get([ "settings", "settingsChanged" ]);
+export const uiAnimations = get([ "settings", "uiAnimations" ]);
 export const changePassphraseError = get([ "control", "changePassphraseError" ]);
 export const changePassphraseSuccess = get([ "control", "changePassphraseSuccess" ]);
 export const updatedStakePoolList = get([ "stakepool", "updatedStakePoolList" ]);


### PR DESCRIPTION
This adds a config option (`ui_animations`) and implements the appropriate behavior to disable animations/transitions/motions when requested.

This is meant as an attempt to track down some recent bugs reported, that might be related to the animations being slow on older machines.

The option is currently not exported on the UI, since for the moment it is meant as a last resort alternative in older machines.