### PR TITLE
[launcher] improve wallet selection responsiveness

### DIFF
--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -434,7 +434,7 @@
 
   .display-wallet-name {
     color: #4c5971;
-    margin-top: 121px;
+    margin-top: 20px;
   }
 }
 

--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -399,7 +399,6 @@
     background-repeat: no-repeat;
     background-size: 45px 45px;
     background-position: 8px 10px;
-    position: absolute;
   }
 
   .wallet-icon.wallet {
@@ -492,7 +491,6 @@
 .display-wallet-name {
   color: #091440;
   text-align: center;
-  margin-top: 67px;
 }
 
 .display-wallet-last-access {
@@ -760,9 +758,8 @@
     position: relative;
   }
 
-  .display-wallet-name {
-    margin-top: 77px;
-  }
+  // .display-wallet-name {
+  // }
 
   .getstarted.loader {
     margin-left: 0px;

--- a/app/style/LanguageSelect.less
+++ b/app/style/LanguageSelect.less
@@ -7,6 +7,12 @@
   display: block;
 }
 
+@media screen and (max-height: 600px) {
+  .page-body.getstarted {
+    height: 82vh;
+  }
+}
+
 .getstarted-logo {
   background-repeat: no-repeat;
   background-image: @logo-launcher;

--- a/app/style/Loading.less
+++ b/app/style/Loading.less
@@ -108,7 +108,7 @@
 }
 
 .linear-progress-text {
-  position: absolute;
+  text-align: left;
   color: #fff;
   font-size: 11px;
   font-weight: 600;


### PR DESCRIPTION
Small improvement in the wallet selection page to allow launching the wallet when screen height < 600px (happens often in laptops).