### PR TITLE
[tests] Fix and return balance tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,23 @@
     "verbose": true,
     "rootDir": "test/unit",
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/__mocks__/fileMock.js",
-      "\\.(css|less)$": "identity-obj-proxy"
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|md)$": "<rootDir>/../mocks/fileMock.js",
+      "\\.(css|less)$": "<rootDir>/../mocks/styleMock.js",
+      "^grpc$": "<rootDir>/../mocks/grpcMock.js",
+      "^electron$": "<rootDir>/../mocks/electronMock.js"
     },
     "transform": {
       "^.+\\.js?$": "babel-jest"
-    }
+    },
+    "setupFiles": [
+      "<rootDir>/../setup.js"
+    ],
+    "modulePaths": [
+      "<rootDir>/../../app",
+      "<rootDir>/../../app/components",
+      "<rootDir>/../../node_modules",
+      "<rootDir>/../../app/node_modules"
+    ]
   },
   "build": {
     "appId": "com.Electron.Decrediton",
@@ -181,11 +192,13 @@
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {
+    "autobind-decorator": "^2.1.0",
     "axios": "^0.18.0",
     "css-loader": "^1.0.0",
     "dom-helpers": "^3.3.1",
     "electron-builder": "^20.28.4",
     "electron-devtools-installer": "^2.2.4",
+    "enzyme-adapter-react-16": "^1.6.0",
     "ini": "^1.3.4",
     "is-running": "^2.1.0",
     "lodash": "^4.17.4",

--- a/test/mocks/electronMock.js
+++ b/test/mocks/electronMock.js
@@ -1,0 +1,6 @@
+export default {};
+
+export const remote = {
+  dialog: {},
+  getCurrentWindow() {}
+};

--- a/test/mocks/fileMock.js
+++ b/test/mocks/fileMock.js
@@ -1,0 +1,1 @@
+export default "test-file-stub";

--- a/test/mocks/grpcMock.js
+++ b/test/mocks/grpcMock.js
@@ -1,0 +1,2 @@
+export default {};
+export function makeGenericClientConstructor() { }

--- a/test/mocks/styleMock.js
+++ b/test/mocks/styleMock.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,11 @@
+import autobind from "autobind-decorator";
+import React from "react";
+import PropTypes from "prop-types";
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+global.autobind = autobind;
+global.React = React;
+global.PropTypes = PropTypes;
+
+configure({ adapter: new Adapter() });

--- a/test/unit/components/Balance.spec.js
+++ b/test/unit/components/Balance.spec.js
@@ -1,39 +1,31 @@
 
-// Replaced the existing tests with a dummy until we decided on what to actually
-// test after translation
-test("dummy", () => {
-});
-
-/*import React from "react";
-import { Balance } from "../../../app/components/Balance";
+import { Balance } from "shared/Balance";
 import { shallow } from "enzyme";
 import sinon from "sinon";
 
 test("atoms display", () => {
   const spy = sinon.spy();
-  // Render a checkbox with label in the document
+
   const balance = shallow(
     <Balance currencyDisplay="atoms" amount={42} onClick={spy} />
   );
 
-  expect(balance.find(".balance-base").childAt(0).text()).toEqual("42 atoms");
+  expect(balance.childAt(0).text()).toEqual("42 atoms");
 
-  balance.find(".balance-base").simulate("click");
-
+  balance.childAt(0).simulate("click");
   expect(spy.calledOnce).toEqual(true);
 });
 
 test("DCR display", () => {
   const spy = sinon.spy();
-  // Render a checkbox with label in the document
+
   const balance = shallow(
     <Balance currencyDisplay="DCR" amount={420000001} onClick={spy} />
   );
 
-  expect(balance.find(".balance-base").text()).toEqual("4.20000001 DCR");
+  expect(balance.childAt(0).childAt(0).childAt(0).prop("value")).toEqual("4.20");
 
-  balance.find(".balance-base").simulate("click");
+  balance.childAt(0).simulate("click");
 
   expect(spy.calledOnce).toEqual(true);
 });
-*/

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,6 +1572,11 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+autobind-decorator@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.1.0.tgz#4451240dbfeff46361c506575a63ed40f0e5bc68"
+  integrity sha512-bgyxeRi1R2Q8kWpHsb1c+lXCulbIAHsyZRddaS+agAUX3hFUVZMociwvRgeZi1zWvfqEEjybSv4zxWvFV8ydQQ==
+
 autoprefixer@^9.0.0:
   version "9.1.5"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.1.5.tgz#8675fd8d1c0d43069f3b19a2c316f3524e4f6671"
@@ -3468,6 +3473,28 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
   integrity sha1-blwtClYhtdra7O+AuQ7ftc13cvA=
+
+enzyme-adapter-react-16@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.6.0.tgz#3fca28d3c32f3ff427495380fe2dd51494689073"
+  integrity sha512-ay9eGFpChyUDnjTFMMJHzrb681LF3hPWJLEA7RoLFG9jSWAdAm2V50pGmFV9dYGJgh5HfdiqM+MNvle41Yf/PA==
+  dependencies:
+    enzyme-adapter-utils "^1.8.0"
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    object.values "^1.0.4"
+    prop-types "^15.6.2"
+    react-is "^16.5.2"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.8.1.tgz#a927d840ce2c14b42892a533aec836809d4e022b"
+  integrity sha512-s3QB3xQAowaDS2sHhmEqrT13GJC4+n5bG015ZkLv60n9k5vhxxHTQRIneZmQ4hmdCZEBrvUJ89PG6fRI5OEeuQ==
+  dependencies:
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    prop-types "^15.6.2"
 
 enzyme@^3.1.0:
   version "3.6.0"
@@ -8028,6 +8055,11 @@ react-intl@^2.4.0:
     intl-relativeformat "^2.1.0"
     invariant "^2.1.1"
 
+react-is@^16.5.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
+  integrity sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -8134,6 +8166,16 @@ react-smooth@1.0.0:
     prop-types "^15.6.0"
     raf "^3.2.0"
     react-transition-group "^2.2.1"
+
+react-test-renderer@^16.0.0-0:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.5.2.tgz#92e9d2c6f763b9821b2e0b22f994ee675068b5ae"
+  integrity sha512-AGbJYbCVx1J6jdUgI4s0hNp+9LxlgzKvXl0ROA3DHTrtjAr00Po1RhDZ/eAq2VC/ww8AHgpDXULh5V2rhEqqJg==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.5.2"
+    schedule "^0.5.0"
 
 react-timeout@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
This re-enables and fixes the unit tests for the Balance component that had been disabled when we introduced the i18n subsystem.

It also adds some global mocks and imports which are required when unit testing other components.
