### PR TITLE
Add options for selecting preferred timezone 

### DIFF
--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -22,6 +22,7 @@ export const saveSettings = (settings) => (dispatch, getState) => {
   config.set("allowed_external_requests", settings.allowedExternalRequests);
   config.set("proxy_type", settings.proxyType);
   config.set("proxy_location", settings.proxyLocation);
+  config.set("timezone", settings.timezone);
 
   const walletConfig = getWalletCfg(isTestNet(getState()), walletName);
   walletConfig.set("currency_display", settings.currencyDisplay);

--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -699,7 +699,7 @@ export const ticketStats = (opts) => (dispatch, getState) => {
     tickets.forEach(t => {
 
       const ticket = normalizeTicket(t);
-      const tsDate = sel.tsDate(getState())
+      const tsDate = sel.tsDate(getState());
       progressFunction(tsDate(ticket.enterTimestamp), {
         spenderTimestamp: ticket.leaveTimestamp ? tsDate(ticket.leaveTimestamp) : null,
         status: ticket.status,

--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -2,7 +2,7 @@ import * as wallet from "wallet";
 import * as sel from "selectors";
 import fs from "fs";
 import { isNumber, isNullOrUndefined, isUndefined } from "util";
-import { tsToDate, endOfDay, reverseRawHash, formatLocalISODate } from "helpers";
+import { endOfDay, reverseRawHash, formatLocalISODate } from "helpers";
 
 const VALUE_TYPE_ATOMAMOUNT = "VALUE_TYPE_ATOMAMOUNT";
 const VALUE_TYPE_DATETIME = "VALUE_TYPE_DATETIME";
@@ -200,8 +200,10 @@ export const transactionStats = (opts) => (dispatch, getState) => {
     };
   };
 
+  const tsDate = sel.tsDate(getState());
+
   const txDataCb = (mined) => {
-    mined.forEach(tx => progressFunction(tsToDate(tx.timestamp), formatTx(tx)));
+    mined.forEach(tx => progressFunction(tsDate(tx.timestamp), formatTx(tx)));
   };
 
   wallet.streamGetTransactions(walletService, 0, currentBlockHeight, 0, txDataCb)
@@ -434,9 +436,11 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
     }, currentBalance);
   }
 
+  const tsDate = sel.tsDate(getState());
+
   // account for this delta in the balances and call the progress function
   let addDelta = (delta) => {
-    backwards && progressFunction(tsToDate(delta.timestamp), { ...currentBalance, delta });
+    backwards && progressFunction(tsDate(delta.timestamp), { ...currentBalance, delta });
 
     currentBalance = {
       spendable: currentBalance.spendable + delta.spendable,
@@ -452,7 +456,7 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
     currentBalance.total = currentBalance.spendable + currentBalance.locked +
       currentBalance.immature;
 
-    !backwards && progressFunction(tsToDate(delta.timestamp), currentBalance);
+    !backwards && progressFunction(tsDate(delta.timestamp), currentBalance);
   };
 
   let lastTxHeight = 0;
@@ -547,7 +551,7 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
       if (mined.length > 0) {
         const lastTx = mined[mined.length-1];
         currentBlock = lastTx.height + pageDir;
-        currentDate = tsToDate(lastTx.timestamp);
+        currentDate = tsDate(lastTx.timestamp);
         toProcess.push(...mined);
       }
       continueGetting =
@@ -695,8 +699,9 @@ export const ticketStats = (opts) => (dispatch, getState) => {
     tickets.forEach(t => {
 
       const ticket = normalizeTicket(t);
-      progressFunction(tsToDate(ticket.enterTimestamp), {
-        spenderTimestamp: ticket.leaveTimestamp ? tsToDate(ticket.leaveTimestamp) : null,
+      const tsDate = sel.tsDate(getState())
+      progressFunction(tsDate(ticket.enterTimestamp), {
+        spenderTimestamp: ticket.leaveTimestamp ? tsDate(ticket.leaveTimestamp) : null,
         status: ticket.status,
         ticketHash: ticket.hash,
         spenderHash: ticket.spenderHash,

--- a/app/components/SideBar/index.js
+++ b/app/components/SideBar/index.js
@@ -1,6 +1,5 @@
 import Bar from "./Bar";
 import { rescan, sideBar } from "connectors";
-import { tsToDate } from "helpers/dateFormat";
 import ReactTimeout from "react-timeout";
 
 @autobind
@@ -32,7 +31,7 @@ class SideBar extends React.Component {
       }
 
       const now = new Date();
-      lastBlockDate = tsToDate(lastBlockTimestamp);
+      lastBlockDate = this.props.tsDate(lastBlockTimestamp);
       const timeFromLastBlock = now.getTime() - lastBlockDate.getTime();
       lastBlockIsRecent = timeFromLastBlock < 60000;
       if (lastBlockIsRecent) {

--- a/app/components/TxHistory/TxHistoryRow/Row.js
+++ b/app/components/TxHistory/TxHistoryRow/Row.js
@@ -3,7 +3,7 @@ import StatusSmall from "./StatusSmall";
 import "style/TxHistory.less";
 
 const Row = ({
-  txAccountName, pending, txTimestamp, onClick, className, children, overview
+  txAccountName, pending, txTimestamp, onClick, className, children, overview, tsDate
 }) => {
   const rowClsname = "tx-history-row";
   const StatusComponent = overview ? StatusSmall : Status;
@@ -15,9 +15,9 @@ const Row = ({
       <div className={[ rowClsname, className,overviewTxIsPending ? "is-row-pending" : null ].join(" ")} {...{ onClick }}>
         {children}
         {!overviewTxIsPending ?
-          <StatusComponent {...{ txAccountName, pending, txTimestamp, overview }} /> : null}
+          <StatusComponent {...{ txAccountName, pending, txTimestamp, overview, tsDate }} /> : null}
       </div>
-      {overviewTxIsPending && <StatusComponent {...{ txAccountName, pending, txTimestamp, overview, onClick }} />}
+      {overviewTxIsPending && <StatusComponent {...{ txAccountName, pending, txTimestamp, overview, onClick, tsDate }} />}
     </div>
   );
 };

--- a/app/components/TxHistory/TxHistoryRow/Status.js
+++ b/app/components/TxHistory/TxHistoryRow/Status.js
@@ -1,5 +1,4 @@
 import { FormattedMessage as T } from "react-intl";
-import { tsToDate } from "helpers/dateFormat";
 import "style/TxHistory.less";
 
 // TODO: use a global component for these indicators
@@ -8,7 +7,7 @@ const indicators = {
   [false]: <span className="indicator confirmed"><T id="transaction.indicatorConfirmed" m="Confirmed" /></span>
 };
 
-const Status = ({ txAccountName, pending, txTimestamp }) => (
+const Status = ({ txAccountName, pending, txTimestamp, tsDate }) => (
   <Aux>
     <div className="transaction-status">
       <span className="transaction-account-name">{txAccountName}</span>
@@ -18,7 +17,7 @@ const Status = ({ txAccountName, pending, txTimestamp }) => (
       <div className="transaction-time-date">
         <T id="transaction.timestamp"
           m="{timestamp, date, medium} {timestamp, time, medium}"
-          values={{ timestamp: tsToDate(txTimestamp) }}/>
+          values={{ timestamp: tsDate(txTimestamp) }}/>
       </div>
     )}
   </Aux>

--- a/app/components/TxHistory/TxHistoryRow/StatusSmall.js
+++ b/app/components/TxHistory/TxHistoryRow/StatusSmall.js
@@ -1,9 +1,8 @@
 import { FormattedDate, FormattedTime, FormattedMessage as T } from "react-intl";
 import "style/TxHistory.less";
-import { tsToDate } from "helpers/dateFormat";
 import { Tooltip } from "shared";
 
-const StatusSmall = ({ pending, txTimestamp, onClick }) => {
+const StatusSmall = ({ pending, txTimestamp, onClick, tsDate }) => {
 
   return (
     <Aux>
@@ -13,10 +12,10 @@ const StatusSmall = ({ pending, txTimestamp, onClick }) => {
             id="txHistory.statusSmall.date"
             defaultMessage="{day} {month} {year} {time}"
             values={{
-              day: <FormattedDate value={tsToDate(txTimestamp)} day="2-digit" />,
-              month: <FormattedDate value={tsToDate(txTimestamp)} month="short" />,
-              year: <FormattedDate value={tsToDate(txTimestamp)} year="numeric" />,
-              time: <FormattedTime value={tsToDate(txTimestamp)} hour12={false} />,
+              day: <FormattedDate value={tsDate(txTimestamp)} day="2-digit" />,
+              month: <FormattedDate value={tsDate(txTimestamp)} month="short" />,
+              year: <FormattedDate value={tsDate(txTimestamp)} year="numeric" />,
+              time: <FormattedTime value={tsDate(txTimestamp)} hour12={false} />,
             }}
           />
         </div>) : (

--- a/app/components/TxHistory/TxHistoryRow/index.js
+++ b/app/components/TxHistory/TxHistoryRow/index.js
@@ -20,7 +20,7 @@ const TxRowByType = { // TODO: use constants instead of string
   "Coinbase": regular("Receive", true),
 };
 
-const TxRow = ({ tx, overview }, { router }) => {
+const TxRow = ({ tx, overview, tsDate }, { router }) => {
   const rowType = tx.status ? tx.status :
     tx.txType ? tx.txType : tx.txDirection;
   const Component = TxRowByType[rowType];
@@ -29,6 +29,7 @@ const TxRow = ({ tx, overview }, { router }) => {
     <Component
       {...{
         ...tx,
+        tsDate,
         overview,
         pending: !tx.txTimestamp,
         onClick: () => router.history.push(`/transactions/history/${tx.txHash}`)

--- a/app/components/TxHistory/index.js
+++ b/app/components/TxHistory/index.js
@@ -1,12 +1,12 @@
 import TxHistoryRow from "./TxHistoryRow";
 
-const TxHistory = ({ transactions = [], limit, overview }) => (
+const TxHistory = ({ transactions = [], limit, overview, tsDate }) => (
   <Aux>
     {transactions.map( (tx, index) => {
       if(limit && index >= limit)
         return;
       return (
-        <TxHistoryRow {...{ key: tx.txHash, overview, tx }} />
+        <TxHistoryRow {...{ key: tx.txHash, overview, tx, tsDate }} />
       );
     })}
   </Aux>

--- a/app/components/views/GovernancePage/Proposals/Details/Page.js
+++ b/app/components/views/GovernancePage/Proposals/Details/Page.js
@@ -13,7 +13,7 @@ import {
 
 export default ({ viewedProposalDetails,
   showPurchaseTicketsPage, hasTickets, onVoteOptionSelected, onUpdateVoteChoice,
-  newVoteChoice, updateVoteChoiceAttempt }) =>
+  newVoteChoice, updateVoteChoiceAttempt, tsDate }) =>
 {
   const { name, token, hasEligibleTickets, voteStatus, voteOptions,
     voteCounts, creator, timestamp, voteDetails, currentVoteChoice } = viewedProposalDetails;
@@ -54,11 +54,11 @@ export default ({ viewedProposalDetails,
               value={creator} />
             <OverviewField
               label={<T id="proposal.overview.submitted.label" m="Submitted" />}
-              value={<TimeValue timestamp={timestamp} />} />
+              value={<TimeValue timestamp={timestamp} tsDate={tsDate} />} />
             <OverviewField
               show={voting && voteDetails && voteDetails.endTimestamp}
               label={<T id="proposal.overview.deadline.label" m="Voting Deadline" />}
-              value={voting ? <TimeValue timestamp={voteDetails.endTimestamp} /> : null } />
+              value={voting ? <TimeValue timestamp={voteDetails.endTimestamp} tsDate={tsDate} /> : null } />
           </div>
         </div>
         <div className="proposal-details-overview-voting">

--- a/app/components/views/GovernancePage/Proposals/Details/helpers.js
+++ b/app/components/views/GovernancePage/Proposals/Details/helpers.js
@@ -1,7 +1,7 @@
 import { KeyBlueButton } from "buttons";
 import { FormattedMessage as T, FormattedRelative } from "react-intl";
 import { StakeyBounceXs, VotingProgress, PoliteiaLoading } from "indicators";
-import { tsToDate, showCheck } from "helpers";
+import { showCheck } from "helpers";
 import UpdateVoteChoiceModalButton from "./UpdateVoteChoiceModalButton";
 import { default as ReactMarkdown }  from "react-markdown";
 
@@ -96,10 +96,10 @@ export const OverviewVotingProgressInfo = ({ voteCounts }) => (
   </div>
 );
 
-export const TimeValue = ({ timestamp }) => (
+export const TimeValue = ({ timestamp, tsDate }) => (
   <Aux>
-    <span className="time-value"><FormattedRelative  value={ tsToDate(timestamp) } /></span>
-    (<T id="proposal.overview.fullTime" m="{timestamp, date, medium} {timestamp, time, short} UTC" values={{ timestamp: tsToDate(timestamp) }} />)
+    <span className="time-value"><FormattedRelative  value={ tsDate(timestamp) } /></span>
+    (<T id="proposal.overview.fullTime" m="{timestamp, date, medium} {timestamp, time, short} UTC" values={{ timestamp: tsDate(timestamp) }} />)
   </Aux>
 );
 

--- a/app/components/views/GovernancePage/Proposals/ProposalList.js
+++ b/app/components/views/GovernancePage/Proposals/ProposalList.js
@@ -1,17 +1,16 @@
 import { FormattedMessage as T, FormattedRelative } from "react-intl";
 import { activeVoteProposals, preVoteProposals, votedProposals, proposals } from "connectors";
 import { VotingProgress } from "indicators";
-import { tsToDate } from "helpers";
 import { PoliteiaLoading, NoProposals } from "indicators";
 
-const ProposalListItem = ({ name, timestamp, token, voting, voteCounts, onClick }) => (
+const ProposalListItem = ({ name, timestamp, token, voting, voteCounts, tsDate, onClick }) => (
   <div className="proposal-list-item" onClick={() => onClick(token)}>
     <div className="info">
       <div className="proposal-name">{ name }</div>
       <div className="proposal-token">{ token }</div>
       <div className="proposal-timestamp">
         <T id="proposalItem.submittedAt" m="Submitted {reldate}" values={{
-          reldate: <FormattedRelative  value={ tsToDate(timestamp) } /> }} />
+          reldate: <FormattedRelative  value={ tsDate(timestamp) } /> }} />
       </div>
     </div>
     {voting ? <VotingProgress voteCounts={voteCounts} /> : null}

--- a/app/components/views/HomePage/tables/RecentTransactions.js
+++ b/app/components/views/HomePage/tables/RecentTransactions.js
@@ -12,7 +12,8 @@ const RecentTransactions = ({
   getTransactionsRequestAttempt,
   getAccountsResponse,
   rowNumber,
-  goToTransactionHistory
+  goToTransactionHistory,
+  tsDate,
 }) => {
   const hasTxs = (transactions.length > 0);
   return (
@@ -30,7 +31,7 @@ const RecentTransactions = ({
         </div>
         <div className="home-content-nest">
           {transactions.length > 0 ?
-            <TxHistory overview limit={rowNumber} {...{ getAccountsResponse, transactions }} /> :
+            <TxHistory overview limit={rowNumber} {...{ getAccountsResponse, transactions, tsDate }} /> :
             <NoTransactionsLinks />}
         </div>
       </Aux>

--- a/app/components/views/HomePage/tables/TicketActivity.js
+++ b/app/components/views/HomePage/tables/TicketActivity.js
@@ -12,7 +12,8 @@ const RecentTickets = ({
   getTransactionsRequestAttempt,
   getAccountsResponse,
   rowNumber,
-  goToMyTickets
+  goToMyTickets,
+  tsDate,
 }) => {
   const hasTickets = tickets.length > 0;
   return (
@@ -30,7 +31,7 @@ const RecentTickets = ({
         </div>
         <div className="home-content-nest">
           {hasTickets
-            ? <TxHistory overview limit={rowNumber} {...{ getAccountsResponse, transactions: tickets }} />
+            ? <TxHistory overview limit={rowNumber} {...{ getAccountsResponse, transactions: tickets, tsDate }} />
             : <NoTicketsLinks />}
         </div>
       </Aux>

--- a/app/components/views/SettingsPage/Page.js
+++ b/app/components/views/SettingsPage/Page.js
@@ -5,6 +5,7 @@ import { WatchOnlyWarnNotification } from "shared";
 import GeneralSettings from "./GeneralSettings";
 import PrivacySettings from "./PrivacySettings";
 import ProxySettings from "./ProxySettings";
+import TimezoneSettings from "./TimezoneSettings";
 import "style/StakePool.less";
 import "style/Settings.less";
 
@@ -50,6 +51,7 @@ const SettingsPage = ({
           </div>
         </div>
         <PrivacySettings {...{ tempSettings, onChangeTempSettings }} />
+        <TimezoneSettings {...{ tempSettings, onChangeTempSettings }} />
       </div>
     </div>
 

--- a/app/components/views/SettingsPage/TimezoneSettings.js
+++ b/app/components/views/SettingsPage/TimezoneSettings.js
@@ -1,0 +1,54 @@
+import { FormattedMessage as T } from "react-intl";
+
+const AllowableRequestType = ({ id, name, label, description, checked, onChange }) => (
+  <div className="settings-row settings-row-checklist">
+    <div className="settings-label">
+      {label}
+    </div>
+    <div className="timezone-radio">
+      <input type="radio" id={id} name={name} checked={checked} onChange={onChange} />
+      <label htmlFor={id}></label>
+    </div>
+    <div className="settings-checklist-description">
+      {description}
+    </div>
+  </div>
+);
+
+
+const TimezoneSettings = ({
+  tempSettings,
+  onChangeTempSettings
+}) => {
+  const update = (value) => () => {
+    onChangeTempSettings({ timezone: value });
+  };
+
+  return (
+    <div className="settings-timezone">
+      <div className="settings-column-title"><T id="settings.timezone.title" m="Timezone" /></div>
+      <div className="settings-column-content">
+        <AllowableRequestType
+          label={<T id="settings.timezone.local.label" m="Local" />}
+          id="local"
+          name="timezone"
+          value="local"
+          onChange={update("local")}
+          checked={tempSettings.timezone == "local" ? true : false}
+          description={<T id="settings.timezone.local.description" m="Use your local timezone" />}
+        />
+        <AllowableRequestType
+          label={<T id="settings.timezone.utc.label" m="UTC" />}
+          id="utc"
+          name="timezone"
+          value="utc"
+          onChange={update("utc")}
+          checked={tempSettings.timezone == "utc" ? true : false}
+          description={<T id="settings.timezone.utx.description" m="Use Universal Coordinated Time" />}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TimezoneSettings;

--- a/app/components/views/TicketsPage/MyTicketsTab/TicketInfoCard.js
+++ b/app/components/views/TicketsPage/MyTicketsTab/TicketInfoCard.js
@@ -1,11 +1,10 @@
 import TicketCard from "./TicketCard";
 import ExpandedInfo from "./ExpandedInfo";
 import { Balance, Tooltip } from "shared";
-import { tsToDate } from "helpers/dateFormat";
 import { FormattedMessage as T } from "react-intl";
 import { statusTxt } from "./messages";
 
-const TicketInfoCard = ({ ticket, onClick, expanded }) => {
+const TicketInfoCard = ({ ticket, onClick, expanded, tsDate }) => {
 
   const className = "ticket-info-card" + (expanded ? " is-expanded" : "");
   let returnTipText;
@@ -54,7 +53,7 @@ const TicketInfoCard = ({ ticket, onClick, expanded }) => {
         <T
           id="ticket.timestamp"
           m="{timestamp, date, medium} {timestamp, time, medium}"
-          values={{ timestamp: tsToDate(ticket.leaveTimestamp || ticket.enterTimestamp) }} />
+          values={{ timestamp: tsDate(ticket.leaveTimestamp || ticket.enterTimestamp) }} />
       </Tooltip>
     </div>
     <ExpandedInfo {...{ ticket }} />

--- a/app/components/views/TicketsPage/MyTicketsTab/TicketListPage.js
+++ b/app/components/views/TicketsPage/MyTicketsTab/TicketListPage.js
@@ -66,12 +66,13 @@ class TicketListPage extends React.Component{
 
   render() {
     const { currentPage, totalPages, expandedTicket } = this.state;
+    const { tsDate } = this.props;
 
     const visibleTickets = this.getVisibleTickets();
     const visibleCards = visibleTickets.map(ticket => {
       const key = ticket.hash;
       const expanded = expandedTicket && ticket.hash === expandedTicket.hash;
-      return <TicketInfoCard {...{ key, ticket, expanded }} onClick={this.onInfoCardClick} />;
+      return <TicketInfoCard {...{ key, ticket, expanded, tsDate }} onClick={this.onInfoCardClick} />;
     });
 
     return (

--- a/app/components/views/TransactionPage/Page.js
+++ b/app/components/views/TransactionPage/Page.js
@@ -1,11 +1,12 @@
 import TxDetails from "../TxDetails";
 
-const Page = ({ transactionDetails, decodedTransaction }) => (
+const Page = ({ transactionDetails, decodedTransaction, tsDate }) => (
   <Aux>
     { transactionDetails ?
-      <TxDetails tx={transactionDetails} {...{ decodedTransaction }}/> :
+      <TxDetails tx={transactionDetails} {...{ decodedTransaction, tsDate }}/> :
       <p>Transaction not found</p> }
   </Aux>
 );
 
 export default Page;
+

--- a/app/components/views/TransactionPage/index.js
+++ b/app/components/views/TransactionPage/index.js
@@ -3,7 +3,7 @@ import TransactionPage from "./Page";
 import { transactionPage } from "connectors";
 
 const Transaction = ({ walletService, viewedTransaction, viewedDecodedTransaction,
-  decodeRawTransactions }) => {
+  decodeRawTransactions, tsDate }) => {
 
   if (!viewedDecodedTransaction) {
     decodeRawTransactions([ viewedTransaction.rawTx ]);
@@ -15,6 +15,7 @@ const Transaction = ({ walletService, viewedTransaction, viewedDecodedTransactio
       {...{
         transactionDetails: viewedTransaction,
         decodedTransaction: viewedDecodedTransaction,
+        tsDate: tsDate,
       }}
     />;
 };

--- a/app/components/views/TransactionsPage/HistoryTab/Page.js
+++ b/app/components/views/TransactionsPage/HistoryTab/Page.js
@@ -18,6 +18,7 @@ const Page = ({
   sortTypes,
   txTypes,
   transactions,
+  tsDate,
   selectedSortOrderKey,
   selectedTxTypeKey,
   searchText,
@@ -74,7 +75,7 @@ const Page = ({
     </div>
     <div className="history-content-nest">
       {transactions.length > 0
-        ? <TxHistory transactions={transactions} />
+        ? <TxHistory {...{ transactions, tsDate }} />
         : null }
     </div>
     {!noMoreTransactions

--- a/app/components/views/TransactionsPage/HistoryTab/index.js
+++ b/app/components/views/TransactionsPage/HistoryTab/index.js
@@ -34,12 +34,14 @@ class History extends React.Component {
     // empirically defined to load 1 page of transactions in default height
     // and an additional page when window.innerHeight > default
     const loadMoreThreshold = 90 + Math.max(0, this.props.window.innerHeight - 765);
+    const tsDate = this.props.tsDate;
 
     return  !this.props.walletService ? <ErrorScreen /> : (
       <HistoryPage
         {...{
           ...this.props,
           ...this.state,
+          tsDate,
           loadMoreThreshold,
           txTypes: this.getTxTypes(),
           sortTypes: this.getSortTypes(),

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -213,7 +213,7 @@ class Send extends React.Component {
     const { onAttemptConstructTransaction } = this.props;
     const confirmations = 0;
 
-    this.setState({ sendAllAmount: this.state.account.spendable })
+    this.setState({ sendAllAmount: this.state.account.spendable });
 
     if (this.getHasEmptyFields()) return;
     this.setState({ hastAttemptedConstruct: true });

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -213,7 +213,7 @@ class Send extends React.Component {
     const { onAttemptConstructTransaction } = this.props;
     const confirmations = 0;
 
-    this.setState({ sendAllAmount: this.state.account.spendable });
+    this.setState({ sendAllAmount: this.state.account.spendable })
 
     if (this.getHasEmptyFields()) return;
     this.setState({ hastAttemptedConstruct: true });

--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -66,11 +66,12 @@ const TxDetails = ({
   },
   currentBlockHeight,
   intl,
-  goBackHistory
+  goBackHistory,
+  tsDate,
 }) => {
   const isConfirmed = !!txTimestamp;
   const icon = headerIcons[txType || txDirection];
-  const subtitle = isConfirmed ? <T id="txDetails.timestamp" m="{timestamp, date, medium} {timestamp, time, medium}" values={{ timestamp: tsToDate(txTimestamp) }}/> : <T id="txDetails.unConfirmed" m="Unconfirmed"/>;
+  const subtitle = isConfirmed ? <T id="txDetails.timestamp" m="{timestamp, date, medium} {timestamp, time, medium}" values={{ timestamp: tsDate(txTimestamp) }}/> : <T id="txDetails.unConfirmed" m="Unconfirmed"/>;
   const goBack = () => goBackHistory();
   const openTxUrl = () => shell.openExternal(txUrl);
   const openBlockUrl = () => shell.openExternal(txBlockUrl);

--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -3,7 +3,7 @@ import { StandaloneHeader, StandalonePage } from "layout";
 import { shell } from "electron";
 import { transactionDetails } from "connectors";
 import { SlateGrayButton } from "buttons";
-import { addSpacingAroundText, tsToDate, reverseHash } from "helpers";
+import { addSpacingAroundText, reverseHash } from "helpers";
 import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
 import { DecodedTransaction }  from "middleware/walletrpc/api_pb";
 import "style/TxDetails.less";

--- a/app/config.js
+++ b/app/config.js
@@ -121,6 +121,9 @@ export function initGlobalCfg() {
   if (!config.has("max_wallet_count")) {
     config.set("max_wallet_count", 3);
   }
+  if (!config.has("timezone")) {
+    config.set("timezone", "local");
+  }
   return(config);
 }
 

--- a/app/connectors/historyPage.js
+++ b/app/connectors/historyPage.js
@@ -11,6 +11,7 @@ const mapStateToProps = selectorMap({
   transactionsFilter: sel.transactionsFilter,
   noMoreTransactions: sel.noMoreTransactions,
   window: sel.mainWindow,
+  tsDate: sel.tsDate,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/connectors/home.js
+++ b/app/connectors/home.js
@@ -16,6 +16,7 @@ const mapStateToProps = selectorMap({
   revokeTicketsSuccess: sel.revokeTicketsSuccess,
   hasTicketsToRevoke: sel.hasTicketsToRevoke,
   totalBalance: sel.totalBalance,
+  tsDate: sel.tsDate,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/connectors/proposals.js
+++ b/app/connectors/proposals.js
@@ -15,6 +15,7 @@ const mapStateToProps = selectorMap({
   hasTickets: sel.hasTickets,
   updateVoteChoiceAttempt: sel.updateVoteChoiceAttempt,
   lastVettedFetchTime: sel.lastVettedFetchTime,
+  tsDate: sel.tsDate,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/connectors/sideBar.js
+++ b/app/connectors/sideBar.js
@@ -15,6 +15,7 @@ const mapStateToProps = selectorMap({
   showingSidebarMenu: sel.showingSidebarMenu,
   expandSideBar: sel.expandSideBar,
   isWatchOnly: sel.isWatchOnly,
+  tsDate: sel.tsDate,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/connectors/ticketsList.js
+++ b/app/connectors/ticketsList.js
@@ -6,7 +6,8 @@ import * as dma from "../actions/DecodeMessageActions";
 import * as ca from "../actions/ClientActions";
 
 const mapStateToProps = selectorMap({
-  tickets: sel.viewedTicketListing
+  tickets: sel.viewedTicketListing,
+  tsDate: sel.tsDate,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/connectors/transactionDetails.js
+++ b/app/connectors/transactionDetails.js
@@ -5,7 +5,8 @@ import * as sel from "../selectors";
 import * as ca from "../actions/ClientActions";
 
 const mapStateToProps = selectorMap({
-  currentBlockHeight: sel.currentBlockHeight
+  currentBlockHeight: sel.currentBlockHeight,
+  tsDate: sel.tsDate,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/connectors/transactionPage.js
+++ b/app/connectors/transactionPage.js
@@ -8,6 +8,7 @@ const mapStateToProps = selectorMap({
   walletService: sel.walletService,
   viewedTransaction: sel.viewedTransaction,
   viewedDecodedTransaction: sel.viewedDecodedTransaction,
+  tsDate: sel.tsDate,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -1,9 +1,45 @@
 import { format } from "util";
+import { getGlobalCfg } from "config";
+
+function dateToLocal(d) {
+  Date.prototype.stdTimezoneOffset = function () {
+    var jan = new Date(this.getFullYear(), 0, 1);
+    var jul = new Date(this.getFullYear(), 6, 1);
+    return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+  };
+
+  Date.prototype.dst = function () {
+    return this.getTimezoneOffset() < this.stdTimezoneOffset();
+  };
+
+  var date = new Date(d);
+  if (date.dst()) {
+    date.setHours(date.getHours() + 1);
+    return date;
+  }
+  return date;
+}
+
+function dateToUTC(d) {
+  const date = new Date(d);
+  return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(),
+    date.getUTCHours(), date.getUTCMinutes(),  date.getUTCSeconds());
+}
 
 // tsToDate converts a transaction timestamp into a date
 // object
 export function tsToDate(txTimestamp) {
-  return new Date(txTimestamp*1000);
+  const ts = txTimestamp * 1000;
+  const tz = getGlobalCfg().get("timezone");
+
+  switch (tz) {
+  case "local":
+    return dateToLocal(ts);
+  case "utc":
+    return dateToUTC(ts);
+  default:
+    return dateToLocal(ts);
+  }
 }
 
 // endOfDay returns a new date pointing to the end of the day (last second)

--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -1,7 +1,7 @@
 import { format } from "util";
 import { getGlobalCfg } from "config";
 
-function dateToLocal(d) {
+export function dateToLocal(d) {
   Date.prototype.stdTimezoneOffset = function () {
     var jan = new Date(this.getFullYear(), 0, 1);
     var jul = new Date(this.getFullYear(), 6, 1);
@@ -12,7 +12,7 @@ function dateToLocal(d) {
     return this.getTimezoneOffset() < this.stdTimezoneOffset();
   };
 
-  var date = new Date(d);
+  var date = new Date(d * 1000);
   if (date.dst()) {
     date.setHours(date.getHours() + 1);
     return date;
@@ -20,8 +20,8 @@ function dateToLocal(d) {
   return date;
 }
 
-function dateToUTC(d) {
-  const date = new Date(d);
+export function dateToUTC(d) {
+  const date = new Date(d * 1000);
   return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(),
     date.getUTCHours(), date.getUTCMinutes(),  date.getUTCSeconds());
 }
@@ -29,7 +29,8 @@ function dateToUTC(d) {
 // tsToDate converts a transaction timestamp into a date
 // object
 export function tsToDate(txTimestamp) {
-  const ts = txTimestamp * 1000;
+  //const ts = txTimestamp * 1000;
+  const ts = txTimestamp;
   const tz = getGlobalCfg().get("timezone");
 
   switch (tz) {

--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -1,5 +1,4 @@
 import { format } from "util";
-import { getGlobalCfg } from "config";
 
 export function dateToLocal(d) {
   Date.prototype.stdTimezoneOffset = function () {
@@ -25,25 +24,6 @@ export function dateToUTC(d) {
   return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(),
     date.getUTCHours(), date.getUTCMinutes(),  date.getUTCSeconds());
 }
-
-// tsToDate converts a transaction timestamp into a date
-// object
-export function tsToDate(txTimestamp) {
-  //const ts = txTimestamp * 1000;
-  /**const ts = txTimestamp;
-  const tz = getGlobalCfg().get("timezone");
-
-  switch (tz) {
-  case "local":
-    return dateToLocal(ts);
-  case "utc":
-    return dateToUTC(ts);
-  default:
-    return dateToLocal(ts);
-  }**/
-  return dateToUTC(txTimestamp);
-}
-
 // endOfDay returns a new date pointing to the end of the day (last second)
 // of the day stored in the given date.
 export function endOfDay(dt) {
@@ -86,7 +66,7 @@ export function formatLocalISODate(d) {
 // represent number of days
 export function diffBetweenTwoTs(date1, date2) {
   const oneDay = 24*60*60*1000;
-  const firstDate = tsToDate(date1);
-  const secondDate = tsToDate(date2);
+  const firstDate = dateToLocal(date1);
+  const secondDate = dateToLocal(date2);
   return Math.round(Math.abs((firstDate.getTime() - secondDate.getTime())/(oneDay)));
 }

--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -30,7 +30,7 @@ export function dateToUTC(d) {
 // object
 export function tsToDate(txTimestamp) {
   //const ts = txTimestamp * 1000;
-  const ts = txTimestamp;
+  /**const ts = txTimestamp;
   const tz = getGlobalCfg().get("timezone");
 
   switch (tz) {
@@ -40,7 +40,8 @@ export function tsToDate(txTimestamp) {
     return dateToUTC(ts);
   default:
     return dateToLocal(ts);
-  }
+  }**/
+  return dateToUTC(txTimestamp);
 }
 
 // endOfDay returns a new date pointing to the end of the day (last second)

--- a/app/index.js
+++ b/app/index.js
@@ -29,6 +29,7 @@ var initialState = {
       proxyType: globalCfg.get("proxy_type"),
       proxyLocation: globalCfg.get("proxy_location"),
       spvMode: globalCfg.get("spv_mode"),
+      timezone: globalCfg.get("timezone"),
     },
     tempSettings: {
       locale: locale,
@@ -37,6 +38,7 @@ var initialState = {
       proxyType: globalCfg.get("proxy_type"),
       proxyLocation: globalCfg.get("proxy_location"),
       spvMode: globalCfg.get("spv_mode"),
+      timezone: globalCfg.get("timezone"),
     },
     settingsChanged: false,
     uiAnimations: globalCfg.get("ui_animations"),

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -173,6 +173,7 @@ export const currencies = () => [ { name: "DCR" }, { name: "atoms" } ];
 export const currencyDisplay = get([ "settings", "currentSettings", "currencyDisplay" ]);
 export const unitDivisor = compose(disp => disp === "DCR" ? 100000000 : 1, currencyDisplay);
 export const currentLocaleName = get([ "settings", "currentSettings", "locale" ]);
+export const timezone = get([ "settings", "currentSettings", "timezone" ]);
 export const defaultLocaleName = createSelector(
   [ currentLocaleName ],
   (currentLocaleName) => {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -9,7 +9,7 @@ import { MainNetParams, TestNetParams } from "wallet/constants";
 import { TicketTypes, decodeVoteScript } from "./helpers/tickets";
 import { EXTERNALREQUEST_STAKEPOOL_LISTING, EXTERNALREQUEST_POLITEIA } from "main_dev/externalRequests";
 import { POLITEIA_URL_TESTNET, POLITEIA_URL_MAINNET } from "./middleware/politeiaapi";
-
+import { dateToLocal, dateToUTC } from "./helpers/dateFormat";
 const EMPTY_ARRAY = [];  // Maintaining identity (will) improve performance;
 
 export const daemonError = get([ "daemon" , "daemonError" ]);
@@ -179,6 +179,7 @@ export const defaultLocaleName = createSelector(
   (currentLocaleName) => {
     return appLocaleFromElectronLocale(currentLocaleName);
   });
+export const tsDate = compose(timezone => timezone === "utc" ? dateToUTC : dateToLocal, timezone);
 
 export const isSPV = get([ "settings", "currentSettings", "spvMode" ]);
 

--- a/app/style/Settings.less
+++ b/app/style/Settings.less
@@ -150,11 +150,13 @@
   margin-top: 2px;
 }
 
-input[type="checkbox"] {
+input[type="checkbox"],
+input[type="radio"] {
   display: none;
 }
 
-input[type="checkbox"]:disabled + label {
+input[type="checkbox"]:disabled + label,
+input[type="radio"]:disabled + label {
   display: inline-block;
   background-color: #e7eaed;
   border: 1px solid #8997a5;
@@ -162,7 +164,8 @@ input[type="checkbox"]:disabled + label {
   height: 12px;
 }
 
-input[type="checkbox"]:checked:disabled + label {
+input[type="checkbox"]:checked:disabled + label,
+input[type="radio"]:checked:disabled + label {
   display: inline-block;
   border: 1px solid #8997a5;
   background-color: #e7eaed;
@@ -174,7 +177,8 @@ input[type="checkbox"]:checked:disabled + label {
   height: 12px;
 }
 
-input[type="checkbox"] + label {
+input[type="checkbox"] + label,
+input[type="radio"] + label {
   display: inline-block;
   border: 1px solid #8997a5;
   background-color: none;
@@ -182,7 +186,8 @@ input[type="checkbox"] + label {
   height: 12px;
 }
 
-input[type="checkbox"]:checked + label {
+input[type="checkbox"]:checked + label,
+input[type="radio"]:checked + label {
   display: inline-block;
   border: 1px solid #2970ff;
   background-color: none;
@@ -192,6 +197,12 @@ input[type="checkbox"]:checked + label {
   background-position: 1px;
   width: 12px;
   height: 12px;
+}
+
+input[type="radio"] + label {
+  border-radius: 50%;
+  width: 15px;
+  height: 15px;
 }
 
 @media screen and (max-width: 676px) {
@@ -206,7 +217,7 @@ input[type="checkbox"]:checked + label {
   .settings-wrapper {
     display: inherit;
     margin-top: -50px;
-    height: 639px;
+    height: 680px;
   }
 
   .app-modal.about-modal,


### PR DESCRIPTION
This adds a radio button for users to select their preferred timezone ("local" or "UTC") with which they want transaction times to be displayed in. 

In local, Daylight savings time is taken into consideration. 

This fixes #1099 

