### PR TITLE
Fixed copy seed button cursor

### DIFF
--- a/app/style/GetStarted.less
+++ b/app/style/GetStarted.less
@@ -319,6 +319,8 @@
     background-position: 16px 3px;
     background-size: 16px auto;
     background-repeat: no-repeat;
+    cursor: pointer;
+    user-select: none;
   }
 
   .copy:hover {


### PR DESCRIPTION
I was testing creating a new wallet and noticed the copy to clipboard button on the new seed page wasn't showing the pointer cursor