### PR TITLE
[transaction] Fix timestamp in headers for votes

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -1030,10 +1030,16 @@ export const fetchMissingStakeTxData = tx => async (dispatch, getState) => {
       decodedSpender = (await dispatch(decodeRawTransactions([ tx.rawTx ])))[tx.txHash];
     }
 
+    // Find the ticket hash of the vote/revoke. Determining whether it's a vote
+    // or revocation by looking at the number of inputs is not great, but works
+    // for now given the current consensus rules.
+    const spenderInputs = decodedSpender.transaction.getInputsList();
+    const outpIdx = spenderInputs.length === 1 ? 0 : 1;
+    const ticketTxHash = rawHashToHex(spenderInputs[outpIdx].getPreviousTransactionHash());
+
     // given that the ticket may be much older than the transactions currently
     // in the `transactions` state var, we need to manually fetch the ticket
     // transaction
-    const ticketTxHash = rawHashToHex(decodedSpender.transaction.getInputsList()[1].getPreviousTransactionHash());
     const ticketTx = await wallet.getTransaction(sel.walletService(getState()),
       ticketTxHash);
 

--- a/app/actions/DecodeMessageActions.js
+++ b/app/actions/DecodeMessageActions.js
@@ -34,6 +34,7 @@ export const decodeRawTransactions = (hexTxs) => (dispatch, getState) => {
       return map;
     }, {});
     dispatch({ transactions, type: DECODERAWTXS_SUCCESS });
+    return transactions;
   };
 
   return Promise

--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -50,7 +50,15 @@ function mapNonWalletInput(input) {
 
 const TxDetails = ({
   decodedTransaction,
-  tx: {
+  tx,
+  currentBlockHeight,
+  intl,
+  goBackHistory,
+  tsDate,
+  publishUnminedTransactions,
+  fetchMissingStakeTxData,
+}) => {
+  const {
     txHash,
     txUrl,
     txHeight,
@@ -68,13 +76,8 @@ const TxDetails = ({
     ticketPrice,
     enterTimestamp,
     leaveTimestamp,
-  },
-  currentBlockHeight,
-  intl,
-  goBackHistory,
-  tsDate,
-  publishUnminedTransactions
-}) => {
+  } = tx;
+
   const isConfirmed = !!txTimestamp;
   const icon = headerIcons[txType || txDirection];
   const goBack = () => goBackHistory();
@@ -110,6 +113,11 @@ const TxDetails = ({
 
   var subtitle = <div/>;
 
+  if (((txType == "Ticket") && (!ticketPrice)) || ((txType == "Vote") && (!leaveTimestamp))) {
+    // don't have the extended stake info for this transaction yet. Request it.
+    fetchMissingStakeTxData(tx);
+  }
+
   switch (txType) {
   case "Ticket":
   case "Vote":
@@ -119,13 +127,13 @@ const TxDetails = ({
         <div className="tx-details-subtitle-pair">
           <div className="tx-details-subtitle-sentfrom"><T id="txDetails.purchasedOn" m="Purchased On" /></div>
           <div className="tx-details-subtitle-date">
-            <T id="txDetails.timestamp" m="{timestamp, date, medium} {timestamp, time, medium}" values={{ timestamp: tsDate(txType == "Vote" ? enterTimestamp : txTimestamp) }}/>
+            <T id="txDetails.timestamp" m="{timestamp, date, medium} {timestamp, time, medium}" values={{ timestamp: tsDate(txType == "Vote" && enterTimestamp ? enterTimestamp : txTimestamp) }}/>
           </div>
         </div>:
         <T id="txDetails.unConfirmed" m="Unconfirmed"/>
       }
       {leaveTimestamp && <div className="tx-details-subtitle-pair"><div className="tx-details-subtitle-sentfrom"><T id="txDetails.votedOn" m="Voted On" /></div><div className="tx-details-subtitle-date"><T id="txDetails.timestamp" m="{timestamp, date, medium} {timestamp, time, medium}" values={{ timestamp: tsDate(leaveTimestamp) }}/></div></div>}
-      <div className="tx-details-subtitle-pair"><div className="tx-details-subtitle-sentfrom"><T id="txDetails.ticketCost" m="Ticket Cost" /></div><div className="tx-details-subtitle-account"><Balance amount={ticketPrice}/></div></div>
+      {ticketPrice && <div className="tx-details-subtitle-pair"><div className="tx-details-subtitle-sentfrom"><T id="txDetails.ticketCost" m="Ticket Cost" /></div><div className="tx-details-subtitle-account"><Balance amount={ticketPrice}/></div></div> }
       {ticketReward && <div className="tx-details-subtitle-pair"><div className="tx-details-subtitle-sentfrom"><T id="txDetails.reward" m="Reward" /></div><div className="tx-details-subtitle-account"><Balance amount={ticketReward}/></div></div>}
     </div>;
     break;

--- a/app/connectors/transactionDetails.js
+++ b/app/connectors/transactionDetails.js
@@ -12,7 +12,8 @@ const mapStateToProps = selectorMap({
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   goBackHistory: ca.goBackHistory,
-  publishUnminedTransactions: cla.publishUnminedTransactionsAttempt
+  publishUnminedTransactions: cla.publishUnminedTransactionsAttempt,
+  fetchMissingStakeTxData: ca.fetchMissingStakeTxData,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/index.js
+++ b/app/index.js
@@ -207,6 +207,10 @@ var initialState = {
     // heights, due to maturing stake transactions. Keys are the heights,
     // values are arrays of account numbers.
     maturingBlockHeights: {},
+
+    // list of outstanding requests for additional stake data from transactions
+    // (indexed by transaction hash)
+    fetchMissingStakeTxDataAttempt: {},
   },
   walletLoader: {
     syncInput: false,

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -23,6 +23,7 @@ import {
   GETBESTBLOCK_ATTEMPT, GETBESTBLOCK_FAILED, GETBESTBLOCK_SUCCESS,
   GETTRANSACTIONSSINCELASTOPPENED_SUCCESS, STARTWALLETSERVICE_ATTEMPT,
   STARTWALLETSERVICE_FAILED, STARTWALLETSERVICE_SUCCESS,
+  FETCHMISSINGSTAKETXDATA_ATTEMPT, FETCHMISSINGSTAKETXDATA_SUCCESS, FETCHMISSINGSTAKETXDATA_FAILED,
 } from "../actions/ClientActions";
 import { STARTUPBLOCK, WALLETREADY } from "../actions/DaemonActions";
 import { NEWBLOCKCONNECTED } from "../actions/NotificationActions";
@@ -378,6 +379,31 @@ export default function grpc(state = {}, action) {
       transactions: [],
       lastTransaction: null,
       noMoreTransactions: false
+    };
+  case FETCHMISSINGSTAKETXDATA_ATTEMPT:
+    return {
+      ...state,
+      fetchMissingStakeTxDataAttempt: {
+        ...state.fetchMissingStakeTxDataAttempt,
+        [action.txHash]: true,
+      }
+    };
+  case FETCHMISSINGSTAKETXDATA_SUCCESS:
+    return {
+      ...state,
+      transactions: action.transactions,
+      fetchMissingStakeTxDataAttempt: {
+        ...state.fetchMissingStakeTxDataAttempt,
+        [action.txHash]: false,
+      }
+    };
+  case FETCHMISSINGSTAKETXDATA_FAILED:
+    return {
+      ...state,
+      fetchMissingStakeTxDataAttempt: {
+        ...state.fetchMissingStakeTxDataAttempt,
+        [action.txHash]: false,
+      }
     };
   case UPDATETIMESINCEBLOCK:
     return {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -334,12 +334,12 @@ const transactionNormalizer = createSelector(
   (accounts, txURLBuilder, blockURLBuilder) => {
     const findAccount = num => accounts.find(account => account.getAccountNumber() === num);
     const getAccountName = num => (act => act ? act.getAccountName() : "")(findAccount(num));
-    return tx => {
-      const { blockHash } = tx;
-      const type = tx.type || (tx.getTransactionType ? tx.getTransactionType() : null);
-      let txInfo = tx.tx ? tx : {};
-      let timestamp = tx.timestamp;
-      tx = tx.tx || tx;
+    return origTx => {
+      const { blockHash } = origTx;
+      const type = origTx.type || (origTx.getTransactionType ? origTx.getTransactionType() : null);
+      let txInfo = origTx.tx ? origTx : {};
+      let timestamp = origTx.timestamp;
+      const tx = origTx.tx || origTx;
       timestamp = timestamp || tx.timestamp;
       let totalFundsReceived = 0;
       let totalChange = 0;
@@ -390,6 +390,12 @@ const transactionNormalizer = createSelector(
             txAccountName: getAccountName(creditedAccount)
           };
 
+      let stakeInfo = {};
+      if (origTx.ticketPrice) stakeInfo.ticketPrice = origTx.ticketPrice;
+      if (origTx.enterTimestamp) stakeInfo.enterTimestamp = origTx.enterTimestamp;
+      if (origTx.leaveTimestamp) stakeInfo.leaveTimestamp = origTx.leaveTimestamp;
+      if (origTx.ticketReward) stakeInfo.ticketReward = origTx.ticketReward;
+
       return {
         txUrl: txURLBuilder(txHash),
         txBlockUrl: txBlockHash ? blockURLBuilder(txBlockHash) : null,
@@ -403,6 +409,8 @@ const transactionNormalizer = createSelector(
         txBlockHash,
         txNumericType: type,
         rawTx: Buffer.from(tx.getTransaction()).toString("hex"),
+        originalTx: origTx,
+        ...stakeInfo,
         ...txDetails
       };
     };

--- a/app/style/TxDetails.less
+++ b/app/style/TxDetails.less
@@ -200,7 +200,6 @@
 .tx-details-subtitle-date {
   .blue-value-highlight-mixin;
 
-  width: 137px;
   max-height: 22px;
 }
 


### PR DESCRIPTION
Part of #1775 

The timestamp bug in the header happens because the information used for showing the timestamp, ticket price and ticket reward was not available in the appropriate selector (due to that ticket not being in the list returned by the last call to `GetTickets()`). 

This needs to be solved by individually requesting the stake information when the data of the respective ticket is not yet available.

There's an outstanding UX issue if details for a very old ticket are requested: given dcrwallet doesn't have an endpoint to request the information for a single ticket, we're unable to show whether this ticket voted or not. To fix this, we first need a new `GetTicket()` endpoint in dcrwallet to then double back and wrap this.