### PR TITLE
[launcher] fix initial wallet creation

### DIFF
--- a/app/actions/VersionActions.js
+++ b/app/actions/VersionActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { loaderRequest } from "./WalletLoaderActions";
+import { loaderRequest, getWalletSeedService } from "./WalletLoaderActions";
 import { getVersionService, getVersionResponse } from "wallet";
 import { push as pushHistory } from "react-router-redux";
 import { ipcRenderer } from "electron";
@@ -52,6 +52,7 @@ export const getWalletRPCVersionAttempt = () => (dispatch, getState) => {
       } else {
         const { address, port } = getState().grpc;
         dispatch(loaderRequest(address,port));
+        dispatch(getWalletSeedService(address, port));
       }
     })
     .catch(error => dispatch({ error, type: WALLETRPCVERSION_FAILED }));

--- a/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
@@ -15,8 +15,10 @@ const CreateForm = ({
   getNeededBlocks,
   getEstimatedTimeLeft,
   getDaemonSynced,
+  isWatchOnly,
+  masterPubKey,
 }) => (
-  (availableWallets.length == 0 && existingOrNew) || !createNewWallet ?
+  ((availableWallets.length == 0 && existingOrNew) || !createNewWallet) && !(isWatchOnly && masterPubKey) ?
     <ExistingOrNewScreen {...{ onSetCreateWalletFromExisting,
       onReturnToWalletSelection,
       getCurrentBlockCount,

--- a/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
@@ -16,7 +16,7 @@ const CreateForm = ({
   getEstimatedTimeLeft,
   getDaemonSynced,
 }) => (
-  (availableWallets.length == 0 && existingOrNew) || createNewWallet ?
+  (availableWallets.length == 0 && existingOrNew) || !createNewWallet ?
     <ExistingOrNewScreen {...{ onSetCreateWalletFromExisting,
       onReturnToWalletSelection,
       getCurrentBlockCount,

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ConfirmSeed/index.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ConfirmSeed/index.js
@@ -52,7 +52,7 @@ class ConfirmSeed extends React.Component {
     if (seedWordStr == mnemonic) {
       this.setState({ seedWordsError: null });
       this.props
-        .decode(mnemonic)
+        .decodeSeed(mnemonic)
         .then(response => this.props.onChange(response.getDecodedSeed()))
         .then(() => this.setState({ seedError: null }))
         .catch(e => console.log(e));

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ExistingSeed/index.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/ExistingSeed/index.js
@@ -58,14 +58,14 @@ class ExistingSeed extends React.Component {
       const mnemonic = this.getSeedWordsStr();
       if (this.props.mnemonic && this.isMatch()) {
         this.props
-          .decode(mnemonic)
+          .decodeSeed(mnemonic)
           .then(response => this.props.onChange(response.getDecodedSeed()))
           .then(() => this.setState({ seedError: null }))
           .catch(onError);
       } else {
         this.props.onChange(null);
         this.props
-          .decode(mnemonic)
+          .decodeSeed(mnemonic)
           .then(response => {
             this.setState({ mnemonic, seedError: null });
             this.props.onChange(response.getDecodedSeed());
@@ -110,14 +110,14 @@ class ExistingSeed extends React.Component {
       const mnemonic = this.getSeedWordsStr();
       if (this.props.mnemonic && this.isMatch()) {
         this.props
-          .decode(mnemonic)
+          .decodeSeed(mnemonic)
           .then(response => this.props.onChange(response.getDecodedSeed()))
           .then(() => this.setState({ seedError: null }))
           .catch(onError);
       } else {
         this.props.onChange(null);
         this.props
-          .decode(mnemonic)
+          .decodeSeed(mnemonic)
           .then(response => {
             this.setState({ mnemonic, seedError: null });
             this.props.onChange(response.getDecodedSeed());

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
@@ -14,7 +14,6 @@ class CreateWalletForm extends React.Component {
       mnemonic: "",
       seed: "",
       passPhrase: "",
-      decode: null,
       showCopySeedConfirm: false,
     };
   }
@@ -65,6 +64,7 @@ class CreateWalletForm extends React.Component {
       getNeededBlocks,
       getEstimatedTimeLeft,
       getDaemonSynced,
+      decodeSeed,
     } = this.props;
     const {
       setSeed,
@@ -74,7 +74,7 @@ class CreateWalletForm extends React.Component {
       onSubmitCopySeedConfirm,
       onCancelCopySeedConfirm,
     } = this;
-    const { mnemonic, decode, showCopySeedConfirm } = this.state;
+    const { mnemonic, showCopySeedConfirm } = this.state;
     const isValid = this.isValid();
 
     return (confirmNewSeed || createWalletExisting)
@@ -87,7 +87,7 @@ class CreateWalletForm extends React.Component {
             createNewWallet,
             setPassPhrase,
             onCreateWallet,
-            decode,
+            decodeSeed,
             isValid,
             onReturnToNewSeed,
             onReturnToWalletSelection,
@@ -126,13 +126,10 @@ class CreateWalletForm extends React.Component {
   }
 
   generateSeed() {
-    return this.props.seedService.then(({ generate, decode }) =>
-      generate().then(response => this.setState({
-        decode,
-        mnemonic: response.getSeedMnemonic(),
-        seed: this.props.isTestNet ? response.getSeedBytes() : null // Allows verification skip in dev
-      }))
-    );
+    return this.props.generateSeed().then(response => this.setState({
+      mnemonic: response.getSeedMnemonic(),
+      seed: this.props.isTestNet ? response.getSeedBytes() : null // Allows verification skip in dev
+    }));
   }
 
   setSeed(seed) {

--- a/app/connectors/createWallet.js
+++ b/app/connectors/createWallet.js
@@ -4,10 +4,8 @@ import { selectorMap } from "fp";
 import * as sel from "selectors";
 import * as wla from "actions/WalletLoaderActions";
 import * as ca from "actions/ClientActions";
-import { getSeedService } from "wallet/seed";
 
 const mapStateToProps = selectorMap({
-  seedService: getSeedService,
   createWalletExisting: sel.createWalletExisting,
   isCreatingWallet: sel.isCreatingWallet,
   confirmNewSeed: sel.confirmNewSeed,
@@ -23,6 +21,8 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   createWalletRequest: wla.createWalletRequest,
   copySeedToClipboard: ca.copySeedToClipboard,
   createWatchOnlyWalletRequest: wla.createWatchOnlyWalletRequest,
+  generateSeed: wla.generateSeed,
+  decodeSeed: wla.decodeSeed,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -43,6 +43,8 @@ const mapStateToProps = selectorMap({
   defaultLocale: sel.defaultLocaleName,
   updateAvailable: sel.updateAvailable,
   createNewWallet: sel.createNewWallet,
+  isWatchOnly: sel.isWatchOnly,
+  masterPubKey: sel.masterPubKey,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -29,7 +29,7 @@ const getServiceClient = (clientClass) => (isTestNet, walletPath, address, port,
 export const getWalletService = getServiceClient(services.WalletServiceClient);
 export const getTicketBuyerService = getServiceClient(services.TicketBuyerServiceClient);
 export const loader = getServiceClient(services.WalletLoaderServiceClient);
-export const seeder = getServiceClient(services.SeedServiceClient);
+export const getSeedService = getServiceClient(services.SeedServiceClient);
 export const getVersionService = getServiceClient(services.VersionServiceClient);
 export const getVotingService = getServiceClient(services.VotingServiceClient);
 export const getAgendaService = getServiceClient(services.AgendaServiceClient);

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -37,6 +37,9 @@ import {
   GETMYTICKETSSTATS_FAILED,
 } from "actions/StatisticsActions";
 import { WALLETREMOVED_FAILED } from "actions/DaemonActions";
+import {
+  GETWALLETSEEDSVC_FAILED
+} from "actions/WalletLoaderActions";
 
 const messages = defineMessages({
   defaultSuccessMessage: {
@@ -243,6 +246,7 @@ export default function snackbar(state = {}, action) {
   case EXPORT_ERROR:
   case GETSTARTUPSTATS_FAILED:
   case GETMYTICKETSSTATS_FAILED:
+  case GETWALLETSEEDSVC_FAILED:
     type = "Error";
     message = messages[action.type] || messages.defaultErrorMessage;
     values = { originalError: String(action.error) };

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -11,6 +11,7 @@ import {
   CREATEWALLET_EXISTINGSEED_INPUT, CREATEWALLET_NEWSEED_INPUT, CREATEWALLET_NEWSEED_CONFIRM_INPUT, CREATEWALLET_NEWSEED_BACK_INPUT,
   CREATEWALLET_GOBACK_EXISITNG_OR_NEW, CREATEWALLET_GOBACK,
   UPDATEDISCOVERACCOUNTS, NEEDED_BLOCKS_DETERMINED, CREATEWATCHONLYWALLET_ATTEMPT,
+  GETWALLETSEEDSVC_ATTEMPT, GETWALLETSEEDSVC_SUCCESS,
 } from "actions/WalletLoaderActions";
 import {
   WALLETCREATED
@@ -278,6 +279,14 @@ export default function walletLoader(state = {}, action) {
   case WALLET_LOADER_SETTINGS:
     return { ...state,
       discoverAccountsComplete: action.discoverAccountsComplete,
+    };
+  case GETWALLETSEEDSVC_ATTEMPT:
+    return { ...state,
+      seedService: null,
+    };
+  case GETWALLETSEEDSVC_SUCCESS:
+    return { ...state,
+      seedService: action.seedService
     };
   default:
     return state;

--- a/app/style/CreateWalletForm.less
+++ b/app/style/CreateWalletForm.less
@@ -255,6 +255,10 @@
   float: left;
   margin: 0px 5px 5px -5px;
 
+  &.hex {
+    width: 90%;
+  }
+
   .Select-arrow-zone {
     width: 0px;
   }

--- a/app/wallet/seed.js
+++ b/app/wallet/seed.js
@@ -1,7 +1,5 @@
-/* global Promise */
-import { seeder as seederFactory } from "../middleware/grpc/client";
 import { GenerateRandomSeedRequest, DecodeSeedRequest } from "../middleware/walletrpc/api_pb";
-import { createSelector } from "reselect";
+import { withLogNoData as log } from "./index";
 
 export const SEED_WORDS = require("../helpers/wordlist.js");
 SEED_WORDS.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
@@ -12,44 +10,13 @@ export const SEED_LENGTH = {
   HEX_MIN: 32,
 };
 
-export const getSeedService = createSelector(
-  [
-    ({ daemon: { network } }) => network,
-    ({ daemon: { walletName } }) => walletName,
-    ({ grpc: { address } }) => address,
-    ({ grpc: { port } }) => port
-  ],
-  (network, walletName, address, port) =>
-    (new Promise((resolve, reject) =>
-      seederFactory(
-        network == "testnet",
-        walletName,
-        address,
-        port,
-        (response, err) => err ? reject(err) : resolve(response)
-      )
-    )).then(seeder => ({
-      generate() {
-        return new Promise((resolve, reject) => {
-          try {
-            const request = new GenerateRandomSeedRequest();
-            seeder.generateRandomSeed(request, (err, response) => err ? reject(err) : resolve(response));
-          } catch(err) {
-            reject(err);
-          }
-        });
-      },
+export const generateSeed = log((seederService) => new Promise((resolve, reject) => {
+  const request = new GenerateRandomSeedRequest();
+  seederService.generateRandomSeed(request, (err, response) => err ? reject(err) : resolve(response));
+}), "Generate Seed");
 
-      decode(mnemonic) {
-        return new Promise((resolve, reject) => {
-          try {
-            const request = new DecodeSeedRequest();
-            request.setUserInput(mnemonic);
-            seeder.decodeSeed(request, (err, response) => err ? reject(err) : resolve(response));
-          } catch(err) {
-            reject(err);
-          }
-        });
-      }
-    }))
-);
+export const decodeSeed = log((seederService, mnemonic) => new Promise((resolve, reject) => {
+  const request = new DecodeSeedRequest();
+  request.setUserInput(mnemonic);
+  seederService.decodeSeed(request, (err, response) => err ? reject(err) : resolve(response));
+}), "Decode Seed");

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -13,6 +13,7 @@ export const getVotingService = promisify(client.getVotingService);
 export const getAgendaService = promisify(client.getAgendaService);
 export const getMessageVerificationService = promisify(client.getMessageVerificationService);
 export const getDecodeService = promisify(client.getDecodeMessageService);
+export const getSeedService = promisify(client.getSeedService);
 
 export const getNextAddress = log((walletService, accountNum) =>
   new Promise((resolve, reject) => {


### PR DESCRIPTION
Fix #1466 

This also refactors the seed service functions so that it follows the same conventions as the other service functions (getting rid of an error message in the process) and also makes it so that when creating a watching only wallet, the user is not presented with the ExistingOrNew screen (as that is superfluous for that particular wallet creation branch).