### PR TITLE
Create wallet page layout fix

### DIFF
--- a/app/style/CreateWalletForm.less
+++ b/app/style/CreateWalletForm.less
@@ -408,3 +408,26 @@
 .wallet-switch {
   padding-right: 5px;
 }
+
+@media screen and (min-width: 1500px) {
+  .confirm-seed-row.passphrase {
+    float: inherit;
+  }
+}
+
+@media screen and (min-width: 1673px) {
+  .confirm-seed-row.passphrase {
+    float: left;
+    margin-left: 165px;
+  }
+}
+
+@media screen and (max-width: 879px) {
+  .confirm-seed-row.seed {
+    margin-left: -205px;
+  }
+
+  .confirm-seed-row.passphrase {
+    margin-left: -170px;
+  }
+}


### PR DESCRIPTION
The create wallet confirm seed page should now be proper and always usable no matter how large the width is. 

Fixes #1578