### PR TITLE
win32ipc: use named pipes

### DIFF
--- a/app/modules/win32ipc/moduleTestNamed.js
+++ b/app/modules/win32ipc/moduleTestNamed.js
@@ -1,0 +1,40 @@
+// Sample script to test the namedpiperx option of dcrwallet in windows.
+// Requires that a wallet config exists in the default decrediton config dir,
+// with a wallet name "default-wallet".
+
+const childProcess = require("child_process");
+const addon = require("./build/Release/win32ipc");
+const path = require("path");
+const os = require("os");
+
+const pipeFname = "\\\\.\\pipe\\dcrwallet-test";
+const walletConfPath = path.join(os.homedir(), "AppData", "Local", "Decrediton",
+  "wallets", "testnet", "default-wallet", "dcrwallet.conf");
+
+childProcess.spawn("dcrwallet", [
+  `-C ${walletConfPath}`,
+  `--namedpiperx ${pipeFname}`, "--debuglevel DCRW=TRACE"
+], { "detached": true, "shell": true });
+
+function sleep(milli) {
+  return new Promise(resolve => setTimeout(resolve, milli));
+}
+
+async function test() {
+  try {
+    const pipe = addon.openNamedPipe(pipeFname);
+    console.log(pipe);
+    await sleep(7000);
+    console.log("Slept to test some. Will try to close the pipe.");
+    console.log(addon.closePipeEnd(pipe.readEnd));
+    console.log("Closed the pipe!");
+  } catch (error) {
+    console.log("Error");
+    console.log(error);
+    return;
+  }
+}
+
+setTimeout(test, 3000);
+
+setTimeout(function () { process.exit(0); }, 30000);

--- a/app/modules/win32ipc/pipe_wrapper.cc
+++ b/app/modules/win32ipc/pipe_wrapper.cc
@@ -48,5 +48,28 @@ err_close_handles:
 err:
     return result<pipe>::error(err_msg);
 }
-    
+
+int close_pipe_end(uintptr_t end_handle) {
+	return CloseHandle((HANDLE)end_handle);
+}
+
+result<pipe> open_named_pipe(const char *pipe_name) {
+    char const* err_msg;
+
+    SECURITY_ATTRIBUTES sec_attr;
+    sec_attr.nLength = sizeof(SECURITY_ATTRIBUTES);
+    sec_attr.bInheritHandle = TRUE;
+    sec_attr.lpSecurityDescriptor = NULL;
+
+    HANDLE hPipe = CreateFile(pipe_name, GENERIC_WRITE, 3, &sec_attr, OPEN_ALWAYS, 0, NULL);
+    if (!hPipe) {
+      err_msg = "OpenNamedPipe";
+      goto err;
+    }
+
+    return result<pipe>::ok(pipe{(uintptr_t) hPipe, (uintptr_t)0});
+err:
+    return result<pipe>::error(err_msg);
+}
+
 } // namespace pipe_wrapper

--- a/app/modules/win32ipc/pipe_wrapper.h
+++ b/app/modules/win32ipc/pipe_wrapper.h
@@ -32,4 +32,8 @@ struct pipe {
 
 result<pipe> create_pipe(pipe_direction direction);
 
+int close_pipe_end(uintptr_t end_handle);
+
+result<pipe> open_named_pipe(const char *pipe_name);
+
 } // namespace pipe_wrapper


### PR DESCRIPTION
**Requires https://github.com/decred/dcrwallet/pull/1288**

This adds the ability to use named pipes to the win32ipc module and to close a previously open named pipe, such that a wallet can be shut down without having to wait for the decrediton process to end.

For the moment this includes only the reading part (which allows decrediton to shutdown the wallet) but depending on the resolution of the decred/dcrwallet#1288 PR, this might be modified to support the writing end as well.

Fix #1645 
Fix #1653 