### PR TITLE
[tickets] Normal mode should allow tickets always

### DIFF
--- a/app/components/views/TicketsPage/PurchaseTab/Tickets.js
+++ b/app/components/views/TicketsPage/PurchaseTab/Tickets.js
@@ -22,7 +22,7 @@ const Tickets = ({
     <div className="tabbed-page-subtitle"><T id="purchase.subtitle" m="Purchase Tickets"/></div>
     <StakeInfo />
     {
-      blocksPassedOnTicketInterval < 5  ?
+      spvMode && blocksPassedOnTicketInterval < 5  ?
         <ShowWarning warn={purchaseTicketSpvWarn(5-blocksPassedOnTicketInterval)}/> : <PurchaseTickets {...{ ...props }} />
     }
     <div className="stakepool-area-spacing"></div>


### PR DESCRIPTION
A few user had reported not being able to purchase tickets in the final 5 blocks of a sdiff window in v1.3.0 while in normal mode.