### PR TITLE
[charts] fix negative startup balance charts

### DIFF
--- a/app/selectors.js
+++ b/app/selectors.js
@@ -305,8 +305,7 @@ export const spendableAndLockedBalance = createSelector(
   ( stats, unitDivisor ) => stats.map(s => ({
     time: s.time,
     available: s.series.spendable / unitDivisor,
-    locked: (s.series.locked + s.series.lockedNonWallet + s.series.immature +
-      s.series.immatureNonWallet) / unitDivisor,
+    locked: (s.series.locked + s.series.immature) / unitDivisor,
   })));
 
 export const balanceSent = createSelector(


### PR DESCRIPTION
Fix #1548 

This fixes the issue by forgoing accounting for non-wallet inputs/outputs of tickets and votes. While this solves the presence of negative balances, it's not ideal because we don't get to see the locked balances in the charts.

Another alternative (but which might require modifications to dcrwallet) is to unlock the wallet during the initial scan for transactions, which allows it to import scripts it finds in the blockchain automatically and seems to also fix the issue.

