### PR TITLE
Remove material ui from snackbar

### DIFF
--- a/app/components/Snackbar/index.js
+++ b/app/components/Snackbar/index.js
@@ -44,12 +44,7 @@ class Snackbar extends React.Component {
     if (message !== this.state.message) {
       const state = this.state;
       this.setState({ ...state, message });
-      if (message) {
-        if (this.hideTimer) {
-          this.props.clearTimeout(this.hideTimer);
-        }
-        this.hideTimer = this.props.setTimeout(this.onDismissMessage, 4000);
-      }
+      message && this.enableHideTimer();
     }
   }
 
@@ -57,14 +52,23 @@ class Snackbar extends React.Component {
     return this.state.message !== nextState.message;
   }
 
-  onDismissMessage() {
-    const state = this.state;
-    this.setState({ ...state, message: null });
-    this.props.onDismissAllMessages();
+  enableHideTimer() {
+    this.clearHideTimer();
+    this.hideTimer = this.props.setTimeout(this.onDismissMessage, 4000);
+  }
+
+  clearHideTimer() {
     if (this.hideTimer) {
       this.props.clearTimeout(this.hideTimer);
       this.hideTimer = null;
     }
+  }
+
+  onDismissMessage() {
+    const state = this.state;
+    this.setState({ ...state, message: null });
+    this.props.onDismissAllMessages();
+    this.clearHideTimer();
   }
 
   onRequestClose(reason) {
@@ -76,7 +80,11 @@ class Snackbar extends React.Component {
   render() {
     const { message } = this.state;
     return (
-      <div className={snackbarClasses(message || "")} >
+      <div
+        className={snackbarClasses(message || "")}
+        onMouseEnter={this.clearHideTimer}
+        onMouseLeave={this.enableHideTimer}
+      >
         {message ? <Notification {...message} /> : ""}
       </div>
     );

--- a/app/components/Snackbar/index.js
+++ b/app/components/Snackbar/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { snackbar } from "connectors";
-import MUISnackbar from "material-ui/Snackbar";
+import ReactTimeout from "react-timeout";
 import Notification from "./Notification";
 import { TRANSACTION_DIR_SENT, TRANSACTION_DIR_RECEIVED,
   TRANSACTION_DIR_TRANSFERED
@@ -29,6 +29,7 @@ class Snackbar extends React.Component {
 
   constructor(props) {
     super(props);
+    this.hideTimer = null;
     this.state = {
       message: props.messages.length > 0
         ? props.messages[props.messages.length-1]
@@ -43,6 +44,12 @@ class Snackbar extends React.Component {
     if (message !== this.state.message) {
       const state = this.state;
       this.setState({ ...state, message });
+      if (message) {
+        if (this.hideTimer) {
+          this.props.clearTimeout(this.hideTimer);
+        }
+        this.hideTimer = this.props.setTimeout(this.onDismissMessage, 4000);
+      }
     }
   }
 
@@ -54,6 +61,10 @@ class Snackbar extends React.Component {
     const state = this.state;
     this.setState({ ...state, message: null });
     this.props.onDismissAllMessages();
+    if (this.hideTimer) {
+      this.props.clearTimeout(this.hideTimer);
+      this.hideTimer = null;
+    }
   }
 
   onRequestClose(reason) {
@@ -65,20 +76,13 @@ class Snackbar extends React.Component {
   render() {
     const { message } = this.state;
     return (
-      <MUISnackbar
-        className={snackbarClasses(message || "")}
-        open={!!message}
-        message={message ? <Notification {...message} /> : ""}
-        autoHideDuration={4000}
-        bodyStyle={{ backgroundColor: "inherited", fontFamily: null,
-          lineHeight: null, height: null }}
-        style={{ fontFamily: null, lineHeight: null }}
-        onRequestClose={this.onRequestClose}
-      />
+      <div className={snackbarClasses(message || "")} >
+        {message ? <Notification {...message} /> : ""}
+      </div>
     );
   }
 }
 
 Snackbar.propTypes = propTypes;
 
-export default snackbar(Snackbar);
+export default ReactTimeout(snackbar(Snackbar));

--- a/app/style/Snackbar.less
+++ b/app/style/Snackbar.less
@@ -2,10 +2,18 @@
 @import (reference) "./Icons.less";
 
 .snackbar {
-  left: 61% !important;
   background-color: rgba(12, 30, 62, 0.5);
   font-family: Source Sans Pro, sans-serif;
   margin-bottom: 0.5em;
+  position: fixed;
+  bottom: 0px;
+  max-width: 568px;
+  z-index: 100;
+  left: 60%;
+  transform: translateX(-40%);
+  font-size: 14px;
+  color: #fff;
+  padding: 0px 24px;
 }
 
 .snackbar.snackbar-warning,

--- a/app/style/Snackbar.less
+++ b/app/style/Snackbar.less
@@ -14,6 +14,11 @@
   font-size: 14px;
   color: #fff;
   padding: 0px 24px;
+  transition: box-shadow 0.2s;
+}
+
+.snackbar:hover {
+  box-shadow: #ccc 0px 0px 24px 8px;
 }
 
 .snackbar.snackbar-warning,

--- a/app/style/Snackbar.less
+++ b/app/style/Snackbar.less
@@ -6,7 +6,7 @@
   font-family: Source Sans Pro, sans-serif;
   margin-bottom: 0.5em;
   position: fixed;
-  bottom: 0px;
+  // bottom: 0px;
   max-width: 568px;
   z-index: 100;
   left: 60%;

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
   "dependencies": {
     "axios": "^0.15.3",
     "css-loader": "^0.28.4",
+    "dom-helpers": "^3.3.1",
     "electron-builder": "^19.45.0",
     "electron-devtools-installer": "^2.2.4",
     "eslint-import-resolver-webpack": "^0.8.3",
@@ -202,6 +203,7 @@
     "raw-loader": "^0.5.1",
     "react": "16.0.0",
     "react-dom": "16.0.0",
+    "react-event-listener": "^0.5.3",
     "react-infinite-scroller": "^1.1.1",
     "react-intl": "^2.4.0",
     "react-intl-po": "^2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,13 @@
   dependencies:
     "@babel/types" "7.0.0-beta.36"
 
+"@babel/runtime@^7.0.0-beta.42":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.49.tgz#03b3bf07eb982072c8e851dd2ddd5110282e61bf"
+  dependencies:
+    core-js "^2.5.6"
+    regenerator-runtime "^0.11.1"
+
 "@babel/template@7.0.0-beta.36":
   version "7.0.0-beta.36"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.36.tgz#02e903de5d68bd7899bce3c5b5447e59529abb00"
@@ -2319,6 +2326,10 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
+core-js@^2.5.6:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2886,7 +2897,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.0:
+dom-helpers@^3.2.0, dom-helpers@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -7589,6 +7600,15 @@ react-event-listener@^0.5.1:
     prop-types "^15.6.0"
     warning "^3.0.0"
 
+react-event-listener@^0.5.3:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.5.9.tgz#c64e84f77156a682614835bdc1bc7ba00912df97"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.42"
+    fbjs "^0.8.16"
+    prop-types "^15.6.0"
+    warning "^3.0.0"
+
 react-infinite-scroller@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.1.3.tgz#c4230024bc237ce876c76b2e38d77dc1f6aabb26"
@@ -7967,7 +7987,7 @@ regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 


### PR DESCRIPTION
Fix #1428 
Part of #1406 

This removes the use of the material-ui snackbar in favor a custom built one. Pretty much the only thing that was needed was moving the event listeners into the snackbar component and fixing the styling.

This also adds an event listener to prevent the snackbar message from disappearing when the user has the mouse hovering over the snackbar (useful for maintaining longer messages visible).

The added dependencies aren't really new: they are just stuff material-ui used that have been moved into the component.