### PR TITLE
Revert changes for win32/64 exe pathing

### DIFF
--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -94,10 +94,7 @@ export function getExecutablePath(name, customBinPath) {
     process.env.NODE_ENV === "development"
       ? path.join(__dirname, "..", "..", "bin")
       : path.join(process.resourcesPath, "bin");
-  let execName = os.platform() !== "win32" ? name :
-    os.arch() == "x64" ? name + "64.exe" :
-      os.arch() == "ia32" ? name + "32.exe" :
-        name + ".exe";
+  let execName = os.platform() !== "win32" ? name : name + ".exe";
 
   return path.join(binPath, execName);
 }


### PR DESCRIPTION
There is still more work to do to get the 32-bit builds properly killing the various spawned processes.  This makes it work again on win64.  The corresponding issue discussing the problem is here: #1345 