### PR TITLE
[tickets] show stats for selected stakepool

### DIFF
--- a/app/components/views/TicketsPage/StatisticsTab/Page.js
+++ b/app/components/views/TicketsPage/StatisticsTab/Page.js
@@ -6,8 +6,8 @@ import StakePoolStats from "./charts/StakePoolStats";
 import { DecredLoading, NoStats } from "indicators";
 import { Tooltip } from "shared";
 
-const TicketsStatsPage = ({ getMyTicketsStatsRequest, hasStats, allTickets, allStakePoolStats }) => {
-  if (allTickets.length === 0 && allStakePoolStats.length === 0) return <NoStats />;
+const TicketsStatsPage = ({ getMyTicketsStatsRequest, hasStats, hasTickets, allStakePoolStats }) => {
+  if (!hasTickets && allStakePoolStats.length === 0) return <NoStats />;
   return (
     <Aux>
       <div className="tabbed-page-subtitle"><T id="statistics.subtitle" m="Statistics"/>

--- a/app/components/views/TicketsPage/StatisticsTab/charts/StakePoolStats.js
+++ b/app/components/views/TicketsPage/StatisticsTab/charts/StakePoolStats.js
@@ -12,8 +12,17 @@ class StakePoolStats extends React.Component{
   }
 
   getInitialState() {
+    let stakePool = this.props.allStakePoolStats[0];
+    if (this.props.selectedStakePool) {
+      const idxSel = this.props.allStakePoolStats.findIndex(
+        s => s.Host === this.props.selectedStakePool.Host);
+      if (idxSel > -1) {
+        stakePool = this.props.allStakePoolStats[idxSel];
+      }
+    }
+
     return {
-      stakePool: this.props.allStakePoolStats[0]
+      stakePool: stakePool,
     };
   }
 

--- a/app/components/views/TicketsPage/StatisticsTab/index.js
+++ b/app/components/views/TicketsPage/StatisticsTab/index.js
@@ -6,7 +6,7 @@ class Statistics extends React.Component{
 
   constructor(props) {
     super(props);
-    if (!props.voteTimeStats && !props.getMyTicketsStatsRequest && props.allTickets.length > 0) {
+    if (!props.voteTimeStats && !props.getMyTicketsStatsRequest && props.hasTickets) {
       props.getMyTicketsStats();
     }
     this.state = { hasStats: props.voteTimeStats && !props.getMyTicketsStatsRequest };

--- a/app/connectors/myTicketsCharts.js
+++ b/app/connectors/myTicketsCharts.js
@@ -14,7 +14,8 @@ const mapStateToProps = selectorMap({
   medianVoteTime: sel.medianVoteTime,
   averageVoteTime: sel.averageVoteTime,
   ninetyFifthPercentileVoteTime: sel.ninetyFifthPercentileVoteTime,
-  allTickets: sel.allTickets,
+  hasTickets: sel.hasTickets,
+  selectedStakePool: sel.selectedStakePool,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -311,6 +311,10 @@ export const ticketsFilter = get([ "grpc", "ticketsFilter" ]);
 export const ticketsNormalizer = createSelector([ ticketNormalizer ], map);
 export const tickets = get([ "grpc", "tickets" ]);
 
+// note that hasTickets means "ever had any tickets", **NOT** "currently has live
+// tickets".
+export const hasTickets = compose(t => t && t.length > 0, tickets);
+
 // aux map from ticket/spender hash => ticket info
 const txHashToTicket = createSelector(
   [ tickets ],
@@ -924,10 +928,6 @@ export const preVoteProposals = get([ "governance", "preVote" ]);
 export const votedProposals = get([ "governance", "voted" ]);
 export const lastVettedFetchTime = get([ "governance", "lastVettedFetchTime" ]);
 
-export const hasTickets = createSelector(
-  [ tickets ],
-  (tickets) => tickets && tickets.length > 0,
-);
 export const getProposalAttempt = get([ "governance", "getProposalAttempt" ]);
 export const getProposalError = get([ "governance", "getProposalError" ]);
 export const proposalDetails = get([ "governance", "proposals" ]);


### PR DESCRIPTION
Close #1668 

This switches the stakepool stats page to initially select the first configured stakepool (if available).

It also fixes a small issue on the tickets stats page introduced by #1667.