### PR TITLE
Replace material-ui linear progress

### DIFF
--- a/app/components/indicators/LinearProgressSmall.js
+++ b/app/components/indicators/LinearProgressSmall.js
@@ -2,7 +2,7 @@ import "style/Loading.less";
 
 const LinearProgressSmall = ({ value, min, max }) =>
   <div className="linear-progress small">
-    <div className="linear-progress-bar" style={{ width: `${(value/max-min)*100}` + "%" }}>
+    <div className="linear-progress-bar" style={{ width: `${((value-min)/(max-min))*100}` + "%" }}>
     </div>
   </div>;
 

--- a/app/components/indicators/RescanProgress.js
+++ b/app/components/indicators/RescanProgress.js
@@ -1,4 +1,4 @@
-import LinearProgress from "material-ui/LinearProgress";
+import { LinearProgressSmall } from "indicators";
 import { rescan } from "connectors";
 import { FormattedMessage as T } from "react-intl";
 import { RescanButton, RescanCancelButton } from "buttons";
@@ -13,12 +13,10 @@ const RescanProgress = ({
 }) => (
   <div className="rescan-progress-area" >
     <div className="rescan-progress-indicator">
-      <LinearProgress
-        mode="determinate"
+      <LinearProgressSmall
         min={0}
         max={1}
         value={rescanCurrentBlock/rescanEndBlock}
-        color="#2ed8a3"
       />
     </div>
     <div className="rescan-button-area">

--- a/app/components/views/GetStartedPage/RescanWallet/Form.js
+++ b/app/components/views/GetStartedPage/RescanWallet/Form.js
@@ -1,4 +1,4 @@
-import LinearProgress from "material-ui/LinearProgress";
+import { LinearProgressSmall } from "indicators";
 import { FormattedMessage as T } from "react-intl";
 import "style/GetStarted.less";
 
@@ -10,8 +10,7 @@ const RescanWalletFormBody = ({
 }) => (
   showLongWaitMessage &&
     <Aux>
-      <LinearProgress
-        mode="determinate"
+      <LinearProgressSmall
         min={rescanStartBlock}
         max={rescanEndBlock}
         value={rescanCurrentBlock}

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -184,6 +184,10 @@
   .go-back-screen-button:hover {
     opacity: 0.7;
   }
+
+  .linear-progress.small {
+    float: left;
+  }
 }
 
 .loader-bar-bottom {

--- a/app/style/Loading.less
+++ b/app/style/Loading.less
@@ -56,9 +56,8 @@
 }
 
 .linear-progress.small {
-  height: 5px;
+  height: 4px;
   width: 100%;
-  float: left;
 }
 
 .linear-progress-box {
@@ -131,6 +130,7 @@
   border-radius: 8px;
   height: 100%;
   box-shadow: 0px 5px 13px rgba(41, 112, 255, 0.21);
+  transition: width 0.3s linear 0ms;
 }
 
 .linear-progress-bar.error {

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -473,6 +473,16 @@
 .rescan-progress-indicator {
   margin: -14px 0px 10px -20px;
   width: @sidebar-width;
+
+  .linear-progress.small {
+    border-radius: 0px;
+    background-color: #132f4b;
+  }
+
+  .linear-progress.small .linear-progress-bar {
+    background: #2ed8a3;
+    border-radius: 0px;
+  }
 }
 
 .rescan-button-area {
@@ -669,4 +679,3 @@
   opacity: 0.3;
   font-size: 75%;
 }
-


### PR DESCRIPTION
Part of #1406 

This replaces all remaining linear progresses from the material-ui library to our custom one.