### PR TITLE
[stats] prevent fetching startup stats twice

### DIFF
--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -12,7 +12,13 @@ export const GETSTARTUPSTATS_SUCCESS = "GETSTARTUPSTATS_SUCCESS";
 export const GETSTARTUPSTATS_FAILED = "GETSTARTUPSTATS_FAILED";
 
 // Calculates all startup statistics
-export const getStartupStats = () => (dispatch) => {
+export const getStartupStats = () => (dispatch, getState) => {
+
+  if (getState().statistics.getStartupStatsAttempt) {
+    return;
+  }
+
+  dispatch({ type: GETSTARTUPSTATS_ATTEMPT });
 
   const endDate = new Date();
   endDate.setDate(endDate.getDate()-16);
@@ -21,7 +27,6 @@ export const getStartupStats = () => (dispatch) => {
     { calcFunction: dailyBalancesStats, backwards: true, endDate },
   ];
 
-  dispatch({ type: GETSTARTUPSTATS_ATTEMPT });
   return Promise.all(startupStats.map(s => dispatch(generateStat(s))))
     .then(([ dailyBalances ]) => {
 

--- a/app/index.js
+++ b/app/index.js
@@ -360,6 +360,7 @@ var initialState = {
     fullDailyBalances: Array(),
     voteTime: null,
     getMyTicketsStatsRequest: false,
+    getStartupStatsAttempt: false,
   },
   governance: {
     politeiaBetaEnabled: globalCfg.get("politeia_beta"), // TODO: remove once politeia hits production

--- a/app/reducers/statistics.js
+++ b/app/reducers/statistics.js
@@ -1,15 +1,26 @@
 
 import {
-  GETSTARTUPSTATS_SUCCESS,
+  GETSTARTUPSTATS_ATTEMPT, GETSTARTUPSTATS_FAILED, GETSTARTUPSTATS_SUCCESS,
   GETMYTICKETSSTATS_ATTEMPT, GETMYTICKETSSTATS_SUCCESS, GETMYTICKETSSTATS_FAILED
 } from "actions/StatisticsActions";
 
 export default function statistics(state = {}, action) {
   switch (action.type) {
+  case GETSTARTUPSTATS_ATTEMPT:
+    return {
+      ...state,
+      getStartupStatsAttempt: true,
+    };
+  case GETSTARTUPSTATS_FAILED:
+    return {
+      ...state,
+      getStartupStatsAttempt: false,
+    };
   case GETSTARTUPSTATS_SUCCESS:
     return {
       ...state,
-      dailyBalances: action.dailyBalances
+      dailyBalances: action.dailyBalances,
+      getStartupStatsAttempt: false
     };
   case GETMYTICKETSSTATS_ATTEMPT:
     return {


### PR DESCRIPTION
This prevents a small race condition (more likely to happen in big wallets) where the stats gathering is started twice.