### PR TITLE
[multi] Refactor sidebar, isWatchingOnly, GetStarted

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -7,7 +7,6 @@ import { getNextAddressAttempt,
 import { transactionNtfnsStart, accountNtfnsStart } from "./NotificationActions";
 import { updateStakepoolPurchaseInformation, setStakePoolVoteChoices, getStakepoolStats } from "./StakePoolActions";
 import { getDecodeMessageServiceAttempt } from "./DecodeMessageActions";
-import { showSidebarMenu, showSidebar } from "./SidebarActions";
 import { push as pushHistory, goBack } from "react-router-redux";
 import { getWalletCfg, getGlobalCfg } from "../config";
 import { onAppReloadRequested } from "wallet";
@@ -59,8 +58,6 @@ const startWalletServicesTrigger = () => (dispatch, getState) => new Promise((re
 
       var goHomeCb = () => {
         dispatch(pushHistory("/home"));
-        dispatch(showSidebar());
-        dispatch(showSidebarMenu());
       };
       await dispatch(getStartupWalletInfo()).then(goHomeCb);
       resolve();

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -496,7 +496,7 @@ export const validateMasterPubKey = masterPubKey => async (dispatch) => {
       dispatch({ type: VALIDATEMASTERPUBKEY_FAILED });
       return { isValid: false, error: validationErr };
     }
-    dispatch({ type: VALIDATEMASTERPUBKEY_SUCCESS, isWatchOnly: true, masterPubKey });
+    dispatch({ type: VALIDATEMASTERPUBKEY_SUCCESS, isWatchingOnly: true, masterPubKey });
     return { isValid: true, error: null };
   } catch (error) {
     dispatch({ error, type: VALIDATEMASTERPUBKEY_FAILED });

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -2,7 +2,6 @@ import { versionCheckAction, spvSyncCancel } from "./WalletLoaderActions";
 import { stopNotifcations } from "./NotificationActions";
 import { saveSettings, updateStateSettingsChanged } from "./SettingsActions";
 import { rescanCancel } from "./ControlActions";
-import { hideSidebarMenu, showSidebar } from "./SidebarActions";
 import { cancelPingAttempt } from "./ClientActions";
 import { semverCompatible } from "./VersionActions";
 import * as wallet from "wallet";
@@ -101,7 +100,6 @@ export const selectLanguage = (selectedLanguage) => (dispatch) => {
 export const finishTutorial = () => (dispatch) => {
   const config = getGlobalCfg();
   config.set("show_tutorial", false);
-  dispatch(showSidebar());
   dispatch({ type: FINISH_TUTORIAL });
   dispatch(pushHistory("/getstarted"));
 };
@@ -109,7 +107,6 @@ export const finishTutorial = () => (dispatch) => {
 export const finishPrivacy = () => (dispatch) => {
   const config = getGlobalCfg();
   config.set("show_privacy", false);
-  dispatch(showSidebar());
   dispatch({ type: FINISH_PRIVACY });
   dispatch(goBack());
 };
@@ -183,7 +180,6 @@ export const shutdownApp = () => (dispatch, getState) => {
   dispatch(rescanCancel());
   dispatch(cancelPingAttempt());
   dispatch(spvSyncCancel());
-  dispatch(hideSidebarMenu());
   dispatch(pushHistory("/shutdown"));
 };
 

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -209,7 +209,8 @@ export const createWallet = (createNewWallet, selectedWallet) => (dispatch, getS
   const { network } = getState().daemon;
   wallet.createNewWallet(selectedWallet.value.wallet, network == "testnet")
     .then(() => {
-      dispatch({ createNewWallet, type: WALLETCREATED });
+      dispatch({ createNewWallet, isWatchingOnly: selectedWallet.value.watchingOnly,
+        type: WALLETCREATED });
       dispatch(startWallet(selectedWallet));
     })
     .catch((err) => {

--- a/app/actions/SidebarActions.js
+++ b/app/actions/SidebarActions.js
@@ -1,35 +1,5 @@
 // @flow
 
-export const SHOW_SIDEBAR_MENU = "SHOW_SIDEBAR_MENU";
-export const HIDE_SIDEBAR_MENU = "HIDE_SIDEBAR_MENU";
-
-export function showSidebarMenu() {
-  return (dispatch) => {
-    dispatch({ type: SHOW_SIDEBAR_MENU });
-  };
-}
-
-export function hideSidebarMenu() {
-  return (dispatch) => {
-    dispatch({ type: HIDE_SIDEBAR_MENU });
-  };
-}
-
-export const SHOW_SIDEBAR = "SHOW_SIDEBAR";
-export const HIDE_SIDEBAR = "HIDE_SIDEBAR";
-
-export function showSidebar() {
-  return (dispatch) => {
-    dispatch({ type: SHOW_SIDEBAR });
-  };
-}
-
-export function hideSidebar() {
-  return (dispatch) => {
-    dispatch({ type: HIDE_SIDEBAR });
-  };
-}
-
 export const EXPAND_SIDE_MENU = "EXPAND_SIDE_MENU";
 export const REDUCE_SIDE_MENU = "REDUCE_SIDE_MENU";
 

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -186,7 +186,7 @@ export const closeWalletRequest = () => async(dispatch, getState) => {
     await closeWallet(getState().walletLoader.loader);
     await wallet.stopWallet();
     dispatch({ type: CLOSEWALLET_SUCCESS });
-    dispatch(pushHistory("/getStarted/initial"));
+    dispatch(pushHistory("/getstarted/initial"));
   } catch (error) {
     dispatch({ error, type: CLOSEWALLET_FAILED });
     dispatch(pushHistory("/error"));

--- a/app/components/SideBar/Bar.js
+++ b/app/components/SideBar/Bar.js
@@ -20,7 +20,6 @@ const Bar = ({
   onHideAccounts,
   rescanRequest,
   rescanAttempt,
-  showingSidebarMenu,
   expandSideBar,
   onExpandSideBar,
   onReduceSideBar,
@@ -28,62 +27,60 @@ const Bar = ({
 }) => (
   <div className={(expandSideBar ? "sidebar-menu " : "sidebar-menu-reduced ") + (isTestNet ? "sidebar-testnet" : "sidebar-mainnet")}>
     <Logo {...{ isTestNet, expandSideBar, onReduceSideBar, onExpandSideBar, isWatchOnly }} />
-    <Aux show={ showingSidebarMenu }>
-      <div className="sidebar-main">
-        <div className="sidebar-scroll">
-          <MenuLinks {...{ expandSideBar }}/>
-        </div>
-        <div className="sidebar-menu-total-balance-extended" style={{ display: isShowingAccounts ? "flex" : "none" }}>
-          <div className="sidebar-menu-total-balance-extended-bottom">
-            { balances.map(({ hidden, total, accountName }) => !hidden &&
-            <div className="sidebar-menu-total-balance-extended-bottom-account" key={accountName}>
-              <div className="sidebar-menu-total-balance-extended-bottom-account-name">{accountName}</div>
-              <div className="sidebar-menu-total-balance-extended-bottom-account-number">{total ? total / 100000000 : 0}</div>
-            </div> )}
-          </div>
+    <div className="sidebar-main">
+      <div className="sidebar-scroll">
+        <MenuLinks {...{ expandSideBar }}/>
+      </div>
+      <div className="sidebar-menu-total-balance-extended" style={{ display: isShowingAccounts ? "flex" : "none" }}>
+        <div className="sidebar-menu-total-balance-extended-bottom">
+          { balances.map(({ hidden, total, accountName }) => !hidden &&
+          <div className="sidebar-menu-total-balance-extended-bottom-account" key={accountName}>
+            <div className="sidebar-menu-total-balance-extended-bottom-account-name">{accountName}</div>
+            <div className="sidebar-menu-total-balance-extended-bottom-account-number">{total ? total / 100000000 : 0}</div>
+          </div> )}
         </div>
       </div>
-      {expandSideBar ?
-        <div className="sidebar-menu-bottom">
-          <div
-            className="sidebar-menu-bottom-total-balance-short"
-            onMouseEnter={rescanRequest ? null : onShowAccounts}
-            onMouseLeave={rescanRequest ? null : onHideAccounts}
-          >
-            <div className="sidebar-menu-bottom-total-balance-short-separator"></div>
-            <div className="sidebar-menu-bottom-total-balance-short-name"><T id="sidebar.totalBalance" m="Total Balance"/>:</div>
-            <div className="sidebar-menu-bottom-total-balance-short-value"><Balance amount={totalBalance} /></div>
-          </div>
-          <div className="sidebar-menu-bottom-latest-block">
-            { rescanRequest ? <RescanProgress/> : null }
-            <Aux show={ currentHeight && !rescanRequest }>
-              <div className="rescan-button-area">
-                <RescanButton {...{ rescanRequest, rescanAttempt }} />
-              </div>
-              <a className="sidebar-menu-bottom-latest-block-name">
-                <T id="sidebar.latestBlock" m="Latest Block" />
-                <span className="sidebar-menu-bottom-latest-block-number"> {currentHeight}</span>
-              </a>
-              <div className="sidebar-menu-bottom-latest-block-time">
-                { lastBlockDate && lastBlockIsRecent ?
-                  <T id="sidebar.lastBlockIsRecent" m="< 1 minute ago" /> :
-                  lastBlockDate && <FormattedRelative value={lastBlockDate} updateInterval={1*1000}/> }
-              </div>
-            </Aux>
-          </div>
-        </div> :
-        <div className="sidebar-menu-bottom-latest-block">
-          <div className="rescan-button-area">
-            <RescanButton {...{ rescanRequest, rescanAttempt }} />
-          </div>
+    </div>
+    {expandSideBar ?
+      <div className="sidebar-menu-bottom">
+        <div
+          className="sidebar-menu-bottom-total-balance-short"
+          onMouseEnter={rescanRequest ? null : onShowAccounts}
+          onMouseLeave={rescanRequest ? null : onHideAccounts}
+        >
+          <div className="sidebar-menu-bottom-total-balance-short-separator"></div>
+          <div className="sidebar-menu-bottom-total-balance-short-name"><T id="sidebar.totalBalance" m="Total Balance"/>:</div>
+          <div className="sidebar-menu-bottom-total-balance-short-value"><Balance amount={totalBalance} /></div>
         </div>
-      }
-    </Aux>
+        <div className="sidebar-menu-bottom-latest-block">
+          { rescanRequest ? <RescanProgress/> : null }
+          <Aux show={ currentHeight && !rescanRequest }>
+            <div className="rescan-button-area">
+              <RescanButton {...{ rescanRequest, rescanAttempt }} />
+            </div>
+            <a className="sidebar-menu-bottom-latest-block-name">
+              <T id="sidebar.latestBlock" m="Latest Block" />
+              <span className="sidebar-menu-bottom-latest-block-number"> {currentHeight}</span>
+            </a>
+            <div className="sidebar-menu-bottom-latest-block-time">
+              { lastBlockDate && lastBlockIsRecent ?
+                <T id="sidebar.lastBlockIsRecent" m="< 1 minute ago" /> :
+                lastBlockDate && <FormattedRelative value={lastBlockDate} updateInterval={1*1000}/> }
+            </div>
+          </Aux>
+        </div>
+      </div> :
+      <div className="sidebar-menu-bottom-latest-block">
+        <div className="rescan-button-area">
+          <RescanButton {...{ rescanRequest, rescanAttempt }} />
+        </div>
+      </div>
+    }
   </div>
 );
 
 Bar.propTypes = {
-  showingSidebarMenu: PropTypes.bool.isRequired,
+  expandSideBar: PropTypes.bool.isRequired,
 };
 
 export default Bar;

--- a/app/components/SideBar/Bar.js
+++ b/app/components/SideBar/Bar.js
@@ -23,10 +23,10 @@ const Bar = ({
   expandSideBar,
   onExpandSideBar,
   onReduceSideBar,
-  isWatchOnly,
+  isWatchingOnly,
 }) => (
   <div className={(expandSideBar ? "sidebar-menu " : "sidebar-menu-reduced ") + (isTestNet ? "sidebar-testnet" : "sidebar-mainnet")}>
-    <Logo {...{ isTestNet, expandSideBar, onReduceSideBar, onExpandSideBar, isWatchOnly }} />
+    <Logo {...{ isTestNet, expandSideBar, onReduceSideBar, onExpandSideBar, isWatchingOnly }} />
     <div className="sidebar-main">
       <div className="sidebar-scroll">
         <MenuLinks {...{ expandSideBar }}/>

--- a/app/components/SideBar/Logo.js
+++ b/app/components/SideBar/Logo.js
@@ -1,10 +1,10 @@
 import { Tooltip } from "shared";
 import { FormattedMessage as T } from "react-intl";
 
-const Logo = ({ isTestNet, expandSideBar, onReduceSideBar, onExpandSideBar, isWatchOnly, }) => (
+const Logo = ({ isTestNet, expandSideBar, onReduceSideBar, onExpandSideBar, isWatchingOnly, }) => (
   <div className={expandSideBar ? "sidebar-logo" : "reduced-sidebar-logo"} onClick={!expandSideBar ? onExpandSideBar : null}>
     {
-      isWatchOnly &&
+      isWatchingOnly &&
       <Tooltip text={<T id="createWallet.goBack" m="This is a watch-only wallet with limited functionality." /> }>
         <div className="sidebar-watch-only-icon"/>
       </Tooltip>

--- a/app/components/SideBar/index.js
+++ b/app/components/SideBar/index.js
@@ -46,9 +46,6 @@ class SideBar extends React.Component {
   }
 
   render() {
-    if (!this.props.showingSidebar) {
-      return null;
-    }
 
     return (
       <Bar
@@ -65,7 +62,6 @@ class SideBar extends React.Component {
           onHideAccounts: this.onHideAccounts,
           rescanRequest: this.props.rescanRequest,
           rescanAttempt: this.props.rescanAttempt,
-          showingSidebarMenu: this.props.showingSidebarMenu,
           expandSideBar: this.props.expandSideBar,
           onExpandSideBar: this.props.onExpandSideBar,
           onReduceSideBar: this.props.onReduceSideBar,
@@ -85,8 +81,7 @@ class SideBar extends React.Component {
 }
 
 SideBar.propTypes = {
-  showingSidebar: PropTypes.bool.isRequired,
-  showingSidebarMenu: PropTypes.bool.isRequired,
+  expandSideBar: PropTypes.bool.isRequired,
 };
 
 export default sideBar(rescan(ReactTimeout(SideBar)));

--- a/app/components/SideBar/index.js
+++ b/app/components/SideBar/index.js
@@ -65,7 +65,7 @@ class SideBar extends React.Component {
           expandSideBar: this.props.expandSideBar,
           onExpandSideBar: this.props.onExpandSideBar,
           onReduceSideBar: this.props.onReduceSideBar,
-          isWatchOnly: this.props.isWatchOnly,
+          isWatchingOnly: this.props.isWatchingOnly,
         }}
       />
     );

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
@@ -19,8 +19,8 @@ class CreateWalletForm extends React.Component {
   }
 
   componentDidMount() {
-    const { isWatchOnly, masterPubKey } = this.props;
-    if (isWatchOnly && masterPubKey) {
+    const { isCreatingWatchingOnly, masterPubKey } = this.props;
+    if (isCreatingWatchingOnly && masterPubKey) {
       this.props.createWatchOnlyWalletRequest(masterPubKey);
       return;
     }

--- a/app/components/views/GetStartedPage/WalletSelection/CreateWalletForm.js
+++ b/app/components/views/GetStartedPage/WalletSelection/CreateWalletForm.js
@@ -32,7 +32,7 @@ const CreateWalletForm = ({
   hasFailedAttemptName,
   hasFailedAttemptPubKey,
   intl,
-  isWatchOnly,
+  isWatchingOnly,
   walletMasterPubKey,
   toggleWatchOnly,
   onChangeCreateWalletMasterPubKey,
@@ -77,10 +77,10 @@ const CreateWalletForm = ({
               <T id="createwallet.walletOnly.label" m="Watch only" />
             </div>
             <div className="advanced-daemon-input">
-              <WatchOnlyWalletSwitch className="wallet-switch" enabled={ isWatchOnly } onClick={ toggleWatchOnly } />
+              <WatchOnlyWalletSwitch className="wallet-switch" enabled={ isWatchingOnly } onClick={ toggleWatchOnly } />
             </div>
           </div>
-          {isWatchOnly &&
+          {isWatchingOnly &&
             <div className="advanced-daemon-row">
               <div className="advanced-daemon-label">
                 <T id="createwallet.walletmasterpubkey.label" m="Master Pub Key" />

--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -20,7 +20,7 @@ const WalletSelectionBodyBase = ({
   editWallets,
   intl,
   toggleWatchOnly,
-  isWatchOnly,
+  isWatchingOnly,
   masterPubKeyError,
   maxWalletCount,
   isSPV,
@@ -48,7 +48,7 @@ const WalletSelectionBodyBase = ({
                       </Tooltip>
                     </div>}
                   <div className={selected && !editWallets ? "display-wallet-complete selected" : "display-wallet-complete"}>
-                    {!wallet.isWatchOnly ? !wallet.finished && <T id="walletselection.setupIncomplete" m="Setup incomplete"/> : <T id="walletselection.watchOnly" m="Watch Only"/>}
+                    {!wallet.isWatchingOnly ? !wallet.finished && <T id="walletselection.setupIncomplete" m="Setup incomplete"/> : <T id="walletselection.watchOnly" m="Watch Only"/>}
                   </div>
                   <div className={selected && !editWallets ? "wallet-icon selected" : "wallet-icon wallet"}/>
                   <div className={selected && !editWallets ? "display-wallet-name selected" : "display-wallet-name"}>
@@ -105,7 +105,9 @@ const WalletSelectionBodyBase = ({
       </div> :
       <div className="advanced-page">
         <div className="advanced-page-form">
-          <CreateWalletForm {...{ ...props, intl, availableWallets, hideCreateWalletForm, createWallet, createNewWallet, isWatchOnly, toggleWatchOnly, masterPubKeyError }} />
+          <CreateWalletForm {...{ ...props, intl, availableWallets,
+            hideCreateWalletForm, createWallet, createNewWallet, isWatchingOnly,
+            toggleWatchOnly, masterPubKeyError }} />
         </div>
       </div>
   );

--- a/app/components/views/GetStartedPage/WalletSelection/index.js
+++ b/app/components/views/GetStartedPage/WalletSelection/index.js
@@ -16,7 +16,7 @@ class WalletSelectionBody extends React.Component {
       newWalletName: "",
       selectedWallet: this.props.availableWallets ? this.props.availableWallets[0] : null,
       hasFailedAttempt: false,
-      isWatchOnly: false,
+      isWatchingOnly: false,
       walletMasterPubKey: "",
       masterPubKeyError: false,
       walletNameError: null,
@@ -60,7 +60,7 @@ class WalletSelectionBody extends React.Component {
       editWallets,
       hasFailedAttemptName,
       hasFailedAttemptPubKey,
-      isWatchOnly,
+      isWatchingOnly,
       walletMasterPubKey,
       masterPubKeyError,
       walletNameError,
@@ -88,7 +88,7 @@ class WalletSelectionBody extends React.Component {
           networkSelected: newWalletNetwork == "mainnet",
           getDaemonSynced,
           toggleWatchOnly,
-          isWatchOnly,
+          isWatchingOnly,
           onChangeCreateWalletMasterPubKey,
           walletMasterPubKey,
           masterPubKeyError,
@@ -133,12 +133,12 @@ class WalletSelectionBody extends React.Component {
   }
   createWallet() {
     const { newWalletName, createNewWallet,
-      isWatchOnly, masterPubKeyError, walletMasterPubKey, walletNameError } = this.state;
+      isWatchingOnly, masterPubKeyError, walletMasterPubKey, walletNameError } = this.state;
     if (newWalletName == "" || walletNameError) {
       this.setState({ hasFailedAttemptName: true });
       return;
     }
-    if (isWatchOnly) {
+    if (isWatchingOnly) {
       if (masterPubKeyError || !walletMasterPubKey) {
         this.setState({ hasFailedAttemptPubKey: true });
         return;
@@ -146,11 +146,11 @@ class WalletSelectionBody extends React.Component {
     }
     this.props.onCreateWallet(
       createNewWallet,
-      { label: newWalletName, value: { wallet: newWalletName } });
+      { label: newWalletName, value: { wallet: newWalletName, watchingOnly: isWatchingOnly } });
   }
   toggleWatchOnly() {
-    const { isWatchOnly } = this.state;
-    this.setState({ isWatchOnly : !isWatchOnly });
+    const { isWatchingOnly } = this.state;
+    this.setState({ isWatchingOnly : !isWatchingOnly });
   }
   async onChangeCreateWalletMasterPubKey(walletMasterPubKey) {
     if (walletMasterPubKey === "") {

--- a/app/connectors/createWallet.js
+++ b/app/connectors/createWallet.js
@@ -11,7 +11,7 @@ const mapStateToProps = selectorMap({
   confirmNewSeed: sel.confirmNewSeed,
   createNewWallet: sel.createNewWallet,
   isTestNet: sel.isTestNet,
-  isWatchOnly: sel.isWatchOnly,
+  isCreatingWatchingOnly: sel.isWatchingOnly,
   masterPubKey: sel.masterPubKey,
   maxWalletCount: sel.maxWalletCount,
 });

--- a/app/connectors/sideBar.js
+++ b/app/connectors/sideBar.js
@@ -12,7 +12,7 @@ const mapStateToProps = selectorMap({
   lastBlockTimestamp: sel.lastBlockTimestamp,
   totalBalance: sel.totalBalance,
   expandSideBar: sel.expandSideBar,
-  isWatchOnly: sel.isWatchingOnly,
+  isWatchingOnly: sel.isWatchingOnly,
   tsDate: sel.tsDate,
 });
 

--- a/app/connectors/sideBar.js
+++ b/app/connectors/sideBar.js
@@ -11,8 +11,6 @@ const mapStateToProps = selectorMap({
   currentBlockHeight: sel.currentBlockHeight,
   lastBlockTimestamp: sel.lastBlockTimestamp,
   totalBalance: sel.totalBalance,
-  showingSidebar: sel.showingSidebar,
-  showingSidebarMenu: sel.showingSidebarMenu,
   expandSideBar: sel.expandSideBar,
   isWatchOnly: sel.isWatchingOnly,
   tsDate: sel.tsDate,

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -43,7 +43,7 @@ const mapStateToProps = selectorMap({
   defaultLocale: sel.defaultLocaleName,
   updateAvailable: sel.updateAvailable,
   createNewWallet: sel.createNewWallet,
-  isWatchOnly: sel.isWatchOnly,
+  isWatchingOnly: sel.isWatchingOnly,
   masterPubKey: sel.masterPubKey,
   fetchHeadersDone: sel.fetchHeadersDone,
   isSPV: sel.isSPV,

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -95,10 +95,10 @@ class App extends React.Component {
         defaultFormats={defaultFormats}
         key={locale.key}>
         <Aux>
-          <Switch><Redirect from="/" exact to="/getStarted" /></Switch>
+          <Switch><Redirect from="/" exact to="/getstarted" /></Switch>
           <Snackbar/>
           <MainSwitch {...topLevelAnimation} className="top-level-container">
-            <Route path="/getStarted"  component={GetStartedContainer} />
+            <Route path="/getstarted"  component={GetStartedContainer} />
             <Route path="/shutdown"    component={ShutdownAppPage} />
             <Route path="/error"       component={FatalErrorPage} />
             <Route path="/"            component={WalletContainer} />

--- a/app/index.js
+++ b/app/index.js
@@ -30,6 +30,7 @@ var initialState = {
       proxyLocation: globalCfg.get("proxy_location"),
       spvMode: globalCfg.get("spv_mode"),
       timezone: globalCfg.get("timezone"),
+      currencyDisplay: "DCR",
     },
     tempSettings: {
       locale: locale,
@@ -39,6 +40,7 @@ var initialState = {
       proxyLocation: globalCfg.get("proxy_location"),
       spvMode: globalCfg.get("spv_mode"),
       timezone: globalCfg.get("timezone"),
+      currencyDisplay: "DCR",
     },
     settingsChanged: false,
     uiAnimations: globalCfg.get("ui_animations"),
@@ -359,8 +361,6 @@ var initialState = {
     messages: Array()
   },
   sidebar: {
-    showingSidebar: !globalCfg.get("show_tutorial"),
-    showingSidebarMenu: false,
     expandSideBar: true,
   },
   statistics: {

--- a/app/index.js
+++ b/app/index.js
@@ -210,6 +210,7 @@ var initialState = {
     curBlocks: 0,
     stepIndex: 0,
     maxWalletCount: globalCfg.get("max_wallet_count"),
+    isWatchingOnly: false,
 
     synced: false,
     syncFetchHeadersComplete: false,

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -24,10 +24,10 @@ export const getAvailableWallets = (network) => {
 
     const cfg = getWalletCfg(isTestNet, wallet);
     const lastAccess = cfg.get("lastaccess");
-    const watchOnly = cfg.get("iswatchonly");
+    const watchingOnly = cfg.get("iswatchonly");
     const walletDbFilePath = getWalletDBPathFromWallets(isTestNet, wallet);
     const finished = fs.pathExistsSync(walletDbFilePath);
-    availableWallets.push({ network, wallet, finished, lastAccess, watchOnly });
+    availableWallets.push({ network, wallet, finished, lastAccess, watchingOnly });
   });
 
   return availableWallets;

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -405,7 +405,7 @@ export default function control(state = {}, action) {
   case VALIDATEMASTERPUBKEY_SUCCESS:
     return { ...state,
       masterPubKey: action.masterPubKey,
-      isWatchOnly: action.isWatchOnly,
+      isCreatingWatchingOnly: true,
     };
   case VALIDATEMASTERPUBKEY_FAILED:
     return { ...state,

--- a/app/reducers/sidebar.js
+++ b/app/reducers/sidebar.js
@@ -1,8 +1,4 @@
 import {
-  SHOW_SIDEBAR,
-  HIDE_SIDEBAR,
-  SHOW_SIDEBAR_MENU,
-  HIDE_SIDEBAR_MENU,
   EXPAND_SIDE_MENU,
   REDUCE_SIDE_MENU
 } from "../actions/SidebarActions";
@@ -18,26 +14,6 @@ export default function sidebar(state = {}, action) {
     return {
       ...state,
       expandSideBar: false
-    };
-  case HIDE_SIDEBAR:
-    return {
-      ...state,
-      showingSidebar: false,
-    };
-  case SHOW_SIDEBAR:
-    return {
-      ...state,
-      showingSidebar: true,
-    };
-  case HIDE_SIDEBAR_MENU:
-    return {
-      ...state,
-      showingSidebarMenu: false,
-    };
-  case SHOW_SIDEBAR_MENU:
-    return {
-      ...state,
-      showingSidebarMenu: true,
     };
   default:
     return state;

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -20,6 +20,7 @@ import {
   SYNC_FETCHED_MISSING_CFILTERS_PROGRESS, SYNC_FETCHED_MISSING_CFILTERS_FINISHED,
   SYNC_DISCOVER_ADDRESSES_STARTED, SYNC_DISCOVER_ADDRESSES_FINISHED,
   SYNC_RESCAN_STARTED, SYNC_RESCAN_PROGRESS, SYNC_RESCAN_FINISHED,
+  GENERATESEED_ATTEMPT
 } from "actions/WalletLoaderActions";
 import {
   WALLETCREATED
@@ -73,6 +74,10 @@ export default function walletLoader(state = {}, action) {
     return { ...state,
       createWalletExisting: action.createNewWallet,
       isWatchingOnly: action.isWatchingOnly,
+    };
+  case GENERATESEED_ATTEMPT:
+    return { ...state,
+      confirmNewSeed: false,
     };
   case CREATEWALLET_GOBACK:
     return { ...state,
@@ -134,6 +139,7 @@ export default function walletLoader(state = {}, action) {
       walletCreateRequestAttempt: false,
       walletCreateResponse: action.response,
       advancedDaemonInputRequest: true,
+      confirmNewSeed: false,
       stepIndex: 3,
     };
   case OPENWALLET_INPUT:

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -72,6 +72,7 @@ export default function walletLoader(state = {}, action) {
   case WALLETCREATED:
     return { ...state,
       createWalletExisting: action.createNewWallet,
+      isWatchingOnly: action.isWatchingOnly,
     };
   case CREATEWALLET_GOBACK:
     return { ...state,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -836,8 +836,10 @@ export const renameAccountError = get([ "control", "renameAccountError" ]);
 export const renameAccountSuccess = get([ "control", "renameAccountSuccess" ]);
 export const renameAccountRequestAttempt = get([ "control", "renameAccountRequestAttempt" ]);
 
-export const showingSidebar = get([ "sidebar", "showingSidebar" ]);
-export const showingSidebarMenu = get([ "sidebar", "showingSidebarMenu" ]);
+export const location = get([ "routing", "location" ]);
+export const isGetStarted = compose(l => /^\/getstarted\//.test(l.pathname), location);
+
+export const showingSidebarMenu = not(isGetStarted);
 export const expandSideBar = get([ "sidebar", "expandSideBar" ]);
 
 export const snackbarMessages = get([ "snackbar", "messages" ]);
@@ -865,8 +867,6 @@ export const blocksNumberToNextTicket = createSelector(
 );
 
 export const exportingData = get([ "control", "exportingData" ]);
-
-export const location = get([ "routing", "location" ]);
 
 export const voteTimeStats = get([ "statistics", "voteTime" ]);
 export const averageVoteTime = createSelector(

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -111,7 +111,7 @@ const availableWalletsSelect = createSelector(
       value: wallet,
       network: wallet.network,
       finished: wallet.finished,
-      isWatchOnly: wallet.watchOnly,
+      isWatchingOnly: wallet.watchingOnly,
       lastAccess: wallet.lastAccess ? new Date(wallet.lastAccess) : null,
     }),
     wallets
@@ -151,7 +151,6 @@ export const getNetworkResponse = get([ "grpc", "getNetworkResponse" ]);
 export const getNetworkError = get([ "grpc", "getNetworkError" ]);
 const accounts = createSelector([ getAccountsResponse ], r => r ? r.getAccountsList() : []);
 
-// set as watching only when openning wallet
 export const isWatchingOnly = get([ "walletLoader", "isWatchingOnly" ]);
 export const accountExtendedKey = createSelector(
   [ get([ "control", "getAccountExtendedKeyResponse" ]) ],
@@ -698,8 +697,6 @@ export const validateAddressSuccess = compose(
   r => r ? r.toObject() : null, validateAddressResponse
 );
 
-// set as watching only when creating wallet
-export const isWatchOnly = get([ "control", "isWatchOnly" ]);
 export const masterPubKey = get([ "control", "masterPubKey" ]);
 
 const getStakeInfoResponse = get([ "grpc", "getStakeInfoResponse" ]);
@@ -924,15 +921,11 @@ export const stakeRewardsStats = createSelector(
 
 export const modalVisible = get([ "control", "modalVisible" ]);
 
-export const isSignMessageDisabled = or(isWatchingOnly, isWatchOnly);
-
-export const isCreateAccountDisabled = or(isWatchingOnly, isWatchOnly);
-
-export const isChangePassPhraseDisabled = or(isWatchingOnly, isWatchOnly);
-
-export const isTransactionsSendTabDisabled = or(isWatchingOnly, isWatchOnly);
-
-export const isTicketPurchaseTabDisabled = or(isWatchingOnly, isWatchOnly);
+export const isSignMessageDisabled = isWatchingOnly;
+export const isCreateAccountDisabled = isWatchingOnly;
+export const isChangePassPhraseDisabled = isWatchingOnly;
+export const isTransactionsSendTabDisabled = isWatchingOnly;
+export const isTicketPurchaseTabDisabled = isWatchingOnly;
 
 export const politeiaBetaEnabled = get([ "governance", "politeiaBetaEnabled" ]); // TODO: remove once politeia hits production
 export const politeiaURL = createSelector(


### PR DESCRIPTION
Fix #1626 and a few other small issues. Can rework into separate PRs if needed.

Things fixed:

- Removed sidebar cruft that is no longer applicable now that we moved the GetStarted pages into a separate container that doesn't have the sidebar
- Unified `isWatchOnly` and `isWatchingOnly` into a single selector to simplify things
- Fix casing of `/getStarted` (converted to `/getstarted`) which was causing a small modal bug when closing a wallet then trying to remove it
- Fix a small bug when trying to create two new wallets in a row (seed was not shown)