### PR TITLE
[launcher] fix notifications for new wallet in normal mode

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -184,6 +184,9 @@ export const loadActiveDataFiltersAttempt = () => (dispatch, getState) => {
       // expectation of address use so rescan can be skipped.
       if (walletCreateExisting) {
         setTimeout(() => { dispatch(rescanAttempt(0, null, true)); }, 1000);
+      } else if (walletCreateResponse) {
+        wallet.bestBlock(sel.walletService(getState()))
+          .then(resp => dispatch(rescanAttempt(resp.getHeight(), null, true)));
       } else if (walletCreateResponse == null && rescanPointResponse != null && rescanPointResponse.getRescanPointHash().length !== 0) {
         setTimeout(() => { dispatch(rescanAttempt(null, rescanPointResponse != null && rescanPointResponse.getRescanPointHash(), true)); }, 1000);
       } else {


### PR DESCRIPTION
Fix #1606 

In a brand new (ie, not imported/recovered) wallet there's no expectation of address use, so we perform an initial rescan at the best block height so that the wallet will start relaying new transaction notification data.

The bug only happened in normal (non-spv) mode.