### PR TITLE
[sidebar] Fix NaN on balance for new account

### DIFF
--- a/app/components/SideBar/Bar.js
+++ b/app/components/SideBar/Bar.js
@@ -38,7 +38,7 @@ const Bar = ({
             { balances.map(({ hidden, total, accountName }) => !hidden &&
             <div className="sidebar-menu-total-balance-extended-bottom-account" key={accountName}>
               <div className="sidebar-menu-total-balance-extended-bottom-account-name">{accountName}</div>
-              <div className="sidebar-menu-total-balance-extended-bottom-account-number">{total / 100000000}</div>
+              <div className="sidebar-menu-total-balance-extended-bottom-account-number">{total ? total / 100000000 : 0}</div>
             </div> )}
           </div>
         </div>


### PR DESCRIPTION
This solves the NaN error returned by balances of new accounts.

if total is empty, set to zero. Newly created accounts would have their balances set to zero. 

Closes #1611 