### PR TITLE
[launcher] add max_wallet_count config

### DIFF
--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -22,6 +22,7 @@ const WalletSelectionBodyBase = ({
   toggleWatchOnly,
   isWatchOnly,
   masterPubKeyError,
+  maxWalletCount,
   ...props,
 }) => {
   return (
@@ -82,7 +83,7 @@ const WalletSelectionBodyBase = ({
                 </Tooltip> :
               <div/>
             }
-            {availableWallets.length < 3 &&
+            {availableWallets.length < maxWalletCount &&
             <Aux>
               <div className="display-wallet new" onClick={()=>showCreateWalletForm(false)}>
                 <div className="wallet-icon createnew" />

--- a/app/components/views/GetStartedPage/WalletSelection/index.js
+++ b/app/components/views/GetStartedPage/WalletSelection/index.js
@@ -34,7 +34,8 @@ class WalletSelectionBody extends React.Component {
 
   render() {
     const {
-      getDaemonSynced
+      getDaemonSynced,
+      maxWalletCount,
     } = this.props;
     const {
       onChangeAvailableWallets,
@@ -89,6 +90,7 @@ class WalletSelectionBody extends React.Component {
           walletMasterPubKey,
           masterPubKeyError,
           walletNameError,
+          maxWalletCount,
           ...this.props,
           ...this.state,
         }}

--- a/app/config.js
+++ b/app/config.js
@@ -115,6 +115,9 @@ export function initGlobalCfg() {
   if (!config.has("politeia_beta")) { // TODO: remove once politeia hits production
     config.set("politeia_beta", false);
   }
+  if (!config.has("max_wallet_count")) {
+    config.set("max_wallet_count", 3);
+  }
   return(config);
 }
 

--- a/app/connectors/createWallet.js
+++ b/app/connectors/createWallet.js
@@ -13,6 +13,7 @@ const mapStateToProps = selectorMap({
   isTestNet: sel.isTestNet,
   isWatchOnly: sel.isWatchOnly,
   masterPubKey: sel.masterPubKey,
+  maxWalletCount: sel.maxWalletCount,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/index.js
+++ b/app/index.js
@@ -199,6 +199,7 @@ var initialState = {
     neededBlocks: 0,
     curBlocks: 0,
     stepIndex: 0,
+    maxWalletCount: globalCfg.get("max_wallet_count"),
     // Loader
     getLoaderRequestAttempt: false,
     loader: null,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -27,6 +27,7 @@ export const getDaemonSynced = get([ "daemon", "daemonSynced" ]);
 export const isAdvancedDaemon = get([ "daemon", "daemonAdvanced" ]);
 export const getWalletReady = get([ "daemon", "walletReady" ]);
 export const createNewWallet = get([ "walletLoader", "createNewWallet" ]);
+export const maxWalletCount = get([ "walletLoader", "maxWalletCount" ]);
 export const isPrepared = and(
   getDaemonStarted,
   getDaemonSynced,


### PR DESCRIPTION
Adds a config option (not currently exposed in the UI) to allow creation of more than 3 wallets.

This is specially useful when testing things that involve wallet creation, since you usually need to create multiple wallets.