### PR TITLE
Update deprecated react code

### DIFF
--- a/app/components/SideBar/LastBlockTime.js
+++ b/app/components/SideBar/LastBlockTime.js
@@ -8,10 +8,10 @@ class LastBlockTime extends React.Component {
     this.state = this.getBlockDate(props.lastBlockTimestamp);
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { lastBlockTimestamp } = this.props;
-    if (lastBlockTimestamp !== nextProps.lastBlockTimestamp) {
-      this.setState(this.getBlockDate(nextProps.lastBlockTimestamp));
+  componentDidUpdate(prevProps) {
+    const { lastBlockTimestamp } = prevProps;
+    if (lastBlockTimestamp !== this.props.lastBlockTimestamp) {
+      this.setState(this.getBlockDate(this.props.lastBlockTimestamp));
     }
   }
 

--- a/app/components/buttons/ModalButton.js
+++ b/app/components/buttons/ModalButton.js
@@ -30,8 +30,8 @@ class ModalButton extends React.Component {
     onShow && this.props.onShow();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.showModal && !this.props.modal) {
+  componentDidUpdate(prevProps) {
+    if (this.props.showModal && !prevProps.modal) {
       this.showModal();
     }
   }

--- a/app/components/inputs/AccountsSelect.js
+++ b/app/components/inputs/AccountsSelect.js
@@ -29,19 +29,19 @@ class AccountsSelect extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     let newState = null;
 
-    if (this.props.account !== nextProps.account) {
-      newState = { account: nextProps.account };
+    if (prevProps.account !== this.props.account) {
+      newState = { account: this.props.account };
     }
 
-    if ((this.props.spendingAccounts !== nextProps.spendingAccounts) ||
-        (this.props.visibleAccounts !== nextProps.visibleAccounts) ||
-        (this.props.accountsType !== nextProps.accountsType)) {
-      newState = { accounts: this.getAccountsToShow(nextProps), ...newState };
-      if (nextProps.account && !newState.account) {
-        const newAccount = newState.accounts.find(a => a.value === nextProps.account.value);
+    if ((prevProps.spendingAccounts !== this.props.spendingAccounts) ||
+        (prevProps.visibleAccounts !== this.props.visibleAccounts) ||
+        (prevProps.accountsType !== this.props.accountsType)) {
+      newState = { accounts: this.getAccountsToShow(this.props), ...newState };
+      if (this.props.account && !newState.account) {
+        const newAccount = newState.accounts.find(a => a.value === this.props.account.value);
         newState = { account: newAccount, ...newState };
       }
     }

--- a/app/components/inputs/DcrInput.js
+++ b/app/components/inputs/DcrInput.js
@@ -34,14 +34,14 @@ class DcrInput extends React.Component {
     this.state = { value: this.amountToDisplayStr(props.amount) };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!nextProps.amount && !this.state.value) {
+  componentDidUpdate(prevProps) {
+    if (!this.props.amount && !this.state.value) {
       //ignore when emptying or setting to 0
       return;
     }
 
-    if (nextProps.amount !== this.props.amount) {
-      this.setState({ value: this.amountToDisplayStr(nextProps.amount) });
+    if (this.props.amount !== prevProps.amount) {
+      this.setState({ value: this.amountToDisplayStr(this.props.amount) });
     }
   }
 

--- a/app/components/inputs/LanguageSelect.js
+++ b/app/components/inputs/LanguageSelect.js
@@ -17,7 +17,7 @@ class SettingsInput extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const { value } = this.props;
     if(value) {
       this.setState({ value: value });

--- a/app/components/inputs/SettingsInput.js
+++ b/app/components/inputs/SettingsInput.js
@@ -17,7 +17,7 @@ class SettingsInput extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const { value } = this.props;
     if(value) {
       this.setState({ value: value });

--- a/app/components/modals/Modal.js
+++ b/app/components/modals/Modal.js
@@ -11,7 +11,7 @@ class Modal extends React.Component {
     super(props);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.props.modalShown();
   }
 

--- a/app/components/shared/VerticalAccordion.js
+++ b/app/components/shared/VerticalAccordion.js
@@ -13,7 +13,7 @@ class VerticalAccordion extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (prevState.show !== this.state.show) {
-      this.chosenStyles(this.props, this.state.show)
+      this.chosenStyles(this.props, this.state.show);
     }
   }
 

--- a/app/components/shared/VerticalAccordion.js
+++ b/app/components/shared/VerticalAccordion.js
@@ -6,14 +6,16 @@ class VerticalAccordion extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      show: false,
       shownStyles: this.chosenStyles(props, false),
     };
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.show !== this.state.show) {
-      this.chosenStyles(this.props, this.state.show);
+  componentDidUpdate(prevProps) {
+    if (prevProps.show !== this.props.show) {
+      this.setState({
+        shownStyles: this.chosenStyles(this.props, this.props.show),
+      });
+      this.chosenStyles(this.props, this.props.show);
     }
   }
 
@@ -63,17 +65,13 @@ class VerticalAccordion extends React.Component {
   }
 
   onToggleAccordion() {
-    this.setState({
-      show: !this.state.show,
-      shownStyles: this.chosenStyles(this.props, !this.state.show),
-    });
     this.props.onToggleAccordion && this.props.onToggleAccordion();
   }
 
   render() {
     const classNames = [
       "vertical-accordion",
-      this.state.show ? "active" : "",
+      this.props.show ? "active" : "",
       this.props.className || "",
     ].join(" ");
 

--- a/app/components/shared/VerticalAccordion.js
+++ b/app/components/shared/VerticalAccordion.js
@@ -18,18 +18,18 @@ class VerticalAccordion extends React.Component {
     }
     if (this.props.children) {
       newChildren = this.props.children;
-      newKeys = Object.keys(newChildren.props)
+      newKeys = Object.keys(newChildren.props);
     }
     if (oldChildren && newChildren) {
       newKeys.forEach( key => {
         if (typeof(newChildren.props[key]) !== "object" &&
             typeof(newChildren.props[key]) !== "function") {
-              if (oldChildren.props[key] !== newChildren.props[key]) {
-                needUpdate = true;
-                return;
-              }
+          if (oldChildren.props[key] !== newChildren.props[key]) {
+            needUpdate = true;
+            return;
+          }
         }
-      })
+      });
     }
 
     if (prevProps.show !== this.props.show || needUpdate) {

--- a/app/components/shared/VerticalAccordion.js
+++ b/app/components/shared/VerticalAccordion.js
@@ -1,17 +1,6 @@
 import TransitionMotionWrapper from "./TransitionMotionWrapper";
 import { spring } from "react-motion";
 
-/**
- * A vertical accordion. Can be used in two modes:
- *
- * 1. Standalone: Provide header, height, and children props to render. It will
- *    be expanded/contracted when the header is clicked.
- *
- * 2. Group: Provide the previous props + groupKey, activeGroupKey and
- *    onToggleAccordion. Then the accordion will be expanded only when
- *    activeGroupKey === groupKey. onToggleAccordion will be triggered once the
- *    accordion header is clicked.
- */
 @autobind
 class VerticalAccordion extends React.Component {
   constructor(props) {
@@ -22,12 +11,9 @@ class VerticalAccordion extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if ((this.props.groupKey !== undefined) && this.props.onToggleAccordion) {
-      const show = nextProps.groupKey === nextProps.activeGroupKey;
-      this.setState({ shownStyles: this.chosenStyles(nextProps, show), show });
-    } else {
-      this.setState({ shownStyles: this.chosenStyles(nextProps, this.state.show) });
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.show !== this.state.show) {
+      this.chosenStyles(this.props, this.state.show)
     }
   }
 
@@ -77,14 +63,11 @@ class VerticalAccordion extends React.Component {
   }
 
   onToggleAccordion() {
-    if ((this.props.groupKey !== undefined) && this.props.onToggleAccordion) {
-      this.props.onToggleAccordion(this.props.groupKey, this.state.show);
-    } else {
-      this.setState({
-        show: !this.state.show,
-        shownStyles: this.chosenStyles(this.props, !this.state.show),
-      });
-    }
+    this.setState({
+      show: !this.state.show,
+      shownStyles: this.chosenStyles(this.props, !this.state.show),
+    });
+    this.props.onToggleAccordion && this.props.onToggleAccordion();
   }
 
   render() {

--- a/app/components/shared/VerticalAccordion.js
+++ b/app/components/shared/VerticalAccordion.js
@@ -11,7 +11,28 @@ class VerticalAccordion extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.show !== this.props.show) {
+    let oldChildren, newChildren, newKeys;
+    let needUpdate = false;
+    if(prevProps.children) {
+      oldChildren = prevProps.children;
+    }
+    if (this.props.children) {
+      newChildren = this.props.children;
+      newKeys = Object.keys(newChildren.props)
+    }
+    if (oldChildren && newChildren) {
+      newKeys.forEach( key => {
+        if (typeof(newChildren.props[key]) !== "object" &&
+            typeof(newChildren.props[key]) !== "function") {
+              if (oldChildren.props[key] !== newChildren.props[key]) {
+                needUpdate = true;
+                return;
+              }
+        }
+      })
+    }
+
+    if (prevProps.show !== this.props.show || needUpdate) {
       this.setState({
         shownStyles: this.chosenStyles(this.props, this.props.show),
       });

--- a/app/components/views/AccountsPage/Accounts/AccountRow/Row.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/Row.js
@@ -28,18 +28,17 @@ const Header = ({
 const Row = ({
   account,
   hidden,
-  accountNumDetailsShown,
   isShowingRenameAccount,
   onToggleShowDetails,
   getAccountDetailsStyles,
   getRenameAccountStyles,
+  isShowingDetails,
 }) => (
   <VerticalAccordion
     header={<Header {...{ account, hidden }} />}
     height={isShowingRenameAccount ? 175 : 275}
-    groupKey={account.accountNumber}
-    activeGroupKey={accountNumDetailsShown}
     onToggleAccordion={onToggleShowDetails}
+    show={isShowingDetails}
     className={"account-row-details-bottom"}
   >
     {isShowingRenameAccount

--- a/app/components/views/AccountsPage/Accounts/AccountRow/index.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/index.js
@@ -27,6 +27,9 @@ class AccountRow extends React.Component {
     if (account.accountNumber !== this.props.accountNumDetailsShown) {
       this.setState({ isShowingDetails: false });
     }
+    if (accountNumDetailsShown === account.accountNumber) {
+      this.setState({ showPubKey: false })
+    }
   }
 
   updateRenameAccountName(accountName) {

--- a/app/components/views/AccountsPage/Accounts/AccountRow/index.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/index.js
@@ -26,9 +26,9 @@ class AccountRow extends React.Component {
     this.setState(this.getInitialState());
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { account, accountNumDetailsShown } = this.props;
-    if (accountNumDetailsShown !== nextProps.accountNumDetailsShown && accountNumDetailsShown == account.accountNumber) {
+  componentDidUpdate(prevProps) {
+    const { account, accountNumDetailsShown } = prevProps;
+    if (accountNumDetailsShown !== this.props.accountNumDetailsShown && accountNumDetailsShown == account.accountNumber) {
       this.setState({ showPubKey: false });
     }
   }

--- a/app/components/views/AccountsPage/Accounts/AccountRow/index.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/index.js
@@ -28,7 +28,7 @@ class AccountRow extends React.Component {
       this.setState({ isShowingDetails: false });
     }
     if (accountNumDetailsShown === account.accountNumber) {
-      this.setState({ showPubKey: false })
+      this.setState({ showPubKey: false });
     }
   }
 
@@ -73,7 +73,7 @@ class AccountRow extends React.Component {
   }
 
   onToggleShowDetails() {
-    this.setState({ isShowingDetails: !this.state.isShowingDetails })
+    this.setState({ isShowingDetails: !this.state.isShowingDetails });
     this.state.isShowingDetails ? this.props.hideAccountDetails()
       : this.props.showAccountDetails(this.props.account.accountNumber);
   }

--- a/app/components/views/AccountsPage/Accounts/AccountRow/index.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/index.js
@@ -8,28 +8,24 @@ class AccountRow extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = this.getInitialState();
-  }
-
-  getInitialState() {
-    return {
+    this.state = {
       isShowingRenameAccount: false,
       renameAccountName: null,
       renameAccountNumber: this.props.account.accountNumber,
       hidden: this.props.account.hidden,
       hasFailedAttempt: false,
       showPubKey: false,
+      isShowingDetails: false,
     };
-  }
-
-  componentWillUnmount() {
-    this.setState(this.getInitialState());
   }
 
   componentDidUpdate(prevProps) {
     const { account, accountNumDetailsShown } = prevProps;
-    if (accountNumDetailsShown !== this.props.accountNumDetailsShown && accountNumDetailsShown == account.accountNumber) {
-      this.setState({ showPubKey: false });
+    if (accountNumDetailsShown === this.props.accountNumDetailsShown) {
+      return;
+    }
+    if (account.accountNumber !== this.props.accountNumDetailsShown) {
+      this.setState({ isShowingDetails: false });
     }
   }
 
@@ -73,10 +69,10 @@ class AccountRow extends React.Component {
     this.setState({ showPubKey: true });
   }
 
-  onToggleShowDetails(accountNum, isVisible) {
-    isVisible && accountNum === this.props.accountNumDetailsShown
-      ? this.props.hideAccountDetails()
-      : this.props.showAccountDetails(accountNum);
+  onToggleShowDetails() {
+    this.setState({ isShowingDetails: !this.state.isShowingDetails })
+    this.state.isShowingDetails ? this.props.hideAccountDetails()
+      : this.props.showAccountDetails(this.props.account.accountNumber);
   }
 
   getRenameAccountStyles () {
@@ -139,7 +135,8 @@ class AccountRow extends React.Component {
     } = this.props;
     const {
       isShowingRenameAccount,
-      hidden
+      hidden,
+      isShowingDetails,
     } = this.state;
 
     return (
@@ -152,6 +149,7 @@ class AccountRow extends React.Component {
           getRenameAccountStyles,
           getAccountDetailsStyles,
           onToggleShowDetails,
+          isShowingDetails,
         }}
       />
     );

--- a/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
+++ b/app/components/views/GetStartedPage/CreateWallet/CreateWalletForm/index.js
@@ -27,9 +27,9 @@ class CreateWalletForm extends React.Component {
     this.generateSeed();
   }
 
-  componentWillUpdate(nextProps) {
-    if (this.props.decodeSeedError !== nextProps.decodeSeedError) {
-      this.setState({ seedError: nextProps.decodeSeedError });
+  componentDidUpdate(prevProps) {
+    if (prevProps.decodeSeedError !== this.props.decodeSeedError) {
+      this.setState({ seedError: this.props.decodeSeedError });
     }
   }
 

--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -28,7 +28,7 @@ const WalletSelectionBodyBase = ({
   ...props,
 }) => {
   return (
-    availableWallets && !createWalletForm ?
+    availableWallets.length > 0 && !createWalletForm ?
       <div className="advanced-page">
         <div className="advanced-page-form">
           <div className="advanced-daemon-row">

--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -28,7 +28,7 @@ const WalletSelectionBodyBase = ({
   ...props,
 }) => {
   return (
-    availableWallets.length > 0 && !createWalletForm ?
+    availableWallets.length > 0 && selectedWallet && !createWalletForm ?
       <div className="advanced-page">
         <div className="advanced-page-form">
           <div className="advanced-daemon-row">

--- a/app/components/views/GetStartedPage/WalletSelection/index.js
+++ b/app/components/views/GetStartedPage/WalletSelection/index.js
@@ -22,13 +22,13 @@ class WalletSelectionBody extends React.Component {
       walletNameError: null,
     };
   }
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.availableWallets && this.props.availableWallets.length !== nextProps.availableWallets.length) {
-      this.setState({ selectedWallet: nextProps.availableWallets[0] });
+  componentDidUpdate(prevProps) {
+    if (this.props.availableWallets.length > 0 && prevProps.availableWallets.length !== this.props.availableWallets.length) {
+      this.setState({ selectedWallet: this.props.availableWallets[0] });
     } else {
-      for (var i = 0; i < this.props.availableWallets.length; i++) {
-        if (nextProps.availableWallets[i].label !== this.props.availableWallets[i].label) {
-          this.setState({ selectedWallet: nextProps.availableWallets[0] });
+      for (var i = 0; i < prevProps.availableWallets.length; i++) {
+        if (this.props.availableWallets[i].label !== prevProps.availableWallets[i].label) {
+          this.setState({ selectedWallet: this.props.availableWallets[0] });
         }
       }
     }

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -35,16 +35,16 @@ class GetStartedPage extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { startStepIndex, getDaemonSynced, onRetryStartRPC, isSPV, startSPVSync } = this.props;
+  componentDidUpdate(prevProps) {
+    const { startStepIndex, getDaemonSynced, onRetryStartRPC, isSPV, startSPVSync } = prevProps;
     if (!isSPV) {
-      if (startStepIndex != nextProps.startStepIndex || getDaemonSynced != nextProps.getDaemonSynced ){
-        if (nextProps.startStepIndex == 3 && nextProps.getDaemonSynced)
+      if (startStepIndex != this.props.startStepIndex || getDaemonSynced != this.props.getDaemonSynced ){
+        if (this.props.startStepIndex == 3 && this.props.getDaemonSynced)
           onRetryStartRPC(false, this.state.walletPrivatePassphrase);
       }
     } else {
-      if (startStepIndex != nextProps.startStepIndex ){
-        if (nextProps.startStepIndex == 3)
+      if (startStepIndex != this.props.startStepIndex ){
+        if (this.props.startStepIndex == 3)
           startSPVSync(this.state.walletPrivatePassphrase);
       }
     }

--- a/app/components/views/GetStartedPosition.js
+++ b/app/components/views/GetStartedPosition.js
@@ -6,7 +6,7 @@ class GetStartedPosition extends React.Component{
     super(props);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     if (this.props.setLanguage) {
       this.props.onShowLanguage();
     } else if (this.props.showPrivacy) {

--- a/app/components/views/GovernancePage/Blockchain/AgendaOverview/index.js
+++ b/app/components/views/GovernancePage/Blockchain/AgendaOverview/index.js
@@ -10,8 +10,8 @@ class AgendaOverview extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.selectedChoice != nextProps.selectedChoice) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.selectedChoice != this.props.selectedChoice) {
       this.setState({ selectedChoiceId: nextProps.selectedChoice });
     }
   }

--- a/app/components/views/GovernancePage/Blockchain/AgendaOverview/index.js
+++ b/app/components/views/GovernancePage/Blockchain/AgendaOverview/index.js
@@ -12,7 +12,7 @@ class AgendaOverview extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.selectedChoice != this.props.selectedChoice) {
-      this.setState({ selectedChoiceId: nextProps.selectedChoice });
+      this.setState({ selectedChoiceId: this.props.selectedChoice });
     }
   }
 

--- a/app/components/views/GovernancePage/Proposals/index.js
+++ b/app/components/views/GovernancePage/Proposals/index.js
@@ -17,8 +17,8 @@ class Proposals extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.politeiaEnabled && !this.props.politeiaEnabled) {
+  componentDidUpdate(prevProps) {
+    if (this.props.politeiaEnabled && !prevProps.politeiaEnabled) {
       this.props.getVettedProposals();
     }
   }

--- a/app/components/views/SecurityPage/SignMessage/index.js
+++ b/app/components/views/SecurityPage/SignMessage/index.js
@@ -21,7 +21,7 @@ class SignMessage extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     if (!this.props.walletService) {
       this.context.router.push("/error");
     }

--- a/app/components/views/SecurityPage/ValidateAddress/index.js
+++ b/app/components/views/SecurityPage/ValidateAddress/index.js
@@ -17,7 +17,7 @@ class ValidateAddress extends React.Component {
     });
   }
 
-  componentWillMount () {
+  componentDidMount () {
     this.props.validateAddressCleanStore();
   }
 

--- a/app/components/views/SecurityPage/VerifyMessage/index.js
+++ b/app/components/views/SecurityPage/VerifyMessage/index.js
@@ -22,7 +22,7 @@ class VerifyMessage extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.props.getMessageVerificationServiceAttempt();
   }
 

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
@@ -21,11 +21,12 @@ class StakePools extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!this.state.selectedUnconfigured) {
-      this.setState({ selectedUnconfigured: nextProps.unconfiguredStakePools[0] });
+  // not tested
+  componentDidMount() {
+    if(!this.state.selectedUnconfigured) {
+      this.setState({ selectedUnconfigured: this.props.unconfiguredStakePools[0] });
     }
-    if (!this.getStakepoolListingEnabled() && nextProps.stakePoolListingEnabled) {
+    if (!this.getStakepoolListingEnabled() && this.props.stakePoolListingEnabled) {
       this.props.discoverAvailableStakepools();
     }
   }

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
@@ -21,7 +21,6 @@ class StakePools extends React.Component {
     }
   }
 
-  // not tested
   componentDidMount() {
     if(!this.state.selectedUnconfigured) {
       this.setState({ selectedUnconfigured: this.props.unconfiguredStakePools[0] });

--- a/app/components/views/TicketsPage/PurchaseTab/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/index.js
@@ -21,9 +21,9 @@ class Purchase extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!this.props.stakePool && nextProps.stakePool) {
-      this.setState({ stakePool: nextProps.stakePool });
+  componentDidMount() {
+    if (!this.props.stakePool && this.props.stakePool) {
+      this.setState({ stakePool: this.props.stakePool });
     }
   }
 

--- a/app/components/views/TicketsPage/StatisticsTab/index.js
+++ b/app/components/views/TicketsPage/StatisticsTab/index.js
@@ -12,8 +12,15 @@ class Statistics extends React.Component{
     this.state = { hasStats: props.voteTimeStats && !props.getMyTicketsStatsRequest };
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({ hasStats: nextProps.voteTimeStats && !nextProps.getMyTicketsStatsRequest });
+  componentDidUpdate(prevProps) {
+    const hasStats = this.props.voteTimeStats && !this.props.getMyTicketsStatsRequest;
+    if ((prevProps.voteTimeStats && !this.props.getMyTicketsStatsRequest) !== hasStats) {
+      this.setState({ hasStats });
+    }
+  }
+
+  componentDidMount() {
+    this.setState({ hasStats: this.props.voteTimeStats && !this.props.getMyTicketsStatsRequest });
   }
 
   render() {

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -39,15 +39,15 @@ class Send extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { nextAddress, constructTxLowBalance } = this.props;
-    const { isSendSelf, outputs } = this.state;
-    if (isSendSelf && (nextAddress != nextProps.nextAddress)) {
-      let newOutputs = outputs.map(o => ({ ...o, data:{ ...o.data, destination: nextProps.nextAddress } }));
+  componentDidUpdate(prevProps, prevState) {
+    const { nextAddress, constructTxLowBalance } = prevProps;
+    const { isSendSelf, outputs } = prevState;
+    if (isSendSelf && (nextAddress != this.props.nextAddress)) {
+      let newOutputs = outputs.map(o => ({ ...o, data:{ ...o.data, destination: this.props.nextAddress } }));
       this.setState({ outputs: newOutputs }, this.onAttemptConstructTransaction);
     }
-    if ( constructTxLowBalance !== nextProps.constructTxLowBalance ) {
-      this.setState({ lowBalanceError: nextProps.constructTxLowBalance });
+    if ( constructTxLowBalance !== this.props.constructTxLowBalance ) {
+      this.setState({ lowBalanceError: this.props.constructTxLowBalance });
     }
   }
 


### PR DESCRIPTION
This PR updates the code that are being deprecated in react 17. 

The methods `componentWillMount`, `componentWillReceiveProps`, and `componentWillUpdate` are going to be deprecated at react 17: 
https://reactjs.org/docs/react-component.html 

Where was needed to do more code refactor then simple changing the props, I committed separated, to make code review easier. 

Also this PR still a work in progress because I could not test `app/components/views/TicketsPage/PurchaseTab/StakePools/index.js` because I am not being able to reimport an API key into my wallet. 

Additionally our snackbar uses componentWillReceiveProps, and I think it would be better to use memoization, one of the methods that is suggested to replace the  componentWillReceiveProps method. Here more about it:
https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization

I think it would be better to discuss that before start coding those changes into the snackbar.