### PR TITLE
multi: Fix for typo issue #1597 discovered when purchasing tickets

### DIFF
--- a/app/components/views/TicketsPage/PurchaseTab/Tickets.js
+++ b/app/components/views/TicketsPage/PurchaseTab/Tickets.js
@@ -7,9 +7,7 @@ import { ShowWarning } from "shared";
 import "style/StakePool.less";
 
 const purchaseTicketSpvWarn = (blocksNumber) => <T id="spv.purchase.warn"
-  m="Purchase Tickets is not available right now,
-  because we are in the beginning of a ticket interval.
-  after {blocksNumber} blocks it will be available again."
+  m="Purchase Tickets is not available right now, because we are in the beginning of a ticket interval. After {blocksNumber} blocks it will be available again."
   values={{
     blocksNumber: blocksNumber
   }}


### PR DESCRIPTION
A fix for the typographic issues #1597 when purchasing tickets. 

The fix can be found in multiple files:

1. The first fix changes the "after" word as contained in the ..\PurchaseTab\Tickets.js file from lowercase to uppercase.

1. The second fix changes the "after" word as contained in the ..\po\decrediton.pt.po file from lowercase to uppercase.

1. The third fix changes the"after" word as contained in the ..\pot\decrediton.pot file from lowercase to uppercase.

1. The fourth fix changes the"after" word as contained in the ..\translations\original.json file from lowercase to uppercase.