### PR TITLE
[charts] fix negative balances

### DIFF
--- a/app/components/charts/TicketChart.js
+++ b/app/components/charts/TicketChart.js
@@ -8,7 +8,6 @@ import ChartTooltip from "./ChartTooltip";
 const BalanceChart = ({ data, intl }) => {
 
   const lockedKey = intl.formatMessage(messages.lockedKey);
-  const immatureKey = intl.formatMessage(messages.immatureKey);
   const votedKey = intl.formatMessage(messages.votedKey);
   const ticketKey = intl.formatMessage(messages.ticketKey);
   const revokedKey = intl.formatMessage(messages.revokedKey);
@@ -19,7 +18,6 @@ const BalanceChart = ({ data, intl }) => {
     [votedKey]: s.voted,
     [revokedKey]: s.revoked,
     [ticketKey]: s.ticket,
-    [immatureKey]: s.immature,
     [lockedKey]: s.locked,
   }));
 
@@ -31,7 +29,6 @@ const BalanceChart = ({ data, intl }) => {
       <Bar barSize={8} dataKey={lockedKey} stackId="a" fill="#2971ff" radius={radiusBottom} />
       <Bar barSize={8} dataKey={revokedKey} stackId="a" fill="#8e1702" radius={radiusMiddle} />
       <Bar barSize={8} dataKey={ticketKey} stackId="a" fill="#69d5f7" radius={radiusMiddle} />
-      <Bar barSize={8} dataKey={immatureKey} stackId="a" fill="#9ee702" radius={radiusMiddle} />
       <Bar barSize={8} dataKey={votedKey} stackId="a" fill="#2ed7a2" radius={radiusTop} />
     </BarChart>
   );


### PR DESCRIPTION
Fix #1493 
Fix #1514 

This removes the immature balance from tickets balances which is calculated as negative in the startup statistics and also fixes the negative balances on the daily balances chart.

The underlying problem was a small difference in how pool fees were being calculated in the forwards vs backwards statistics.