### PR TITLE
[multi] Hide watching only functionalities

### DIFF
--- a/app/components/views/AccountsPage/Accounts/List.js
+++ b/app/components/views/AccountsPage/Accounts/List.js
@@ -67,6 +67,7 @@ AccountsList.propTypes = {
   onShowAccountDetails: PropTypes.func.isRequired,
   onHideAccountDetails: PropTypes.func.isRequired,
   accountNumDetailsShown: PropTypes.number,
+  isCreateAccountDisabled: PropTypes.bool.isRequired,
 };
 
 export default AccountsList;

--- a/app/components/views/AccountsPage/Accounts/List.js
+++ b/app/components/views/AccountsPage/Accounts/List.js
@@ -5,19 +5,21 @@ import { DecredLoading } from "indicators";
 import { InfoDocModalButton, PassphraseModalButton } from "buttons";
 import { AddAccountModal } from "modals";
 
-const AccountsListHeader = ({ onGetNextAccountAttempt }) =>
-  <StandaloneHeader
+const AccountsListHeader = ({ onGetNextAccountAttempt, isCreateAccountDisabled }) =>{
+  return  <StandaloneHeader
     title={<T id="accounts.title" m="Accounts" />}
     description={<T id="accounts.description" m={"Accounts allow you to keep separate records of your DCR funds.\nTransferring DCR across accounts will create a transaction on the blockchain."}/>}
     iconClassName="accounts"
     actionButton={
+      !isCreateAccountDisabled &&
       <PassphraseModalButton
         modalTitle={<T id="accounts.newAccountConfirmations" m="Create new account" />}
         modalComponent={AddAccountModal}
         onSubmit={onGetNextAccountAttempt}
         buttonLabel={<T id="accounts.addNewButton" m="Add New" />}
       />}
-  />;
+  />
+    }
 
 const AccountsList = ({
   accounts,
@@ -29,8 +31,9 @@ const AccountsList = ({
   onShowAccountDetails,
   onHideAccountDetails,
   accountNumDetailsShown,
+  isCreateAccountDisabled,
 }) => (
-  <StandalonePage header={<AccountsListHeader {...{ onGetNextAccountAttempt }} />}>
+  <StandalonePage header={<AccountsListHeader {...{ onGetNextAccountAttempt, isCreateAccountDisabled }} />}>
     { isLoading ? <DecredLoading/> :
       <Aux>
         <div className="account-content-title-buttons-area">

--- a/app/components/views/AccountsPage/Accounts/List.js
+++ b/app/components/views/AccountsPage/Accounts/List.js
@@ -5,21 +5,19 @@ import { DecredLoading } from "indicators";
 import { InfoDocModalButton, PassphraseModalButton } from "buttons";
 import { AddAccountModal } from "modals";
 
-const AccountsListHeader = ({ onGetNextAccountAttempt, isCreateAccountDisabled }) =>{
-  return  <StandaloneHeader
-    title={<T id="accounts.title" m="Accounts" />}
-    description={<T id="accounts.description" m={"Accounts allow you to keep separate records of your DCR funds.\nTransferring DCR across accounts will create a transaction on the blockchain."}/>}
-    iconClassName="accounts"
-    actionButton={
-      !isCreateAccountDisabled &&
-      <PassphraseModalButton
-        modalTitle={<T id="accounts.newAccountConfirmations" m="Create new account" />}
-        modalComponent={AddAccountModal}
-        onSubmit={onGetNextAccountAttempt}
-        buttonLabel={<T id="accounts.addNewButton" m="Add New" />}
-      />}
-  />
-    }
+const AccountsListHeader = ({ onGetNextAccountAttempt, isCreateAccountDisabled }) => <StandaloneHeader
+  title={<T id="accounts.title" m="Accounts" />}
+  description={<T id="accounts.description" m={"Accounts allow you to keep separate records of your DCR funds.\nTransferring DCR across accounts will create a transaction on the blockchain."}/>}
+  iconClassName="accounts"
+  actionButton={
+    !isCreateAccountDisabled &&
+    <PassphraseModalButton
+      modalTitle={<T id="accounts.newAccountConfirmations" m="Create new account" />}
+      modalComponent={AddAccountModal}
+      onSubmit={onGetNextAccountAttempt}
+      buttonLabel={<T id="accounts.addNewButton" m="Add New" />}
+    />}
+/>;
 
 const AccountsList = ({
   accounts,

--- a/app/components/views/AccountsPage/Accounts/index.js
+++ b/app/components/views/AccountsPage/Accounts/index.js
@@ -16,6 +16,7 @@ class Accounts extends React.Component {
         {...{
           accounts: this.props.accounts,
           isLoading: this.props.isLoading,
+          isCreateAccountDisabled: this.props.isCreateAccountDisabled,
           onGetNextAccountAttempt: this.onGetNextAccountAttempt,
           onHideAccount: this.props.onHideAccount,
           onShowAccount: this.props.onShowAccount,

--- a/app/components/views/AccountsPage/Page.js
+++ b/app/components/views/AccountsPage/Page.js
@@ -3,10 +3,11 @@ import ErrorScreen from "ErrorScreen";
 import "style/AccountsPage.less";
 
 const Page = ({
-  walletService
+  walletService,
+  isCreateAccountDisabled,
 }) => (
   !walletService ? <ErrorScreen/> :
-    <Accounts />
+    <Accounts {...{ isCreateAccountDisabled }}/>
 );
 
 export default Page;

--- a/app/components/views/AccountsPage/Page.js
+++ b/app/components/views/AccountsPage/Page.js
@@ -10,4 +10,9 @@ const Page = ({
     <Accounts {...{ isCreateAccountDisabled }}/>
 );
 
+Page.propTypes = {
+  walletService: PropTypes.object.isRequired,
+  isCreateAccountDisabled: PropTypes.bool.isRequired,
+}
+
 export default Page;

--- a/app/components/views/AccountsPage/Page.js
+++ b/app/components/views/AccountsPage/Page.js
@@ -13,6 +13,6 @@ const Page = ({
 Page.propTypes = {
   walletService: PropTypes.object.isRequired,
   isCreateAccountDisabled: PropTypes.bool.isRequired,
-}
+};
 
 export default Page;

--- a/app/components/views/AccountsPage/index.js
+++ b/app/components/views/AccountsPage/index.js
@@ -10,6 +10,7 @@ class AccountsPage extends React.Component {
       <Page
         {...{
           walletService: this.props.walletService,
+          isCreateAccountDisabled: this.props.isCreateAccountDisabled,
         }}
       />
     );

--- a/app/components/views/SecurityPage/index.js
+++ b/app/components/views/SecurityPage/index.js
@@ -39,26 +39,26 @@ class SecurityPage extends React.Component {
     const { isSignVerifyMessageDisabled } = this.props;
     return (
       <StandalonePage header={<SecurityHeader />}>
-      {
-        !isSignVerifyMessageDisabled &&
-        <Aux>
-          <div className="advanced-page-toggle security-page">
-            <div className="text-toggle">
-              <div className={"text-toggle-button-left " + (sideActive && "text-toggle-button-active")} onClick={!sideActive ? onShowVerify : null}>
-                <T id="security.signTitle" m="Sign Message" />
-              </div>
-              <div className={"text-toggle-button-right " + (!sideActive && "text-toggle-button-active")} onClick={sideActive ? onShowSign : null}>
-                <T id="security.verifyTitle" m="Verify Message" />
+        {
+          !isSignVerifyMessageDisabled &&
+          <Aux>
+            <div className="advanced-page-toggle security-page">
+              <div className="text-toggle">
+                <div className={"text-toggle-button-left " + (sideActive && "text-toggle-button-active")} onClick={!sideActive ? onShowVerify : null}>
+                  <T id="security.signTitle" m="Sign Message" />
+                </div>
+                <div className={"text-toggle-button-right " + (!sideActive && "text-toggle-button-active")} onClick={sideActive ? onShowSign : null}>
+                  <T id="security.verifyTitle" m="Verify Message" />
+                </div>
               </div>
             </div>
-          </div>
-          <div className="security-page-form">
-            {sideActive ?
-              <SignTab /> : <VerifyMessageTab />
-            }
-          </div>
-        </Aux>
-      }
+            <div className="security-page-form">
+              {sideActive ?
+                <SignTab /> : <VerifyMessageTab />
+              }
+            </div>
+          </Aux>
+        }
         <ValidateAddressTab />
       </StandalonePage>
     );

--- a/app/components/views/SecurityPage/index.js
+++ b/app/components/views/SecurityPage/index.js
@@ -3,6 +3,7 @@ import { StandalonePage, StandaloneHeader } from "layout";
 import { default as SignTab } from "./SignMessage";
 import { default as ValidateAddressTab } from "./ValidateAddress";
 import { default as VerifyMessageTab } from "./VerifyMessage";
+import { security } from "connectors";
 
 const SecurityHeader = () =>
   <StandaloneHeader
@@ -35,23 +36,29 @@ class SecurityPage extends React.Component {
   render() {
     const { sideActive } = this.state;
     const { onShowSign, onShowVerify } = this;
+    const { isSignVerifyMessageDisabled } = this.props;
     return (
       <StandalonePage header={<SecurityHeader />}>
-        <div className="advanced-page-toggle security-page">
-          <div className="text-toggle">
-            <div className={"text-toggle-button-left " + (sideActive && "text-toggle-button-active")} onClick={!sideActive ? onShowVerify : null}>
-              <T id="security.signTitle" m="Sign Message" />
-            </div>
-            <div className={"text-toggle-button-right " + (!sideActive && "text-toggle-button-active")} onClick={sideActive ? onShowSign : null}>
-              <T id="security.verifyTitle" m="Verify Message" />
+      {
+        !isSignVerifyMessageDisabled &&
+        <Aux>
+          <div className="advanced-page-toggle security-page">
+            <div className="text-toggle">
+              <div className={"text-toggle-button-left " + (sideActive && "text-toggle-button-active")} onClick={!sideActive ? onShowVerify : null}>
+                <T id="security.signTitle" m="Sign Message" />
+              </div>
+              <div className={"text-toggle-button-right " + (!sideActive && "text-toggle-button-active")} onClick={sideActive ? onShowSign : null}>
+                <T id="security.verifyTitle" m="Verify Message" />
+              </div>
             </div>
           </div>
-        </div>
-        <div className="security-page-form">
-          {sideActive ?
-            <SignTab /> : <VerifyMessageTab />
-          }
-        </div>
+          <div className="security-page-form">
+            {sideActive ?
+              <SignTab /> : <VerifyMessageTab />
+            }
+          </div>
+        </Aux>
+      }
         <ValidateAddressTab />
       </StandalonePage>
     );
@@ -65,4 +72,4 @@ class SecurityPage extends React.Component {
   }
 }
 
-export default SecurityPage;
+export default security(SecurityPage);

--- a/app/components/views/SettingsPage/Page.js
+++ b/app/components/views/SettingsPage/Page.js
@@ -33,20 +33,20 @@ const SettingsPage = ({
         <ProxySettings {...{ tempSettings, onChangeTempSettings }} />
       </div>
       <div className="settings-columns">
-      {
-        !isChangePassPhraseDisabled &&
-        <div className="settings-security">
-          <div className="settings-column-title"><T id="settings.security.title" m="Security" /></div>
-          <div className="settings-action-buttons">
-            <div className="settings-update-passphrase-button">
-              <T id="settings.updatePrivatePassphrase" m="Update Private Passphrase" />
-              <ChangePassphraseButton
-                modalTitle={<T id="settings.changeConfirmation" m="Change your passphrase" />}
-                onSubmit={onAttemptChangePassphrase} />
+        {
+          !isChangePassPhraseDisabled &&
+          <div className="settings-security">
+            <div className="settings-column-title"><T id="settings.security.title" m="Security" /></div>
+            <div className="settings-action-buttons">
+              <div className="settings-update-passphrase-button">
+                <T id="settings.updatePrivatePassphrase" m="Update Private Passphrase" />
+                <ChangePassphraseButton
+                  modalTitle={<T id="settings.changeConfirmation" m="Change your passphrase" />}
+                  onSubmit={onAttemptChangePassphrase} />
+              </div>
             </div>
           </div>
-        </div>
-      }
+        }
         <PrivacySettings {...{ tempSettings, onChangeTempSettings }} />
       </div>
     </div>
@@ -73,6 +73,6 @@ SettingsPage.propTypes = {
   onSaveSettings: PropTypes.func.isRequired,
   onAttemptChangePassphrase: PropTypes.func,
   isChangePassPhraseDisabled: PropTypes.bool.isRequired,
-}
+};
 
 export default SettingsPage;

--- a/app/components/views/SettingsPage/Page.js
+++ b/app/components/views/SettingsPage/Page.js
@@ -63,4 +63,16 @@ const SettingsPage = ({
   </StandalonePage>
 );
 
+SettingsPage.propTypes = {
+  areSettingsDirty: PropTypes.bool.isRequired,
+  tempSettings: PropTypes.object.isRequired,
+  networks: PropTypes.array.isRequired,
+  currencies: PropTypes.array.isRequired,
+  locales: PropTypes.array,
+  onChangeTempSettings: PropTypes.func.isRequired,
+  onSaveSettings: PropTypes.func.isRequired,
+  onAttemptChangePassphrase: PropTypes.func,
+  isChangePassPhraseDisabled: PropTypes.bool.isRequired,
+}
+
 export default SettingsPage;

--- a/app/components/views/SettingsPage/Page.js
+++ b/app/components/views/SettingsPage/Page.js
@@ -23,6 +23,7 @@ const SettingsPage = ({
   onChangeTempSettings,
   onSaveSettings,
   onAttemptChangePassphrase,
+  isChangePassPhraseDisabled,
 }) => (
   <StandalonePage header={<SettingsPageHeader />}>
     <div className="settings-wrapper">
@@ -32,6 +33,8 @@ const SettingsPage = ({
         <ProxySettings {...{ tempSettings, onChangeTempSettings }} />
       </div>
       <div className="settings-columns">
+      {
+        !isChangePassPhraseDisabled &&
         <div className="settings-security">
           <div className="settings-column-title"><T id="settings.security.title" m="Security" /></div>
           <div className="settings-action-buttons">
@@ -43,6 +46,7 @@ const SettingsPage = ({
             </div>
           </div>
         </div>
+      }
         <PrivacySettings {...{ tempSettings, onChangeTempSettings }} />
       </div>
     </div>

--- a/app/connectors/accountsPage.js
+++ b/app/connectors/accountsPage.js
@@ -3,7 +3,8 @@ import { selectorMap } from "../fp";
 import * as sel from "../selectors";
 
 const mapStateToProps = selectorMap({
-  walletService: sel.walletService
+  walletService: sel.walletService,
+  isCreateAccountDisabled: sel.isCreateAccountDisabled,
 });
 
 export default connect(mapStateToProps);

--- a/app/connectors/index.js
+++ b/app/connectors/index.js
@@ -12,6 +12,7 @@ export { default as purchaseTickets } from "./purchaseTickets";
 export { default as receive } from "./receive";
 export { default as receiveAccountsSelect } from "./receiveAccountsSelect";
 export { default as rescan } from "./rescan";
+export { default as security } from "./security";
 export { default as send } from "./send";
 export { default as service } from "./service";
 export { default as settings } from "./settings";

--- a/app/connectors/security.js
+++ b/app/connectors/security.js
@@ -3,7 +3,7 @@ import { selectorMap } from "../fp";
 import * as sel from "../selectors";
 
 const mapStateToProps = selectorMap({
-    isSignVerifyMessageDisabled: sel.isSignVerifyMessageDisabled,
+  isSignVerifyMessageDisabled: sel.isSignVerifyMessageDisabled,
 });
 
 export default connect(mapStateToProps);

--- a/app/connectors/security.js
+++ b/app/connectors/security.js
@@ -1,0 +1,9 @@
+import { connect } from "react-redux";
+import { selectorMap } from "../fp";
+import * as sel from "../selectors";
+
+const mapStateToProps = selectorMap({
+    isSignVerifyMessageDisabled: sel.isSignVerifyMessageDisabled,
+});
+
+export default connect(mapStateToProps);

--- a/app/connectors/settings.js
+++ b/app/connectors/settings.js
@@ -10,7 +10,8 @@ const mapStateToProps = selectorMap({
   networks: sel.networks,
   locales: sel.sortedLocales,
   tempSettings: sel.tempSettings,
-  areSettingsDirty: sel.settingsChanged
+  areSettingsDirty: sel.settingsChanged,
+  isChangePassPhraseDisabled: sel.isChangePassPhraseDisabled,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -881,8 +881,8 @@ export const stakeRewardsStats = createSelector(
 export const modalVisible = get([ "control", "modalVisible" ]);
 
 // Functionalities deactivated
-export const isSignVerifyMessageDisabled = compose(v => v, isWatchingOnly);
+export const isSignVerifyMessageDisabled = or(isWatchingOnly, isWatchOnly);
 
-export const isCreateAccountDisabled = compose(v => v, isWatchingOnly);
+export const isCreateAccountDisabled = or(isWatchingOnly, isWatchOnly);
 
-export const isChangePassPhraseDisabled = compose(v => v, isWatchingOnly);
+export const isChangePassPhraseDisabled = or(isWatchingOnly, isWatchOnly);

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -881,9 +881,7 @@ export const stakeRewardsStats = createSelector(
 export const modalVisible = get([ "control", "modalVisible" ]);
 
 // Functionalities deactivated
-export const isSignMessageDisabled = compose(v => v, isWatchingOnly);
-
-export const isVerifyMessageDisabled = compose(v => v, isWatchingOnly);
+export const isSignVerifyMessageDisabled = compose(v => v, isWatchingOnly);
 
 export const isCreateAccountDisabled = compose(v => v, isWatchingOnly);
 

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -879,3 +879,12 @@ export const stakeRewardsStats = createSelector(
   })));
 
 export const modalVisible = get([ "control", "modalVisible" ]);
+
+// Functionalities deactivated
+export const isSignMessageDisabled = compose(v => v, isWatchingOnly);
+
+export const isVerifyMessageDisabled = compose(v => v, isWatchingOnly);
+
+export const isCreateAccountDisabled = compose(v => v, isWatchingOnly);
+
+export const isChangePassPhraseDisabled = compose(v => v, isWatchingOnly);


### PR DESCRIPTION
starts #1490 

This PR hides some functionalities when in watching wallet only mode. 

- sign/verify message
- new account button
- change passphrase button

We still need to figure what to do with tabs that need to be hidden.

I believe hiding the tabs would be fine, if we have a message showing that the wallet is not fully functional because of the watching only mode.