### PR TITLE
Wrong label for delete wallet fix

### DIFF
--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -42,7 +42,7 @@ const WalletSelectionBodyBase = ({
                         <RemoveWalletButton
                           className="display-wallet-button remove"
                           modalTitle={<T id="walletselection.removeConfirmModal.title" m="Remove {wallet}"
-                            values={{ wallet: (<span className="mono">{selectedWallet && selectedWallet.label}</span>) }}/>}
+                            values={{ wallet: (<span className="mono">{wallet.value.wallet}</span>) }}/>}
                           modalContent={
                             <T id="walletselection.removeConfirmModal.content" m="Warning this action is permanent! Please make sure you have backed up your wallet's seed before proceeding."/>}
                           onSubmit={() => onRemoveWallet(wallet)} />

--- a/app/style/Global.less
+++ b/app/style/Global.less
@@ -24,6 +24,7 @@
 
 .mono {
   font-family: Inconsolata, monospace;
+  text-transform: lowercase;
 }
 
 .shutdown-text {

--- a/app/style/Global.less
+++ b/app/style/Global.less
@@ -24,7 +24,6 @@
 
 .mono {
   font-family: Inconsolata, monospace;
-  text-transform: lowercase;
 }
 
 .shutdown-text {

--- a/app/style/Modals.less
+++ b/app/style/Modals.less
@@ -507,6 +507,10 @@
   text-transform: capitalize;
 }
 
+.confirm-modal-header-title .mono {
+  text-transform: lowercase;
+}
+
 .confirm-seed-copy-warning-text {
   white-space: pre-line;
   margin-bottom: 20px;


### PR DESCRIPTION
When you want to delete any wallet from home view a module popup with "remove default-wallet (mainnet)" used to come up no matter which one clicked now with this PR it says "remove name-of-wallet-selected"

Fixes number 5 of #1725