### PR TITLE
[stats] Improve startup stats in large wallets

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -820,7 +820,6 @@ export const newTransactionsReceived = (newlyMinedTransactions, newlyUnminedTran
   if (newlyMinedTransactions.length > 0) {
     const { startupStatsEndCalcTime, startupStatsCalcSeconds } = getState().statistics;
     const secFromLastStats = (new Date() - startupStatsEndCalcTime) / 1000;
-    console.log(secFromLastStats, startupStatsCalcSeconds, secFromLastStats);
     if (secFromLastStats > 5*startupStatsCalcSeconds) {
       dispatch(getStartupStats());
     }

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -818,7 +818,12 @@ export const newTransactionsReceived = (newlyMinedTransactions, newlyUnminedTran
     newlyMinedTransactions, recentRegularTransactions, recentStakeTransactions, type: NEW_TRANSACTIONS_RECEIVED });
 
   if (newlyMinedTransactions.length > 0) {
-    dispatch(getStartupStats());
+    const { startupStatsEndCalcTime, startupStatsCalcSeconds } = getState().statistics;
+    const secFromLastStats = (new Date() - startupStatsEndCalcTime) / 1000;
+    console.log(secFromLastStats, startupStatsCalcSeconds, secFromLastStats);
+    if (secFromLastStats > 5*startupStatsCalcSeconds) {
+      dispatch(getStartupStats());
+    }
   }
 };
 

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -168,17 +168,14 @@ export const findImmatureTransactions = () => async (dispatch, getState) => {
   let txs = await walletGetTransactions(walletService, immatureHeight,
     currentBlockHeight, pageSize);
 
-  let tot = txs.mined.length;
-
   while (txs.mined.length > 0) {
-    tot += txs.mined.length;
     let lastTx = txs.mined[txs.mined.length-1];
     mergeCheckHeights(transactionsMaturingHeights(txs.mined, chainParams));
     txs = await walletGetTransactions(walletService, lastTx.height+1,
       currentBlockHeight+1, pageSize);
   }
 
-  dispatch({ tot, type: "FINDIMMATURETRANSACTIONS_FINISHED" });
+  dispatch({ type: "FINDIMMATURETRANSACTIONS_FINISHED" });
 
   dispatch({ maturingBlockHeights: checkHeights, type: MATURINGHEIGHTS_CHANGED });
 };

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -98,7 +98,7 @@ export const getStartupWalletInfo = () => (dispatch) => {
         await dispatch(publishUnminedTransactionsAttempt());
         await dispatch(findImmatureTransactions());
         await dispatch(getAccountsAttempt(true));
-        // await dispatch(getStartupStats());
+        await dispatch(getStartupStats());
         dispatch({ type: GETSTARTUPWALLETINFO_SUCCESS });
         resolve();
       } catch (error) {
@@ -149,7 +149,6 @@ export const findImmatureTransactions = () => async (dispatch, getState) => {
 
   const pageSize = 30;
   const checkHeightDeltas = [
-    // chainParams.TicketExpiry,
     chainParams.TicketMaturity,
     chainParams.CoinbaseMaturity,
     chainParams.SStxChangeMaturity
@@ -819,7 +818,7 @@ export const newTransactionsReceived = (newlyMinedTransactions, newlyUnminedTran
     newlyMinedTransactions, recentRegularTransactions, recentStakeTransactions, type: NEW_TRANSACTIONS_RECEIVED });
 
   if (newlyMinedTransactions.length > 0) {
-    //dispatch(getStartupStats());
+    dispatch(getStartupStats());
   }
 };
 

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -171,6 +171,16 @@ export const findImmatureTransactions = () => async (dispatch, getState) => {
   while (txs.mined.length > 0) {
     let lastTx = txs.mined[txs.mined.length-1];
     mergeCheckHeights(transactionsMaturingHeights(txs.mined, chainParams));
+
+    if (lastTx && lastTx.height >= currentBlockHeight) {
+      // this may happen on wallets that take a long time to start up (eg: large
+      // wallet left closed for a long time performing a rescan). If a new
+      // block comes in with wallet transactions then the height of the new
+      // transaction will exceed the currentBlockHeight (which is fetched at
+      // the beginning of the startup procedure).
+      break;
+    }
+
     txs = await walletGetTransactions(walletService, lastTx.height+1,
       currentBlockHeight+1, pageSize);
   }

--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -64,7 +64,10 @@ export const getStartupStats = () => (dispatch, getState) => {
       dispatch({ dailyBalances: lastBalances, startupStatsCalcSeconds,
         startupStatsEndCalcTime: endCalcTime, type: GETSTARTUPSTATS_SUCCESS });
     })
-    .catch(error => dispatch({ error, type: GETSTARTUPSTATS_FAILED }));
+    .catch(error => {
+      console.error("getStartupStats errored", error);
+      dispatch({ error, type: GETSTARTUPSTATS_FAILED });
+    });
 };
 
 export const GETMYTICKETSSTATS_ATTEMPT = "GETMYTICKETSSTATS_ATTEMPT";
@@ -82,7 +85,10 @@ export const getMyTicketsStats = () => (dispatch) => {
     .then(([ voteTime, dailyBalances ]) => {
       dispatch({ voteTime, dailyBalances, type: GETMYTICKETSSTATS_SUCCESS });
     })
-    .catch(error => dispatch({ error, type: GETMYTICKETSSTATS_FAILED }));
+    .catch(error => {
+      console.error("getMyTicketsStats errored", error);
+      dispatch({ error, type: GETMYTICKETSSTATS_FAILED });
+    });
 };
 
 // generateStat starts generating the statistic as defined on the opts. It

--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -364,10 +364,6 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
   const voteRevokeInfo = async tx => {
     const isVote = tx.txType === wallet.TRANSACTION_TYPE_VOTE;
 
-    // const decodedSpender = await wallet.decodeTransaction(decodeMessageService, tx.tx.getTransaction());
-    // const spenderInputs = decodedSpender.getTransaction().getInputsList();
-    // const ticketHash = reverseRawHash(spenderInputs[spenderInputs.length-1].getPreviousTransactionHash());
-
     const decodedSpender = await wallet.decodeTransactionLocal(tx.tx.getTransaction());
     const spenderInputs = decodedSpender.inputs;
     const ticketHash = reverseRawHash(spenderInputs[spenderInputs.length-1].prevTxId);

--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -3,7 +3,6 @@ import * as sel from "selectors";
 import fs from "fs";
 import { isNumber, isNullOrUndefined, isUndefined } from "util";
 import { endOfDay, reverseRawHash, formatLocalISODate } from "helpers";
-import { format as formatDate } from "date-fns";
 
 const VALUE_TYPE_ATOMAMOUNT = "VALUE_TYPE_ATOMAMOUNT";
 const VALUE_TYPE_DATETIME = "VALUE_TYPE_DATETIME";
@@ -547,8 +546,6 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
   const toProcess = [];
 
   try {
-    console.log(formatDate(new Date(), "HH:mm:ss.SSS"), "starting process");
-
     if (backwards) {
       // when calculating backwards, we need to account for unmined txs, because
       // the account balances for locked tickets include them. To simplify the
@@ -580,8 +577,6 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
         ((!endDate) || (endDate && !backwards && currentDate < endDate) || (endDate && backwards && currentDate > endDate)) ;
     }
 
-    console.log(formatDate(new Date(), "HH:mm:ss.SSS"), "got all txs", toProcess[toProcess.length-1]);
-
     // grab all txs that are ticket/coinbase maturity blocks from the last tx
     // so that we can account for tickets and votes maturing
     endBlock = currentBlock + maxMaturity * pageDir;
@@ -593,8 +588,6 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
       }
     }
 
-    console.log(formatDate(new Date(), "HH:mm:ss.SSS"), "got extra txs for maturity", toProcess[toProcess.length-1]);
-
     if (backwards) {
       // on backwards stats, we find vote txs before finding ticket txs, so
       // pre-process tickets from all grabbed txs to avoid making the separate
@@ -605,15 +598,10 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
           recordTicket(tx, commitAmount, isWallet);
         }
       });
-      console.log(formatDate(new Date(), "HH:mm:ss.SSS"), "Processed tickets");
     }
 
     await callback({ mined: toProcess });
-
-    console.log(formatDate(new Date(), "HH:mm:ss.SSS"), "Processed txs");
     endFunction();
-
-    console.log(formatDate(new Date(), "HH:mm:ss.SSS"), "end function called");
   } catch (err) {
     errorFunction(err);
   }

--- a/app/index.js
+++ b/app/index.js
@@ -371,6 +371,7 @@ var initialState = {
     voteTime: null,
     getMyTicketsStatsRequest: false,
     getStartupStatsAttempt: false,
+    startupStatsEndCalcTime: new Date(0),
   },
   governance: {
     getVettedAttempt: false,

--- a/app/reducers/statistics.js
+++ b/app/reducers/statistics.js
@@ -23,7 +23,9 @@ export default function statistics(state = {}, action) {
     return {
       ...state,
       dailyBalances: action.dailyBalances,
-      getStartupStatsAttempt: false
+      getStartupStatsAttempt: false,
+      startupStatsCalcSeconds: action.startupStatsCalcSeconds,
+      startupStatsEndCalcTime: action.startupStatsEndCalcTime,
     };
   case GETMYTICKETSSTATS_ATTEMPT:
     return {

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -39,18 +39,10 @@ export const validateAddress = withLogNoData((walletService, address) =>
     walletService.validateAddress(request, (error, response) => error ? reject(error) : resolve(response));
   }), "Validate Address");
 
-export const decodeTransactionLocal = (decodeMessageService, rawTx) =>
-  new Promise((resolve, reject) => {
-    var buffer = Buffer.isBuffer(rawTx) ? rawTx : Buffer.from(rawTx, "hex");
-    //var buff = new Uint8Array(buffer);
-    decodeRawTransaction(buffer, (error, tx) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(tx);
-      }
-    });
-  });
+export const decodeTransactionLocal = (rawTx) => {
+  var buffer = Buffer.isBuffer(rawTx) ? rawTx : Buffer.from(rawTx, "hex");
+  return Promise.resolve(decodeRawTransaction(buffer));
+};
 
 export const decodeTransaction = withLogNoData((decodeMessageService, rawTx) =>
   new Promise((resolve, reject) => {
@@ -263,7 +255,7 @@ export const committedTickets = withLogNoData((walletService, ticketHashes) => n
   walletService.committedTickets(req, (err, tickets) => err ? reject(err) : resolve(tickets));
 }), "Committed Tickets");
 
-const decodeRawTransaction = (rawTx, cb) => {
+const decodeRawTransaction = (rawTx) => {
   var position = 0;
 
   var tx = {};
@@ -344,5 +336,5 @@ const decodeRawTransaction = (rawTx, cb) => {
   position += 4;
   tx.expiry = rawTx.readUInt32LE(position);
   position += 4;
-  return cb(null, tx);
+  return tx;
 };

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -330,7 +330,15 @@ const decodeRawTransaction = (rawTx, cb) => {
   }
 
   for (var i = 0; i < tx.numInputs; i++) {
-    var input = "";
+    var input;
+    input.prevTxId = rawTx.slice(position, position+32);
+    position += 32;
+    input.outputIndex = rawTx.readUInt32LE(position);
+    position += 4;
+    input.outputTree = rawTx.readUInt8(position);
+    position += 1;
+    input.sequence = rawTx.readUInt32LE(position);
+    position += 4;
     tx.inputs.push(input);
   }
 
@@ -350,7 +358,7 @@ const decodeRawTransaction = (rawTx, cb) => {
   }
 
   for (var j = 0; j < tx.numOutputs; j++) {
-    var output = "";
+    var output;
     tx.outputs.push(output);
   }
 

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -1,6 +1,7 @@
 import Promise from "promise";
 import * as client from "middleware/grpc/client";
 import { reverseHash, strHashToRaw, rawHashToHex } from "../helpers/byteActions";
+import { Uint64LE } from "int64-buffer";
 import { CommittedTicketsRequest } from "middleware/walletrpc/api_pb";
 import { withLog as log, withLogNoData, logOptionNoResponseData } from "./index";
 import * as api from "middleware/walletrpc/api_pb";
@@ -359,6 +360,28 @@ const decodeRawTransaction = (rawTx, cb) => {
 
   for (var j = 0; j < tx.numOutputs; j++) {
     var output;
+    output.value = Uint64LE(rawTx.slice(position, position+8)).toNumber();
+    position += 8;
+    output.version = rawTx.readUInt16LE(position);
+    position += 2;
+    // check length of scripts
+    var scriptLen;
+    first = rawTx.readUInt8(position);
+    position += 1;
+    switch (first) {
+    case 0xFD:
+      scriptLen = rawTx.readUInt16LE(position);
+      position += 2;
+      break;
+    case 0xFE:
+      scriptLen = rawTx.readUInt32LE(position);
+      position += 4;
+      break;
+    default:
+      scriptLen = first;
+    }
+    output.script = rawTx.slice(position, position+scriptLen);
+    position += scriptLen;
     tx.outputs.push(output);
   }
 

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -2,7 +2,6 @@ import Promise from "promise";
 import * as client from "middleware/grpc/client";
 import { reverseHash, strHashToRaw, rawHashToHex } from "../helpers/byteActions";
 import { CommittedTicketsRequest } from "middleware/walletrpc/api_pb";
-import Parser from "binary-parser";
 import { withLog as log, withLogNoData, logOptionNoResponseData } from "./index";
 import * as api from "middleware/walletrpc/api_pb";
 
@@ -309,72 +308,56 @@ const decodeRawTransaction = (rawTx, cb) => {
     transactionType: "vote",
   };
   */
-  var txParser = new Parser()
-    .endianess("little")
-    .uint32("version")
-    .uint32("numInputs")
-    .array("inputs", {
-      type: inputParser,
-      length: "numInputs"
-    })
-    .uint32("numOutputs")
-    .array("outputs", {
-      type: outputParser,
-      length: "numOutputs"
-    })
-    .uint32("lockTime")
-    .uint32("expiry");
+  var position = 0;
 
-  var inputParser = new Parser()
-    .endianess("big")
-    .buffer(32, "prevTxId")
-    .uint32("outIndex")
-    .bit3("outputTree")
-    .bit13("sequence");
+  var tx;
+  tx.version = rawTx.readUInt32LE(position);
+  position += 4;
 
-  var outputParser = new Parser()
-    .endianess("big")
-    .uint32("bu")
-    .uint16("id")
-    .bit3("offset")
-    .bit13("fragOffset");
-
-  this.version = reader.readInt32LE();
-  var sizeTxIns = reader.readVarintNum();
-
-  // check for segwit
-  var hasWitnesses = false;
-  if (sizeTxIns === 0 && reader.buf[reader.pos] !== 0) {
-    reader.pos += 1;
-    hasWitnesses = true;
-    sizeTxIns = reader.readVarintNum();
+  var first = rawTx.readUInt8(position);
+  position += 1;
+  switch (first) {
+  case 0xFD:
+    tx.numInputs = rawTx.readUInt16LE(position);
+    position += 2;
+    break;
+  case 0xFE:
+    tx.numInputs = rawTx.readUInt32LE(position);
+    position += 4;
+    break;
+  default:
+    tx.numInputs = first;
   }
 
-  for (var i = 0; i < sizeTxIns; i++) {
-    var input = Input.fromBufferReader(reader);
-    this.inputs.push(input);
+  for (var i = 0; i < tx.numInputs; i++) {
+    var input = "";
+    tx.inputs.push(input);
   }
 
-  var sizeTxOuts = reader.readVarintNum();
-  for (var j = 0; j < sizeTxOuts; j++) {
-    this.outputs.push(Output.fromBufferReader(reader));
+  first = rawTx.readUInt8(position);
+  position += 1;
+  switch (first) {
+  case 0xFD:
+    tx.numOutputs = rawTx.readUInt16LE(position);
+    position += 2;
+    break;
+  case 0xFE:
+    tx.numOutputs = rawTx.readUInt32LE(position);
+    position += 4;
+    break;
+  default:
+    tx.numOutputs = first;
   }
 
-  if (hasWitnesses) {
-    for (var k = 0; k < sizeTxIns; k++) {
-      var itemCount = reader.readVarintNum();
-      var witnesses = [];
-      for (var l = 0; l < itemCount; l++) {
-        var size = reader.readVarintNum();
-        var item = reader.read(size);
-        witnesses.push(item);
-      }
-      this.inputs[k].setWitnesses(witnesses);
-    }
+  for (var j = 0; j < tx.numOutputs; j++) {
+    var output = "";
+    tx.outputs.push(output);
   }
 
-  this.nLockTime = reader.readUInt32LE();
-
-  var tx = txParser.parse(rawTx);
+  tx.lockTime = rawTx.readUInt32LE(position);
+  position += 4;
+  tx.expiry = rawTx.readUInt32LE(position);
+  position += 4;
+  console.log(tx);
   return cb(null, tx);
 };

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
   "dependencies": {
     "autobind-decorator": "^2.1.0",
     "axios": "^0.18.0",
+    "binary-parser": "^1.3.2",
     "css-loader": "^1.0.1",
     "dom-helpers": "^3.3.1",
     "electron-builder": "^20.29.0",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,6 @@
   "dependencies": {
     "autobind-decorator": "^2.1.0",
     "axios": "^0.18.0",
-    "binary-parser": "^1.3.2",
     "css-loader": "^1.0.1",
     "dom-helpers": "^3.3.1",
     "electron-builder": "^20.29.0",

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "electron-devtools-installer": "^2.2.4",
     "enzyme-adapter-react-16": "^1.6.0",
     "ini": "^1.3.4",
+    "int64-buffer": "^0.1.10",
     "is-running": "^2.1.0",
     "lodash": "^4.17.4",
     "mv": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,9 +1987,9 @@ big.js@^3.1.3:
   integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
 
 binary-extensions@^1.0.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
-  integrity sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
+  integrity sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==
 
 block-stream@*:
   version "0.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5074,6 +5074,11 @@ inquirer@^6.1.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+int64-buffer@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.10.tgz#277b228a87d95ad777d07c13832022406a473423"
+  integrity sha1-J3siiofZWtd30HwTgyAiQGpHNCM=
+
 interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,9 +1987,14 @@ big.js@^3.1.3:
   integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
 
 binary-extensions@^1.0.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
-  integrity sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
+  integrity sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=
+
+binary-parser@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/binary-parser/-/binary-parser-1.3.2.tgz#5bd04f948ada1a6d78c528762308a9a335d63db9"
+  integrity sha512-VDhHcpeF1/ZZy1XvDmYD67bBjRNm1gacw+772xNd5BnTH6ax5TzlDV5dl7216/UlQXQoN9vug07ehk7e0PhNUw==
 
 block-stream@*:
   version "0.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,11 +1991,6 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
   integrity sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=
 
-binary-parser@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/binary-parser/-/binary-parser-1.3.2.tgz#5bd04f948ada1a6d78c528762308a9a335d63db9"
-  integrity sha512-VDhHcpeF1/ZZy1XvDmYD67bBjRNm1gacw+772xNd5BnTH6ax5TzlDV5dl7216/UlQXQoN9vug07ehk7e0PhNUw==
-
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"


### PR DESCRIPTION
This improves the startup time and usability for large wallets by:

- Using local (js) code to decode transactions instead of the wallet service
- Only starting to listen for tx/account notifications after full startup
- Preventing repeated stats calculation if the initial calc time was big

Testing on a large testnet wallet (96k+ votes, 3k+ live tickets) startup time reduced from ~10min to ~2min.

Currently a WIP as there's some instrumentation left to facilitate testing.

The initial code for transaction decoding was done by @alexlyp 