### PR TITLE
[various] Changes to allow new dcrwallet SPV mode

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -45,9 +45,13 @@ export const RESCAN_PROGRESS = "RESCAN_PROGRESS";
 export const RESCAN_COMPLETE = "RESCAN_COMPLETE";
 export const RESCAN_CANCEL = "RESCAN_CANCEL";
 
-export function rescanAttempt(beginHeight) {
+export function rescanAttempt(beginHeight, beginHash) {
   var request = new RescanRequest();
-  request.setBeginHeight(beginHeight);
+  if (beginHeight !== null) {
+    request.setBeginHeight(beginHeight);
+  } else {
+    request.setBeginHash(new Uint8Array(Buffer.from(beginHash)));
+  }
   return (dispatch, getState) => {
     return new Promise((resolve, reject) => {
       dispatch({ request: request, type: RESCAN_ATTEMPT });
@@ -76,8 +80,10 @@ export function rescanAttempt(beginHeight) {
 export function rescanCancel() {
   return (dispatch, getState) => {
     const { rescanCall } = getState().control;
-    rescanCall.cancel();
-    dispatch({ type: RESCAN_CANCEL });
+    if (rescanCall) {
+      rescanCall.cancel();
+      dispatch({ type: RESCAN_CANCEL });
+    }
   };
 }
 

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -1,15 +1,16 @@
-import { versionCheckAction } from "./WalletLoaderActions";
+import { versionCheckAction, spvSyncCancel } from "./WalletLoaderActions";
 import { stopNotifcations } from "./NotificationActions";
+import { saveSettings, updateStateSettingsChanged } from "./SettingsActions";
+import { rescanCancel } from "./ControlActions";
+import { hideSidebarMenu, showSidebar } from "./SidebarActions";
+import { semverCompatible } from "./VersionActions";
 import * as wallet from "wallet";
 import { push as pushHistory, goBack } from "react-router-redux";
 import { ipcRenderer } from "electron";
 import { setMustOpenForm, getWalletCfg, getAppdataPath, getRemoteCredentials, getGlobalCfg, setLastHeight } from "../config";
-import { hideSidebarMenu, showSidebar } from "./SidebarActions";
 import { isTestNet } from "selectors";
 import axios from "axios";
-import { semverCompatible } from "./VersionActions";
 import { STANDARD_EXTERNAL_REQUESTS } from "main_dev/externalRequests";
-import { saveSettings, updateStateSettingsChanged } from "./SettingsActions";
 
 export const DECREDITON_VERSION = "DECREDITON_VERSION";
 export const SELECT_LANGUAGE = "SELECT_LANGUAGE";
@@ -175,6 +176,8 @@ export const shutdownApp = () => (dispatch, getState) => {
   }
   dispatch({ type: SHUTDOWN_REQUESTED });
   dispatch(stopNotifcations());
+  dispatch(rescanCancel());
+  dispatch(spvSyncCancel());
   ipcRenderer.on("daemon-stopped", () => {
     dispatch({ type: DAEMONSTOPPED });
   });

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -175,12 +175,12 @@ export const shutdownApp = () => (dispatch, getState) => {
     setLastHeight(currentBlockHeight);
   }
   dispatch({ type: SHUTDOWN_REQUESTED });
-  dispatch(stopNotifcations());
-  dispatch(rescanCancel());
-  dispatch(spvSyncCancel());
   ipcRenderer.on("daemon-stopped", () => {
     dispatch({ type: DAEMONSTOPPED });
   });
+  dispatch(stopNotifcations());
+  dispatch(rescanCancel());
+  dispatch(spvSyncCancel());
   dispatch(hideSidebarMenu());
   dispatch(pushHistory("/shutdown"));
 };

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -1,16 +1,18 @@
 // @flow
 import {
   getLoader, startRpc, getWalletExists, createWallet, openWallet, closeWallet, discoverAddresses,
-  subscribeToBlockNotifications, fetchHeaders, getStakePoolInfo,
+  subscribeToBlockNotifications, fetchHeaders, getStakePoolInfo, fetchMissingCFilters,
+  rescanPoint
 } from "wallet";
 import * as wallet from "wallet";
-import { getWalletServiceAttempt, startWalletServices } from "./ClientActions";
+import { getWalletServiceAttempt, startWalletServices, getBestBlockHeightAttempt } from "./ClientActions";
 import { getVersionServiceAttempt } from "./VersionActions";
 import { getAvailableWallets, WALLETREMOVED_FAILED } from "./DaemonActions";
 import { getWalletCfg, getDcrdCert } from "../config";
 import { getWalletPath } from "main_dev/paths";
 import { isTestNet } from "selectors";
 import axios from "axios";
+import { SpvSyncRequest } from "../middleware/walletrpc/api_pb";
 
 const MAX_RPC_RETRIES = 5;
 const RPC_RETRY_DELAY = 5000;
@@ -107,11 +109,11 @@ export const createWalletRequest = (pubPass, privPass, seed, existing) =>
         const { daemon: { walletName } } = getState();
         const config = getWalletCfg(isTestNet(getState()), walletName);
         config.delete("discoveraccounts");
+        config.set("discoveraccounts", !existing);
+        dispatch({ complete: !existing, type: UPDATEDISCOVERACCOUNTS });
         dispatch({ response: {}, type: CREATEWALLET_SUCCESS });
         dispatch(clearStakePoolConfigNewWallet());
         dispatch(getWalletServiceAttempt());
-        dispatch({ complete: !existing, type: UPDATEDISCOVERACCOUNTS });
-        config.set("discoveraccounts", !existing);
       })
       .catch(error => dispatch({ error, type: CREATEWALLET_FAILED }));
   };
@@ -206,7 +208,6 @@ export const startRpcRequestFunc = (isRetry) =>
       daemonhost = "127.0.0.1";
       rpcport = "9109";
     }
-
     const loader = getState().walletLoader.loader;
 
     const cert = getDcrdCert(rpccertPath);
@@ -214,12 +215,12 @@ export const startRpcRequestFunc = (isRetry) =>
     return startRpc(loader, daemonhost, rpcport, rpcuser, rpcpass, cert)
       .then(() => {
         dispatch({ type: STARTRPC_SUCCESS });
-        dispatch(subscribeBlockAttempt());
+        dispatch(fetchMissingCFiltersAttempt());
       })
       .catch(error => {
         if (error.message.includes("RPC client already created")) {
           dispatch({ type: STARTRPC_SUCCESS });
-          dispatch(subscribeBlockAttempt());
+          dispatch(fetchMissingCFiltersAttempt());
         } else if (isRetry) {
           const { rpcRetryAttempts } = getState().walletLoader;
           if (rpcRetryAttempts < MAX_RPC_RETRIES) {
@@ -244,50 +245,67 @@ export const DISCOVERADDRESS_FAILED = "DISCOVERADDRESS_FAILED";
 export const DISCOVERADDRESS_SUCCESS = "DISCOVERADDRESS_SUCCESS";
 
 export const discoverAddressAttempt = (privPass) => (dispatch, getState) => {
-  const { walletLoader: { loader, discoverAccountsComplete } } = getState();
+  const { walletLoader: { loader, discoverAccountsComplete, rescanPointResponse } } = getState();
   const { daemon: { walletName } } = getState();
   dispatch({ type: DISCOVERADDRESS_ATTEMPT });
-  discoverAddresses(loader, !discoverAccountsComplete, privPass)
-    .then(() => {
-
-      if (!discoverAccountsComplete) {
-        const config = getWalletCfg(isTestNet(getState()), walletName);
-        config.delete("discoveraccounts");
-        config.set("discoveraccounts", true);
-        dispatch({ complete: true, type: UPDATEDISCOVERACCOUNTS });
-      } else {
-        const { subscribeBlockNtfnsResponse } = getState().walletLoader;
-        if (subscribeBlockNtfnsResponse !== null) dispatch(fetchHeadersAttempt());
-      }
-
-      dispatch({ response: {}, complete: discoverAccountsComplete, type: DISCOVERADDRESS_SUCCESS });
-    })
-    .catch(error => {
-      if (error.message.includes("invalid passphrase") && error.message.includes("private key")) {
-        dispatch({ error, type: DISCOVERADDRESS_FAILED_INPUT });
-      } else {
-        dispatch({ error, type: DISCOVERADDRESS_FAILED });
-      }
-    });
+  var startingBlockHash = "";
+  if (rescanPointResponse) {
+    startingBlockHash = rescanPointResponse.getRescanPointHash();
+  }
+  if ((startingBlockHash !== null && startingBlockHash.length !== 0) || !discoverAccountsComplete) {
+    discoverAddresses(loader, !discoverAccountsComplete, privPass, startingBlockHash)
+      .then(() => {
+        dispatch({ response: {}, complete: discoverAccountsComplete, type: DISCOVERADDRESS_SUCCESS });
+        if (!discoverAccountsComplete) {
+          const config = getWalletCfg(isTestNet(getState()), walletName);
+          config.delete("discoveraccounts");
+          config.set("discoveraccounts", true);
+          dispatch({ complete: true, type: UPDATEDISCOVERACCOUNTS });
+        } else {
+          dispatch(startWalletServices());
+        }
+      })
+      .catch(error => {
+        if (error.message.includes("invalid passphrase") && error.message.includes("private key")) {
+          dispatch({ error, type: DISCOVERADDRESS_FAILED_INPUT });
+        } else {
+          dispatch({ error, type: DISCOVERADDRESS_FAILED });
+        }
+      });
+  } else {
+    dispatch(startWalletServices());
+  }
 };
+
+export const FETCHMISSINGCFILTERS_ATTEMPT = "FETCHMISSINGCFILTERS_ATTEMPT";
+export const FETCHMISSINGCFILTERS_FAILED = "FETCHMISSINGCFILTERS_FAILED";
+export const FETCHMISSINGCFILTERS_SUCCESS = "FETCHMISSINGCFILTERS_SUCCESS";
+
+const fetchMissingCFiltersAttempt = () => (dispatch, getState) => {
+  const { loader } = getState().walletLoader;
+
+  dispatch({ request: {}, type: FETCHMISSINGCFILTERS_ATTEMPT });
+  return fetchMissingCFilters(loader)
+    .then(() => {
+      dispatch({ response: {}, type: FETCHMISSINGCFILTERS_SUCCESS });
+      dispatch(subscribeBlockAttempt());
+    })
+    .catch(error => dispatch({ error, type: FETCHMISSINGCFILTERS_FAILED }));
+};
+
 
 export const SUBSCRIBEBLOCKNTFNS_ATTEMPT = "SUBSCRIBEBLOCKNTFNS_ATTEMPT";
 export const SUBSCRIBEBLOCKNTFNS_FAILED = "SUBSCRIBEBLOCKNTFNS_FAILED";
 export const SUBSCRIBEBLOCKNTFNS_SUCCESS = "SUBSCRIBEBLOCKNTFNS_SUCCESS";
 
 const subscribeBlockAttempt = () => (dispatch, getState) => {
-  const { loader, discoverAccountsComplete } = getState().walletLoader;
+  const { loader } = getState().walletLoader;
 
   dispatch({ request: {}, type: SUBSCRIBEBLOCKNTFNS_ATTEMPT });
   return subscribeToBlockNotifications(loader)
     .then(() => {
       dispatch({ response: {}, type: SUBSCRIBEBLOCKNTFNS_SUCCESS });
-      if (discoverAccountsComplete) {
-        dispatch(discoverAddressAttempt());
-      } else {
-        // This is dispatched to indicate we should wait for user input to discover addresses.
-        dispatch({ response: {}, type: DISCOVERADDRESS_INPUT });
-      }
+      dispatch(fetchHeadersAttempt());
     })
     .catch(error => dispatch({ error, type: SUBSCRIBEBLOCKNTFNS_FAILED }));
 };
@@ -302,7 +320,7 @@ export const fetchHeadersAttempt = () => (dispatch, getState) => {
   return fetchHeaders(getState().walletLoader.loader)
     .then(response => {
       dispatch({ response, type: FETCHHEADERS_SUCCESS });
-      dispatch(startWalletServices());
+      dispatch(rescanPointAttempt());
     })
     .catch(error => dispatch({ error, type: FETCHHEADERS_FAILED }));
 };
@@ -384,4 +402,85 @@ export const decodeSeed = (mnemonic) => async (dispatch, getState) => {
     dispatch({ error, type: DECODESEED_FAILED });
     throw error;
   }
+};
+
+export const SPVSYNC_ATTEMPT = "SPVSYNC_ATTEMPT";
+export const SPVSYNC_FAILED = "SPVSYNC_FAILED";
+export const SPVSYNC_SUCCESS = "SPVSYNC_SUCCESS";
+export const SPVSYNC_UPDATE = "SPVSYNC_UPDATE";
+export const SPVSYNC_INPUT = "SPVSYNC_INPUT";
+export const SPVSYNC_CANCEL = "SPVSYNC_CANCEL";
+
+export const spvSyncAttempt = (privPass) => (dispatch, getState) => {
+  const { discoverAccountsComplete, spvConnect } = getState().walletLoader;
+  var request = new SpvSyncRequest();
+  if (spvConnect) {
+    request.setSpvConnect(spvConnect);
+  }
+  if (!discoverAccountsComplete && privPass) {
+    request.setDiscoverAccounts(true);
+    request.setPrivatePassphrase(new Uint8Array(Buffer.from(privPass)));
+  } else if (!discoverAccountsComplete && !privPass) {
+    dispatch({ type: SPVSYNC_INPUT });
+    return;
+  }
+  return new Promise(() => {
+    dispatch({ type: SPVSYNC_ATTEMPT });
+    const { loader } = getState().walletLoader;
+    var spvSyncCall = loader.spvSync(request);
+    spvSyncCall.on("data", function(response) {
+      if (!discoverAccountsComplete) {
+        const { daemon: { walletName } } = getState();
+        const config = getWalletCfg(isTestNet(getState()), walletName);
+        config.delete("discoveraccounts");
+        config.set("discoveraccounts", true);
+        dispatch({ complete: true, type: UPDATEDISCOVERACCOUNTS });
+      }
+      dispatch({ syncCall: spvSyncCall, synced: response.getSynced(), type: SPVSYNC_UPDATE });
+      dispatch(getBestBlockHeightAttempt(startWalletServices));
+    });
+    spvSyncCall.on("end", function() {
+      dispatch({ type: SPVSYNC_SUCCESS });
+    });
+    spvSyncCall.on("error", function(status) {
+      status = status + "";
+      if (status.indexOf("Cancelled") < 0) {
+        console.log(status);
+        //reject(status);
+        dispatch({ error: status, type: SPVSYNC_FAILED });
+      }
+    });
+  });
+};
+
+export function spvSyncCancel() {
+  return (dispatch, getState) => {
+    const { syncCall } = getState().walletLoader;
+    if (syncCall) {
+      syncCall.cancel();
+      dispatch({ type: SPVSYNC_CANCEL });
+    }
+  };
+}
+
+export const RESCANPOINT_ATTEMPT = "RESCANPOINT_ATTEMPT";
+export const RESCANPOINT_FAILED = "RESCANPOINT_FAILED";
+export const RESCANPOINT_SUCCESS = "RESCANPOINT_SUCCESS";
+
+export const rescanPointAttempt = () => (dispatch, getState) => {
+  const { discoverAccountsComplete } = getState().walletLoader;
+  dispatch({ type: RESCANPOINT_ATTEMPT });
+  return rescanPoint(getState().walletLoader.loader)
+    .then((response) => {
+      dispatch({ response, type: RESCANPOINT_SUCCESS });
+      if (discoverAccountsComplete) {
+        dispatch(discoverAddressAttempt());
+      } else {
+        // This is dispatched to indicate we should wait for user input to discover addresses.
+        dispatch({ response: {}, type: DISCOVERADDRESS_INPUT });
+      }
+    })
+    .catch(async error => {
+      dispatch({ error, type: RESCANPOINT_FAILED });
+    });
 };

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -215,12 +215,12 @@ export const startRpcRequestFunc = (isRetry) =>
     return startRpc(loader, daemonhost, rpcport, rpcuser, rpcpass, cert)
       .then(() => {
         dispatch({ type: STARTRPC_SUCCESS });
-        dispatch(fetchMissingCFiltersAttempt());
+        dispatch(subscribeBlockAttempt());
       })
       .catch(error => {
         if (error.message.includes("RPC client already created")) {
           dispatch({ type: STARTRPC_SUCCESS });
-          dispatch(fetchMissingCFiltersAttempt());
+          dispatch(subscribeBlockAttempt());
         } else if (isRetry) {
           const { rpcRetryAttempts } = getState().walletLoader;
           if (rpcRetryAttempts < MAX_RPC_RETRIES) {
@@ -288,7 +288,7 @@ const fetchMissingCFiltersAttempt = () => (dispatch, getState) => {
   return fetchMissingCFilters(loader)
     .then(() => {
       dispatch({ response: {}, type: FETCHMISSINGCFILTERS_SUCCESS });
-      dispatch(subscribeBlockAttempt());
+      dispatch(fetchHeadersAttempt());
     })
     .catch(error => dispatch({ error, type: FETCHMISSINGCFILTERS_FAILED }));
 };
@@ -305,7 +305,7 @@ const subscribeBlockAttempt = () => (dispatch, getState) => {
   return subscribeToBlockNotifications(loader)
     .then(() => {
       dispatch({ response: {}, type: SUBSCRIBEBLOCKNTFNS_SUCCESS });
-      dispatch(fetchHeadersAttempt());
+      dispatch(fetchMissingCFiltersAttempt());
     })
     .catch(error => dispatch({ error, type: SUBSCRIBEBLOCKNTFNS_FAILED }));
 };

--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -25,6 +25,7 @@ export default ({
   updateAvailable,
   appVersion,
   isDaemonRemote,
+  isSPV,
   ...props,
 }) => (
   <div className="page-body getstarted">
@@ -65,7 +66,7 @@ export default ({
         <div className="loader-bar">
           <LinearProgressFull
             error={startupError}
-            getDaemonSynced={getDaemonSynced}
+            getDaemonSynced={getDaemonSynced || isSPV}
             disabled={!getDaemonStarted || getCurrentBlockCount == null}
             barText={barText}
             min={0}
@@ -92,7 +93,7 @@ export default ({
           }
           <DecredLoading hidden={startupError || isInputRequest} />
         </div>
-        { Form && <Form {...{ ...props, isInputRequest, startupError, getCurrentBlockCount, getDaemonSynced }}/> }
+        { Form && <Form {...{ ...props, isInputRequest, startupError, getCurrentBlockCount, getDaemonSynced, isSPV }}/> }
       </Aux>
     </div>
   </div>

--- a/app/components/views/GetStartedPage/DaemonLoading/index.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/index.js
@@ -26,10 +26,12 @@ class DaemonLoading extends React.Component {
         this.setState({ showLongWaitMessage: true });
       }
     }, 2000);
-    const neededBlocksInterval = this.props.network === "mainnet"
-      ? 5 * 60 * 1000
-      : 2 * 60 * 1000;
-    this.props.setInterval(this.props.determineNeededBlocks, neededBlocksInterval);
+    if (!this.props.isSPV) {
+      const neededBlocksInterval = this.props.network === "mainnet"
+        ? 5 * 60 * 1000
+        : 2 * 60 * 1000;
+      this.props.setInterval(this.props.determineNeededBlocks, neededBlocksInterval);
+    }
   }
 
   render() {

--- a/app/components/views/GetStartedPage/SpvSync/Form.js
+++ b/app/components/views/GetStartedPage/SpvSync/Form.js
@@ -1,0 +1,56 @@
+import { KeyBlueButton } from "buttons";
+import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
+import { PasswordInput } from "inputs";
+import "style/GetStarted.less";
+
+const messages = defineMessages({
+  passphrasePlaceholder: {
+    id: "getStarted.discoverAddresses.passphrasePlaceholder",
+    defaultMessage: "Private Passphrase"
+  }
+});
+
+const SpvSyncFormBodyBase = ({
+  passPhrase,
+  isSpvSyncAttempt,
+  intl,
+  onSetPassPhrase,
+  onSpvSync,
+  onKeyDown
+}) => (
+  !isSpvSyncAttempt ? (
+    <Aux>
+      <div className="advanced-page-form">
+        <div className="advanced-daemon-row">
+          <T id="getStarted.discoverAccountsInfo" m={`
+            Enter the passphrase you just created to scan the blockchain for additional accounts you may have previously created with your wallet.
+
+            Your account names aren't stored on the blockchain, so you will have to rename them after setting up Decrediton.
+          `}/>
+        </div>
+        <div className="advanced-daemon-row">
+          <div className="advanced-daemon-label">
+            <T id="getStarted.discover.label" m="Scan for accounts" />
+          </div>
+          <div className="advanced-daemon-input">
+            <PasswordInput
+              autoFocus
+              className="get-started-input-private-password"
+              placeholder={intl.formatMessage(messages.passphrasePlaceholder)}
+              value={passPhrase}
+              onChange={(e) => onSetPassPhrase(e.target.value)}
+              onKeyDown={onKeyDown}/>
+          </div>
+        </div>
+        <div className="loader-bar-buttons">
+          <KeyBlueButton onClick={onSpvSync}>
+            <T id="getStarted.discoverAddresses.scanBtn" m="Scan" />
+          </KeyBlueButton>
+        </div>
+      </div>
+    </Aux>
+  ) : null
+);
+const SpvSyncFormBody = injectIntl(SpvSyncFormBodyBase);
+
+export { SpvSyncFormBody };

--- a/app/components/views/GetStartedPage/SpvSync/index.js
+++ b/app/components/views/GetStartedPage/SpvSync/index.js
@@ -1,10 +1,10 @@
 import {
-  DiscoverAddressesFormHeader as DiscoverAddressesHeader,
-  DiscoverAddressesFormBody
+  SpvSyncFormHeader as SpvSyncHeader,
+  SpvSyncFormBody
 } from "./Form";
 
 @autobind
-class DiscoverAddressesBody extends React.Component {
+class SpvSyncBody extends React.Component {
   constructor(props)  {
     super(props);
     this.state = this.getInitialState();
@@ -16,7 +16,7 @@ class DiscoverAddressesBody extends React.Component {
 
   componentDidMount() {
     if (this.props.walletPrivatePassphrase && this.props.fetchHeadersDone !== null) {
-      this.props.onDiscoverAddresses(this.props.walletPrivatePassphrase);
+      this.props.onSpvSynces(this.props.walletPrivatePassphrase);
     }
   }
 
@@ -29,16 +29,16 @@ class DiscoverAddressesBody extends React.Component {
 
   render() {
     const { passPhrase, hasAttemptedDiscover } = this.state;
-    const { onSetPassPhrase, onDiscoverAddresses, onKeyDown } = this;
+    const { onSetPassPhrase, onSpvSync, onKeyDown } = this;
 
     return (
-      <DiscoverAddressesFormBody
+      <SpvSyncFormBody
         {...{
           ...this.props,
           passPhrase,
           hasAttemptedDiscover,
           onSetPassPhrase,
-          onDiscoverAddresses,
+          onSpvSync,
           onKeyDown
         }}
       />
@@ -53,27 +53,27 @@ class DiscoverAddressesBody extends React.Component {
     this.setState({ passPhrase });
   }
 
-  onDiscoverAddresses() {
+  onSpvSync() {
     const { passPhrase } = this.state;
 
     if (!passPhrase) {
       return this.setState({ hasAttemptedDiscover: true });
     }
 
-    const { onDiscoverAddresses, onSetWalletPrivatePassphrase } = this.props;
+    const { startSPVSync, onSetWalletPrivatePassphrase } = this.props;
 
     onSetWalletPrivatePassphrase && onSetWalletPrivatePassphrase(passPhrase);
-    onDiscoverAddresses(passPhrase);
+    startSPVSync(passPhrase);
     this.resetState();
   }
 
   onKeyDown(e) {
     if(e.keyCode == 13) {   // Enter key
       e.preventDefault();
-      this.onDiscoverAddresses();
+      this.onSpvSync();
     }
   }
 
 }
 
-export { DiscoverAddressesHeader, DiscoverAddressesBody };
+export { SpvSyncHeader, SpvSyncBody };

--- a/app/components/views/GetStartedPage/StakePools/index.js
+++ b/app/components/views/GetStartedPage/StakePools/index.js
@@ -51,7 +51,7 @@ class StakePoolsBody extends React.Component {
       const { onSetWalletPrivatePassphrase } = this.props;
       onSetWalletPrivatePassphrase && onSetWalletPrivatePassphrase(this.state.passPhrase);
     }
-    this.props.onFetchHeaders();
+    this.props.startWalletServices();
   }
 
   onSetStakePoolInfo() {

--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -23,6 +23,7 @@ const WalletSelectionBodyBase = ({
   isWatchOnly,
   masterPubKeyError,
   maxWalletCount,
+  isSPV,
   ...props,
 }) => {
   return (
@@ -61,7 +62,7 @@ const WalletSelectionBodyBase = ({
                       <T id="walletselection.canelChanges" m="Cancel Changes"/>
                     </div>
                   }
-                  {!editWallets && getDaemonSynced && selected ?
+                  {!editWallets && (getDaemonSynced || isSPV) && selected ?
                     <Aux>
                       <div className={"display-wallet-launch"} onClick={startWallet}>
                         <T id="walletselection.launchWallet" m="Launch Wallet "/>

--- a/app/components/views/GetStartedPage/WalletSelection/index.js
+++ b/app/components/views/GetStartedPage/WalletSelection/index.js
@@ -36,6 +36,7 @@ class WalletSelectionBody extends React.Component {
     const {
       getDaemonSynced,
       maxWalletCount,
+      isSPV
     } = this.props;
     const {
       onChangeAvailableWallets,
@@ -91,6 +92,7 @@ class WalletSelectionBody extends React.Component {
           masterPubKeyError,
           walletNameError,
           maxWalletCount,
+          isSPV,
           ...this.props,
           ...this.state,
         }}

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -144,11 +144,13 @@ class GetStartedPage extends React.Component {
       }
     } else {
       switch (startStepIndex || 0) {
+      case 0:
       case 1:
         text = startupError ? startupError :
           <T id="getStarted.header.checkingWalletState.meta" m="Checking wallet state" />;
         break;
       case 2:
+        text = <T id="getStarted.header.openingwallet.meta" m="Opening Wallet" />;
         if (hasExistingWallet) {
           Form = OpenWallet;
         } else {
@@ -156,9 +158,11 @@ class GetStartedPage extends React.Component {
         }
         break;
       case 3:
-      case 4:
         text = <T id="getStarted.header.startrpc.meta" m="Establishing RPC connection" />;
         Form = StartRPCBody;
+        break;
+      case 4:
+        text = <T id="getStarted.header.subcribe.meta" m="Subscribing to Block Notifications" />;
         break;
       case 4.5:
         text = <T id="getStarted.header.fetchingMissingCFilter.meta" m="Fetching Missing CFilters" />;

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -6,6 +6,7 @@ import Settings from "./Settings";
 import ReleaseNotes from "./ReleaseNotes";
 import WalletSelectionBody from "./WalletSelection";
 import StartRPCBody from "./StartRPC";
+import { SpvSyncBody } from "./SpvSync";
 import { DiscoverAddressesBody } from "./DiscoverAddresses";
 import { FetchBlockHeadersBody } from "./FetchBlockHeaders";
 import { AdvancedStartupBody, RemoteAppdataError } from "./AdvancedStartup";
@@ -24,14 +25,14 @@ class GetStartedPage extends React.Component {
   }
 
   componentDidMount() {
-    const { getWalletReady, getDaemonStarted, getNeededBlocks, onGetAvailableWallets, onStartWallet, prepStartDaemon, determineNeededBlocks } = this.props;
+    const { getWalletReady, getDaemonStarted, getNeededBlocks, onGetAvailableWallets, onStartWallet, prepStartDaemon, determineNeededBlocks, isSPV } = this.props;
     if (!getWalletReady) {
       onGetAvailableWallets()
         .then(({ previousWallet }) => {
           previousWallet && onStartWallet(previousWallet);
         });
     }
-    if (!getNeededBlocks) {
+    if (!getNeededBlocks && !isSPV) {
       determineNeededBlocks();
     }
     if (!getDaemonStarted) {
@@ -40,10 +41,17 @@ class GetStartedPage extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { startStepIndex, getDaemonSynced, onRetryStartRPC } = this.props;
-    if (startStepIndex != nextProps.startStepIndex || getDaemonSynced != nextProps.getDaemonSynced ){
-      if (nextProps.startStepIndex == 3 && nextProps.getDaemonSynced)
-        onRetryStartRPC();
+    const { startStepIndex, getDaemonSynced, onRetryStartRPC, isSPV, startSPVSync } = this.props;
+    if (!isSPV) {
+      if (startStepIndex != nextProps.startStepIndex || getDaemonSynced != nextProps.getDaemonSynced ){
+        if (nextProps.startStepIndex == 3 && nextProps.getDaemonSynced)
+          onRetryStartRPC();
+      }
+    } else {
+      if (startStepIndex != nextProps.startStepIndex ){
+        if (nextProps.startStepIndex == 3)
+          startSPVSync(this.state.walletPrivatePassphrase);
+      }
     }
   }
 
@@ -91,6 +99,8 @@ class GetStartedPage extends React.Component {
       hasExistingWallet,
       appVersion,
       updateAvailable,
+      isSPV,
+      spvInput,
       ...props
     } = this.props;
 
@@ -118,12 +128,19 @@ class GetStartedPage extends React.Component {
       return <Logs {...{ onShowSettings, onHideLogs, getWalletReady, appVersion, updateAvailable,  ...props }} />;
     } else if (showReleaseNotes) {
       return <ReleaseNotes {...{ onShowSettings, onShowLogs, onHideReleaseNotes, getWalletReady, ...props }} />;
-    } else if (isAdvancedDaemon && openForm && !remoteAppdataError && !isPrepared && !getWalletReady) {
+    } else if (isAdvancedDaemon && openForm && !remoteAppdataError && !isPrepared && !getWalletReady && !isSPV) {
       Form = AdvancedStartupBody;
-    } else if (remoteAppdataError && !isPrepared && !getWalletReady) {
+    } else if (remoteAppdataError && !isPrepared && !getWalletReady && !isSPV) {
       Form = RemoteAppdataError;
     } else if (!getWalletReady) {
       Form = WalletSelectionBody;
+    } else if (isSPV && startStepIndex > 2) {
+      text = <T id="getStarted.header.syncSpv.meta" m="Syncing SPV Wallet" />;
+      if (spvInput) {
+        Form = SpvSyncBody;
+      } else {
+        Form = FetchBlockHeadersBody;
+      }
     } else {
       switch (startStepIndex || 0) {
       case 1:
@@ -142,17 +159,21 @@ class GetStartedPage extends React.Component {
         text = <T id="getStarted.header.startrpc.meta" m="Establishing RPC connection" />;
         Form = StartRPCBody;
         break;
+      case 4.5:
+        text = <T id="getStarted.header.fetchingMissingCFilter.meta" m="Fetching Missing CFilters" />;
+        Form = FetchBlockHeadersBody;
+        break;
       case 5:
+        text = <T id="getStarted.header.fetchingBlockHeaders.meta" m="Fetching block headers" />;
+        Form = FetchBlockHeadersBody;
+        break;
+      case 6:
         text = <T id="getStarted.header.discoveringAddresses.meta" m="Discovering addresses" />;
         Form = DiscoverAddressesBody;
         break;
-      case 6:
+      case 7:
         text = <T id="getStarted.header.stakePools.meta" m="Import StakePools" />;
         Form = StakePoolsBody;
-        break;
-      case 7:
-        text = <T id="getStarted.header.fetchingBlockHeaders.meta" m="Fetching block headers" />;
-        Form = FetchBlockHeadersBody;
         break;
       case 8:
         text = <T id="getStarted.header.rescanWallet.meta" m="Scanning blocks for transactions" />;
@@ -181,6 +202,8 @@ class GetStartedPage extends React.Component {
         onSetWalletPrivatePassphrase,
         appVersion,
         updateAvailable,
+        isSPV,
+        spvInput
       }} />;
   }
 }

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -101,6 +101,7 @@ class GetStartedPage extends React.Component {
       updateAvailable,
       isSPV,
       spvInput,
+      isInputRequest,
       ...props
     } = this.props;
 
@@ -169,7 +170,9 @@ class GetStartedPage extends React.Component {
         break;
       case 6:
         text = <T id="getStarted.header.discoveringAddresses.meta" m="Discovering addresses" />;
-        Form = DiscoverAddressesBody;
+        if (isInputRequest) {
+          Form = DiscoverAddressesBody;
+        }
         break;
       case 7:
         text = <T id="getStarted.header.stakePools.meta" m="Import StakePools" />;
@@ -203,7 +206,8 @@ class GetStartedPage extends React.Component {
         appVersion,
         updateAvailable,
         isSPV,
-        spvInput
+        spvInput,
+        isInputRequest
       }} />;
   }
 }

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -35,7 +35,7 @@ class GetStartedPage extends React.Component {
     if (!getNeededBlocks && !isSPV) {
       determineNeededBlocks();
     }
-    if (!getDaemonStarted) {
+    if (!getDaemonStarted && !isSPV) {
       setTimeout(()=>prepStartDaemon(), 1000);
     }
   }

--- a/app/components/views/TicketsPage/PurchaseTab/Tickets.js
+++ b/app/components/views/TicketsPage/PurchaseTab/Tickets.js
@@ -15,8 +15,6 @@ const purchaseTicketSpvWarn = (blocksNumber) => <T id="spv.purchase.warn"
   }}
 />;
 
-const autoBuyerSpvWarn = <T id="spv.auto.buyer.warn" m="Ticket Auto Buyer Not available in spv mode" />;
-
 const Tickets = ({
   spvMode,
   blocksPassedOnTicketInterval,
@@ -31,7 +29,7 @@ const Tickets = ({
     }
     <div className="stakepool-area-spacing"></div>
     {
-      spvMode ? <ShowWarning warn={autoBuyerSpvWarn}/>  : <TicketAutoBuyer {...{ ...props }} />
+      spvMode ? <div className="spv-autobuyer-warning"><T id="spv.auto.buyer.warn" m="Ticket Auto Buyer not available while using SPV" /></div>  : <TicketAutoBuyer {...{ ...props }} />
     }
   </Aux>
 );

--- a/app/components/views/TicketsPage/PurchaseTab/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/index.js
@@ -1,6 +1,5 @@
 import { substruct, compose, eq, get } from "fp";
 import { service, ticketsPage } from "connectors";
-import ErrorScreen from "ErrorScreen";
 import PurchasePage from "./Page";
 import { FormattedMessage as T } from "react-intl";
 
@@ -28,7 +27,7 @@ class Purchase extends React.Component {
   }
 
   render() {
-    return (!this.props.walletService || !this.props.ticketBuyerService) ? <ErrorScreen /> : (
+    return (
       <PurchasePage
         {...{
           ...this.props,
@@ -48,8 +47,7 @@ class Purchase extends React.Component {
             onRevokeTickets: null,
           }, this)
         }}
-      />
-    );
+      />);
   }
 
   onToggleTicketStakePool(side) {

--- a/app/config.js
+++ b/app/config.js
@@ -112,6 +112,9 @@ export function initGlobalCfg() {
   if (!config.has("spv_mode")) {
     config.set("spv_mode", false);
   }
+  if (!config.has("spv_connect")) {
+    config.set("spv_connect", "");
+  }
   if (!config.has("politeia_beta")) { // TODO: remove once politeia hits production
     config.set("politeia_beta", false);
   }

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -5,6 +5,7 @@ import * as sel from "../selectors";
 import * as wla from "../actions/WalletLoaderActions";
 import * as da from "../actions/DaemonActions";
 import * as ca from "../actions/ControlActions";
+import * as cla from "../actions/ClientActions";
 
 const mapStateToProps = selectorMap({
   appVersion: sel.appVersion,
@@ -45,6 +46,9 @@ const mapStateToProps = selectorMap({
   createNewWallet: sel.createNewWallet,
   isWatchOnly: sel.isWatchOnly,
   masterPubKey: sel.masterPubKey,
+  fetchHeadersDone: sel.fetchHeadersDone,
+  isSPV: sel.isSPV,
+  spvInput: sel.spvInput,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({
@@ -70,11 +74,13 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onFetchHeaders: wla.fetchHeadersAttempt,
   onStartDaemon: da.startDaemon,
   onStartWallet: da.startWallet,
+  startSPVSync: wla.spvSyncAttempt,
   onCreateWallet: da.createWallet,
   onRemoveWallet: da.removeWallet,
   setCredentialsAppdataError: da.setCredentialsAppdataError,
   onGetAvailableWallets: da.getAvailableWallets,
   validateMasterPubKey: ca.validateMasterPubKey,
+  startWalletServices: cla.startWalletServices,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/index.js
+++ b/app/index.js
@@ -79,7 +79,7 @@ var initialState = {
   },
   version: {
     // RequiredVersion
-    requiredVersion: "4.40.0",
+    requiredVersion: "5.0.1",
     versionInvalid: false,
     versionInvalidError: null,
     // VersionService
@@ -194,6 +194,8 @@ var initialState = {
     maturingBlockHeights: {},
   },
   walletLoader: {
+    spvConnect: globalCfg.get("spv_connect"),
+    spvInput: false,
     existingOrNew: false,
     rpcRetryAttempts: 0,
     neededBlocks: 0,

--- a/app/middleware/api.proto
+++ b/app/middleware/api.proto
@@ -72,6 +72,9 @@ service WalletLoaderService {
 	rpc DiscoverAddresses (DiscoverAddressesRequest) returns (DiscoverAddressesResponse);
 	rpc SubscribeToBlockNotifications (SubscribeToBlockNotificationsRequest) returns (SubscribeToBlockNotificationsResponse);
 	rpc FetchHeaders(FetchHeadersRequest) returns (FetchHeadersResponse);
+	rpc FetchMissingCFilters(FetchMissingCFiltersRequest) returns (FetchMissingCFiltersResponse);
+	rpc SpvSync(SpvSyncRequest) returns (stream SpvSyncResponse);
+	rpc RescanPoint(RescanPointRequest) returns (RescanPointResponse);
 }
 
 service TicketBuyerService {
@@ -188,6 +191,7 @@ message RenameAccountResponse {}
 
 message RescanRequest {
 	int32 begin_height = 1;
+	bytes begin_hash = 2;
 }
 message RescanResponse {
 	int32 rescanned_through = 1;
@@ -659,8 +663,12 @@ message StartConsensusRpcResponse {}
 message DiscoverAddressesRequest {
 	bool discover_accounts = 1;
 	bytes private_passphrase = 2;
+	bytes starting_block_hash = 3;
 }
 message DiscoverAddressesResponse {}
+
+message FetchMissingCFiltersRequest {}
+message FetchMissingCFiltersResponse {}
 
 message SubscribeToBlockNotificationsRequest {}
 message SubscribeToBlockNotificationsResponse {}
@@ -672,6 +680,20 @@ message FetchHeadersResponse {
 	int32 first_new_block_height = 3;
 	bytes main_chain_tip_block_hash = 4;
 	int32 main_chain_tip_block_height = 5;
+}
+
+message SpvSyncRequest {
+	bool discover_accounts = 1;
+	bytes private_passphrase = 2;
+	string spv_connect = 3;
+}
+message SpvSyncResponse {
+	bool synced = 1;
+}
+
+message RescanPointRequest {}
+message RescanPointResponse {
+	bytes rescan_point_hash = 1;
 }
 
 message GenerateRandomSeedRequest {

--- a/app/middleware/walletrpc/api_grpc_pb.js
+++ b/app/middleware/walletrpc/api_grpc_pb.js
@@ -422,6 +422,28 @@ function deserialize_walletrpc_FetchHeadersResponse(buffer_arg) {
   return api_pb.FetchHeadersResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
+function serialize_walletrpc_FetchMissingCFiltersRequest(arg) {
+  if (!(arg instanceof api_pb.FetchMissingCFiltersRequest)) {
+    throw new Error('Expected argument of type walletrpc.FetchMissingCFiltersRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_walletrpc_FetchMissingCFiltersRequest(buffer_arg) {
+  return api_pb.FetchMissingCFiltersRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_walletrpc_FetchMissingCFiltersResponse(arg) {
+  if (!(arg instanceof api_pb.FetchMissingCFiltersResponse)) {
+    throw new Error('Expected argument of type walletrpc.FetchMissingCFiltersResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_walletrpc_FetchMissingCFiltersResponse(buffer_arg) {
+  return api_pb.FetchMissingCFiltersResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
 function serialize_walletrpc_FundTransactionRequest(arg) {
   if (!(arg instanceof api_pb.FundTransactionRequest)) {
     throw new Error('Expected argument of type walletrpc.FundTransactionRequest');
@@ -818,6 +840,28 @@ function deserialize_walletrpc_RenameAccountResponse(buffer_arg) {
   return api_pb.RenameAccountResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
+function serialize_walletrpc_RescanPointRequest(arg) {
+  if (!(arg instanceof api_pb.RescanPointRequest)) {
+    throw new Error('Expected argument of type walletrpc.RescanPointRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_walletrpc_RescanPointRequest(buffer_arg) {
+  return api_pb.RescanPointRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_walletrpc_RescanPointResponse(arg) {
+  if (!(arg instanceof api_pb.RescanPointResponse)) {
+    throw new Error('Expected argument of type walletrpc.RescanPointResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_walletrpc_RescanPointResponse(buffer_arg) {
+  return api_pb.RescanPointResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
 function serialize_walletrpc_RescanRequest(arg) {
   if (!(arg instanceof api_pb.RescanRequest)) {
     throw new Error('Expected argument of type walletrpc.RescanRequest');
@@ -1168,6 +1212,28 @@ function serialize_walletrpc_SignTransactionsResponse(arg) {
 
 function deserialize_walletrpc_SignTransactionsResponse(buffer_arg) {
   return api_pb.SignTransactionsResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_walletrpc_SpvSyncRequest(arg) {
+  if (!(arg instanceof api_pb.SpvSyncRequest)) {
+    throw new Error('Expected argument of type walletrpc.SpvSyncRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_walletrpc_SpvSyncRequest(buffer_arg) {
+  return api_pb.SpvSyncRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_walletrpc_SpvSyncResponse(arg) {
+  if (!(arg instanceof api_pb.SpvSyncResponse)) {
+    throw new Error('Expected argument of type walletrpc.SpvSyncResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_walletrpc_SpvSyncResponse(buffer_arg) {
+  return api_pb.SpvSyncResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
 function serialize_walletrpc_StakeInfoRequest(arg) {
@@ -2018,6 +2084,39 @@ var WalletLoaderServiceService = exports.WalletLoaderServiceService = {
     requestDeserialize: deserialize_walletrpc_FetchHeadersRequest,
     responseSerialize: serialize_walletrpc_FetchHeadersResponse,
     responseDeserialize: deserialize_walletrpc_FetchHeadersResponse,
+  },
+  fetchMissingCFilters: {
+    path: '/walletrpc.WalletLoaderService/FetchMissingCFilters',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.FetchMissingCFiltersRequest,
+    responseType: api_pb.FetchMissingCFiltersResponse,
+    requestSerialize: serialize_walletrpc_FetchMissingCFiltersRequest,
+    requestDeserialize: deserialize_walletrpc_FetchMissingCFiltersRequest,
+    responseSerialize: serialize_walletrpc_FetchMissingCFiltersResponse,
+    responseDeserialize: deserialize_walletrpc_FetchMissingCFiltersResponse,
+  },
+  spvSync: {
+    path: '/walletrpc.WalletLoaderService/SpvSync',
+    requestStream: false,
+    responseStream: true,
+    requestType: api_pb.SpvSyncRequest,
+    responseType: api_pb.SpvSyncResponse,
+    requestSerialize: serialize_walletrpc_SpvSyncRequest,
+    requestDeserialize: deserialize_walletrpc_SpvSyncRequest,
+    responseSerialize: serialize_walletrpc_SpvSyncResponse,
+    responseDeserialize: deserialize_walletrpc_SpvSyncResponse,
+  },
+  rescanPoint: {
+    path: '/walletrpc.WalletLoaderService/RescanPoint',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.RescanPointRequest,
+    responseType: api_pb.RescanPointResponse,
+    requestSerialize: serialize_walletrpc_RescanPointRequest,
+    requestDeserialize: deserialize_walletrpc_RescanPointRequest,
+    responseSerialize: serialize_walletrpc_RescanPointResponse,
+    responseDeserialize: deserialize_walletrpc_RescanPointResponse,
   },
 };
 

--- a/app/middleware/walletrpc/api_pb.js
+++ b/app/middleware/walletrpc/api_pb.js
@@ -66,6 +66,8 @@ goog.exportSymbol('proto.walletrpc.DiscoverAddressesRequest', null, global);
 goog.exportSymbol('proto.walletrpc.DiscoverAddressesResponse', null, global);
 goog.exportSymbol('proto.walletrpc.FetchHeadersRequest', null, global);
 goog.exportSymbol('proto.walletrpc.FetchHeadersResponse', null, global);
+goog.exportSymbol('proto.walletrpc.FetchMissingCFiltersRequest', null, global);
+goog.exportSymbol('proto.walletrpc.FetchMissingCFiltersResponse', null, global);
 goog.exportSymbol('proto.walletrpc.FundTransactionRequest', null, global);
 goog.exportSymbol('proto.walletrpc.FundTransactionResponse', null, global);
 goog.exportSymbol('proto.walletrpc.FundTransactionResponse.PreviousOutput', null, global);
@@ -108,6 +110,8 @@ goog.exportSymbol('proto.walletrpc.PurchaseTicketsRequest', null, global);
 goog.exportSymbol('proto.walletrpc.PurchaseTicketsResponse', null, global);
 goog.exportSymbol('proto.walletrpc.RenameAccountRequest', null, global);
 goog.exportSymbol('proto.walletrpc.RenameAccountResponse', null, global);
+goog.exportSymbol('proto.walletrpc.RescanPointRequest', null, global);
+goog.exportSymbol('proto.walletrpc.RescanPointResponse', null, global);
 goog.exportSymbol('proto.walletrpc.RescanRequest', null, global);
 goog.exportSymbol('proto.walletrpc.RescanResponse', null, global);
 goog.exportSymbol('proto.walletrpc.RevokeTicketsRequest', null, global);
@@ -147,6 +151,8 @@ goog.exportSymbol('proto.walletrpc.SignTransactionsRequest.AdditionalScript', nu
 goog.exportSymbol('proto.walletrpc.SignTransactionsRequest.UnsignedTransaction', null, global);
 goog.exportSymbol('proto.walletrpc.SignTransactionsResponse', null, global);
 goog.exportSymbol('proto.walletrpc.SignTransactionsResponse.SignedTransaction', null, global);
+goog.exportSymbol('proto.walletrpc.SpvSyncRequest', null, global);
+goog.exportSymbol('proto.walletrpc.SpvSyncResponse', null, global);
 goog.exportSymbol('proto.walletrpc.StakeInfoRequest', null, global);
 goog.exportSymbol('proto.walletrpc.StakeInfoResponse', null, global);
 goog.exportSymbol('proto.walletrpc.StartAutoBuyerRequest', null, global);
@@ -3697,7 +3703,8 @@ proto.walletrpc.RescanRequest.prototype.toObject = function(opt_includeInstance)
  */
 proto.walletrpc.RescanRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    beginHeight: jspb.Message.getFieldWithDefault(msg, 1, 0)
+    beginHeight: jspb.Message.getFieldWithDefault(msg, 1, 0),
+    beginHash: msg.getBeginHash_asB64()
   };
 
   if (includeInstance) {
@@ -3738,6 +3745,10 @@ proto.walletrpc.RescanRequest.deserializeBinaryFromReader = function(msg, reader
       var value = /** @type {number} */ (reader.readInt32());
       msg.setBeginHeight(value);
       break;
+    case 2:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setBeginHash(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -3774,6 +3785,13 @@ proto.walletrpc.RescanRequest.serializeBinaryToWriter = function(message, writer
       f
     );
   }
+  f = message.getBeginHash_asU8();
+  if (f.length > 0) {
+    writer.writeBytes(
+      2,
+      f
+    );
+  }
 };
 
 
@@ -3789,6 +3807,45 @@ proto.walletrpc.RescanRequest.prototype.getBeginHeight = function() {
 /** @param {number} value */
 proto.walletrpc.RescanRequest.prototype.setBeginHeight = function(value) {
   jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional bytes begin_hash = 2;
+ * @return {!(string|Uint8Array)}
+ */
+proto.walletrpc.RescanRequest.prototype.getBeginHash = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * optional bytes begin_hash = 2;
+ * This is a type-conversion wrapper around `getBeginHash()`
+ * @return {string}
+ */
+proto.walletrpc.RescanRequest.prototype.getBeginHash_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getBeginHash()));
+};
+
+
+/**
+ * optional bytes begin_hash = 2;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getBeginHash()`
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.RescanRequest.prototype.getBeginHash_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getBeginHash()));
+};
+
+
+/** @param {!(string|Uint8Array)} value */
+proto.walletrpc.RescanRequest.prototype.setBeginHash = function(value) {
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -20728,7 +20785,8 @@ proto.walletrpc.DiscoverAddressesRequest.prototype.toObject = function(opt_inclu
 proto.walletrpc.DiscoverAddressesRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     discoverAccounts: jspb.Message.getFieldWithDefault(msg, 1, false),
-    privatePassphrase: msg.getPrivatePassphrase_asB64()
+    privatePassphrase: msg.getPrivatePassphrase_asB64(),
+    startingBlockHash: msg.getStartingBlockHash_asB64()
   };
 
   if (includeInstance) {
@@ -20773,6 +20831,10 @@ proto.walletrpc.DiscoverAddressesRequest.deserializeBinaryFromReader = function(
       var value = /** @type {!Uint8Array} */ (reader.readBytes());
       msg.setPrivatePassphrase(value);
       break;
+    case 3:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setStartingBlockHash(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -20813,6 +20875,13 @@ proto.walletrpc.DiscoverAddressesRequest.serializeBinaryToWriter = function(mess
   if (f.length > 0) {
     writer.writeBytes(
       2,
+      f
+    );
+  }
+  f = message.getStartingBlockHash_asU8();
+  if (f.length > 0) {
+    writer.writeBytes(
+      3,
       f
     );
   }
@@ -20872,6 +20941,45 @@ proto.walletrpc.DiscoverAddressesRequest.prototype.getPrivatePassphrase_asU8 = f
 /** @param {!(string|Uint8Array)} value */
 proto.walletrpc.DiscoverAddressesRequest.prototype.setPrivatePassphrase = function(value) {
   jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional bytes starting_block_hash = 3;
+ * @return {!(string|Uint8Array)}
+ */
+proto.walletrpc.DiscoverAddressesRequest.prototype.getStartingBlockHash = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/**
+ * optional bytes starting_block_hash = 3;
+ * This is a type-conversion wrapper around `getStartingBlockHash()`
+ * @return {string}
+ */
+proto.walletrpc.DiscoverAddressesRequest.prototype.getStartingBlockHash_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getStartingBlockHash()));
+};
+
+
+/**
+ * optional bytes starting_block_hash = 3;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getStartingBlockHash()`
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.DiscoverAddressesRequest.prototype.getStartingBlockHash_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getStartingBlockHash()));
+};
+
+
+/** @param {!(string|Uint8Array)} value */
+proto.walletrpc.DiscoverAddressesRequest.prototype.setStartingBlockHash = function(value) {
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -20987,6 +21095,238 @@ proto.walletrpc.DiscoverAddressesResponse.prototype.serializeBinary = function()
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
 proto.walletrpc.DiscoverAddressesResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.walletrpc.FetchMissingCFiltersRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.walletrpc.FetchMissingCFiltersRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.walletrpc.FetchMissingCFiltersRequest.displayName = 'proto.walletrpc.FetchMissingCFiltersRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.walletrpc.FetchMissingCFiltersRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.walletrpc.FetchMissingCFiltersRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.walletrpc.FetchMissingCFiltersRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.FetchMissingCFiltersRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.walletrpc.FetchMissingCFiltersRequest}
+ */
+proto.walletrpc.FetchMissingCFiltersRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.walletrpc.FetchMissingCFiltersRequest;
+  return proto.walletrpc.FetchMissingCFiltersRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.walletrpc.FetchMissingCFiltersRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.walletrpc.FetchMissingCFiltersRequest}
+ */
+proto.walletrpc.FetchMissingCFiltersRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.FetchMissingCFiltersRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.walletrpc.FetchMissingCFiltersRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.walletrpc.FetchMissingCFiltersRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.FetchMissingCFiltersRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.walletrpc.FetchMissingCFiltersResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.walletrpc.FetchMissingCFiltersResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.walletrpc.FetchMissingCFiltersResponse.displayName = 'proto.walletrpc.FetchMissingCFiltersResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.walletrpc.FetchMissingCFiltersResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.walletrpc.FetchMissingCFiltersResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.walletrpc.FetchMissingCFiltersResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.FetchMissingCFiltersResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.walletrpc.FetchMissingCFiltersResponse}
+ */
+proto.walletrpc.FetchMissingCFiltersResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.walletrpc.FetchMissingCFiltersResponse;
+  return proto.walletrpc.FetchMissingCFiltersResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.walletrpc.FetchMissingCFiltersResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.walletrpc.FetchMissingCFiltersResponse}
+ */
+proto.walletrpc.FetchMissingCFiltersResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.FetchMissingCFiltersResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.walletrpc.FetchMissingCFiltersResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.walletrpc.FetchMissingCFiltersResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.FetchMissingCFiltersResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
 };
 
@@ -21634,6 +21974,654 @@ proto.walletrpc.FetchHeadersResponse.prototype.getMainChainTipBlockHeight = func
 /** @param {number} value */
 proto.walletrpc.FetchHeadersResponse.prototype.setMainChainTipBlockHeight = function(value) {
   jspb.Message.setField(this, 5, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.walletrpc.SpvSyncRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.walletrpc.SpvSyncRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.walletrpc.SpvSyncRequest.displayName = 'proto.walletrpc.SpvSyncRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.walletrpc.SpvSyncRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.walletrpc.SpvSyncRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.walletrpc.SpvSyncRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.SpvSyncRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    discoverAccounts: jspb.Message.getFieldWithDefault(msg, 1, false),
+    privatePassphrase: msg.getPrivatePassphrase_asB64(),
+    spvConnect: jspb.Message.getFieldWithDefault(msg, 3, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.walletrpc.SpvSyncRequest}
+ */
+proto.walletrpc.SpvSyncRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.walletrpc.SpvSyncRequest;
+  return proto.walletrpc.SpvSyncRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.walletrpc.SpvSyncRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.walletrpc.SpvSyncRequest}
+ */
+proto.walletrpc.SpvSyncRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setDiscoverAccounts(value);
+      break;
+    case 2:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setPrivatePassphrase(value);
+      break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setSpvConnect(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.SpvSyncRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.walletrpc.SpvSyncRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.walletrpc.SpvSyncRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.SpvSyncRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getDiscoverAccounts();
+  if (f) {
+    writer.writeBool(
+      1,
+      f
+    );
+  }
+  f = message.getPrivatePassphrase_asU8();
+  if (f.length > 0) {
+    writer.writeBytes(
+      2,
+      f
+    );
+  }
+  f = message.getSpvConnect();
+  if (f.length > 0) {
+    writer.writeString(
+      3,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional bool discover_accounts = 1;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
+ */
+proto.walletrpc.SpvSyncRequest.prototype.getDiscoverAccounts = function() {
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 1, false));
+};
+
+
+/** @param {boolean} value */
+proto.walletrpc.SpvSyncRequest.prototype.setDiscoverAccounts = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional bytes private_passphrase = 2;
+ * @return {!(string|Uint8Array)}
+ */
+proto.walletrpc.SpvSyncRequest.prototype.getPrivatePassphrase = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * optional bytes private_passphrase = 2;
+ * This is a type-conversion wrapper around `getPrivatePassphrase()`
+ * @return {string}
+ */
+proto.walletrpc.SpvSyncRequest.prototype.getPrivatePassphrase_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getPrivatePassphrase()));
+};
+
+
+/**
+ * optional bytes private_passphrase = 2;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getPrivatePassphrase()`
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.SpvSyncRequest.prototype.getPrivatePassphrase_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getPrivatePassphrase()));
+};
+
+
+/** @param {!(string|Uint8Array)} value */
+proto.walletrpc.SpvSyncRequest.prototype.setPrivatePassphrase = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional string spv_connect = 3;
+ * @return {string}
+ */
+proto.walletrpc.SpvSyncRequest.prototype.getSpvConnect = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/** @param {string} value */
+proto.walletrpc.SpvSyncRequest.prototype.setSpvConnect = function(value) {
+  jspb.Message.setField(this, 3, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.walletrpc.SpvSyncResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.walletrpc.SpvSyncResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.walletrpc.SpvSyncResponse.displayName = 'proto.walletrpc.SpvSyncResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.walletrpc.SpvSyncResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.walletrpc.SpvSyncResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.walletrpc.SpvSyncResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.SpvSyncResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    synced: jspb.Message.getFieldWithDefault(msg, 1, false)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.walletrpc.SpvSyncResponse}
+ */
+proto.walletrpc.SpvSyncResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.walletrpc.SpvSyncResponse;
+  return proto.walletrpc.SpvSyncResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.walletrpc.SpvSyncResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.walletrpc.SpvSyncResponse}
+ */
+proto.walletrpc.SpvSyncResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setSynced(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.SpvSyncResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.walletrpc.SpvSyncResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.walletrpc.SpvSyncResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.SpvSyncResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getSynced();
+  if (f) {
+    writer.writeBool(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional bool synced = 1;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
+ */
+proto.walletrpc.SpvSyncResponse.prototype.getSynced = function() {
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 1, false));
+};
+
+
+/** @param {boolean} value */
+proto.walletrpc.SpvSyncResponse.prototype.setSynced = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.walletrpc.RescanPointRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.walletrpc.RescanPointRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.walletrpc.RescanPointRequest.displayName = 'proto.walletrpc.RescanPointRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.walletrpc.RescanPointRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.walletrpc.RescanPointRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.walletrpc.RescanPointRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.RescanPointRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.walletrpc.RescanPointRequest}
+ */
+proto.walletrpc.RescanPointRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.walletrpc.RescanPointRequest;
+  return proto.walletrpc.RescanPointRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.walletrpc.RescanPointRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.walletrpc.RescanPointRequest}
+ */
+proto.walletrpc.RescanPointRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.RescanPointRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.walletrpc.RescanPointRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.walletrpc.RescanPointRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.RescanPointRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.walletrpc.RescanPointResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.walletrpc.RescanPointResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.walletrpc.RescanPointResponse.displayName = 'proto.walletrpc.RescanPointResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.walletrpc.RescanPointResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.walletrpc.RescanPointResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.walletrpc.RescanPointResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.RescanPointResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    rescanPointHash: msg.getRescanPointHash_asB64()
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.walletrpc.RescanPointResponse}
+ */
+proto.walletrpc.RescanPointResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.walletrpc.RescanPointResponse;
+  return proto.walletrpc.RescanPointResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.walletrpc.RescanPointResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.walletrpc.RescanPointResponse}
+ */
+proto.walletrpc.RescanPointResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setRescanPointHash(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.RescanPointResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.walletrpc.RescanPointResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.walletrpc.RescanPointResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.walletrpc.RescanPointResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getRescanPointHash_asU8();
+  if (f.length > 0) {
+    writer.writeBytes(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional bytes rescan_point_hash = 1;
+ * @return {!(string|Uint8Array)}
+ */
+proto.walletrpc.RescanPointResponse.prototype.getRescanPointHash = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/**
+ * optional bytes rescan_point_hash = 1;
+ * This is a type-conversion wrapper around `getRescanPointHash()`
+ * @return {string}
+ */
+proto.walletrpc.RescanPointResponse.prototype.getRescanPointHash_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getRescanPointHash()));
+};
+
+
+/**
+ * optional bytes rescan_point_hash = 1;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getRescanPointHash()`
+ * @return {!Uint8Array}
+ */
+proto.walletrpc.RescanPointResponse.prototype.getRescanPointHash_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getRescanPointHash()));
+};
+
+
+/** @param {!(string|Uint8Array)} value */
+proto.walletrpc.RescanPointResponse.prototype.setRescanPointHash = function(value) {
+  jspb.Message.setField(this, 1, value);
 };
 
 

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -19,6 +19,7 @@ import {
   GETVOTECHOICES_ATTEMPT, GETVOTECHOICES_FAILED, GETVOTECHOICES_SUCCESS,
   SETVOTECHOICES_ATTEMPT, SETVOTECHOICES_FAILED, SETVOTECHOICES_SUCCESS,
   MATURINGHEIGHTS_CHANGED, GETTRANSACTIONSSINCELASTOPPENED_ATTEMPT, GETTRANSACTIONSSINCELASTOPPENED_FAILED,
+  GETBESTBLOCK_ATTEMPT, GETBESTBLOCK_FAILED, GETBESTBLOCK_SUCCESS,
   GETTRANSACTIONSSINCELASTOPPENED_SUCCESS,
 } from "../actions/ClientActions";
 import { STARTUPBLOCK, WALLETREADY } from "../actions/DaemonActions";
@@ -144,6 +145,25 @@ export default function grpc(state = {}, action) {
       getAccountNumberError: "",
       getAccountNumberRequestAttempt: false,
       getAccountNumberResponse: action.getAccountNumberResponse,
+    };
+  case GETBESTBLOCK_ATTEMPT:
+    return {
+      ...state,
+      getBestBlockHeightRequest: true,
+      getAccountNumberError: null,
+    };
+  case GETBESTBLOCK_FAILED:
+    return {
+      ...state,
+      getBestBlockHeightRequest: false,
+      getAccountNumberError: action.error,
+    };
+  case GETBESTBLOCK_SUCCESS:
+    return {
+      ...state,
+      getBestBlockHeightRequest: false,
+      getAccountNumberError: null,
+      currentBlockHeight: action.height,
     };
   case GETNETWORK_ATTEMPT:
     return {

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -40,7 +40,8 @@ import {
 } from "actions/StatisticsActions";
 import { WALLETREMOVED_FAILED } from "actions/DaemonActions";
 import {
-  GETWALLETSEEDSVC_FAILED
+  GETWALLETSEEDSVC_FAILED,
+  SPVSYNC_FAILED,
 } from "actions/WalletLoaderActions";
 
 import {
@@ -197,6 +198,10 @@ const messages = defineMessages({
     id: "accountExtendedKey.failed",
     defaultMessage: "Error getting account extended key: {originalError}"
   },
+  SPVSYNC_FAILED: {
+    id: "spvSync.Failed",
+    defaultMessage: "Error syncing SPV wallet: {originalError}"
+  }
 });
 
 export default function snackbar(state = {}, action) {
@@ -270,6 +275,7 @@ export default function snackbar(state = {}, action) {
   case GETACTIVEVOTE_FAILED:
   case GETVETTED_FAILED:
   case GETPROPOSAL_FAILED:
+  case SPVSYNC_FAILED:
   case UPDATEVOTECHOICE_FAILED:
   case GETACCOUNTEXTENDEDKEY_FAILED:
     type = "Error";

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -12,6 +12,9 @@ import {
   CREATEWALLET_GOBACK_EXISITNG_OR_NEW, CREATEWALLET_GOBACK,
   UPDATEDISCOVERACCOUNTS, NEEDED_BLOCKS_DETERMINED, CREATEWATCHONLYWALLET_ATTEMPT,
   GETWALLETSEEDSVC_ATTEMPT, GETWALLETSEEDSVC_SUCCESS,
+  FETCHMISSINGCFILTERS_ATTEMPT, FETCHMISSINGCFILTERS_FAILED, FETCHMISSINGCFILTERS_SUCCESS,
+  RESCANPOINT_ATTEMPT, RESCANPOINT_FAILED, RESCANPOINT_SUCCESS,
+  SPVSYNC_SUCCESS, SPVSYNC_UPDATE, SPVSYNC_FAILED, SPVSYNC_ATTEMPT, SPVSYNC_INPUT
 } from "actions/WalletLoaderActions";
 import {
   WALLETCREATED
@@ -221,12 +224,11 @@ export default function walletLoader(state = {}, action) {
       discoverAddressError: null,
       discoverAddressRequestAttempt: false,
       discoverAddressResponse: true,
-      stepIndex: action.complete ? 7 : 6, // 6 = stakepool selection, 7 = fetch headers
+      stepIndex: action.complete ? 6 : 7, // 6 = stakepool selection, 7 = fetch headers
     };
   case FETCHHEADERS_ATTEMPT:
     return { ...state,
       fetchHeadersRequestAttempt: true,
-      stepIndex: 7,
     };
   case FETCHHEADERS_FAILED:
     return { ...state,
@@ -242,6 +244,7 @@ export default function walletLoader(state = {}, action) {
       fetchHeadersError: null,
       fetchHeadersRequestAttempt: false,
       fetchHeadersResponse: action.response,
+      stepIndex: 6,
     };
   case RESCAN_ATTEMPT:
     return { ...state,
@@ -250,6 +253,24 @@ export default function walletLoader(state = {}, action) {
   case GETSTARTUPWALLETINFO_ATTEMPT:
     return { ...state,
       stepIndex: 9
+    };
+  case FETCHMISSINGCFILTERS_ATTEMPT:
+    return { ...state,
+      fetchHeadersError: null,
+      fetchHeadersRequestAttempt: true,
+      fetchHeadersResponse: null,
+    };
+  case FETCHMISSINGCFILTERS_FAILED:
+    return { ...state,
+      fetchHeadersError: action.error,
+      fetchHeadersRequestAttempt: false,
+      fetchHeadersResponse: null,
+    };
+  case FETCHMISSINGCFILTERS_SUCCESS:
+    return { ...state,
+      fetchHeadersError: null,
+      fetchHeadersRequestAttempt: false,
+      stepIndex: 4.5
     };
   case SUBSCRIBEBLOCKNTFNS_ATTEMPT:
     return { ...state,
@@ -287,6 +308,53 @@ export default function walletLoader(state = {}, action) {
   case GETWALLETSEEDSVC_SUCCESS:
     return { ...state,
       seedService: action.seedService
+    };
+  case RESCANPOINT_ATTEMPT:
+    return { ...state,
+      rescanPointAttemptRequest: true,
+      rescanPointError: null,
+      rescanPointResponse: null,
+    };
+  case RESCANPOINT_FAILED:
+    return { ...state,
+      rescanPointAttemptRequest: false,
+      rescanPointError: action.error,
+      rescanPointResponse: null,
+    };
+  case RESCANPOINT_SUCCESS:
+    return { ...state,
+      rescanPointAttemptRequest: false,
+      rescanPointError: null,
+      rescanPointResponse: action.response,
+    };
+  case SPVSYNC_INPUT:
+    return { ...state,
+      spvInput: true,
+    };
+  case SPVSYNC_ATTEMPT:
+    return { ...state,
+      spvInput: false,
+      spvSyncAttemptRequest: true,
+      spvSyncError: null,
+      spvSynced: false,
+    };
+  case SPVSYNC_FAILED:
+    return { ...state,
+      spvInput: true,
+      spvSyncAttemptRequest: false,
+      spvSynced: false,
+    };
+  case SPVSYNC_UPDATE:
+    return { ...state,
+      spvSyncError: null,
+      spvSynced: action.synced,
+      syncCall: action.syncCall,
+    };
+  case SPVSYNC_SUCCESS:
+    return { ...state,
+      spvSyncAttemptRequest: false,
+      spvSyncError: null,
+      spvSynced: false,
     };
   default:
     return state;

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -224,7 +224,7 @@ export default function walletLoader(state = {}, action) {
       discoverAddressError: null,
       discoverAddressRequestAttempt: false,
       discoverAddressResponse: true,
-      stepIndex: action.complete ? 6 : 7, // 6 = stakepool selection, 7 = fetch headers
+      stepIndex: action.complete ? 8 : 7, // 7 = stakepool selection, 8 = rescanning
     };
   case FETCHHEADERS_ATTEMPT:
     return { ...state,
@@ -270,7 +270,7 @@ export default function walletLoader(state = {}, action) {
     return { ...state,
       fetchHeadersError: null,
       fetchHeadersRequestAttempt: false,
-      stepIndex: 4.5
+      stepIndex: 5
     };
   case SUBSCRIBEBLOCKNTFNS_ATTEMPT:
     return { ...state,
@@ -287,7 +287,7 @@ export default function walletLoader(state = {}, action) {
       subscribeBlockNtfnsRequestAttempt: false,
       subscribeBlockNtfnsRequest: null,
       subscribeBlockNtfnsResponse: action.response,
-      stepIndex: 5,  // Onto final prep
+      stepIndex: 4.5,
     };
   case UPDATEDISCOVERACCOUNTS:
     return { ...state,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -60,6 +60,7 @@ export const versionInvalidError = createSelector(
   [ versionInvalid, get([ "version", "versionInvalidError" ]) ],
   (invalid, error) => invalid ? error || "Unknown Error" : null
 );
+export const spvInput = get([ "walletLoader", "spvInput" ]);
 
 const isStartStepOpen = compose(eq(START_STEP_OPEN), startStepIndex);
 const isStartStepDiscover = compose(eq(START_STEP_DISCOVER), startStepIndex);
@@ -72,6 +73,8 @@ const walletOpenError = and(get([ "walletLoader", "walletOpenError" ]), isStartS
 const startRpcError = and(get([ "walletLoader", "startRpcError" ]), isStartStepRPC);
 const discoverAddrError = and(get([ "walletLoader", "discoverAddressError" ]), isStartStepDiscover);
 const fetchHeadersError = and(get([ "walletLoader", "fetchHeadersError" ]), isStartStepFetch);
+export const fetchHeadersDone = (get([ "walletLoader", "fetchHeadersResponse" ]));
+
 export const startupError = or(
   getVersionServiceError,
   getWalletRPCVersionError,
@@ -175,6 +178,8 @@ export const defaultLocaleName = createSelector(
   (currentLocaleName) => {
     return appLocaleFromElectronLocale(currentLocaleName);
   });
+
+export const isSPV = get([ "settings", "currentSettings", "spvMode" ]);
 
 export const sortedLocales = createSelector(
   [ get([ "locales" ]) ],

--- a/app/style/StakePool.less
+++ b/app/style/StakePool.less
@@ -1226,3 +1226,10 @@ textarea.stakepool-content-nest-content-settings {
     margin-top: 49px;
   }
 }
+
+.spv-autobuyer-warning {
+  text-align: center;
+  color: #596d81;
+  font-size: 20px;
+  line-height: 25px;
+}

--- a/app/wallet/client.js
+++ b/app/wallet/client.js
@@ -9,6 +9,7 @@ const promisifyReq = (fnName, Req) => log((service, ...args) => new Promise((ok,
 const promisifyReqLogNoData = (fnName, Req) => withLogNoData((service, ...args) => new Promise((ok, fail) =>
   service[fnName](new Req(), ...args, (err, res) => err ? fail(err) : ok(res))), fnName);
 
+export const bestBlock = promisifyReq("bestBlock", api.BestBlockRequest);
 export const getNetwork = promisifyReq("network", api.NetworkRequest);
 export const getStakeInfo = promisifyReqLogNoData("stakeInfo", api.StakeInfoRequest);
 export const getTicketPrice = promisifyReq("ticketPrice", api.TicketPriceRequest);


### PR DESCRIPTION
~This PR requires https://github.com/decred/dcrwallet/pull/1221 binary to be used.~

The new SPV mode in dcrwallet uses a simple all-inclusive startupSync method that does everything required to prepare the wallet for usage while in SPV mode.  This is accessed by the new rpc `SpvSync`.  This creates a new response stream that will stay open for the life of the dcrwallet process, is canceled or has an unrecoverable error.  

This PR also includes updates and refinements to the existing normal mode startup procedures.  A new call for `FetchMissingCFilters` has been added.  Also we now rely on `RescanPoint` requests to tell us where the last rescan had ended so we can consistently pick up from there.  There was also some juggling of startupSteps that took place to further correct and smooth out this process.
