### PR TITLE
Fix Watch only logo

### DIFF
--- a/app/connectors/sideBar.js
+++ b/app/connectors/sideBar.js
@@ -14,7 +14,7 @@ const mapStateToProps = selectorMap({
   showingSidebar: sel.showingSidebar,
   showingSidebarMenu: sel.showingSidebarMenu,
   expandSideBar: sel.expandSideBar,
-  isWatchOnly: sel.isWatchOnly,
+  isWatchOnly: sel.isWatchingOnly,
   tsDate: sel.tsDate,
 });
 

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -137,6 +137,7 @@ export const getNetworkResponse = get([ "grpc", "getNetworkResponse" ]);
 export const getNetworkError = get([ "grpc", "getNetworkError" ]);
 const accounts = createSelector([ getAccountsResponse ], r => r ? r.getAccountsList() : []);
 
+// set as watching only when openning wallet
 export const isWatchingOnly = get([ "walletLoader", "isWatchingOnly" ]);
 export const accountExtendedKey = createSelector(
   [ get([ "control", "getAccountExtendedKeyResponse" ]) ],
@@ -687,6 +688,7 @@ export const validateAddressSuccess = compose(
   r => r ? r.toObject() : null, validateAddressResponse
 );
 
+// set as watching only when creating wallet
 export const isWatchOnly = get([ "control", "isWatchOnly" ]);
 export const masterPubKey = get([ "control", "masterPubKey" ]);
 


### PR DESCRIPTION
This fixes the logo being undefined when opening a watching only wallet. I will also open an issue to refactor these selectors so use only one in both case using an `or` method. 