### PR TITLE
[launcher] Label watch-only wallets

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -126,6 +126,7 @@ export const createWatchOnlyWalletRequest = (extendedPubKey, pubPass ="") => (di
     .then(() => {
       const { daemon: { walletName } } = getState();
       const config = getWalletCfg(isTestNet(getState()), walletName);
+      config.set("iswatchonly", true);
       config.delete("discoveraccounts");
       dispatch({ response: {}, type: CREATEWATCHONLYWALLET_SUCCESS });
       dispatch(getWalletServiceAttempt());

--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -46,7 +46,7 @@ const WalletSelectionBodyBase = ({
                       </Tooltip>
                     </div>}
                   <div className={selected && !editWallets ? "display-wallet-complete selected" : "display-wallet-complete"}>
-                    {!wallet.finished && "Setup incomplete"}
+                    {!wallet.isWatchOnly ? !wallet.finished && <T id="walletselection.setupIncomplete" m="Setup incomplete"/> : <T id="walletselection.watchOnly" m="Watch Only"/>}
                   </div>
                   <div className={selected && !editWallets ? "wallet-icon selected" : "wallet-icon wallet"}/>
                   <div className={selected && !editWallets ? "display-wallet-name selected" : "display-wallet-name"}>

--- a/app/config.js
+++ b/app/config.js
@@ -53,6 +53,9 @@ export function initWalletCfg(testnet, walletPath) {
   if (!config.has("gaplimit")) {
     config.set("gaplimit","20");
   }
+  if (!config.has("iswatchonly")) {
+    config.set("iswatchonly", false);
+  }
   stakePoolInfo(function(foundStakePoolConfigs) {
     if (foundStakePoolConfigs !== null) {
       updateStakePoolConfig(config, foundStakePoolConfigs);

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -35,7 +35,7 @@ const mapStateToProps = selectorMap({
   rescanEndBlock: sel.rescanEndBlock,
   rescanStartBlock: sel.rescanStartBlock,
   rescanCurrentBlock: sel.rescanCurrentBlock,
-  availableWallets: sel.availableWalletsSelect,
+  availableWallets: sel.sortedAvailableWallets,
   walletName: sel.getWalletName,
   previousWallet: sel.previousWallet,
   availableLanguages: sel.sortedLocales,

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -24,9 +24,10 @@ export const getAvailableWallets = (network) => {
 
     const cfg = getWalletCfg(isTestNet, wallet);
     const lastAccess = cfg.get("lastaccess");
+    const watchOnly = cfg.get("iswatchonly");
     const walletDbFilePath = getWalletDBPathFromWallets(isTestNet, wallet);
     const finished = fs.pathExistsSync(walletDbFilePath);
-    availableWallets.push({ network, wallet, finished, lastAccess });
+    availableWallets.push({ network, wallet, finished, lastAccess, watchOnly });
   });
 
   return availableWallets;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -84,7 +84,7 @@ export const startupError = or(
 
 const availableWallets = get([ "daemon", "availableWallets" ]);
 
-export const availableWalletsSelect = createSelector(
+const availableWalletsSelect = createSelector(
   [ availableWallets ],
   (wallets) => map(
     wallet => ({
@@ -97,6 +97,11 @@ export const availableWalletsSelect = createSelector(
     }),
     wallets
   )
+);
+
+export const sortedAvailableWallets = createSelector(
+  [ availableWalletsSelect ],
+  (availableWallets) => (availableWallets.sort((a, b) => (b.lastAccess - a.lastAccess)))
 );
 export const previousWallet = get([ "daemon", "previousWallet" ]);
 export const getWalletName = get([ "daemon", "walletName" ]);

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -92,6 +92,7 @@ export const availableWalletsSelect = createSelector(
       value: wallet,
       network: wallet.network,
       finished: wallet.finished,
+      isWatchOnly: wallet.watchOnly,
       lastAccess: wallet.lastAccess ? new Date(wallet.lastAccess) : null,
     }),
     wallets


### PR DESCRIPTION
Close #1530 
Close #1460 

This isn't backwards compatible (won't label already created watch only wallets), but I think that's acceptable since it will really only effect the devs that have been recently using watch only wallets.

This also includes a sort for available wallets so the most recently user wallet is list on the left.