### PR TITLE
[launcher] Delay getBestBlock slightly to avoid issues on reload

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -324,6 +324,10 @@ export const getBestBlockHeightAttempt = (cb) => (dispatch, getState) => {
   if (getBestBlockHeightRequest) {
     return;
   }
+  if (sel.walletService(getState()) == null) {
+    dispatch(getBestBlockHeightAttempt(cb));
+    return;
+  }
   dispatch({ type: GETBESTBLOCK_ATTEMPT });
   wallet.bestBlock(sel.walletService(getState()))
     .then(resp => {

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -325,7 +325,7 @@ export const getBestBlockHeightAttempt = (cb) => (dispatch, getState) => {
     return;
   }
   if (sel.walletService(getState()) == null) {
-    dispatch(getBestBlockHeightAttempt(cb));
+    setTimeout(() => dispatch(getBestBlockHeightAttempt(cb)), 100);
     return;
   }
   dispatch({ type: GETBESTBLOCK_ATTEMPT });

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -437,7 +437,7 @@ const syncConsumer = (response) => (dispatch, getState) => {
   switch (response.getNotificationType()) {
   case SyncNotificationType.SYNCED: {
     dispatch({ type: SYNC_SYNCED });
-    setTimeout(() => dispatch(getBestBlockHeightAttempt(startWalletServices)), 1000);
+    dispatch(getBestBlockHeightAttempt(startWalletServices));
     break;
   }
   case SyncNotificationType.UNSYNCED: {

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -437,7 +437,7 @@ const syncConsumer = (response) => (dispatch, getState) => {
   switch (response.getNotificationType()) {
   case SyncNotificationType.SYNCED: {
     dispatch({ type: SYNC_SYNCED });
-    dispatch(getBestBlockHeightAttempt(startWalletServices));
+    setTimeout(() => dispatch(getBestBlockHeightAttempt(startWalletServices)), 1000);
     break;
   }
   case SyncNotificationType.UNSYNCED: {


### PR DESCRIPTION
Close #1701 

I can regularly hit the getBestBlock failure error without this change.  I was able to complete 10 reloads in a row with no issues.  This was the case in both SPV and normal mode.