### PR TITLE
[Fix #1428] - Increment *autoHideDuration* for Snackbar

### DIFF
--- a/app/components/Snackbar/index.js
+++ b/app/components/Snackbar/index.js
@@ -69,7 +69,7 @@ class Snackbar extends React.Component {
         className={snackbarClasses(message || "")}
         open={!!message}
         message={message ? <Notification {...message} /> : ""}
-        autoHideDuration={4000}
+        autoHideDuration={10000}
         bodyStyle={{ backgroundColor: "inherited", fontFamily: null,
           lineHeight: null, height: null }}
         style={{ fontFamily: null, lineHeight: null }}


### PR DESCRIPTION
Issue #1428 stated that message box disappears too quickly, this is due to Snackbar **autoHideDuration**  config set to 4secs, this property has now been changed to 10secs.