### PR TITLE
[multi] refactor tx, msg and accounts components

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -6,7 +6,6 @@ import { getAccountsAttempt, getStartupWalletInfo, getStakeInfoAttempt } from ".
 import { getWalletCfg } from "../config";
 import { RescanRequest, ConstructTransactionRequest } from "../middleware/walletrpc/api_pb";
 
-
 export const GETNEXTADDRESS_ATTEMPT = "GETNEXTADDRESS_ATTEMPT";
 export const GETNEXTADDRESS_FAILED = "GETNEXTADDRESS_FAILED";
 export const GETNEXTADDRESS_SUCCESS = "GETNEXTADDRESS_SUCCESS";
@@ -491,7 +490,7 @@ export function signMessageAttempt(address, message, passphrase ) {
     dispatch({ type: SIGNMESSAGE_ATTEMPT });
     wallet.signMessage(sel.walletService(getState()), address, message, passphrase)
       .then(getSignMessageResponse =>
-        dispatch({ getSignMessageResponse, type: SIGNMESSAGE_SUCCESS }))
+        dispatch({ getSignMessageSignature: getSignMessageResponse.toObject().signature, type: SIGNMESSAGE_SUCCESS }))
       .catch(error => dispatch({ error, type: SIGNMESSAGE_FAILED }));
   };
 }

--- a/app/components/buttons/SendTransactionButton.js
+++ b/app/components/buttons/SendTransactionButton.js
@@ -1,0 +1,36 @@
+import { send } from "connectors";
+import { PassphraseModalButton } from "./index";
+import { FormattedMessage as T } from "react-intl";
+
+@autobind
+class SendTransactionButton extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  async onAttemptSignTransaction(privpass) {
+    const { unsignedTransaction, onAttemptSignTransaction, disabled, onSubmit } = this.props;
+    if (!privpass || disabled || !onAttemptSignTransaction) return;
+    await onAttemptSignTransaction(privpass, unsignedTransaction);
+    onSubmit && onSubmit();
+  }
+
+  render() {
+    const { disabled, isSendingTransaction, children } = this.props;
+
+    return (
+      <PassphraseModalButton
+        modalTitle={<T id="send.sendConfirmations" m="Transaction Confirmation" />}
+        modalDescription={children}
+        disabled={disabled || isSendingTransaction}
+        className="content-send"
+        onSubmit={this.onAttemptSignTransaction}
+        loading={isSendingTransaction}
+        buttonLabel={<T id="send.sendBtn" m="Send" />}
+      />
+    );
+  }
+}
+
+export default send(SendTransactionButton);

--- a/app/components/buttons/SignMessageButton.js
+++ b/app/components/buttons/SignMessageButton.js
@@ -1,0 +1,41 @@
+import { signMessagePage } from "connectors";
+import { PassphraseModalButton } from "./index";
+import { FormattedMessage as T } from "react-intl";
+
+@autobind
+class SignMessageButton extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  async onAttemptSignMessage(passphrase) {
+    const { address, message, disabled, signMessageAttempt, onSubmit } = this.props;
+    if (!passphrase || disabled || !signMessageAttempt) return;
+    await signMessageAttempt(address, message, passphrase);
+    onSubmit && onSubmit();
+  }
+
+  render() {
+    const { disabled, isSigningMessage, className } = this.props;
+
+    return (
+      <PassphraseModalButton
+        modalTitle={<T id="securitycenter.signMessageModal" m="Sign Message" />}
+        className={className}
+        disabled={disabled}
+        onSubmit={this.onAttemptSignMessage}
+        loading={isSigningMessage}
+        buttonLabel={<T id="securitycenter.signMessageBtn" m="Sign Message" />}
+      />
+    );
+  }
+}
+
+SignMessageButton.propTypes = {
+  message: PropTypes.string.isRequired,
+  address: PropTypes.string.isRequired,
+  signMessageAttempt: PropTypes.func.isRequired,
+};
+
+export default signMessagePage(SignMessageButton);

--- a/app/components/buttons/index.js
+++ b/app/components/buttons/index.js
@@ -9,6 +9,8 @@ export { default as TicketsCogs } from "./TicketsCogs";
 export { default as TransactionLink } from "./TransactionLink";
 export { default as VerticalExpand } from "./VerticalExpand";
 export { default as EnableExternalRequestButton } from "./EnableExternalRequestButton";
+export { default as SendTransactionButton } from "./SendTransactionButton";
+export { default as SignMessageButton } from "./SignMessageButton";
 
 import ModalButton from "./ModalButton";
 import KeyBlueButton from "./KeyBlueButton";

--- a/app/components/shared/VerticalAccordion.js
+++ b/app/components/shared/VerticalAccordion.js
@@ -78,6 +78,7 @@ class VerticalAccordion extends React.Component {
       <div className={classNames}>
         <div className="vertical-accordion-header" onClick={this.onToggleAccordion} >
           {this.props.header}
+          <div className="vertical-accordion-arrow" />
         </div>
 
         <div className="vertical-accordion-body">

--- a/app/components/shared/VerticalAccordion.js
+++ b/app/components/shared/VerticalAccordion.js
@@ -1,0 +1,94 @@
+import TransitionMotionWrapper from "./TransitionMotionWrapper";
+import { spring } from "react-motion";
+
+@autobind
+class VerticalAccordion extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      show: false,
+      shownStyles: this.chosenStyles(props, false),
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ shownStyles: this.chosenStyles(nextProps, this.state.show) });
+  }
+
+  // Style when body is hidden
+  getNullStyles() {
+    return [ {
+      data: <div />,
+      key: "body",
+      style: {
+        height: spring(0, { stiffness: 90, damping: 16 }),
+        opacity: spring(0, { stiffness: 30, damping: 15 }),
+      }
+    } ];
+  }
+
+  // "default" style when initializing the component
+  getDefaultStyles() {
+    return [ {
+      key: "body",
+      style: {
+        height: 0,
+        opacity: 0
+      }
+    } ];
+  }
+
+  // style when body is shown. You need to specify props because this might be
+  // changing due to caller changing eg content of body.
+  getShownStyles(props) {
+    return [ {
+      data: React.isValidElement(props.children) ? props.children : <Aux>{props.children}</Aux>,
+      key: "body",
+      style: {
+        height: spring(props.height || 100, { stiffness: 110, damping: 14 }),
+        opacity: spring(1, { stiffness: 65, damping: 35 }),
+      }
+    } ];
+  }
+
+  // this returns the chosen style based on the passed props
+  chosenStyles(props, show) {
+    if (show && props.children) {
+      return this.getShownStyles(props);
+    } else {
+      return this.getNullStyles();
+    }
+  }
+
+  onToggleAccordion() {
+    this.setState({
+      show: !this.state.show,
+      shownStyles: this.chosenStyles(this.props, !this.state.show),
+    });
+  }
+
+  render() {
+    const classNames = [
+      "vertical-accordion",
+      this.state.show ? "active" : "",
+      this.props.className || "",
+    ].join(" ");
+
+    return (
+      <div className={classNames}>
+        <div className="vertical-accordion-header" onClick={this.onToggleAccordion} >
+          {this.props.header}
+        </div>
+
+        <div className="vertical-accordion-body">
+          <TransitionMotionWrapper
+            styles={this.state.shownStyles}
+            defaultStyles={this.getDefaultStyles()}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default VerticalAccordion;

--- a/app/components/shared/index.js
+++ b/app/components/shared/index.js
@@ -10,4 +10,5 @@ export { default as ShowWarning } from "./ShowWarning";
 export { default as ShowError } from "./ShowError";
 export { default as Documentation } from "./Documentation";
 export { default as StaticSwitch } from "./StaticSwitch";
+export { default as VerticalAccordion } from "./VerticalAccordion";
 export * from "./RoutedTabsHeader";

--- a/app/components/views/AccountsPage/Accounts/AccountRow/RenameAccount.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/RenameAccount.js
@@ -18,17 +18,15 @@ const RenameAccount = ({
   intl,
   hasFailedAttempt
 }) => (
-  <div className="account-row-details-bottom" key={"details" + account.accountNumber}>
-    <div className="account-row-details-bottom-title">
-      <div className="account-row-details-bottom-title-name">
-        <T id="accounts.rename" m="Rename Account" />
-      </div>
+  <div className="account-row-rename-bottom" key={"details" + account.accountNumber}>
+    <div className="account-row-rename-bottom-title">
+      <T id="accounts.rename" m="Rename Account" />
     </div>
-    <div className="account-row-details-bottom-rename">
-      <div className="account-row-details-bottom-rename-name">
+    <div className="account-row-rename-bottom-fields">
+      <div className="account-row-rename-bottom-label">
         <T id="accounts.newName" m="New Account Name" />:
       </div>
-      <div className="account-row-details-bottom-rename-field">
+      <div className="account-row-rename-bottom-value">
         <TextInput
           required
           autoFocus={true}
@@ -41,7 +39,7 @@ const RenameAccount = ({
         />
       </div>
     </div>
-    <div className="account-rename-form-buttons">
+    <div className="account-row-rename-bottom-buttons">
       <KeyBlueButton
         className="content-confirm-new-account"
         onClick={renameAccount}>

--- a/app/components/views/AccountsPage/Accounts/AccountRow/Row.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/Row.js
@@ -1,84 +1,45 @@
 import { FormattedMessage as T } from "react-intl";
-import { Balance, TransitionMotionWrapper } from "shared";
+import { Balance, VerticalAccordion } from "shared";
 import "style/Fonts.less";
 import "style/AccountRow.less";
 
-const wrapperComponent = props => <div className="account-wrapper" { ...props } />;
-
-const Row = ({
+const Header = ({
   account,
-  hideAccountDetails,
-  showAccountDetails,
-  isShowingAccountDetails,
-  isShowingRenameAccount,
-  hidden,
-  willEnter,
-  willLeave,
-  getAccountDetailsStyles,
-  getRenameAccountStyles,
-  getNullStyles,
-  getDefaultStyles,
+  hidden
 }) => (
-  <div
-    className={
-      isShowingAccountDetails
-        ? isShowingRenameAccount
-          ? "account-row-rename"
-          : "account-row-long"
-        : "account-row-short"
-    }
-  >
-    <div
-      className={
-        isShowingAccountDetails
-          ? "account-row-details-top"
-          : hidden
-            ? "account-row-hidden"
-            : "account-row"
-      }
-      key={"top" + account.accountNumber}
-      onClick={
-        isShowingAccountDetails
-          ? hideAccountDetails
-          : () => showAccountDetails(account.accountNumber)
-      }
-    >
-      <div className="account-row-top-top">
-        <div className="account-row-wallet-icon" />
-        <div className="account-row-top-account-name">{account.accountName}{
-          hidden
-            ? <span> (hidden)</span>
-            : <span></span>
-        }</div>
-        <div className="account-row-top-account-funds">
-          <Balance amount={account.total} />
-          <div className="account-row-top-last-tx"></div>
-          <div className="account-row-top-spendable">
-            <div className="account-row-top-spendable-label">
-              <T id="accounts.row.spendable" m="Spendable" />
-            </div>
-            <div className="account-row-top-spendable-value">
-              <Balance flat amount={account.spendable} />
-            </div>
-          </div>
-        </div>
+  <div className={"account-row-details-top" + (hidden ? " account-hidden" : "")} >
+    <div className="account-row-top-account-name">{account.accountName}{
+      hidden
+        ? <span> (hidden)</span>
+        : <span></span>
+    }</div>
+    <div className="account-row-top-account-funds">
+      <div className="account-row-top-total-value">
+        <Balance amount={account.total} />
+      </div>
+      <div className="account-row-top-spendable">
+        <T id="accounts.row.spendable" m="Spendable" />
+        <Balance classNameWrapper="account-row-top-spendable-value" flat amount={account.spendable} />
       </div>
     </div>
-    {
-      <TransitionMotionWrapper
-        {
-        ...{
-          styles: !isShowingAccountDetails ?
-            getNullStyles() :
-            isShowingRenameAccount ? getRenameAccountStyles() :
-              getAccountDetailsStyles(),
-          defaultStyles: getDefaultStyles(),
-          wrapperComponent,
-          willEnter,
-          willLeave }}
-      />
-    }
   </div>
+);
+
+const Row = ({
+  isShowingRenameAccount,
+  getAccountDetailsStyles,
+  getRenameAccountStyles,
+  ...props,
+}) => (
+  <VerticalAccordion
+    header={<Header {...{ ...props, isShowingRenameAccount }} />}
+    height={isShowingRenameAccount ? 175 : 275}
+  >
+    {isShowingRenameAccount
+      ? getRenameAccountStyles()
+      : getAccountDetailsStyles()
+    }
+  </VerticalAccordion>
 );
 
 export default Row;

--- a/app/components/views/AccountsPage/Accounts/AccountRow/index.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/index.js
@@ -1,5 +1,4 @@
 import Row from "./Row";
-import { spring } from "react-motion";
 import AccountDetails from "./AccountDetails";
 import RenameAccount from "./RenameAccount";
 import { injectIntl } from "react-intl";
@@ -61,21 +60,6 @@ class AccountRow extends React.Component {
     this.setState({ hidden: true });
   }
 
-  getDefaultStyles() {
-    return [ { key: "output_0",style: { height: 0, opacity: 0 } } ];
-  }
-
-  getNullStyles () {
-    return [ {
-      data: <div />,
-      key: "output_0",
-      style: {
-        height: spring(0, { stiffness: 90, damping: 16 }),
-        opacity: spring(0, { stiffness: 30, damping: 15 }),
-      }
-    } ];
-  }
-
   getRenameAccountStyles () {
     const { account, intl } = this.props;
     const {
@@ -84,8 +68,8 @@ class AccountRow extends React.Component {
       hideRenameAccount,
     } = this;
     const { hasFailedAttempt, renameAccountName } = this.state;
-    return [ {
-      data: <RenameAccount
+    return (
+      <RenameAccount
         {...{
           account,
           updateRenameAccountName,
@@ -95,13 +79,8 @@ class AccountRow extends React.Component {
           intl,
           hasFailedAttempt,
         }}
-      />,
-      key: "output_0",
-      style: {
-        height: spring(140, { stiffness: 110, damping: 14 }),
-        opacity: spring(1, { stiffness: 65, damping: 35 }),
-      }
-    } ];
+      />
+    );
   }
 
   getAccountDetailsStyles() {
@@ -112,8 +91,8 @@ class AccountRow extends React.Component {
       hideAccount,
     } = this;
     const { hidden } = this.state;
-    return [ {
-      data: <AccountDetails
+    return (
+      <AccountDetails
         {...{
           account,
           showRenameAccount,
@@ -121,13 +100,8 @@ class AccountRow extends React.Component {
           hideAccount,
           showAccount,
         }}
-      />,
-      key: "output_0",
-      style: {
-        height: spring(245, { stiffness: 110, damping: 14 }),
-        opacity: spring(1, { stiffness: 65, damping: 35 }),
-      }
-    } ];
+      />
+    );
   }
 
   render() {

--- a/app/components/views/SecurityPage/SignMessage/Form.js
+++ b/app/components/views/SecurityPage/SignMessage/Form.js
@@ -1,5 +1,5 @@
 import { FormattedMessage as T, defineMessages } from "react-intl";
-import { InfoDocModalButton, PassphraseModalButton } from "buttons";
+import { InfoDocModalButton, SignMessageButton } from "buttons";
 import { TextInput } from "inputs";
 
 const messages = defineMessages({
@@ -14,7 +14,6 @@ const messages = defineMessages({
 });
 
 const SignMessageForm = ({
-  onSubmit,
   onChangeAddress,
   onChangeMessage,
   address,
@@ -63,20 +62,17 @@ const SignMessageForm = ({
           </div>
         </div>
       </div>
-      <PassphraseModalButton
-        modalTitle={<T id="securitycenter.signMessageModal" m="Sign Message" />}
+      <SignMessageButton
         className="stakepool-content-purchase-button"
+        address={address}
+        message={message}
         disabled={isSigningMessage || address == "" || message == "" || addressError || messageError}
-        onSubmit={onSubmit}
-        loading={isSigningMessage}
-        buttonLabel={<T id="securitycenter.signMessageBtn" m="Sign Message" />}
       />
     </Aux>
   );
 };
 
 SignMessageForm.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
   formatMessage: PropTypes.func.isRequired,
   error: PropTypes.string,
 };

--- a/app/components/views/SecurityPage/SignMessage/index.js
+++ b/app/components/views/SecurityPage/SignMessage/index.js
@@ -32,19 +32,19 @@ class SignMessage extends React.Component {
   }
 
   render() {
-    const { signMessageSuccess, isSigningMessage, intl } = this.props;
-    const { onChangeAddress, onChangeMessage, onSubmit } = this;
+    const { signMessageSignature, isSigningMessage, intl } = this.props;
+    const { onChangeAddress, onChangeMessage } = this;
     const { address, addressError, message, messageError } = this.state;
     let result = null;
-    if (signMessageSuccess) {
+    if (signMessageSignature) {
       result = (
         <div className="message">
           <div className="message-nest">
             <div className="message-content">
               <div>
-                {signMessageSuccess.signature}
+                {signMessageSignature}
               </div>
-              <CopyToClipboard textToCopy={signMessageSuccess.signature} className="message-content-nest-copy-to-clipboard-icon" />
+              <CopyToClipboard textToCopy={signMessageSignature} className="message-content-nest-copy-to-clipboard-icon" />
             </div>
           </div>
         </div>
@@ -53,7 +53,7 @@ class SignMessage extends React.Component {
 
     return (
       <Aux>
-        <SignMessageForm {...{ onSubmit, onChangeAddress, onChangeMessage, address, addressError, message, messageError, formatMessage: intl.formatMessage, isSigningMessage } }/>
+        <SignMessageForm {...{ onChangeAddress, onChangeMessage, address, addressError, message, messageError, formatMessage: intl.formatMessage, isSigningMessage } }/>
         {result}
       </Aux>
     );
@@ -77,21 +77,13 @@ class SignMessage extends React.Component {
     if (message == "") this.setState({ message: "", messageError: "Please enter a message" });
     else this.setState({ message, messageError: null });
   }
-
-  onSubmit(passphrase) {
-    const { address, addressError, message, messageError } = this.state;
-    if (addressError || messageError) return;
-    this.props.signMessageAttempt(address, message, passphrase);
-  }
 }
 
 SignMessage.propTypes = {
   intl: PropTypes.object.isRequired,
   walletService: PropTypes.object,
   signMessageCleanStore: PropTypes.func.isRequired,
-  signMessageSuccess: PropTypes.shape({
-    signature: PropTypes.string,
-  }),
+  signMessageSignature: PropTypes.string,
 };
 
 SignMessage.contextTypes = {

--- a/app/components/views/TransactionsPage/SendTab/Page.js
+++ b/app/components/views/TransactionsPage/SendTab/Page.js
@@ -1,7 +1,7 @@
 import { AccountsSelect } from "inputs";
 import { FormattedMessage as T } from "react-intl";
 import { Balance, Tooltip, TransitionMotionWrapper } from "shared";
-import { PassphraseModalButton, KeyBlueButton } from "buttons";
+import { SendTransactionButton, KeyBlueButton } from "buttons";
 import OutputAccountRow from "./OutputAccountRow";
 import "style/SendPage.less";
 import "style/MiscComponents.less";
@@ -10,7 +10,6 @@ const wrapperComponent = props => <div className="output-row" { ...props } />;
 
 const SendPage = ({
   account,
-  isSendingTransaction,
   isSendAll,
   isSendSelf,
   outputs,
@@ -70,33 +69,26 @@ const SendPage = ({
       </div>
     </div>
     <div className="send-button-area">
-      <PassphraseModalButton
-        modalTitle={<T id="send.sendConfirmations" m="Transaction Confirmation" />}
-        modalDescription={
-          <div className="passphrase-modal-confirm-send">
-            {!isSendSelf ?
-              <Aux>
-                <div className="passphrase-modal-confirm-send-label">{outputs.length > 1 ? <T id="send.confirmAmountAddresses" m="Destination addresses" /> : <T id="send.confirmAmountAddress" m="Destination address" /> }:</div>
-                {outputs.map((output, index) => {
-                  return (
-                    <div className="passphrase-modal-confirm-send-address" key={"confirm-" + index}>{output.data.destination}</div>
-                  );}
-                )}
-              </Aux> :
-              <Aux>
-                <div className="passphrase-modal-confirm-send-label"><T id="send.confirmAmountAccount" m="Destination account" />:</div>
-                <div className="passphrase-modal-confirm-send-address">{nextAddressAccount.name}</div>
-              </Aux>
-            }
-            <div className="passphrase-modal-confirm-send-label"><T id="send.confirmAmountLabelFor" m="Total Spent" />:</div>
-            <div className="passphrase-modal-confirm-send-balance"><Balance amount={totalSpent} /></div>
-          </div>}
-        disabled={!isValid}
-        className="content-send"
-        onSubmit={onAttemptSignTransaction}
-        loading={isSendingTransaction}
-        buttonLabel={<T id="send.sendBtn" m="Send" />}
-      />
+      <SendTransactionButton disabled={!isValid} onSubmit={onAttemptSignTransaction} >
+        <div className="passphrase-modal-confirm-send">
+          {!isSendSelf ?
+            <Aux>
+              <div className="passphrase-modal-confirm-send-label">{outputs.length > 1 ? <T id="send.confirmAmountAddresses" m="Destination addresses" /> : <T id="send.confirmAmountAddress" m="Destination address" /> }:</div>
+              {outputs.map((output, index) => {
+                return (
+                  <div className="passphrase-modal-confirm-send-address" key={"confirm-" + index}>{output.data.destination}</div>
+                );}
+              )}
+            </Aux> :
+            <Aux>
+              <div className="passphrase-modal-confirm-send-label"><T id="send.confirmAmountAccount" m="Destination account" />:</div>
+              <div className="passphrase-modal-confirm-send-address">{nextAddressAccount.name}</div>
+            </Aux>
+          }
+          <div className="passphrase-modal-confirm-send-label"><T id="send.confirmAmountLabelFor" m="Total Spent" />:</div>
+          <div className="passphrase-modal-confirm-send-balance"><Balance amount={totalSpent} /></div>
+        </div>
+      </SendTransactionButton>
       <Aux show={hasUnminedTransactions}>
         <Tooltip md text={<T id="send.rebroadcastTooltip" m="Rebroadcasting transactions may help in situations when a transaction has been sent to a node that had poor connectivity to the general Decred network."/>}>
           <KeyBlueButton onClick={onRebroadcastUnmined}>

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -152,11 +152,8 @@ class Send extends React.Component {
     this.setState({ account }, this.onAttemptConstructTransaction);
   }
 
-  onAttemptSignTransaction(privpass) {
-    const { unsignedTransaction, onAttemptSignTransaction,
-      getNextAddressAttempt, nextAddressAccount } = this.props;
-    if (!privpass || !this.getIsValid()) return;
-    onAttemptSignTransaction && onAttemptSignTransaction(privpass, unsignedTransaction);
+  onAttemptSignTransaction() {
+    const { getNextAddressAttempt, nextAddressAccount } = this.props;
     getNextAddressAttempt && nextAddressAccount && getNextAddressAttempt(nextAddressAccount.value);
     this.onClearTransaction();
   }

--- a/app/connectors/signMessagePage.js
+++ b/app/connectors/signMessagePage.js
@@ -1,13 +1,20 @@
 import { connect } from "react-redux";
-import * as sel from "../selectors";
-import { signMessageAttempt, validateAddress, signMessageCleanStore } from "../actions/ControlActions";
+import { bindActionCreators } from "redux";
 import { selectorMap } from "../fp";
+import * as sel from "../selectors";
+import * as ca from "../actions/ControlActions";
 
 const mapStateToProps = selectorMap({
   signMessageError: sel.signMessageError,
-  signMessageSuccess: sel.signMessageSuccess,
+  signMessageSignature: sel.signMessageSignature,
   isSigningMessage: sel.isSigningMessage,
   walletService: sel.walletService,
 });
 
-export default connect(mapStateToProps, { signMessageAttempt, validateAddress, signMessageCleanStore });
+const mapDispatchToProps = dispatch => bindActionCreators({
+  signMessageAttempt: ca.signMessageAttempt,
+  validateAddress: ca.validateAddress,
+  signMessageCleanStore: ca.signMessageCleanStore,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/helpers/byteActions.js
+++ b/app/helpers/byteActions.js
@@ -16,3 +16,17 @@ export function reverseRawHash(arr) {
 export function strHashToRaw(hash) {
   return new Uint8Array(Buffer.from(hash, "hex").reverse());
 }
+
+// Convert hash encoded as raw bytes into an hex (reversed) string hash.
+export function rawHashToHex(raw) {
+  return reverseHash(Buffer.from(raw).toString("hex"));
+}
+
+// Convert raw bytes (from grpc endpoint) to hex
+export function rawToHex(bin) {
+  return Buffer.from(bin).toString("hex");
+}
+
+export function hexToRaw(hex) {
+  return new Uint8Array(Buffer.from(hex, "hex"));
+}

--- a/app/helpers/index.js
+++ b/app/helpers/index.js
@@ -1,7 +1,7 @@
 import { createElement as h } from "react";
 export * from "./dateFormat";
 export { addSpacingAroundText, restrictToStdDecimalNumber } from "./strings";
-export { reverseHash, reverseRawHash } from "./byteActions";
+export * from "./byteActions";
 export * from "./addresses";
 export * from "./arrays";
 export * from "./dom.js";

--- a/app/index.js
+++ b/app/index.js
@@ -136,7 +136,7 @@ var initialState = {
     // SignMessage
     getSignMessageError: null,
     getSignMessageRequestAttempt: false,
-    getSignMessageResponse: null,
+    getSignMessageSignature: null,
     // VerifyMessage
     getVerifyMessageError: null,
     getVerifyMessageRequestAttempt: false,

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -372,7 +372,7 @@ export default function grpc(state = {}, action) {
   case SIGNMESSAGE_FAILED:
     return {
       ...state,
-      getSignMessageSuccess: null,
+      getSignMessageSignature: null,
       getSignMessageError: String(action.error),
       getSignMessageRequestAttempt: false,
     };
@@ -380,14 +380,14 @@ export default function grpc(state = {}, action) {
     return {
       ...state,
       getSignMessageError: null,
-      getSignMessageResponse: action.getSignMessageResponse,
+      getSignMessageSignature: action.getSignMessageSignature,
       getSignMessageRequestAttempt: false,
     };
   case SIGNMESSAGE_CLEANSTORE:
     return {
       ...state,
       getSignMessageError: null,
-      getSignMessageResponse: null,
+      getSignMessageSignature: null,
       getSignMessageRequestAttempt: false,
     };
   case VERIFYMESSAGE_ATTEMPT:

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -652,10 +652,7 @@ export const spvMode = get([ "settings", "currentSettings", "spvMode" ]);
 
 export const isSigningMessage = get([ "grpc", "getSignMessageRequestAttempt" ]);
 export const signMessageError = get([ "grpc", "getSignMessageError" ]);
-export const signMessageResponse = get([ "grpc", "getSignMessageResponse" ]);
-export const signMessageSuccess = compose(
-  r => r ? r.toObject() : null, signMessageResponse
-);
+export const signMessageSignature = get([ "grpc", "getSignMessageSignature" ]);
 
 export const messageVerificationService = get([ "grpc", "messageVerificationService" ]);
 export const isVerifyingMessage = get([ "grpc", "getVerifyMessageRequestAttempt" ]);

--- a/app/style/AccountRow.less
+++ b/app/style/AccountRow.less
@@ -1,124 +1,59 @@
 @import (reference) "./main.less";
 @import (reference) "./Icons.less";
 
-.address-content-nest-address-hash-to {
-  width: 96%;
-  height: 100%;
-}
-
-.account-row,
-.account-row-hidden {
-  position: relative;
-  overflow: hidden;
-  padding: 27px 30px 10px 15px;
-  border-top: 1px solid #f0f4f4;
-  background-image: @arrow-right-gray-icon;
-  background-position: 60px;
-  background-size: 5px auto;
-  background-repeat: no-repeat;
-  cursor: pointer;
-}
-
-.account-row {
-  background-color: #fff;
-}
-
-.account-row-hidden {
-  background-color: transparent;
-}
-
-.account-row:hover,
-.account-row-hidden:hover {
-  background-color: rgba(212, 240, 253, 0.5);
-  background-image: @arrow-right-key-blue-icon;
-  background-size: 5px;
-}
-
-// .account-row-top-top {
-// }
-
-.account-row-top-bottom {
-  font-size: 12px;
-}
-
-.account-row-top-last-tx {
-  color: #132f4b;
-  font-size: 12px;
-}
-
 .account-row-top-spendable {
   color: #596d81;
   font-size: 13px;
   line-height: 17px;
-  width: 230px;
-}
-
-.account-row-top-spendable-label {
-  float: left;
-  margin-left: 30px;
 }
 
 .account-row-top-spendable-value {
-  float: right;
-  width: 130px;
   color: #091440;
-}
-
-.account-row-wallet-icon {
-  .inline-block-mixin;
-
-  width: 20px;
-  height: 20px;
-  margin-right: 3em;
-  background-image: @wallet-gray-icon;
-  background-size: 20px auto;
-  background-repeat: no-repeat;
+  display: inline-block;
+  width: 140px;
 }
 
 .account-row-top-account-name {
-  .inline-block-mixin;
-
   color: #091440;
   font-size: 19px;
   line-height: 24px;
 }
 
 .account-row-top-account-funds {
-  float: right;
   color: #091440;
   font-size: 19px;
-  line-height: 24px;
-  display: flex;
-  flex-direction: column;
   text-align: right;
 }
 
 .account-row-details-top {
-  position: relative;
-  z-index: 0;
-  background-color: transparent;
-  background-image: @arrow-down-mid-blue-icon;
-  background-position: 57px 36px;
-  background-size: 10px auto;
-  background-repeat: no-repeat;
   cursor: pointer;
-  padding: 27px 30px 10px 15px;
+  padding: 21px 30px 21px 90px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  background-image: @wallet-gray-icon;
+  background-size: 20px auto;
+  background-repeat: no-repeat;
+  background-position: 15px center;
+  background-color: #fff;
+  border-top: 1px solid #f0f4f4;
+}
+
+.account-row-details-top.account-hidden,
+.vertical-accordion.active .account-row-details-top {
+  background-color: #f0f4f4;
 }
 
 .account-row-details-top:hover {
-  background-image: @arrow-down-key-blue-icon;
-  background-size: 10px;
+  background-color: #f0f4f4;
 }
 
-.account-wrapper {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-}
+// .account-row-details-bottom {
+// }
 
 .account-row-details-bottom-column-left {
-  float: left;
-  width: 50%;
+  width: 24em;
 }
 
 .account-row-details-bottom-columns {
@@ -126,11 +61,13 @@
   color: #596d81;
   margin-bottom: 20px;
   margin-top: 15px;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .account-row-details-bottom-column-right {
-  float: right;
-  width: 50%;
+  width: 22em;
 }
 
 .account-row-details-bottom-columns::after,
@@ -140,10 +77,8 @@
   .clearfloat-mixin;
 }
 
-// .account-row-details-bottom {
-// }
-
-.account-row-details-bottom-title {
+.account-row-details-bottom-title,
+.account-row-rename-bottom-title {
   font-size: 19px;
 }
 
@@ -158,6 +93,7 @@
   text-align: right;
   font-size: 12px;
   margin-bottom: 0.5em;
+  display: flex;
 }
 
 .account-row-details-bottom-spec-last {
@@ -170,49 +106,28 @@
   margin-right: 10px;
   width: 117px;
   margin-left: 40px;
-  float: left;
 }
 
 .account-row-details-bottom-spec-value {
   width: 200px;
-  float: left;
   text-align: left;
   color: #091440;
 }
 
-.account-row-details-bottom-rename {
+.account-row-rename-bottom {
   color: #091440;
   font-size: 12px;
+  padding: 14px;
 }
 
-.account-row-details-bottom-rename-name {
-  float: left;
-  width: 12em;
+.account-row-rename-bottom-fields {
+  display: flex;
+  margin: 12px 0px;
 }
 
-.account-row-details-bottom-rename-field {
-  float: left;
-  width: 40%;
-  height: 36px;
-}
-
-.account-rename-form-buttons {
-  float: left;
-  width: 100%;
-  margin-top: 10px;
-}
-
-.account-row-long {
-  border-bottom: 1px #a9b4bf solid;
-}
-
-.account-row-short-hidden {
-  background-color: transparent;
-}
-
-.account-row-rename {
-  border-top: 1px #a9b4bf solid;
-  border-bottom: 1px #a9b4bf solid;
+.account-row-rename-bottom-value {
+  width: 70%;
+  margin-left: 10px;
 }
 
 .content-confirm-new-account {

--- a/app/style/AccountsPage.less
+++ b/app/style/AccountsPage.less
@@ -16,28 +16,15 @@
   padding-top: 1px;
 }
 
+.account-content-nest .vertical-accordion-arrow {
+  right: 0px;
+  left: 65px;
+  top: 44%;
+  transform: rotate(0deg);
+}
+
 .account-content-title-buttons-area {
   position: absolute;
   top: 15px;
   right: 80px;
-}
-
-.account-name {
-  width: 25%;
-  padding-right: 15px;
-  padding-left: 5px;
-  float: left;
-  height: 100%;
-  padding-top: 5px;
-  font-size: 19px;
-  text-align: left;
-}
-
-.account-rename {
-  width: 25%;
-  float: left;
-  height: 100%;
-  padding-top: 5px;
-  font-size: 19px;
-  text-align: right;
 }

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -777,3 +777,26 @@
     bottom: 18px;
   }
 }
+
+.vertical-accordion-header {
+  cursor: pointer;
+}
+
+.vertical-accordion-header:after {
+  content:"";
+  background-image: @arrow-right-gray-icon;
+  background-repeat: no-repeat;
+  background-position: center right;
+  background-size: contain;
+  width: 10px;
+  height: 14px;
+  display: inline-block;
+  float: right;
+  margin-top: 6px;
+  transition: transform 0.25s ease-in-out;
+  transform: rotate(-90deg);
+}
+
+.vertical-accordion.active .vertical-accordion-header:after {
+  transform: rotate(90deg);
+}

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -778,11 +778,15 @@
   }
 }
 
-.vertical-accordion-header {
-  cursor: pointer;
+.vertical-accordion {
 }
 
-.vertical-accordion-header:after {
+.vertical-accordion-header {
+  cursor: pointer;
+  position: relative;
+}
+
+.vertical-accordion-arrow {
   content:"";
   background-image: @arrow-right-gray-icon;
   background-repeat: no-repeat;
@@ -790,13 +794,18 @@
   background-size: contain;
   width: 10px;
   height: 14px;
-  display: inline-block;
-  float: right;
-  margin-top: 6px;
+  display: block;
+  position: absolute;
+  top: 50%;
+  right: 10px;
   transition: transform 0.25s ease-in-out;
   transform: rotate(-90deg);
 }
 
-.vertical-accordion.active .vertical-accordion-header:after {
+.vertical-accordion-header:hover .vertical-accordion-arrow {
+  background-image: @arrow-right-blue-icon;
+}
+
+.vertical-accordion.active .vertical-accordion-arrow {
   transform: rotate(90deg);
 }

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -778,8 +778,8 @@
   }
 }
 
-.vertical-accordion {
-}
+// .vertical-accordion {
+// }
 
 .vertical-accordion-header {
   cursor: pointer;
@@ -787,7 +787,7 @@
 }
 
 .vertical-accordion-arrow {
-  content:"";
+  content: "";
   background-image: @arrow-right-gray-icon;
   background-repeat: no-repeat;
   background-position: center right;


### PR DESCRIPTION
Part of #1491 

This PR should *not* have any trezor references, but is a step in integrating it. These commits have been extracted from my main trezor branch and are sent as a separate PR in order to facilitate review and merge, since the actual trezor code will require a lot of review.

This refactors 3 ui elements into their own components, which will (in the actual trezor PR) be used:

- SendTransactionButton (which will have to decide how to sign a transaction before sending)
- SignMessageButton (same thing)
- VerticalAccordion (which is used in the config page)

I've refactored the AccountsList page to use the new VerticalAccordion, which removes quite some code and styles, simplifying it a bit. It also has slightly better responsiveness.