### PR TITLE
[notifications] Delay transaction notifications

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -86,19 +86,19 @@ export const GETSTARTUPWALLETINFO_FAILED = "GETSTARTUPWALLETINFO_FAILED";
 
 export const getStartupWalletInfo = () => (dispatch) => {
   dispatch({ type: GETSTARTUPWALLETINFO_ATTEMPT });
-  setTimeout( () => { dispatch(getStakeInfoAttempt()); }, 1000);
-  setTimeout( () => { dispatch(reloadTickets()); }, 1000);
   return new Promise((resolve, reject) => {
     setTimeout( async () => {
       try {
-        await dispatch(getAccountsAttempt(true));
+        await dispatch(getStakeInfoAttempt());
+        await dispatch(reloadTickets());
         await dispatch(getMostRecentRegularTransactions());
         await dispatch(getTransactionsSinceLastOppened());
         await dispatch(getMostRecentStakeTransactions());
         await dispatch(getMostRecentTransactions());
         await dispatch(publishUnminedTransactionsAttempt());
+        await dispatch(findImmatureTransactions());
+        await dispatch(getAccountsAttempt(true));
         await dispatch(getStartupStats());
-        dispatch(findImmatureTransactions());
         dispatch({ type: GETSTARTUPWALLETINFO_SUCCESS });
         resolve();
       } catch (error) {
@@ -276,7 +276,7 @@ const getAccountsBalances = (accounts) => (dispatch, getState) => {
     };
   });
 
-  Promise.all(promises)
+  return Promise.all(promises)
     .then(balances => dispatch({ balances, type: GETBALANCE_SUCCESS }))
     .catch(error => dispatch({ error, type: GETBALANCE_FAILED }));
 };
@@ -443,7 +443,7 @@ export const getAccountsAttempt = (startup) => async (dispatch, getState) => {
   dispatch({ type: GETACCOUNTS_ATTEMPT });
   try {
     const response = await wallet.getAccounts(sel.walletService(getState()));
-    if (startup) dispatch(getAccountsBalances(response.getAccountsList()));
+    if (startup) await dispatch(getAccountsBalances(response.getAccountsList()));
     dispatch({ accounts: response.getAccountsList(), response, type: GETACCOUNTS_SUCCESS });
   } catch (error) {
     dispatch({ error, type: GETACCOUNTS_FAILED });

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -752,7 +752,11 @@ export const newTransactionsReceived = (newlyMinedTransactions, newlyUnminedTran
   accountsToUpdate = Array.from(new Set(accountsToUpdate));
   accountsToUpdate.forEach(v => dispatch(getBalanceUpdateAttempt(v, 0)));
 
-  if (checkForStakeTransactions(unminedDupeCheck) || checkForStakeTransactions(newlyMinedTransactions)) dispatch(getStakeInfoAttempt());
+  const hasStakeTxs = checkForStakeTransactions(unminedDupeCheck) || checkForStakeTransactions(newlyMinedTransactions);
+  if (hasStakeTxs) {
+    dispatch(getStakeInfoAttempt());
+    dispatch(reloadTickets());
+  }
 
   unminedTransactions = filterTransactions([
     ...newlyUnminedTransactions,

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -2,10 +2,11 @@
 import * as wallet from "wallet";
 import * as sel from "selectors";
 import { isValidAddress, isValidMasterPubKey } from "helpers";
-import { getAccountsAttempt, getStakeInfoAttempt, startWalletServices,
-  getStartupWalletInfo, reloadTickets } from "./ClientActions";
+import { getStakeInfoAttempt, startWalletServices,
+  getStartupWalletInfo } from "./ClientActions";
 import { getWalletCfg } from "../config";
 import { RescanRequest, ConstructTransactionRequest } from "../middleware/walletrpc/api_pb";
+import { reverseRawHash } from "../helpers/byteActions";
 
 export const GETNEXTADDRESS_ATTEMPT = "GETNEXTADDRESS_ATTEMPT";
 export const GETNEXTADDRESS_FAILED = "GETNEXTADDRESS_FAILED";
@@ -227,8 +228,7 @@ export const publishTransactionAttempt = (tx) => (dispatch, getState) => {
   dispatch({ type: PUBLISHTX_ATTEMPT });
   return wallet.publishTransaction(sel.walletService(getState()), tx)
     .then(res => {
-      dispatch({ publishTransactionResponse: Buffer.from(res.getTransactionHash()), type: PUBLISHTX_SUCCESS });
-      setTimeout( () => {dispatch(getAccountsAttempt());}, 4000);
+      dispatch({ hash: reverseRawHash(res.getTransactionHash()), type: PUBLISHTX_SUCCESS });
     })
     .catch(error => dispatch({ error, type: PUBLISHTX_FAILED }));
 };
@@ -255,9 +255,6 @@ export const purchaseTicketsAttempt = (
       )
         .then(purchaseTicketsResponse => {
           dispatch({ purchaseTicketsResponse, type: PURCHASETICKETS_SUCCESS });
-          setTimeout(() => { dispatch(getAccountsAttempt()); }, 4000);
-          setTimeout(() => { dispatch(getStakeInfoAttempt()); }, 4000);
-          setTimeout(() => { dispatch(reloadTickets()); }, 4000);
         })
         .catch(error => dispatch({ error, type: PURCHASETICKETS_FAILED }))
   ));

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -16,7 +16,7 @@ export const NEWBLOCKCONNECTED = "NEWBLOCKCONNECTED";
 // transactionNtfnsDataHandler is closed over (dispatch, getState) and returns
 // a function that is to be called directly by the transaction notification data
 // stream. This is done for performance reasons, as it allows the top level
-// function (transactionNtfnsDataHandler) to create a local state closed which
+// function (transactionNtfnsDataHandler) to create a local state which
 // the child (anonymous) function closes over to buffer the notifications so
 // that on a heavily used wallet, where a large number of notifications is
 // received in a short period of time after a new block is connected, only a

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -10,18 +10,42 @@ export const TRANSACTIONNTFNS_END = "TRANSACTIONNTFNS_END";
 
 export const NEWBLOCKCONNECTED = "NEWBLOCKCONNECTED";
 
-function transactionNtfnsData(response) {
-  return (dispatch, getState) => {
-    const attachedBlocks = response.getAttachedBlocksList();
-    const unminedTxList = response.getUnminedTransactionsList();
+// transactionNtfnsDataHandler builds the handler for transaction notifications.
+// Note that this is inverted from the usual redux idiom of using
+// dispatch(transactionNtfnsDataHandler(data)). Instead,
+// transactionNtfnsDataHandler is closed over (dispatch, getState) and returns
+// a function that is to be called directly by the transaction notification data
+// stream. This is done for performance reasons, as it allows the top level
+// function (transactionNtfnsDataHandler) to create a local state closed which
+// the child (anonymous) function closes over to buffer the notifications so
+// that on a heavily used wallet, where a large number of notifications is
+// received in a short period of time after a new block is connected, only a
+// single global state change is dispatched instead of many individual changes.
+const transactionNtfnsDataHandler = (dispatch, getState) => {
 
-    // Block was mined
-    if (attachedBlocks.length > 0) {
-      var currentBlockTimestamp = attachedBlocks[attachedBlocks.length-1].getTimestamp();
-      var currentBlockHeight = attachedBlocks[attachedBlocks.length-1].getHeight();
+  let ntfTimer;
+  let newlyMined = [];
+  let newlyUnmined = [];
+  let newlyMinedMap = {};
+  let newlyUnminedMap = {};
+  let currentBlockHeight, currentBlockTimestamp;
+
+  // alertNewlyReceived is the function that actually sends the state update to
+  // redux, triggering all calculations.
+  const alertNewlyReceived = () => {
+    ntfTimer = null;
+
+    const mined = newlyMined;
+    const unmined = newlyUnmined;
+    newlyMined = [];
+    newlyUnmined = [];
+    newlyMinedMap = {};
+    newlyUnminedMap = {};
+
+    if (currentBlockHeight) {
       const { maturingBlockHeights } = getState().grpc;
       dispatch({ currentBlockHeight, currentBlockTimestamp, type: NEWBLOCKCONNECTED });
-      setTimeout( () => {dispatch(getTicketPriceAttempt());}, 1000);
+      dispatch(getTicketPriceAttempt());
 
       const maturedHeights = Object.keys(maturingBlockHeights).filter(h => h <= currentBlockHeight);
       if (maturedHeights.length > 0) {
@@ -32,7 +56,55 @@ function transactionNtfnsData(response) {
         dispatch(getAccountNumbersBalances(accountNumbers));
       }
 
-      const newlyMined = attachedBlocks.reduce((l, b) => {
+      currentBlockHeight = null;
+      currentBlockTimestamp = null;
+    }
+
+    dispatch(newTransactionsReceived(mined, unmined));
+  };
+
+  // addToOutstandingTxs adds the received (mined, unmined) txs to the list of
+  // outstanding (newlyMined, newlyUnmined) txs that will be notified to the app
+  // and resets the notification timer.
+  const addToOutstandingTxs = (mined, unmined) => {
+    if (ntfTimer) {
+      clearTimeout(ntfTimer);
+      ntfTimer = null;
+    }
+
+    unmined.forEach(tx => { if (!newlyUnminedMap[tx.txHash]) {
+      newlyUnmined.push(tx);
+      newlyUnminedMap[tx.txHash] = tx;
+    }});
+
+    mined.forEach(tx => {
+      if (!newlyMinedMap[tx.txHash]) {
+        newlyMined.push(tx);
+        newlyMined[tx.txHash] = tx;
+      }
+      if (newlyUnminedMap[tx.txHash]) {
+        // remove from txs that have already been mined from the unmined list
+        delete(newlyUnminedMap[tx.txHash]);
+        const i = newlyUnmined.findIndex(v => tx.txHash === v.txHash);
+        (i > -1) && newlyUnmined.splice(i, 1);
+      }
+    });
+
+    ntfTimer = setTimeout(alertNewlyReceived, 5000);
+  };
+
+  // this is the actual function that is repeatedly called by the transaction
+  // notification data stream
+  return (response) => {
+    const attachedBlocks = response.getAttachedBlocksList();
+    const unminedTxList = response.getUnminedTransactionsList();
+
+    // Block was mined
+    if (attachedBlocks.length > 0) {
+      currentBlockTimestamp = attachedBlocks[attachedBlocks.length-1].getTimestamp();
+      currentBlockHeight = attachedBlocks[attachedBlocks.length-1].getHeight();
+
+      const mined = attachedBlocks.reduce((l, b) => {
         b.getTransactionsList().forEach((t, i) => {
           const tx = wallet.formatTransaction(b, t, i);
           l.push(tx);
@@ -40,21 +112,21 @@ function transactionNtfnsData(response) {
         return l;
       }, []);
 
-      const newlyUnmined = unminedTxList.map((t, i) => wallet.formatUnminedTransaction(t, i));
-      dispatch(newTransactionsReceived(newlyMined, newlyUnmined));
+      const unmined = unminedTxList.map((t, i) => wallet.formatUnminedTransaction(t, i));
+      addToOutstandingTxs(mined, unmined);
     } else if (unminedTxList.length > 0) {
-      const newlyUnmined = unminedTxList.map((t, i) => wallet.formatUnminedTransaction(t, i));
-      dispatch(newTransactionsReceived([], newlyUnmined));
+      const unmined = unminedTxList.map((t, i) => wallet.formatUnminedTransaction(t, i));
+      addToOutstandingTxs([], unmined);
     }
   };
-}
+};
 
 export const transactionNtfnsStart = () => (dispatch, getState) => {
   var request = new TransactionNotificationsRequest();
   const { walletService } = getState().grpc;
   let transactionNtfns = walletService.transactionNotifications(request);
   dispatch({ transactionNtfns, type: TRANSACTIONNTFNS_START });
-  transactionNtfns.on("data", data => dispatch(transactionNtfnsData(data)));
+  transactionNtfns.on("data", transactionNtfnsDataHandler(dispatch, getState));
   transactionNtfns.on("end", () => {
     console.log("Transaction notifications done");
     dispatch({ type: TRANSACTIONNTFNS_END });

--- a/app/connectors/send.js
+++ b/app/connectors/send.js
@@ -10,7 +10,6 @@ const mapStateToProps = selectorMap({
   unsignedTransaction: sel.unsignedTransaction,
   estimatedFee: sel.estimatedFee,
   totalSpent: sel.totalSpent,
-  publishedTransactionHash: sel.publishedTransactionHash,
   isSendingTransaction: sel.isSendingTransaction,
   isConstructingTransaction: sel.isConstructingTransaction,
   nextAddress: sel.nextAddress,

--- a/app/fp.js
+++ b/app/fp.js
@@ -1,5 +1,5 @@
 export { createSelector } from "reselect";
-export { compose, reduce, find, filter, get, eq, map } from "lodash/fp";
+export { compose, reduce, find, filter, get, eq, map, keyBy } from "lodash/fp";
 import compose from "lodash/fp/compose";
 import get from "lodash/fp/get";
 

--- a/app/index.js
+++ b/app/index.js
@@ -307,7 +307,6 @@ var initialState = {
     signTransactionRespsonse: null,
     // PublishTransaction
     publishTransactionRequestAttempt: false,
-    publishTransactionResponse: null,
     // PurchaseTicket
     purchaseTicketsRequestAttempt: false,
     purchaseTicketsResponse: null,

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -222,8 +222,8 @@ export default function snackbar(state = {}, action) {
   case NEW_TRANSACTIONS_RECEIVED: {
     // TODO: show more notifications or a summary when receiving many transactions.
     const tx = action.newlyMinedTransactions.length
-      ? action.newlyMinedTransactions[0]
-      : action.newlyUnminedTransactions[0];
+      ? action.newlyMinedTransactions[action.newlyMinedTransactions.length-1]
+      : action.newlyUnminedTransactions[action.newlyUnminedTransactions.length-1];
 
     type = tx.direction || wallet.TRANSACTION_TYPES[tx.type];
     message = { ...tx, type };

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -19,6 +19,7 @@ import {
   SIGNMESSAGE_FAILED, VERIFYMESSAGE_FAILED,
   PUBLISHUNMINEDTRANSACTIONS_SUCCESS, PUBLISHUNMINEDTRANSACTIONS_FAILED,
   GETACCOUNTEXTENDEDKEY_FAILED,
+  PUBLISHTX_SUCCESS,
 } from "../actions/ControlActions";
 import {
   UPDATESTAKEPOOLCONFIG_SUCCESS, UPDATESTAKEPOOLCONFIG_FAILED,
@@ -300,6 +301,12 @@ export default function snackbar(state = {}, action) {
     type = "Success";
     message = messages[ADDCUSTOMSTAKEPOOL_SUCCESS];
     values = { host: action.poolInfo.Host };
+    break;
+
+  case PUBLISHTX_SUCCESS:
+    type = "Success";
+    message = messages[PUBLISHTX_SUCCESS];
+    values = { hash: action.hash };
     break;
   }
 

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -616,7 +616,6 @@ const constructTxResponse = get([ "control", "constructTxResponse" ]);
 const constructTxRequestAttempt = get([ "control", "constructTxRequestAttempt" ]);
 const signTransactionRequestAttempt = get([ "control", "signTransactionRequestAttempt" ]);
 export const signTransactionError = get([ "control", "signTransactionError" ]);
-const publishTransactionResponse = get([ "control", "publishTransactionResponse" ]);
 const publishTransactionRequestAttempt = get([ "control", "publishTransactionRequestAttempt" ]);
 const totalOutputAmount = compose(r => r ? r.getTotalOutputAmount() : 0, constructTxResponse);
 const totalAmount = compose(res => res ? res.totalAmount : 0, constructTxResponse);
@@ -641,10 +640,6 @@ export const totalSpent = createSelector(
   [ totalPreviousOutputAmount, totalOutputAmount, totalAmount ],
   (totalPreviousOutputAmount, totalOutputAmount, totalAmount) =>
     totalPreviousOutputAmount - totalOutputAmount + totalAmount
-);
-
-export const publishedTransactionHash = compose(
-  r => r ? reverseHash(r.toString("hex")) : null, publishTransactionResponse
 );
 
 export const isSendingTransaction = bool(or(

--- a/app/style/Snackbar.less
+++ b/app/style/Snackbar.less
@@ -17,7 +17,7 @@
   background-size: 30px;
   background-repeat: no-repeat;
   margin-bottom: 20px;
-  position: relative;
+  position: fixed;
 }
 
 .snackbar-panel {


### PR DESCRIPTION
Close #1718 

I was doing this in the context of improving performance for large wallets (so that after loading, the wallets didn't have so many state updates) but refactored it into a separate PR.

This changes the transaction notification handler to collect all notifications issued during a period of time (currently hard coded at 5 seconds) and perform a single state change with the new transactions.

This is specially useful for large wallets which receive multiple notifications once a new block is connected (eg: due to new tickets/votes being published by an online hot wallet). This has the side effect of also handling #1718 by bundling split and ticket transactions (which are received as separate notifications of new unmined transactions) into a single `NEW_TRANSACTIONS_RECEIVED` state change.

I have also slightly improved the behavior of snackbar notifications when animations are turned on.