### PR TITLE
[deps] Update electron to 2.0.8 due to a vulnerbility

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "cross-env": "^3.1.3",
     "dateformat": "^2.0.0",
     "devtron": "^1.4.0",
-    "electron": "2.0.0",
+    "electron": "2.0.8",
     "enzyme": "^3.1.0",
     "eslint": "^4.16.0",
     "eslint-config-airbnb": "^16.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3122,9 +3122,9 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   dependencies:
     electron-releases "^2.1.0"
 
-electron@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.0.tgz#e95dc7f3a089a52b8c2a52c7c9e1024db0c8d46e"
+electron@2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.8.tgz#6ec7113b356e09cc9899797e0d41ebff8163e962"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
Resolves: https://electronjs.org/blog/web-preferences-fix