### PR TITLE
Fix win32ipc node location

### DIFF
--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -11,6 +11,7 @@ import { concat, isString } from "lodash";
 const argv = parseArgs(process.argv.slice(1), OPTIONS);
 const debug = argv.debug || process.env.NODE_ENV === "development";
 const logger = createLogger(debug);
+const win32ipcLocation = "../node_modules/win32ipc/build/Release/win32ipc.node";
 
 let dcrdPID;
 let dcrwPID;
@@ -104,7 +105,7 @@ export const launchDCRD = (mainWindow, daemonIsAdvanced, daemonPath, appdata, te
   if (os.platform() == "win32") {
     try {
       const util = require("util");
-      const win32ipc = require("./node_modules/win32ipc/build/Release/win32ipc.node");
+      const win32ipc = require(win32ipcLocation);
       var pipe = win32ipc.createPipe("out");
       args.push(util.format("--piperx=%d", pipe.readEnd));
     } catch (e) {
@@ -190,7 +191,7 @@ export const launchDCRWallet = (mainWindow, daemonIsAdvanced, walletPath, testne
   if (os.platform() == "win32") {
     try {
       const util = require("util");
-      const win32ipc = require("../../node_modules/win32ipc/build/Release/win32ipc.node");
+      const win32ipc = require(win32ipcLocation);
       const pipe = win32ipc.createPipe("out");
       args.push(util.format("--piperx=%d", pipe.readEnd));
     } catch (e) {


### PR DESCRIPTION
Fix #1467 

Location for the win32ipc node module was wrong after all the main_dev refactorings, causing the module not to be loaded.