### PR TITLE
[tickets] Fix SPV ticket purchasing

### DIFF
--- a/app/components/views/TicketsPage/PurchaseTab/Tickets.js
+++ b/app/components/views/TicketsPage/PurchaseTab/Tickets.js
@@ -15,15 +15,15 @@ const purchaseTicketSpvWarn = (blocksNumber) => <T id="spv.purchase.warn"
 
 const Tickets = ({
   spvMode,
-  blocksPassedOnTicketInterval,
+  blocksNumberToNextTicket,
   ...props,
 }) => (
   <Aux>
     <div className="tabbed-page-subtitle"><T id="purchase.subtitle" m="Purchase Tickets"/></div>
     <StakeInfo />
     {
-      spvMode && blocksPassedOnTicketInterval < 5  ?
-        <ShowWarning warn={purchaseTicketSpvWarn(5-blocksPassedOnTicketInterval)}/> : <PurchaseTickets {...{ ...props }} />
+      spvMode && blocksNumberToNextTicket < 2  ?
+        <ShowWarning warn={purchaseTicketSpvWarn(2-blocksNumberToNextTicket)}/> : <PurchaseTickets {...{ ...props }} />
     }
     <div className="stakepool-area-spacing"></div>
     {

--- a/app/components/views/TicketsPage/PurchaseTab/Tickets.js
+++ b/app/components/views/TicketsPage/PurchaseTab/Tickets.js
@@ -6,13 +6,6 @@ import { spv } from "connectors";
 import { ShowWarning } from "shared";
 import "style/StakePool.less";
 
-const purchaseTicketSpvWarn = (blocksNumber) => <T id="spv.purchase.warn"
-  m="Purchase Tickets is not available right now, because we are in the beginning of a ticket interval. After {blocksNumber} blocks it will be available again."
-  values={{
-    blocksNumber: blocksNumber
-  }}
-/>;
-
 const Tickets = ({
   spvMode,
   blocksNumberToNextTicket,
@@ -22,8 +15,9 @@ const Tickets = ({
     <div className="tabbed-page-subtitle"><T id="purchase.subtitle" m="Purchase Tickets"/></div>
     <StakeInfo />
     {
-      spvMode && blocksNumberToNextTicket < 2  ?
-        <ShowWarning warn={purchaseTicketSpvWarn(2-blocksNumberToNextTicket)}/> : <PurchaseTickets {...{ ...props }} />
+      spvMode && blocksNumberToNextTicket == 2  ?
+        <ShowWarning warn={<T id="spv.purchase.warn" m="Purchase Tickets is not available right now, because we are at the end of a ticket interval. After one block it will be available again."/>}/> :
+        <PurchaseTickets {...{ ...props }} />
     }
     <div className="stakepool-area-spacing"></div>
     {

--- a/app/connectors/spv.js
+++ b/app/connectors/spv.js
@@ -5,7 +5,6 @@ import * as sel from "../selectors";
 const mapStateToProps = selectorMap({
   spvMode: sel.spvMode,
   blocksNumberToNextTicket: sel.blocksNumberToNextTicket,
-  blocksPassedOnTicketInterval: sel.blocksPassedOnTicketInterval,
 });
 
 export default connect(mapStateToProps);

--- a/app/connectors/spv.js
+++ b/app/connectors/spv.js
@@ -4,6 +4,7 @@ import * as sel from "../selectors";
 
 const mapStateToProps = selectorMap({
   spvMode: sel.spvMode,
+  blocksNumberToNextTicket: sel.blocksNumberToNextTicket,
   blocksPassedOnTicketInterval: sel.blocksPassedOnTicketInterval,
 });
 

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -837,9 +837,11 @@ export const blocksPassedOnTicketInterval = createSelector(
 );
 
 export const blocksNumberToNextTicket = createSelector(
-  [ blocksPassedOnTicketInterval, chainParams ],
-  (chainParams, blocksPassedOnTicketInterval) =>
-    chainParams.WorkDiffWindowSize - blocksPassedOnTicketInterval
+  [ chainParams, blocksPassedOnTicketInterval ],
+  (chainParams, blocksPassedOnTicketInterval) => {
+    const { WorkDiffWindowSize } = chainParams;
+    return WorkDiffWindowSize - blocksPassedOnTicketInterval;
+  }
 );
 
 export const exportingData = get([ "control", "exportingData" ]);


### PR DESCRIPTION
Currently ticket purchasing for SPV is only not allowed on the second to last block of a window.  This is due to the upcoming changing price will ultimately cause the ticket itself to be pruned from the mempool.  Now we are just blocking ticket purchasing on that 1 block.