### PR TITLE
[transactions] Misaligned search button fix

### DIFF
--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -442,7 +442,6 @@
   background-color: transparent;
   background-image: @search-icon;
   background-size: 16px 16px;
-  margin-top: 5px;
 }
 
 .path-button:hover {


### PR DESCRIPTION
Close #1669 
Fix for the misaligned search button in the Transactions Exports page.

First option: just removed the margin (the one I used)
![screenshot from 2018-10-29 16-51-30 margin](https://user-images.githubusercontent.com/33964313/47677618-5e682780-db9e-11e8-869b-4e77bec40c33.png)

Second option: smaller icon
![screenshot from 2018-10-29 16-50-34](https://user-images.githubusercontent.com/33964313/47677616-5e682780-db9e-11e8-8821-68f19126dde6.png)

Which do you guys prefer?

