### PR TITLE
[launcher] Fix start up sequencing of normal mode

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -2,7 +2,7 @@
 import * as wallet from "wallet";
 import * as sel from "selectors";
 import eq from "lodash/fp/eq";
-import { getNextAddressAttempt, loadActiveDataFiltersAttempt, rescanAttempt,
+import { getNextAddressAttempt, loadActiveDataFiltersAttempt,
   stopAutoBuyerAttempt, getTicketBuyerConfigAttempt, publishUnminedTransactionsAttempt } from "./ControlActions";
 import { transactionNtfnsStart, accountNtfnsStart } from "./NotificationActions";
 import { updateStakepoolPurchaseInformation, setStakePoolVoteChoices, getStakepoolStats } from "./StakePoolActions";
@@ -36,7 +36,7 @@ function getWalletServiceSuccess(walletService) {
 
 export function startWalletServices() {
   return (dispatch, getState) => {
-    const { walletCreateExisting, walletCreateResponse, rescanPointResponse, spvSynced } = getState().walletLoader;
+    const { spvSynced } = getState().walletLoader;
     if (!spvSynced) {
       dispatch(loadActiveDataFiltersAttempt());
       setTimeout(() => { dispatch(getTicketBuyerServiceAttempt()); }, 1000);
@@ -58,17 +58,7 @@ export function startWalletServices() {
       setTimeout(() => { dispatch(showSidebar()); }, 1000);
       setTimeout(() => { dispatch(showSidebarMenu()); }, 1000);
     };
-
-    // Check here to see if wallet was just created from an existing
-    // seed.  If it was created from a newly generated seed there is no
-    // expectation of address use so rescan can be skipped.
-    if (walletCreateExisting && !spvSynced) {
-      setTimeout(() => { dispatch(rescanAttempt(0)).then(goHomeCb); }, 1000);
-    } else if (walletCreateResponse == null && rescanPointResponse != null && rescanPointResponse.getRescanPointHash().length !== 0) {
-      setTimeout(() => { dispatch(rescanAttempt(null, rescanPointResponse.getRescanPointHash())).then(goHomeCb); }, 1000);
-    } else {
-      dispatch(getStartupWalletInfo()).then(goHomeCb);
-    }
+    dispatch(getStartupWalletInfo()).then(goHomeCb);
   };
 }
 


### PR DESCRIPTION
We were previously starting the transaction notifications prior to beginning the initial rescan.  This had a possibility of a race that would cause RESOURCE_EXHAUSTED errors in dcrwallet due to too large of message sizes being sent.  