### PR TITLE
[ui] update accounts select balance on tx

### DIFF
--- a/app/components/inputs/AccountsSelect.js
+++ b/app/components/inputs/AccountsSelect.js
@@ -23,20 +23,40 @@ class AccountsSelect extends React.Component {
 
   constructor(props) {
     super(props);
-    let accountsPerType = {
-      "spending": this.props.spendingAccounts,
-      "visible": this.props.visibleAccounts
-    };
     this.state = {
       account: props.account || props.defaultSpendingAccount,
-      accounts: accountsPerType[this.props.accountsType||"spending"]
+      accounts: this.getAccountsToShow(props),
     };
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.state.account !== nextProps.account) {
-      this.setState({ account: nextProps.account });
+    let newState = null;
+
+    if (this.props.account !== nextProps.account) {
+      newState = { account: nextProps.account };
     }
+
+    if ((this.props.spendingAccounts !== nextProps.spendingAccounts) ||
+        (this.props.visibleAccounts !== nextProps.visibleAccounts) ||
+        (this.props.accountsType !== nextProps.accountsType)) {
+      newState = { accounts: this.getAccountsToShow(nextProps), ...newState };
+      if (nextProps.account && !newState.account) {
+        const newAccount = newState.accounts.find(a => a.value === nextProps.account.value);
+        newState = { account: newAccount, ...newState };
+      }
+    }
+
+    if (newState) {
+      this.setState(newState);
+    }
+  }
+
+  getAccountsToShow(nextProps) {
+    let accountsPerType = {
+      "spending": nextProps.spendingAccounts,
+      "visible": nextProps.visibleAccounts
+    };
+    return accountsPerType[this.props.accountsType||"spending"];
   }
 
   render() {

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -21,6 +21,7 @@ class Send extends React.Component {
   constructor(props) {
     super(props);
     this.state = this.getInitialState();
+    this.state.account = this.props.defaultSpendingAccount;
   }
 
   getInitialState() {
@@ -29,7 +30,6 @@ class Send extends React.Component {
       isSendAll: false,
       isSendSelf: false,
       hastAttemptedConstruct: false,
-      account: this.props.defaultSpendingAccount,
       outputs: [ { key: "output_0", data:{ ...BASE_OUTPUT } } ],
       outputAccount: this.props.defaultSpendingAccount,
       lowBalanceError: false,

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -345,7 +345,6 @@
 
 .menu-link.governanceIcon {
   background-image: @menu-governance-default;
-  cursor: default;
 }
 
 .menu-link-active.governanceIcon {


### PR DESCRIPTION
This fixes an issue where the balance displayed on an AccountsSelect (eg: on the send transaction page) was not updated upon publishing (or receiving) a transaction.

It also slightly changes the ux of the send page to maintain the currently selected source account after attempting to publish a transaction.