### PR TITLE
[charts] use forward daily balances to calculate stake rewards

### DIFF
--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -64,12 +64,13 @@ export const GETMYTICKETSSTATS_FAILED = "GETMYTICKETSSTATS_FAILED";
 export const getMyTicketsStats = () => (dispatch) => {
   const startupStats = [
     { calcFunction: voteTimeStats },
+    { calcFunction: dailyBalancesStats },
   ];
 
   dispatch({ type: GETMYTICKETSSTATS_ATTEMPT });
   return Promise.all(startupStats.map(s => dispatch(generateStat(s))))
-    .then(([ voteTime ]) => {
-      dispatch({ voteTime, type: GETMYTICKETSSTATS_SUCCESS });
+    .then(([ voteTime, dailyBalances ]) => {
+      dispatch({ voteTime, dailyBalances, type: GETMYTICKETSSTATS_SUCCESS });
     })
     .catch(error => dispatch({ error, type: GETMYTICKETSSTATS_FAILED }));
 };

--- a/app/connectors/myTicketsCharts.js
+++ b/app/connectors/myTicketsCharts.js
@@ -8,7 +8,7 @@ const mapStateToProps = selectorMap({
   voteTimeStats: sel.voteTimeStats,
   getMyTicketsStatsRequest: sel.getMyTicketsStatsRequest,
   stakeRewardsStats: sel.stakeRewardsStats,
-  dailyBalancesStats: sel.dailyBalancesStats,
+  dailyBalancesStats: sel.fullDailyBalancesStats,
   medianVoteTime: sel.medianVoteTime,
   averageVoteTime: sel.averageVoteTime,
   ninetyFifthPercentileVoteTime: sel.ninetyFifthPercentileVoteTime,

--- a/app/index.js
+++ b/app/index.js
@@ -345,6 +345,7 @@ var initialState = {
   },
   statistics: {
     dailyBalances: Array(),
+    fullDailyBalances: Array(),
     voteTime: null,
     getMyTicketsStatsRequest: false,
   },

--- a/app/reducers/statistics.js
+++ b/app/reducers/statistics.js
@@ -21,6 +21,7 @@ export default function statistics(state = {}, action) {
       ...state,
       getMyTicketsStatsRequest: false,
       voteTime: action.voteTime,
+      fullDailyBalances: action.dailyBalances.data,
     };
   case GETMYTICKETSSTATS_FAILED:
     return {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -833,9 +833,11 @@ export const ninetyFifthPercentileVoteTime = createSelector(
 );
 export const getMyTicketsStatsRequest = get([ "statistics", "getMyTicketsStatsRequest" ]);
 
+export const fullDailyBalancesStats = get([ "statistics", "fullDailyBalances" ]);
+
 export const stakeRewardsStats = createSelector(
-  [ dailyBalancesStats, unitDivisor ],
-  ( stats, unitDivisor ) => stats.map(s => ({
+  [ fullDailyBalancesStats, unitDivisor ],
+  ( stats, unitDivisor ) => stats.slice(-15).map(s => ({
     time: s.time,
     stakeRewards: s.series.stakeRewards / unitDivisor,
     stakeFees: s.series.stakeFees / unitDivisor,


### PR DESCRIPTION
Fix #1456 

This reverts the stake reward statistics to use the forward-calculating daily balances.