### PR TITLE
Improve non-whitelsited external request blocking error

### DIFF
--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -58,7 +58,8 @@ export const installSessionHandlers = (mainLogger) => {
   session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
     const isURLAllowed = (urlRegexp) => urlRegexp.test(details.url);
     if (!allowedURLs.some(isURLAllowed)) {
-      logger.log("warn", "Cancelling external request " + details.method + " " + details.url);
+      logger.log("error", "Blocking external request: " + details.method + " " + details.url);
+      logger.log("error", "Make sure that the request is whitelisted in main_dev/externalRequests.js");
       callback({ cancel: true, requestHeaders: details.requestHeaders });
     } else {
       logger.log("verbose", details.method + " " + details.url);


### PR DESCRIPTION
The default message does not make it clear what is happening and why, while the renderer process only throws `err:BLOCKED_BY_CLIENT`. The new message makes it clear how to resolve the problem and could help save time in future debugging. 

The blocking can happen if 1) a request was not whitelisted or 2) an unintentional external request is being made in the app, neither of which are desirable. For this reason I found `error` to be a more appropriate log level. 