### PR TITLE
[launcher] fix ui reload on non-advanced mode

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -149,8 +149,14 @@ export function getWalletCert(certPath) {
 
 export function readDcrdConfig(configPath, testnet) {
   try {
-    if (!fs.existsSync(dcrdCfg(configPath))) return;
-    const readCfg = ini.parse(Buffer.from(fs.readFileSync(dcrdCfg(configPath))).toString());
+    let readCfg;
+    if (fs.existsSync(dcrdCfg(configPath))) {
+      readCfg = ini.parse(Buffer.from(fs.readFileSync(dcrdCfg(configPath))).toString());
+    } else if (fs.existsSync(dcrdCfg(appDataDirectory()))) {
+      readCfg = ini.parse(Buffer.from(fs.readFileSync(dcrdCfg(appDataDirectory()))).toString());
+    } else {
+      return;
+    }
     let newCfg = {};
     newCfg.rpc_host = "127.0.0.1";
     if (testnet) {


### PR DESCRIPTION
This particular fix is for the case when `~/.dcrd/dcrd.conf` is **not** present. If that file existed, this error wasn't triggered.