### PR TITLE
[stakepools] allow adding custom stakepool

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -129,7 +129,7 @@ const importScriptSuccess = (importScriptResponse, votingAddress, cb, willRescan
 export const importScriptAttempt = (passphrase, script, rescan, scanFrom, votingAddress, cb) =>
   (dispatch, getState) => {
     dispatch({ type: IMPORTSCRIPT_ATTEMPT });
-    return wallet.importScript(sel.walletService(getState()), passphrase, script, rescan, scanFrom)
+    return wallet.importScript(sel.walletService(getState()), passphrase, script, false, 0)
       .then(importScriptResponse => {
         if (rescan) dispatch(rescanAttempt(0));
         dispatch(importScriptSuccess(importScriptResponse, votingAddress, cb));

--- a/app/components/buttons/index.js
+++ b/app/components/buttons/index.js
@@ -26,7 +26,7 @@ export { ModalButton, AutoBuyerSwitch, KeyBlueButton, DangerButton,
  ***************************************************/
 import {
   InfoModal, PassphraseModal, ChangePassphraseModal,
-  ConfirmModal, InfoConfirmModal, InfoDocumentModal,
+  ConfirmModal, InfoDocumentModal,
 } from "modals";
 
 // mbb = ModalButtonBuilder (func to build a functional ModalButton component
@@ -54,4 +54,4 @@ export const PassphraseModalSwitch = mbb(null, PassphraseModal, AutoBuyerSwitch)
 export const RemoveStakePoolButton = mbb(null, ConfirmModal, DangerButton);
 export const RemoveWalletButton = mbb(null, ConfirmModal, DangerButton);
 export const RemoveDaemonButton = mbb(null, ConfirmModal, DangerButton);
-export const ScriptRedeemableButton = mbb(null, InfoConfirmModal, helpLinkButton);
+export const ScriptRedeemableButton = mbb(null, InfoModal, helpLinkButton);

--- a/app/components/inputs/StakePoolSelect.js
+++ b/app/components/inputs/StakePoolSelect.js
@@ -19,7 +19,7 @@ class StakePoolSelect extends React.Component {
   }
 
   onChange(value) {
-    if (!value) return;
+    if (!value || !value.Host) return;
 
     const { onChange, addCustomStakePool } = this.props;
     if (!onChange) return;
@@ -52,12 +52,24 @@ class StakePoolSelect extends React.Component {
     this.lastInput = input;
   }
 
+  getOptions() {
+    if (!this.props.creatable || this.lastInput) return this.props.options;
+    const options = [ ...this.props.options ];
+    options.unshift({
+      label: <T id="stakePoolSelect.addNewPromptEmpty" m="Type to add new Stake Pool" />,
+      Host: null
+    });
+    return options;
+  }
+
   render() {
     const Component = this.props.creatable ? Creatable : Select;
+    const options = this.getOptions();
 
     return (
       <Component
         {...this.props}
+        options={options}
         placeholder={this.props.intl.formatMessage(messages.placeholder)}
         promptTextCreator={this.addStakePoolLabel}
         onChange={this.onChange}
@@ -68,5 +80,9 @@ class StakePoolSelect extends React.Component {
     );
   }
 }
+
+StakePoolSelect.defaultProps = {
+  clearable: false,
+};
 
 export default injectIntl(newStakePool(StakePoolSelect));

--- a/app/components/inputs/StakePoolSelect.js
+++ b/app/components/inputs/StakePoolSelect.js
@@ -1,5 +1,7 @@
+import { Creatable } from "react-select";
 import Select from "react-select";
-import { injectIntl, defineMessages } from "react-intl";
+import {  FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
+import { newStakePool } from "connectors";
 
 const messages = defineMessages({
   placeholder: {
@@ -8,36 +10,63 @@ const messages = defineMessages({
   }
 });
 
-function selectKeyDown(e) {
-  switch(e.keyCode) {
-  case 8:
-  case 46:
-    e.preventDefault();
-    break;
+@autobind
+class StakePoolSelect extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.lastInput = "";
+  }
+
+  onChange(value) {
+    if (!value) return;
+
+    const { onChange, addCustomStakePool } = this.props;
+    if (!onChange) return;
+
+    if (value.newOption) {
+      if (!addCustomStakePool) return;
+
+      addCustomStakePool(value.Host).then(poolInfo => {
+        if (!poolInfo) return;
+        const opt = { ...poolInfo, label: poolInfo.Host, value: poolInfo,
+          isVersionValid: true };
+        onChange(opt);
+      });
+      return;
+    }
+    onChange(value);
+  }
+
+  addStakePoolLabel(host) {
+    return <T id="stakePoolSelect.addNewPrompt" m="Add StakePool {host}" values={{ host }} />;
+  }
+
+  newOptionCreator({ label }) {
+    return { label, Host: this.lastInput, newOption: true };
+  }
+
+  onInputChange(input) {
+    // not a state var because <Select> already accounts for it. It is used only
+    // when a new stakepool is supposed to be added.
+    this.lastInput = input;
+  }
+
+  render() {
+    const Component = this.props.creatable ? Creatable : Select;
+
+    return (
+      <Component
+        {...this.props}
+        placeholder={this.props.intl.formatMessage(messages.placeholder)}
+        promptTextCreator={this.addStakePoolLabel}
+        onChange={this.onChange}
+        newOptionCreator={this.newOptionCreator}
+        onInputChange={this.onInputChange}
+        isValidNewOption={this.isValidNewOption}
+      />
+    );
   }
 }
 
-const StakePoolSelect = ({
-  valueKey="value",
-  labelKey="label",
-  multi=false,
-  clearable=false,
-  style={ zIndex:"9" },
-  intl,
-  ...props
-}) => (
-  <Select
-    placeholder={intl.formatMessage(messages.placeholder)}
-    {...{
-      valueKey,
-      labelKey,
-      multi,
-      clearable,
-      style,
-      onInputKeyDown: selectKeyDown,
-      ...props
-    }}
-  />
-);
-
-export default injectIntl(StakePoolSelect);
+export default injectIntl(newStakePool(StakePoolSelect));

--- a/app/components/views/GetStartedPage/StakePools/Form.js
+++ b/app/components/views/GetStartedPage/StakePools/Form.js
@@ -32,6 +32,7 @@ const Form = ({
           </div>
           <div className="value">
             <StakePoolSelect
+              creatable
               options={unconfiguredStakePools}
               value={selectedUnconfigured}
               onChange={onChangeSelectedUnconfigured}

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/AddForm.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/AddForm.js
@@ -13,6 +13,12 @@ const messages = defineMessages({
   }
 });
 
+const UnconfiguedStakepoolLink = ({ selectedUnconfigured }) => (
+  selectedUnconfigured
+    ? <ExternalLink href={selectedUnconfigured.label}>{selectedUnconfigured.label}</ExternalLink>
+    : null
+);
+
 const StakePoolsAddForm = ({
   selectedUnconfigured,
   unconfiguredStakePools,
@@ -66,7 +72,7 @@ const StakePoolsAddForm = ({
             "Create an account or login to your existing account at {stakePoolLink} Once logged in, select the ‘Settings’ tab, copy and paste your API KEY into the field."
           }
           values={{
-            stakePoolLink: <ExternalLink href={selectedUnconfigured.label}>{selectedUnconfigured.label}</ExternalLink>
+            stakePoolLink: <UnconfiguedStakepoolLink { ...{ selectedUnconfigured } } />
           }}/>
           <ScriptRedeemableButton
             modalTitle={<T id="stake.notRedeemed" m="Script not redeemable?" />}

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/AddForm.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/AddForm.js
@@ -37,6 +37,7 @@ const StakePoolsAddForm = ({
           </div>
           <div className="stakepool-field-value">
             <StakePoolSelect
+              creatable
               options={unconfiguredStakePools}
               value={selectedUnconfigured}
               onChange={onChangeSelectedUnconfigured}

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/List.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/List.js
@@ -5,7 +5,6 @@ import "style/StakePool.less";
 
 const StakePoolsList = ({
   configuredStakePools,
-  unconfiguredStakePools,
   onShowAddStakePool,
   onHideStakePoolConfig,
   onRemoveStakePool,
@@ -54,11 +53,9 @@ const StakePoolsList = ({
         ))}
       </div>
     </div>
-    {unconfiguredStakePools.length > 0 ? (
-      <KeyBlueButton className="stakepool-content-send" disabled={rescanRequest} onClick={onShowAddStakePool}>
-        <T id="stakepools.list.form.submit" m="Add stakepool" />
-      </KeyBlueButton>
-    ) : null}
+    <KeyBlueButton className="stakepool-content-send" disabled={rescanRequest} onClick={onShowAddStakePool}>
+      <T id="stakepools.list.form.submit" m="Add stakepool" />
+    </KeyBlueButton>
     <SlateGrayButton
       className="stakepool-hide-config"
       onClick={onHideStakePoolConfig}

--- a/app/connectors/index.js
+++ b/app/connectors/index.js
@@ -44,3 +44,4 @@ export { default as modalVisible } from "./modalVisible";
 export { default as locale } from "./locale";
 export { default as fatalErrorPage } from "./fatalErrorPage";
 export { default as theming } from "./theming";
+export { default as newStakePool } from "./newStakePool";

--- a/app/connectors/newStakePool.js
+++ b/app/connectors/newStakePool.js
@@ -1,0 +1,15 @@
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import { selectorMap } from "../fp";
+import * as sel from "../selectors";
+import * as sa from "../actions/StakePoolActions";
+
+const mapStateToProps = selectorMap({
+  isAddingCustomStakePool: sel.isAddingCustomStakePool,
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  addCustomStakePool: sa.addCustomStakePool,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/index.js
+++ b/app/index.js
@@ -47,6 +47,7 @@ var initialState = {
     activeStakePoolConfig: false,
     selectedStakePool: null,
     updatedStakePoolList: false,
+    addCustomStakePoolAttempt: false,
   },
   daemon: {
     appVersion: pkg.version,

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -81,6 +81,7 @@ export const allowStakepoolRequests = (stakePoolHost) => {
   addAllowedURL(stakePoolHost + "/api/v1/address");
   addAllowedURL(stakePoolHost + "/api/v2/voting");
   addAllowedURL(stakePoolHost + "/api/v1/getpurchaseinfo");
+  addAllowedURL(stakePoolHost + "/api/v1/stats");
 };
 
 export const reloadAllowedExternalRequests = () => {

--- a/app/middleware/stakepoolapi.js
+++ b/app/middleware/stakepoolapi.js
@@ -103,3 +103,12 @@ export function getPurchaseInfo(apiUrl, apiToken, cb) {
       cb(null, error, apiUrl);
     });
 }
+
+// statsFromStakePool grabs stats and config information directly from the
+// stakepool host.
+export function statsFromStakePool(host, cb) {
+  const url = host + "/api/v1/stats";
+  axios.get(url)
+    .then(resp => cb(resp, null, host))
+    .catch(error => cb(null, error, host));
+}

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -22,7 +22,8 @@ import {
 import {
   UPDATESTAKEPOOLCONFIG_SUCCESS, UPDATESTAKEPOOLCONFIG_FAILED,
   SETSTAKEPOOLVOTECHOICES_SUCCESS, SETSTAKEPOOLVOTECHOICES_FAILED,
-  REMOVESTAKEPOOLCONFIG
+  REMOVESTAKEPOOLCONFIG,
+  ADDCUSTOMSTAKEPOOL_SUCCESS, ADDCUSTOMSTAKEPOOL_FAILED,
 } from "../actions/StakePoolActions";
 import {
   NEW_TRANSACTIONS_RECEIVED,
@@ -175,6 +176,14 @@ const messages = defineMessages({
     id: "export.completed",
     defaultMessage: "Export of file '{filename}' completed!"
   },
+  ADDCUSTOMSTAKEPOOL_FAILED: {
+    id: "addCustomStakePool.failed",
+    defaultMessage: "Error trying to add custom stakepool: {originalError}"
+  },
+  ADDCUSTOMSTAKEPOOL_SUCCESS: {
+    id: "addCustomStakePool.success",
+    defaultMessage: "Successfully added stakepool {host}!"
+  }
 });
 
 export default function snackbar(state = {}, action) {
@@ -235,6 +244,7 @@ export default function snackbar(state = {}, action) {
   case STARTAUTOBUYER_FAILED:
   case UPDATESTAKEPOOLCONFIG_FAILED:
   case SETSTAKEPOOLVOTECHOICES_FAILED:
+  case ADDCUSTOMSTAKEPOOL_FAILED:
   case DECODERAWTXS_FAILED:
   case SIGNMESSAGE_FAILED:
   case VERIFYMESSAGE_FAILED:
@@ -253,6 +263,12 @@ export default function snackbar(state = {}, action) {
     type = "Success";
     message = messages[PURCHASETICKETS_SUCCESS];
     values = { numTickets: action.purchaseTicketsResponse.getTicketHashesList().length };
+    break;
+
+  case ADDCUSTOMSTAKEPOOL_SUCCESS:
+    type = "Success";
+    message = messages[ADDCUSTOMSTAKEPOOL_SUCCESS];
+    values = { host: action.poolInfo.Host };
     break;
   }
 

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -2,7 +2,8 @@ import {
   UPDATESTAKEPOOLCONFIG_ATTEMPT, UPDATESTAKEPOOLCONFIG_FAILED, UPDATESTAKEPOOLCONFIG_SUCCESS,
   DISCOVERAVAILABLESTAKEPOOLS_SUCCESS, CHANGESELECTEDSTAKEPOOL,
   REMOVESTAKEPOOLCONFIG,
-  GETSTAKEPOOLSTATS_ATTEMPT, GETSTAKEPOOLSTATS_FAILED, GETSTAKEPOOLSTATS_SUCCESS
+  GETSTAKEPOOLSTATS_ATTEMPT, GETSTAKEPOOLSTATS_FAILED, GETSTAKEPOOLSTATS_SUCCESS,
+  ADDCUSTOMSTAKEPOOL_ATTEMPT, ADDCUSTOMSTAKEPOOL_SUCCESS, ADDCUSTOMSTAKEPOOL_FAILED,
 } from "../actions/StakePoolActions";
 import { CLEARSTAKEPOOLCONFIG } from "../actions/WalletLoaderActions";
 import { WALLET_STAKEPOOL_SETTINGS } from "actions/DaemonActions";
@@ -67,6 +68,19 @@ export default function stakepool(state = {}, action) {
     return { ...state,
       getStakePoolInfoAttempt: false,
       getStakePoolInfo: action.allStakePoolStats,
+    };
+  case ADDCUSTOMSTAKEPOOL_ATTEMPT:
+    return { ...state,
+      addCustomStakePoolAttempt: true
+    };
+  case ADDCUSTOMSTAKEPOOL_SUCCESS:
+    return { ...state,
+      addCustomStakePoolAttempt: false,
+      currentStakePoolConfig: action.currentStakePoolConfig,
+    };
+  case ADDCUSTOMSTAKEPOOL_FAILED:
+    return { ...state,
+      addCustomStakePoolAttempt: false
     };
   default:
     return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -780,6 +780,7 @@ const purchaseTicketsRequestAttempt = get([ "control", "purchaseTicketsRequestAt
 const importScriptRequestAttempt = get([ "control", "importScriptRequestAttempt" ]);
 
 export const isSavingStakePoolConfig = bool(currentStakePoolConfigRequest);
+export const isAddingCustomStakePool = bool(get([ "stakePool", "addCustomStakePoolAttempt" ]));
 export const isPurchasingTickets = bool(purchaseTicketsRequestAttempt);
 export const isImportingScript = bool(importScriptRequestAttempt);
 

--- a/app/style/Modals.less
+++ b/app/style/Modals.less
@@ -49,6 +49,7 @@
 }
 
 .app-modal.info-modal,
+.app-modal.confirm-modal,
 .app-modal-reduced-bar.info-modal,
 .app-modal-standalone.info-modal {
   max-height: 60%;
@@ -82,12 +83,14 @@
 .app-modal-reduced-bar.info-modal.double,
 .app-modal-standalone.info-modal.double,
 .app-modal.passphrase-modal,
+.app-modal.confirm-modal,
 .app-modal-reduced-bar.passphrase-modal {
   width: 540px;
   margin-top: 172px;
 }
 
 .app-modal.info-modal.double,
+.app-modal.confirm-modal,
 .app-modal.passphrase-modal {
   margin-left: 134px;
 }
@@ -156,6 +159,7 @@
 
 @media screen and (max-height: 420px) {
   .app-modal.passphrase-modal,
+  .app-modal.confirm-modal,
   .app-modal.reduced-bar.passphrase-modal {
     top: 10%;
     max-height: 60%;
@@ -285,7 +289,7 @@
 }
 
 .confirm-seed-copy-modal-toolbar > .confirm-modal-close-button {
-  float: left;
+  float: right;
 }
 
 .confirm-seed-copy-modal-header {
@@ -345,7 +349,7 @@
 }
 
 .confirm-modal-toolbar {
-  position: absolute;
+  margin-top: 2em;
   bottom: 20px;
   right: 20px;
 }
@@ -355,7 +359,7 @@
 }
 
 .confirm-modal-toolbar > .confirm-modal-close-button {
-  float: left;
+  float: right;
 }
 
 .confirm-modal-header {

--- a/app/wallet/stakePool.js
+++ b/app/wallet/stakePool.js
@@ -23,4 +23,8 @@ export const setVoteChoices = log((poolHost, apiKey, voteBits) =>
 
 export const getAllStakePoolStats = withLogNoData(() =>
   new Promise((resolve, reject) =>
-    api.allStakePoolStats((response, error) => !response ? reject(error) : resolve(response))), "Get Stakepool Stats");
+    api.allStakePoolStats((response, error) => !response ? reject(error) : resolve(response))), "Get All Stakepool Stats");
+
+export const getStakePoolStats = withLogNoData(host =>
+  new Promise((resolve, reject) =>
+    api.statsFromStakePool(host, (response, error) => !response ? reject(error) : resolve(response))), "Get Single Stakepool Stats");


### PR DESCRIPTION
Close #1464 

Adds the ability to add a custom stakepool by typing its address in the stakepool select drop down, and selecting and option to add that stakepool.

Before adding the stakepool, a request is made to its `/api/v1/stats` endpoint, to check if it exists and get its available api versions. Only then is the stakepool added to the supported list.

Easiest way to test it is probably to run a local webserver (eg: via `php -S` or python simplewebserver) that returns a fixed json with the required fields (eg: copy from an existing stakepool). 