### PR TITLE
Add cursor pointer to GetStarted view

### DIFF
--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -391,6 +391,7 @@
   border: 1px solid #f7f8f9;
   background: linear-gradient(225deg, rgba(209, 213, 219, 1), rgba(149, 157, 172, 1));
   font-size: 15px;
+  cursor: pointer;
 
   .wallet-icon {
     margin-left: 54px;
@@ -564,6 +565,7 @@
   background-size: 20px 20px;
   background-position: 50% 50%;
   background-image: @launcher-edit-wallets;
+  cursor: pointer;
 }
 
 .edit-wallets-button:hover {
@@ -655,6 +657,7 @@
   padding: 1px;
   background-color: #fff;
   color: #48566e;
+  cursor: pointer;
 }
 
 .privacy-option:hover {


### PR DESCRIPTION
Needed on MacOS when hovering over clickable area.
See screenshots below of mouse pointer style without these changes.

![display_wallet](https://user-images.githubusercontent.com/921390/44112947-df56a64c-a006-11e8-8a4a-1e5b8bf060b6.jpg)
![edit_btn](https://user-images.githubusercontent.com/921390/44112951-df75e82c-a006-11e8-9c4d-b1a68f66c9b8.jpg)
![privacy_option](https://user-images.githubusercontent.com/921390/44112953-df922e24-a006-11e8-8e0a-4236748ec623.jpg)
