### PR TITLE
Add event listener to submit send transaction form on enter key press

### DIFF
--- a/app/components/buttons/ModalButton.js
+++ b/app/components/buttons/ModalButton.js
@@ -12,6 +12,7 @@ class ModalButton extends React.Component {
 
   showModal() {
     this.setState({ show: true });
+    this.onShow();
   }
 
   hideModal() {
@@ -22,6 +23,17 @@ class ModalButton extends React.Component {
     const { onSubmit } = this.props;
     this.hideModal();
     onSubmit && this.props.onSubmit(...args);
+  }
+
+  onShow() {
+    const { onShow } = this.props;
+    onShow && this.props.onShow();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.showModal) {
+      this.showModal();
+    }
   }
 
   render() {

--- a/app/components/buttons/ModalButton.js
+++ b/app/components/buttons/ModalButton.js
@@ -31,7 +31,7 @@ class ModalButton extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.showModal) {
+    if (nextProps.showModal && !this.props.modal) {
       this.showModal();
     }
   }

--- a/app/components/buttons/SendTransactionButton.js
+++ b/app/components/buttons/SendTransactionButton.js
@@ -17,12 +17,14 @@ class SendTransactionButton extends React.Component {
   }
 
   render() {
-    const { disabled, isSendingTransaction, children } = this.props;
+    const { disabled, isSendingTransaction, onShow, showModal, children } = this.props;
 
     return (
       <PassphraseModalButton
         modalTitle={<T id="send.sendConfirmations" m="Transaction Confirmation" />}
         modalDescription={children}
+        showModal={showModal}
+        onShow={onShow}
         disabled={disabled || isSendingTransaction}
         className="content-send"
         onSubmit={this.onAttemptSignTransaction}

--- a/app/components/inputs/AccountsSelect.js
+++ b/app/components/inputs/AccountsSelect.js
@@ -64,13 +64,16 @@ class AccountsSelect extends React.Component {
     );
   }
 
-  selectKeyDown (e) {
+  selectKeyDown(e) {
+    const { onKeyDown } = this.props;
+
     switch(e.keyCode) {
     case 8:
     case 46:
       e.preventDefault();
       break;
     }
+    onKeyDown && this.props.onKeyDown(e);
   }
 
   valueRenderer(option) {

--- a/app/components/views/TransactionsPage/SendTab/OutputAccountRow.js
+++ b/app/components/views/TransactionsPage/SendTab/OutputAccountRow.js
@@ -14,6 +14,7 @@ const SendOutputAccountRow = ({
   amount,
   amountError,
   getOnChangeOutputAmount,
+  onKeyDown,
   isSendAll,
   totalSpent,
   intl,
@@ -37,6 +38,7 @@ const SendOutputAccountRow = ({
             className="send-address-input-amount"
             disabled={true}
             amount={totalSpent}
+            onKeyDown={onKeyDown}
           />
           <DcrInput
             showErrors={true}
@@ -47,6 +49,7 @@ const SendOutputAccountRow = ({
             className="send-address-input-amount"
             placeholder={intl.formatMessage(messages.amountPlaceholder)}
             onChangeAmount={getOnChangeOutputAmount(index)}
+            onKeyDown={onKeyDown}
           />
         </div>
       </div>

--- a/app/components/views/TransactionsPage/SendTab/OutputAccountRow.js
+++ b/app/components/views/TransactionsPage/SendTab/OutputAccountRow.js
@@ -26,6 +26,7 @@ const SendOutputAccountRow = ({
         <ReceiveAccountsSelect
           getAddressForSelected={true}
           showAccountsButton={false}
+          onKeyDown={onKeyDown}
         />
       </div>
 

--- a/app/components/views/TransactionsPage/SendTab/OutputRow.js
+++ b/app/components/views/TransactionsPage/SendTab/OutputRow.js
@@ -27,6 +27,7 @@ const SendOutputRow = ({
   getOnChangeOutputAmount,
   isSendAll,
   totalSpent,
+  onKeyDown,
   intl
 }) => (
   <div className="send-row">
@@ -43,6 +44,7 @@ const SendOutputRow = ({
             className="send-address-hash-to"
             placeholder={intl.formatMessage(messages.destinationAddrPlaceholder)}
             onChange={compose(getOnChangeOutputDestination(index), e => e.target.value)}
+            onKeyDown={onKeyDown}
           />
         </div>
         {index === 0 && !isSendAll ? (
@@ -64,6 +66,7 @@ const SendOutputRow = ({
             className="send-address-input-amount"
             disabled={true}
             amount={totalSpent}
+            onKeyDown={onKeyDown}
           />
           <DcrInput
             showErrors={true}
@@ -74,6 +77,7 @@ const SendOutputRow = ({
             className="send-address-input-amount"
             placeholder={intl.formatMessage(messages.amountPlaceholder)}
             onChangeAmount={getOnChangeOutputAmount(index)}
+            onKeyDown={onKeyDown}
           />
         </div>
       </div>

--- a/app/components/views/TransactionsPage/SendTab/Page.js
+++ b/app/components/views/TransactionsPage/SendTab/Page.js
@@ -41,7 +41,7 @@ const SendPage = ({
       <div className="send-select-account-area">
         <div className="send-label"><T id="send.from" m="From" />:</div>
         <AccountsSelect className="send-select-account-input"
-          {...{ account }} onChange={onChangeAccount} showAccountsButton={true} onKeyUp={onKeyDown}/>
+          {...{ account }} onChange={onChangeAccount} showAccountsButton={true} onKeyDown={onKeyDown}/>
         <div className="send-send-all-input">
           {!isSendSelf ?
             <Tooltip text={<T id="send.sendSelfTitle" m="Send funds to another account"/>}>
@@ -66,7 +66,7 @@ const SendPage = ({
           !isSendSelf
             ? <TransitionMotionWrapper {...{ styles: getStyles(), willLeave, willEnter, wrapperComponent }} />
             : <OutputAccountRow
-              {...{ index: 0, ...props, ...outputs[0].data, isSendAll, totalSpent }}
+              {...{ index: 0, ...props, ...outputs[0].data, isSendAll, totalSpent, onKeyDown }}
               amountError={getAmountError(0)} />
         }
       </div>

--- a/app/components/views/TransactionsPage/SendTab/Page.js
+++ b/app/components/views/TransactionsPage/SendTab/Page.js
@@ -30,6 +30,7 @@ const SendPage = ({
   hasUnminedTransactions,
   onRebroadcastUnmined,
   nextAddressAccount,
+  onKeyDown,
   ...props
 }) => (
   <Aux>
@@ -38,7 +39,7 @@ const SendPage = ({
       <div className="send-select-account-area">
         <div className="send-label"><T id="send.from" m="From" />:</div>
         <AccountsSelect className="send-select-account-input"
-          {...{ account }} onChange={onChangeAccount} showAccountsButton={true} />
+          {...{ account }} onChange={onChangeAccount} showAccountsButton={true} onKeyUp={onKeyDown}/>
         <div className="send-send-all-input">
           {!isSendSelf ?
             <Tooltip text={<T id="send.sendSelfTitle" m="Send funds to another account"/>}>

--- a/app/components/views/TransactionsPage/SendTab/Page.js
+++ b/app/components/views/TransactionsPage/SendTab/Page.js
@@ -31,6 +31,8 @@ const SendPage = ({
   onRebroadcastUnmined,
   nextAddressAccount,
   onKeyDown,
+  showPassphraseModal,
+  resetShowPassphraseModal,
   ...props
 }) => (
   <Aux>
@@ -70,7 +72,11 @@ const SendPage = ({
       </div>
     </div>
     <div className="send-button-area">
-      <SendTransactionButton disabled={!isValid} onSubmit={onAttemptSignTransaction} >
+      <SendTransactionButton
+        disabled={!isValid}
+        showModal={showPassphraseModal}
+        onShow={resetShowPassphraseModal}
+        onSubmit={onAttemptSignTransaction} >
         <div className="passphrase-modal-confirm-send">
           {!isSendSelf ?
             <Aux>

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -231,7 +231,7 @@ class Send extends React.Component {
   }
 
   onKeyDown(e) {
-    if (e.keyCode === 13 || this.getIsValid()) {
+    if (e.keyCode === 13 && this.getIsValid()) {
       this.setState({ showPassphraseModal: true });
     }
   }

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -74,6 +74,7 @@ class Send extends React.Component {
       willLeave,
       getStyles,
       getDefaultStyles,
+      onKeyDown,
     } = this;
     const isValid = this.getIsValid();
 
@@ -82,6 +83,7 @@ class Send extends React.Component {
         {...{ ...this.props, ...this.state }}
         {...{
           isValid,
+          onKeyDown,
           onChangeAccount,
           onAttemptSignTransaction,
           onClearTransaction,
@@ -124,6 +126,7 @@ class Send extends React.Component {
           getOnChangeOutputAmount={this.getOnChangeOutputAmount}
           onAddOutput={this.onAddOutput}
           getOnRemoveOutput={this.getOnRemoveOutput(index)}
+          onKeyDown={this.onKeyDown}
         />,
         key: "output_" + index,
         style: {
@@ -220,6 +223,15 @@ class Send extends React.Component {
   onRebroadcastUnmined() {
     const { publishUnminedTransactions } = this.props;
     publishUnminedTransactions && publishUnminedTransactions();
+  }
+
+  onKeyDown(e) {
+    if (e.keyCode === 13 && this.getIsValid()) {
+      var b = document.getElementsByClassName("content-send");
+      if (b.length > 0) {
+        b[0].click();
+      }
+    }
   }
 
   getOnRemoveOutput(key) {

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -33,6 +33,7 @@ class Send extends React.Component {
       outputs: [ { key: "output_0", data:{ ...BASE_OUTPUT } } ],
       outputAccount: this.props.defaultSpendingAccount,
       lowBalanceError: false,
+      canEnterPassphrase: false,
     };
   }
 
@@ -75,8 +76,10 @@ class Send extends React.Component {
       getStyles,
       getDefaultStyles,
       onKeyDown,
+      resetShowPassphraseModal,
     } = this;
     const isValid = this.getIsValid();
+    const showPassphraseModal = this.getShowPassphraseModal();
 
     return !this.props.walletService ? <ErrorScreen /> : (
       <SendPage
@@ -104,6 +107,8 @@ class Send extends React.Component {
           willLeave,
           getStyles,
           getDefaultStyles,
+          showPassphraseModal,
+          resetShowPassphraseModal,
         }}
       />
     );
@@ -226,12 +231,17 @@ class Send extends React.Component {
   }
 
   onKeyDown(e) {
-    if (e.keyCode === 13 && this.getIsValid()) {
-      var b = document.getElementsByClassName("content-send");
-      if (b.length > 0) {
-        b[0].click();
-      }
+    if (e.keyCode === 13 || this.getIsValid()) {
+      this.setState({ showPassphraseModal: true });
     }
+  }
+
+  getShowPassphraseModal() {
+    return this.state.showPassphraseModal;
+  }
+
+  resetShowPassphraseModal() {
+    this.setState({ showPassphraseModal: false });
   }
 
   getOnRemoveOutput(key) {


### PR DESCRIPTION
This enables the Enter key shortcut on the send transaction page such that when e enter key is pressed, it defaults to the send button if the transaction is valid

This fixes #1221 