### PR TITLE
Fix the Timezone on exported transaction records when set to UTC

### DIFF
--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -122,13 +122,14 @@ export const exportStatToCSV = (opts) => (dispatch, getState) => {
 
   // constants (may be overridden/parametrized in the future)
   const unitDivisor = sel.unitDivisor(getState());
+  const timezone = sel.timezone(getState());
   const vsep = ","; // value separator
   const ln = "\n";  // line separator
   const precision = Math.ceil(Math.log10(unitDivisor)); // maximum decimal precision
 
   // formatting functions
   const quote = (v) => "\"" + v.replace("\"", "\\\"") + "\"";
-  const formatTime = v => v ? formatLocalISODate(v) : "";
+  const formatTime = v => v ? formatLocalISODate(v, timezone) : "";
   const csvValue = (v) => isNullOrUndefined(v) ? "" : isNumber(v) ? v.toFixed(precision) : quote(v);
   const csvLine = (values) => values.map(csvValue).join(vsep);
 

--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -39,7 +39,7 @@ export function endOfDay(dt) {
 
 // formatLocalISODate formats the given Date object d in an ISO8601 format, using
 // the local timezone (instead of UTC as d.ToISOString())
-export function formatLocalISODate(d) {
+export function formatLocalISODate(d, timezone) {
   const pad = (s, n) => {
     n = n || 2;
     s = Array(n).join("0") + s;
@@ -54,12 +54,13 @@ export function formatLocalISODate(d) {
   }
   let tzOffsetHours = Math.trunc(tzOffset / 60);
   let tzOffsetMinutes = Math.trunc(tzOffset % 60);
+  let tz = timezone === "utc" ? "Z" : tzOffsetSign + pad(tzOffsetHours, 2) + pad(tzOffsetMinutes, 2);
 
-  return format("%s-%s-%sT%s:%s:%s.%s%s%s%s",
+  return format("%s-%s-%sT%s:%s:%s.%s%s",
     d.getFullYear(), pad(d.getMonth()+1, 2), pad(d.getDate(), 2),
     pad(d.getHours(), 2), pad(d.getMinutes(), 2),
     pad(d.getSeconds(), 2), pad(d.getMilliseconds(), 3),
-    tzOffsetSign, pad(tzOffsetHours, 2), pad(tzOffsetMinutes, 2));
+    tz);
 }
 
 // calculate the difference between two timestamps and return an int


### PR DESCRIPTION
Part of #1775 
If you set your timezone in settings to "UTC", and export transactions, the time is still exported with your local timezone offset.  In my case this made the time value the correct instant in UTC, however there was -0500 appended to the time, which then makes the whole time value incorrect.

By the way, I believe if your local machine timezone is GMT and your offset is 0000, the time would have been formatted to 12:20:21.000-0000, which is not ISO 8601 format, so this fixes that issue also.

This is my first contrib, so I'm very open to tweaks.  I considered using a constant for "utc" but it wasn't obvious.  Also, I found another use of the hardcoded string, and given utc is self-explanatory, I left it.  Current example in selectors.js 
`export const tsDate = compose(timezone => timezone === "utc" ? dateToUTC : dateToLocal, timezone);`
