### PR TITLE
Fix transaction listing when wallet has airdrop coins

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -540,6 +540,7 @@ export const getTransactions = () => async (dispatch, getState) => {
 
     if ( transactionsFilter.listDirection === "desc" ) {
       startRequestHeight = lastTransaction ? lastTransaction.height -1 : currentBlockHeight;
+      if (startRequestHeight < 1) break;
       endRequestHeight = 1;
     } else {
       startRequestHeight = lastTransaction ? lastTransaction.height +1 : 1;


### PR DESCRIPTION
This fixes a potential race condition that happens during startup when the wallet has airdropped coins (coins in ledger of the block with height == 1) and not many more transactions after that.

This was preventing users from accessing the app.