### PR TITLE
[launcher] Wallet name and Watch only styling

### DIFF
--- a/app/components/buttons/WatchOnlyWalletSwitch.js
+++ b/app/components/buttons/WatchOnlyWalletSwitch.js
@@ -1,17 +1,15 @@
 import { Tooltip } from "shared";
-import { InvisibleButton } from "buttons";
 import { FormattedMessage as T } from "react-intl";
 import "style/EyeFilterMenu.less";
 import "style/StakePool.less";
 
 const WatchOnlyWalletSwitch = ({ enabled, onClick, className }) => (
   <div className={className ? className : ""}>
-    <Tooltip text={enabled ? <T id="autobuyer.enabled" m="Watch only Wallet" /> : <T id="autobuyer.disabled" m="Not Watch only Wallet" />}>
-      <div className="eye-filter-menu-button">
-        <InvisibleButton
-          className={ enabled ? "eye-filter-menu-button-icon" : "eye-filter-menu-button-icon-disabled" }
-          onClick={onClick}
-        />
+    <Tooltip text={enabled ? <T id="watchOnly.enabled" m="Watch Only" /> : <T id="watchOnly.disabled" m="Normal" />}>
+      <div className="autobuyer-switch">
+        <div className={enabled ? "autobuyer-switch-enabled" : "autobuyer-switch-disabled"} onClick={onClick}>
+          <div className={enabled ? "autobuyer-switch-knob-enabled" : "autobuyer-switch-knob-disabled"}/>
+        </div>
       </div>
     </Tooltip>
   </div>

--- a/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateForm.js
@@ -1,40 +1,22 @@
 import CreateWalletForm from "./CreateWalletForm";
-import ExistingOrNewScreen from "./ExistingOrNewScreen";
 import "style/GetStarted.less";
 
 const CreateForm = ({
-  availableWallets,
-  existingOrNew,
-  createNewWallet,
   onReturnToNewSeed,
   onReturnToWalletSelection,
-  onReturnToExistingOrNewScreen,
-  onSetCreateWalletFromExisting,
   onSetWalletPrivatePassphrase,
   getCurrentBlockCount,
   getNeededBlocks,
   getEstimatedTimeLeft,
-  getDaemonSynced,
-  isWatchOnly,
-  masterPubKey,
 }) => (
-  ((availableWallets.length == 0 && existingOrNew) || !createNewWallet) && !(isWatchOnly && masterPubKey) ?
-    <ExistingOrNewScreen {...{ onSetCreateWalletFromExisting,
-      onReturnToWalletSelection,
-      getCurrentBlockCount,
-      getNeededBlocks,
-      getEstimatedTimeLeft,
-      getDaemonSynced,
-      onSetWalletPrivatePassphrase }} /> :
-    <CreateWalletForm {...{
-      onReturnToNewSeed,
-      onReturnToExistingOrNewScreen,
-      onReturnToWalletSelection,
-      getCurrentBlockCount,
-      getNeededBlocks,
-      getEstimatedTimeLeft,
-      onSetWalletPrivatePassphrase
-    } }/>
+  <CreateWalletForm {...{
+    onReturnToNewSeed,
+    onReturnToWalletSelection,
+    getCurrentBlockCount,
+    getNeededBlocks,
+    getEstimatedTimeLeft,
+    onSetWalletPrivatePassphrase
+  } }/>
 );
 
 export default CreateForm;

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/CreateWallet.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/CreateWallet.js
@@ -13,18 +13,16 @@ const CreateWallet = ({
   showCopySeedConfirm,
   onCancelCopySeedConfirm,
   onSubmitCopySeedConfirm,
-  onReturnToExistingOrNewScreen,
   onReturnToWalletSelection,
   getCurrentBlockCount,
   getNeededBlocks,
   getEstimatedTimeLeft,
   getDaemonSynced,
-  createNewWallet
 }) => (
   <Aux>
     <div className="getstarted content">
       <div className="go-back-screen-button-area">
-        <Tooltip text={ <T id="createWallet.goBack" m="Go back" /> }><div className="go-back-screen-button" onClick={onReturnToExistingOrNewScreen}/></Tooltip>
+        <Tooltip text={ <T id="createWallet.goBack" m="Go back" /> }><div className="go-back-screen-button" onClick={onReturnToWalletSelection}/></Tooltip>
       </div>
       <div className="content-title">
         <T id="createWallet.title" m={"Create a new wallet"}/>
@@ -48,7 +46,7 @@ const CreateWallet = ({
         </KeyBlueButton>
         <InvisibleButton
           className="go-back-button"
-          onClick={!createNewWallet ? onReturnToWalletSelection : onReturnToExistingOrNewScreen}>
+          onClick={onReturnToWalletSelection}>
           <T id="getStarted.backBtn" m="Cancel" />
         </InvisibleButton>
       </div>

--- a/app/components/views/GetStartedPage/WalletSelection/CreateWalletForm.js
+++ b/app/components/views/GetStartedPage/WalletSelection/CreateWalletForm.js
@@ -1,24 +1,27 @@
 import { FormattedMessage as T, defineMessages } from "react-intl";
 import { TextInput } from "inputs";
-import { WatchOnlyWalletSwitch } from "buttons";
+import { KeyBlueButton, InvisibleButton, WatchOnlyWalletSwitch } from "buttons";
 import "style/LoginForm.less";
 
 const messages = defineMessages({
   messageWalletNamePlaceholder: {
     id: "createwallet.walletname.placehlder",
-    defaultMessage: "Enter your wallet name here",
+    defaultMessage: "Choose a Name",
   },
   messageWalletMasterPubKey: {
     id: "createwallet.walletpubkey.placeholder",
-    defaultMessage: "Enter wallet master pub key here",
+    defaultMessage: "Master Pub Key",
   },
   messageWalletMasterPubkeyError: {
     id: "createwallet.walletWatchOnly.error",
-    defaultMessage: "Wrong Master Pubkey",
+    defaultMessage: "Invalid Master Pubkey",
   }
 });
 
 const CreateWalletForm = ({
+  createWallet,
+  hideCreateWalletForm,
+  availableWallets,
   newWalletName,
   createNewWallet,
   onChangeCreateWalletName,
@@ -32,12 +35,23 @@ const CreateWalletForm = ({
 }) => {
   return (
     <Aux>
+      {!createNewWallet ?
+        <div className="new-wallet-title-area">
+          <div className="wallet-icon-small createnew" />
+          <div className="new-wallet-title">
+            <T id="getStarted.newSeedTab" m="Create a New Wallet"/>
+          </div>
+        </div> :
+        <div className="new-wallet-title-area">
+          <div className="wallet-icon-small restore" />
+          <div className="new-wallet-title">
+            <T id="getStarted.restore" m="Restore Existing Wallet"/>
+          </div>
+        </div>
+      }
       <div className="advanced-daemon-row">
         <div className="advanced-daemon-label">
-          {!createNewWallet ?
-            <T id="createwallet.walletname.label" m="New Wallet Name" /> :
-            <T id="createwallet.walletname.restored.label" m="Restored Wallet Name" />
-          }
+          <T id="createwallet.walletname.label" m="Wallet Name" />
         </div>
         <div className="advanced-daemon-input">
           <TextInput
@@ -49,32 +63,44 @@ const CreateWalletForm = ({
           />
         </div>
       </div>
+      {createNewWallet &&
+        <Aux>
+          <div className="advanced-daemon-row">
+            <div className="advanced-daemon-label">
+              <T id="createwallet.walletOnly.label" m="Watch only" />
+            </div>
+            <div className="advanced-daemon-input">
+              <WatchOnlyWalletSwitch className="wallet-switch" enabled={ isWatchOnly } onClick={ toggleWatchOnly } />
+            </div>
+          </div>
+          {isWatchOnly &&
+            <div className="advanced-daemon-row">
+              <div className="advanced-daemon-label">
+                <T id="createwallet.walletmasterpubkey.label" m="Master Pub Key" />
+              </div>
+              <div className="advanced-daemon-long-input">
+                <TextInput
+                  required
+                  value={ walletMasterPubKey }
+                  onChange={(e) => onChangeCreateWalletMasterPubKey(e.target.value)}
+                  placeholder={ intl.formatMessage(messages.messageWalletMasterPubKey) }
+                  showErrors={ hasFailedAttempt || masterPubKeyError }
+                  invalid={ masterPubKeyError }
+                  invalidMessage={ intl.formatMessage(messages.messageWalletMasterPubkeyError) }
+                />
+              </div>
+            </div>}
+        </Aux>}
       <div className="advanced-daemon-row">
-        <div className="wallet-switch-wrapper">
-          <WatchOnlyWalletSwitch className="wallet-switch" enabled={ isWatchOnly } onClick={ toggleWatchOnly } />
-          {isWatchOnly ? <T id="createwallet.walletOnly.label" m="Watch only wallet" /> :
-            <T id="createwallet.notWalletOnly.label" m="Not Watch only wallet" />}
-        </div>
+        <KeyBlueButton onClick={createWallet}>
+          <T id="wallet.create.button" m="Continue" />
+        </KeyBlueButton>
+        {availableWallets && availableWallets.length > 0 &&
+          <InvisibleButton onClick={hideCreateWalletForm}>
+            <T id="advancedStartup.cancel" m="Cancel"/>
+          </InvisibleButton>
+        }
       </div>
-      {isWatchOnly &&
-              (
-                <div className="advanced-daemon-row">
-                  <div className="advanced-daemon-label">
-                    <T id="createwallet.walletmasterpubkey.label" m="Master Pub key here" />
-                  </div>
-                  <div className="advanced-daemon-long-input">
-                    <TextInput
-                      required
-                      value={ walletMasterPubKey }
-                      onChange={(e) => onChangeCreateWalletMasterPubKey(e.target.value)}
-                      placeholder={ intl.formatMessage(messages.messageWalletMasterPubKey) }
-                      showErrors={ hasFailedAttempt || masterPubKeyError }
-                      invalid={ masterPubKeyError }
-                      invalidMessage={ intl.formatMessage(messages.messageWalletMasterPubkeyError) }
-                    />
-                  </div>
-                </div>
-              )}
     </Aux>
   );
 };

--- a/app/components/views/GetStartedPage/WalletSelection/CreateWalletForm.js
+++ b/app/components/views/GetStartedPage/WalletSelection/CreateWalletForm.js
@@ -21,7 +21,6 @@ const messages = defineMessages({
 const CreateWalletForm = ({
   createWallet,
   hideCreateWalletForm,
-  availableWallets,
   newWalletName,
   createNewWallet,
   onChangeCreateWalletName,
@@ -95,11 +94,9 @@ const CreateWalletForm = ({
         <KeyBlueButton onClick={createWallet}>
           <T id="wallet.create.button" m="Continue" />
         </KeyBlueButton>
-        {availableWallets && availableWallets.length > 0 &&
-          <InvisibleButton onClick={hideCreateWalletForm}>
-            <T id="advancedStartup.cancel" m="Cancel"/>
-          </InvisibleButton>
-        }
+        <InvisibleButton onClick={hideCreateWalletForm}>
+          <T id="advancedStartup.cancel" m="Cancel"/>
+        </InvisibleButton>
       </div>
     </Aux>
   );

--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -25,7 +25,7 @@ const WalletSelectionBodyBase = ({
   ...props,
 }) => {
   return (
-    availableWallets && availableWallets.length > 0 && !createWalletForm ?
+    availableWallets && !createWalletForm ?
       <div className="advanced-page">
         <div className="advanced-page-form">
           <div className="advanced-daemon-row">
@@ -72,13 +72,15 @@ const WalletSelectionBodyBase = ({
                 </div>
               );
             })}
-            {editWallets ?
-              <Tooltip text={<T id="walletselection.closeEditWallets" m="Close"/>}>
-                <div className="edit-wallets-button close" onClick={onCloseEditWallets}/>
-              </Tooltip> :
-              <Tooltip text={<T id="walletselection.editWallets" m="Edit Wallets"/>}>
-                <div className="edit-wallets-button" onClick={onEditWallets}/>
-              </Tooltip>
+            {availableWallets.length > 0 ?
+              editWallets ?
+                <Tooltip text={<T id="walletselection.closeEditWallets" m="Close"/>}>
+                  <div className="edit-wallets-button close" onClick={onCloseEditWallets}/>
+                </Tooltip> :
+                <Tooltip text={<T id="walletselection.editWallets" m="Edit Wallets"/>}>
+                  <div className="edit-wallets-button" onClick={onEditWallets}/>
+                </Tooltip> :
+              <div/>
             }
             {availableWallets.length < 3 &&
             <Aux>

--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -1,6 +1,6 @@
 import CreateWalletForm from "./CreateWalletForm";
 import { FormattedMessage as T, injectIntl, FormattedRelative } from "react-intl";
-import { KeyBlueButton, RemoveWalletButton, InvisibleButton } from "buttons";
+import { RemoveWalletButton } from "buttons";
 import { Tooltip } from "shared";
 
 const WalletSelectionBodyBase = ({
@@ -101,17 +101,7 @@ const WalletSelectionBodyBase = ({
       </div> :
       <div className="advanced-page">
         <div className="advanced-page-form">
-          <CreateWalletForm {...{ ...props, intl, createNewWallet, isWatchOnly, toggleWatchOnly, masterPubKeyError }} />
-          <div className="loader-bar-buttons">
-            {availableWallets && availableWallets.length > 0 &&
-              <InvisibleButton onClick={hideCreateWalletForm}>
-                <T id="advancedStartup.cancel" m="Cancel"/>
-              </InvisibleButton>
-            }
-            <KeyBlueButton onClick={createWallet}>
-              <T id="wallet.create.button" m="Create new wallet" />
-            </KeyBlueButton>
-          </div>
+          <CreateWalletForm {...{ ...props, intl, availableWallets, hideCreateWalletForm, createWallet, createNewWallet, isWatchOnly, toggleWatchOnly, masterPubKeyError }} />
         </div>
       </div>
   );

--- a/app/index.js
+++ b/app/index.js
@@ -192,7 +192,7 @@ var initialState = {
     maturingBlockHeights: {},
   },
   walletLoader: {
-    existingOrNew: true,
+    existingOrNew: false,
     rpcRetryAttempts: 0,
     neededBlocks: 0,
     curBlocks: 0,

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -68,7 +68,7 @@ export default function walletLoader(state = {}, action) {
   case CREATEWALLET_GOBACK:
     return { ...state,
       stepIndex: 1,
-      existingOrNew: true,
+      existingOrNew: false,
       createNewWallet: false,
     };
   case CREATEWATCHONLYWALLET_ATTEMPT:

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -20,7 +20,8 @@
   float: left;
   width: 75%;
   height: 44px;
-  padding-top: 10px;
+  margin-bottom: 10px;
+  margin-left: 30px;
 }
 
 .advanced-daemon-label {
@@ -596,6 +597,38 @@
     background-image: @launcher-network-active;
     color: #2970ff;
   }
+}
+
+.new-wallet-title-area {
+  float: left;
+  width: 100%;
+  margin-left: 22px;
+  margin-top: 20px;
+  margin-bottom: 22px;
+}
+
+.new-wallet-title {
+  float: left;
+  font-size: 15px;
+  line-height: 19px;
+  margin-top: 3px;
+}
+
+.wallet-icon-small {
+  float: left;
+  height: 30px;
+  width: 30px;
+  background-repeat: no-repeat;
+  background-size: 30px;
+  margin-right: 10px;
+}
+
+.wallet-icon-small.createnew {
+  background-image: @createnewwallet;
+}
+
+.wallet-icon-small.restore {
+  background-image: @restorewallet;
 }
 
 .get-started-custom-privacy-settings {

--- a/app/style/Global.less
+++ b/app/style/Global.less
@@ -12,6 +12,10 @@
   margin: 0px;
   background-color: #fff;
   box-sizing: border-box;
+  font-variant-ligatures: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  text-shadow: rgba(0, 0, 0, 0.01) 0 0 1px;
 }
 
 .bold {

--- a/app/style/LanguageSelect.less
+++ b/app/style/LanguageSelect.less
@@ -54,7 +54,7 @@
   }
 
   .language-select-button {
-    padding: 10px 16px 10px 16px;
+    padding: 5px 16px 10px 16px;
   }
 }
 

--- a/app/style/StakePool.less
+++ b/app/style/StakePool.less
@@ -271,30 +271,31 @@
 .autobuyer-switch-enabled,
 .autobuyer-switch-disabled {
   display: block;
-  width: 60px;
-  height: 24px;
-  border-radius: 5px;
+  width: 50px;
+  height: 20px;
+  border-radius: 3px;
   transition: all 200ms ease-in-out;
   background-color: #d1d5db;
   float: left;
 }
 
 .autobuyer-switch-enabled:hover {
-  width: 56px;
-  padding-left: 4px;
+  width: 47px;
+  padding-left: 3px;
 }
 
 .autobuyer-switch-disabled:hover {
-  width: 56px;
-  padding-right: 4px;
+  width: 47px;
+  padding-right: 3px;
 }
 
 .autobuyer-switch-knob-enabled,
 .autobuyer-switch-knob-disabled {
-  width: 30px;
+  width: 25px;
   height: 100%;
-  border-radius: 5px;
+  border-radius: 3px;
   box-shadow: 0 3px 8px rgba(12, 30, 62, 0.21);
+  transition: all 200ms ease-in-out;
 }
 
 .autobuyer-switch-knob-enabled {

--- a/app/style/StakePool.less
+++ b/app/style/StakePool.less
@@ -275,15 +275,8 @@
   height: 24px;
   border-radius: 5px;
   transition: all 200ms ease-in-out;
+  background-color: #d1d5db;
   float: left;
-}
-
-.autobuyer-switch-enabled {
-  background-color: #2971ff;
-}
-
-.autobuyer-switch-disabled {
-  background-color: @disabled-background-color;
 }
 
 .autobuyer-switch-enabled:hover {
@@ -301,16 +294,16 @@
   width: 30px;
   height: 100%;
   border-radius: 5px;
-  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+  box-shadow: 0 3px 8px rgba(12, 30, 62, 0.21);
 }
 
 .autobuyer-switch-knob-enabled {
-  background-color: #fff;
+  background-color: #2971ff;
 }
 
 .autobuyer-switch-knob-disabled {
   float: right;
-  background-color: #596d81;
+  background-color: #959dac;
 }
 
 .stakepool-auto-buyer-label {


### PR DESCRIPTION
Partially completes #1476 

This mostly completes the design/flow of wallet creation.  I have removed the intermediate step (where only the 2 choices are shown new/restore) temporarily so it can be reworked.  The logic to decide whether to show that screen was becoming cumbersome and too easy to break.  In a following PR I will be addressing that and making sure that the flow proposed by @linnutee is implemented.