### PR TITLE
[logs] Clean after closing wallet

### DIFF
--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -1,6 +1,7 @@
 import { dcrwalletCfg, getWalletPath, getExecutablePath, dcrdCfg, getDcrdRpcCert } from "./paths";
 import { getWalletCfg, readDcrdConfig } from "../config";
-import { createLogger, AddToDcrdLog, AddToDcrwalletLog, GetDcrdLogs, GetDcrwalletLogs, lastErrorLine } from "./logging";
+import { createLogger, AddToDcrdLog, AddToDcrwalletLog, GetDcrdLogs,
+  GetDcrwalletLogs, lastErrorLine, ClearDcrwalletLogs } from "./logging";
 import parseArgs from "minimist";
 import { OPTIONS } from "./constants";
 import os from "os";
@@ -238,6 +239,7 @@ export const launchDCRWallet = (mainWindow, daemonIsAdvanced, walletPath, testne
   });
 
   dcrwallet.on("close", (code) => {
+    ClearDcrwalletLogs();
     if (daemonIsAdvanced)
       return;
     if (code !== 0) {

--- a/app/main_dev/logging.js
+++ b/app/main_dev/logging.js
@@ -118,3 +118,7 @@ export function lastErrorLine(log) {
   let lastLineBuff = log.slice(lastLineIdx, endOfErrorLineIdx).toString("utf-8");
   return lastLineBuff.trim();
 }
+
+export function ClearDcrwalletLogs() {
+  dcrwalletLogs = Buffer.from("");
+}


### PR DESCRIPTION
This fixes a small UI issue where after closing the wallet and going back to the wallet selection page you'd see a log line superimposed to the list.