### PR TITLE
[history] Fix a couple styling issues with tx history on Overview and History pages

### DIFF
--- a/app/style/HistoryPage.less
+++ b/app/style/HistoryPage.less
@@ -15,6 +15,8 @@
 .history-content-nest {
   padding-top: 1px;
   margin-bottom: 2em;
+  float: left;
+  width: 100%;
 }
 
 .history-content-title-text {

--- a/app/style/TxHistory.less
+++ b/app/style/TxHistory.less
@@ -33,7 +33,7 @@
 .pending-overview-details {
   background-color: rgba(12, 30, 62, 0.0296);
   width: 32px;
-  height: 100%;
+  height: 42px;
   cursor: pointer;
   text-align: center;
   padding-top: 12px;
@@ -41,7 +41,6 @@
 
 .tx-history-row-wrapper {
   float: left;
-  width: 96%;
 }
 
 .is-overview-pending {
@@ -60,7 +59,7 @@
 }
 
 .tx-history-row.is-row-pending {
-  width: 289px;
+  width: 291px;
 }
 
 .tx-history-row:hover {
@@ -73,7 +72,6 @@
   height: 20px;
   background-repeat: no-repeat;
   background-size: 20px 20px;
-  display: inline-block;
   margin-right: 12px;
 }
 


### PR DESCRIPTION
- Pending transactions were causing slightly smaller rows on overview
- Pending indicator was overlapping with other pending in a row beneath.
- Tx History page was showing a row off to the right next to the title area.