### PR TITLE
Prevention of third click (mouse wheel) opening new window open

### DIFF
--- a/app/components/views/HomePage/index.js
+++ b/app/components/views/HomePage/index.js
@@ -66,21 +66,4 @@ class Home extends React.Component{
 
 }
 
-// Prevent middle click from opening new electron window
-(function () {
-  function callback(e) {
-   // var e = window.e || e;
-      e.preventDefault();
-      //shell.openExternal(e.target.href);
-    return
-  }
-
-  if (document.addEventListener) {
-    document.addEventListener('auxclick', callback, false);
-  } else {
-    document.attachEvent('onauxclick', callback);
-  }
-})();
-
-
 export default service(home(Home));

--- a/app/components/views/HomePage/index.js
+++ b/app/components/views/HomePage/index.js
@@ -2,7 +2,6 @@ import ErrorScreen from "ErrorScreen";
 import HomePage from "./Page";
 import { service, home } from "connectors";
 import { substruct } from "fp";
-import { shell } from "electron";
 
 const ROWS_NUMBER_ON_TABLE = 5;
 

--- a/app/components/views/HomePage/index.js
+++ b/app/components/views/HomePage/index.js
@@ -2,6 +2,7 @@ import ErrorScreen from "ErrorScreen";
 import HomePage from "./Page";
 import { service, home } from "connectors";
 import { substruct } from "fp";
+import { shell } from "electron";
 
 const ROWS_NUMBER_ON_TABLE = 5;
 
@@ -65,5 +66,22 @@ class Home extends React.Component{
   }
 
 }
+
+// Prevent middle click from opening new electron window
+(function () {
+  function callback(e) {
+   // var e = window.e || e;
+      e.preventDefault();
+      //shell.openExternal(e.target.href);
+    return
+  }
+
+  if (document.addEventListener) {
+    document.addEventListener('auxclick', callback, false);
+  } else {
+    document.attachEvent('onauxclick', callback);
+  }
+})();
+
 
 export default service(home(Home));

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -102,4 +102,18 @@ class App extends React.Component {
   }
 }
 
+// Prevent middle click from opening new electron window
+(function () {
+  function callback(e) {
+    e.preventDefault();
+    return
+  }
+
+  if (document.addEventListener) {
+    document.addEventListener('auxclick', callback, false);
+  } else {
+    document.attachEvent('onauxclick', callback);
+  }
+})();
+
 export default app(theming(App));

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -28,6 +28,7 @@ class App extends React.Component {
     const { window } = props;
     window.addEventListener("beforeunload", this.beforeWindowUnload);
     window.addEventListener("click", this.onClick);
+    window.addEventListener("auxclick", this.onAuxClick);
     this.refreshing = false;
 
     props.listenForAppReloadRequest(this.onReloadRequested);
@@ -69,6 +70,13 @@ class App extends React.Component {
     }
   }
 
+  // Prevent middle click from opening new electron window
+  onAuxClick(event) {
+    event.stopPropagation();
+    event.preventDefault();
+    return false;
+  }
+
   onReloadRequested(event) {
     log("info", "Main app received reload UI request");
     this.refreshing = true;
@@ -101,19 +109,5 @@ class App extends React.Component {
     );
   }
 }
-
-// Prevent middle click from opening new electron window
-(function () {
-  function callback(e) {
-    e.preventDefault();
-    return
-  }
-
-  if (document.addEventListener) {
-    document.addEventListener('auxclick', callback, false);
-  } else {
-    document.attachEvent('onauxclick', callback);
-  }
-})();
 
 export default app(theming(App));


### PR DESCRIPTION
By default doing a third click on something on the sidebar opens a new electron window however with this fix that action is stopped.

Fixes #1537 