### PR TITLE
[send] Show insufficient funds error below field

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -376,6 +376,7 @@ export const stopAutoBuyerAttempt = () => (dispatch, getState) => {
 
 export const CONSTRUCTTX_ATTEMPT = "CONSTRUCTTX_ATTEMPT";
 export const CONSTRUCTTX_FAILED = "CONSTRUCTTX_FAILED";
+export const CONSTRUCTTX_FAILED_LOW_BALANCE = "CONSTRUCTTX_FAILED_LOW_BALANCE";
 export const CONSTRUCTTX_SUCCESS = "CONSTRUCTTX_SUCCESS";
 
 export function constructTransactionAttempt(account, confirmations, outputs, all) {
@@ -418,7 +419,11 @@ export function constructTransactionAttempt(account, confirmations, outputs, all
     walletService.constructTransaction(request,
       function(error, constructTxResponse) {
         if (error) {
-          dispatch({ error, type: CONSTRUCTTX_FAILED });
+          if (String(error).indexOf("insufficient balance") > 0) {
+            dispatch({ error, type: CONSTRUCTTX_FAILED_LOW_BALANCE });
+          } else {
+            dispatch({ error, type: CONSTRUCTTX_FAILED });
+          }
         } else {
           if (!all) {
             constructTxResponse.totalAmount = totalAmount;

--- a/app/components/inputs/Input.js
+++ b/app/components/inputs/Input.js
@@ -72,7 +72,7 @@ class Input extends React.Component{
               onBlur={this.onInputBlur}
               onKeyDown={this.onKeyDown}
             />
-            {unit ? <div className="unit-area">{unit}</div> : null}
+            {unit && !(showErrors && ((invalid && value) || (required && !value))) ? <div className="unit-area">{unit}</div> : null}
           </div>
           {showErrors ? (
             <div className="input-errors-area">

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -32,15 +32,19 @@ class Send extends React.Component {
       account: this.props.defaultSpendingAccount,
       outputs: [ { key: "output_0", data:{ ...BASE_OUTPUT } } ],
       outputAccount: this.props.defaultSpendingAccount,
+      lowBalanceError: false,
     };
   }
 
   componentWillReceiveProps(nextProps) {
-    const { nextAddress } = this.props;
+    const { nextAddress, constructTxLowBalance } = this.props;
     const { isSendSelf, outputs } = this.state;
     if (isSendSelf && (nextAddress != nextProps.nextAddress)) {
       let newOutputs = outputs.map(o => ({ ...o, data:{ ...o.data, destination: nextProps.nextAddress } }));
       this.setState({ outputs: newOutputs }, this.onAttemptConstructTransaction);
+    }
+    if ( constructTxLowBalance !== nextProps.constructTxLowBalance ) {
+      this.setState({ lowBalanceError: nextProps.constructTxLowBalance });
     }
   }
 
@@ -269,7 +273,8 @@ class Send extends React.Component {
               amount: newAmount
             },
           };
-        })
+        }),
+        lowBalanceError: false,
       }, () => reconstruct && this.onAttemptConstructTransaction());
     };
   }
@@ -307,10 +312,11 @@ class Send extends React.Component {
   }
 
   getAmountError(key) {
-    const { outputs, isSendAll } = this.state;
+    const { outputs, isSendAll, lowBalanceError } = this.state;
     const { amount } = outputs[key].data;
     if (isNaN(amount) && !isSendAll) return <T id="send.errors.invalidAmount" m="Please enter a valid amount" /> ;
     if (amount <= 0 && !isSendAll) return <T id="send.errors.negativeAmount" m="Please enter a valid amount (> 0)" />;
+    if (lowBalanceError) return <T id="send.errors.insufficientFunds" m="Not Enough Funds" />;
   }
 }
 

--- a/app/connectors/send.js
+++ b/app/connectors/send.js
@@ -16,7 +16,8 @@ const mapStateToProps = selectorMap({
   nextAddress: sel.nextAddress,
   nextAddressAccount: sel.nextAddressAccount,
   unitDivisor: sel.unitDivisor,
-  hasUnminedTransactions: sel.hasUnminedTransactions
+  hasUnminedTransactions: sel.hasUnminedTransactions,
+  constructTxLowBalance: sel.constructTxLowBalance,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -16,7 +16,7 @@ import { GETNEXTADDRESS_ATTEMPT, GETNEXTADDRESS_FAILED, GETNEXTADDRESS_SUCCESS,
   SETTICKETBUYERCONFIG_ATTEMPT, SETTICKETBUYERCONFIG_FAILED, SETTICKETBUYERCONFIG_SUCCESS,
   STARTAUTOBUYER_ATTEMPT, STARTAUTOBUYER_FAILED, STARTAUTOBUYER_SUCCESS,
   STOPAUTOBUYER_ATTEMPT, STOPAUTOBUYER_FAILED, STOPAUTOBUYER_SUCCESS,
-  CONSTRUCTTX_ATTEMPT, CONSTRUCTTX_FAILED, CONSTRUCTTX_SUCCESS,
+  CONSTRUCTTX_ATTEMPT, CONSTRUCTTX_FAILED, CONSTRUCTTX_SUCCESS, CONSTRUCTTX_FAILED_LOW_BALANCE,
   SETBALANCETOMAINTAIN, SETMAXFEE, SETMAXPRICEABSOLUTE, SETMAXPRICERELATIVE, SETMAXPERBLOCK,
   VALIDATEADDRESS_ATTEMPT, VALIDATEADDRESS_SUCCESS, VALIDATEADDRESS_FAILED, VALIDATEADDRESS_CLEANSTORE,
   MODAL_SHOWN, MODAL_HIDDEN, VALIDATEMASTERPUBKEY_SUCCESS, VALIDATEMASTERPUBKEY_FAILED,
@@ -191,6 +191,7 @@ export default function control(state = {}, action) {
   case CLEARTX:
     return { ...state,
       constructTxResponse: null,
+      constructTxLowBalance: false,
       validateAddressResponse: null,
       validateAddressError: null,
     };
@@ -363,11 +364,18 @@ export default function control(state = {}, action) {
   case CONSTRUCTTX_ATTEMPT:
     return { ...state,
       constructTxRequestAttempt: true,
+      constructTxLowBalance: false,
     };
   case CONSTRUCTTX_FAILED:
     return { ...state,
       constructTxRequestAttempt: false,
       constructTxResponse: null,
+    };
+  case CONSTRUCTTX_FAILED_LOW_BALANCE:
+    return { ...state,
+      constructTxRequestAttempt: false,
+      constructTxResponse: null,
+      constructTxLowBalance: true,
     };
   case CONSTRUCTTX_SUCCESS:
     return { ...state,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -589,6 +589,7 @@ export const defaultSpendingAccount = createSelector(
   [ spendingAccounts ], find(compose(eq(0), get("value")))
 );
 
+export const constructTxLowBalance = get([ "control", "constructTxLowBalance" ]);
 const constructTxResponse = get([ "control", "constructTxResponse" ]);
 const constructTxRequestAttempt = get([ "control", "constructTxRequestAttempt" ]);
 const signTransactionRequestAttempt = get([ "control", "signTransactionRequestAttempt" ]);


### PR DESCRIPTION
Instead of passing the insufficient funds error through to be used in the snack bar, we instead capture it and alert the amount fields instead.

This also includes a fix to hide the "unit" of an input field if there is an error detected.