### PR TITLE
More allusive passphrase update failed message

### DIFF
--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -156,7 +156,7 @@ const messages = defineMessages({
   },
   CHANGEPASSPHRASE_FAILED: {
     id: "settings.errors.changePassphraseFailed",
-    defaultMessage: "{originalError}"
+    defaultMessage: "Entered incorrect private passphrase reset blocked."
   },
   DECODERAWTXS_FAILED: {
     id: "decodeRawTx.errors.decodeFailed",

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -156,7 +156,7 @@ const messages = defineMessages({
   },
   CHANGEPASSPHRASE_FAILED: {
     id: "settings.errors.changePassphraseFailed",
-    defaultMessage: "Entered incorrect private passphrase reset blocked."
+    defaultMessage: "Update passphrase failed. Incorrect private passphrase, please try again."
   },
   DECODERAWTXS_FAILED: {
     id: "decodeRawTx.errors.decodeFailed",


### PR DESCRIPTION
Fixes #1694

Now it says "Entered incorrect private passphrase reset blocked."