### PR TITLE
[ui] fix coinbase tx type and airdrop wallets

### DIFF
--- a/app/components/TxHistory/TxHistoryRow/index.js
+++ b/app/components/TxHistory/TxHistoryRow/index.js
@@ -16,7 +16,8 @@ const TxRowByType = { // TODO: use constants instead of string
   "live": stake("Live"),
   "out": regular("Send", true),
   "in": regular("Receive", false),
-  "transfer": regular("Transfer", true)
+  "transfer": regular("Transfer", true),
+  "Coinbase": regular("Receive", true),
 };
 
 const TxRow = ({ tx, overview }, { router }) => {

--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -12,12 +12,14 @@ import "style/Fonts.less";
 const messages = defineMessages({
   Ticket:     { id: "transaction.type.ticket", defaultMessage: "Ticket" },
   Vote:       { id: "transaction.type.vote",   defaultMessage: "Vote" },
-  Revocation: { id: "transaction.type.revoke", defaultMessage: "Revoke" }
+  Revocation: { id: "transaction.type.revoke", defaultMessage: "Revoke" },
+  Coinbase:   { id: "transaction.type.coinbase", defaultMessage: "Coinbase" },
 });
 
 const headerIcons = {
   in:         "plusBig",
   out:        "minusBig",
+  Coinbase:   "plusBig",
   transfer:   "walletGray",
   Ticket:     "ticketSmall",
   Vote:       "ticketSmall",


### PR DESCRIPTION
This fixes transaction listing for airdropped wallets with few transactions. Previously, the transaction listing page didn't stop showing the "loading more transactions" indicator when there were airdropped transactions in the wallet.

It also handles Coinbase transactions (both airdropped and mined) in the transaction listing page. They are currently shown using the same style as "receive" transactions (don't think there's a pressing need for a custom type since this type of transaction should be pretty rare for decrediton users).