### PR TITLE
Improve motion effect

### DIFF
--- a/app/components/layout/TabbedPage.js
+++ b/app/components/layout/TabbedPage.js
@@ -28,14 +28,21 @@ class TabbedPage extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    if (this.props.location === prevProps.location) {
+      return;
+    }
+
     if (this.props.children !== prevProps.children) {
       this._tabs = getTabs(this.props.children);
     }
     if (this.props.location !== prevProps.location) {
       const matchedTab = this.matchedTab(this.props.location);
-      const dir =
-        prevState.matchedTab && matchedTab && prevState.matchedTab.index > matchedTab.index
-          ? "r2l" : "l2r";
+      const haveBoth = prevState.matchedTab && matchedTab;
+      if (haveBoth && prevState.matchedTab.index === matchedTab.index) {
+        return;
+      }
+      const dir = haveBoth && prevState.matchedTab.index > matchedTab.index 
+        ? "r2l" : "l2r";
       const styles = this.getStyles(matchedTab);
       this.setState({ matchedTab, dir, styles });
     }
@@ -68,20 +75,6 @@ class TabbedPage extends React.Component {
     return { left: pos };
   }
 
-  scrollbarOverlayGetStyles(showScroll) {
-    if (!showScroll) return [];
-
-    return [ {
-      key: "scrollbar",
-      data: {},
-      style: { opacity: spring(1, theme("springs.tab")) }
-    } ];
-  }
-
-  scrollbarOverlayWillLeave() {
-    return { opacity: spring(0, theme("springs.tab")) };
-  }
-
   // returns the state.styles in a static container, without animations.
   staticStyles() {
     return (
@@ -108,26 +101,15 @@ class TabbedPage extends React.Component {
             {interpolatedStyles.map(s => {
               return (
                 <div
-                  className={[ "tab-content", Math.abs(s.style.left) < 0.1 ? "visible" : "" ].join(" ")}
-                  style={{ left: s.style.left, right: -s.style.left }}
+                  className={"tab-content"}
+                  style={{ left: s.style.left, right: -s.style.left,
+                    visibility: Math.abs(s.style.left) > 990 ? "hidden" : "" }}
                   key={s.key}
                 >
                   {s.data.element}
                 </div>
               );
             })}
-            <TransitionMotion
-              styles={this.scrollbarOverlayGetStyles(interpolatedStyles.length !== 1)}
-              willLeave={this.scrollbarOverlayWillLeave}
-            >
-              {sbStyle => {
-                return <Aux>
-                  {sbStyle.map(s =>
-                    <div className="scrollbar-overlay" key={s.key} style={{ opacity: s.style.opacity }} />
-                  )}
-                </Aux>;
-              }}
-            </TransitionMotion>
           </Aux>);
         }}
       </TransitionMotion>

--- a/app/components/layout/TabbedPage.js
+++ b/app/components/layout/TabbedPage.js
@@ -19,7 +19,6 @@ function getTabs(children) {
 
 @autobind
 class TabbedPage extends React.Component {
-
   constructor(props) {
     super(props);
     this._tabs = getTabs(props.children);
@@ -28,15 +27,14 @@ class TabbedPage extends React.Component {
     this.state = { matchedTab, dir: "l2r", styles };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.children !== this.props.children) {
-      this._tabs = getTabs(nextProps.children);
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.children !== prevProps.children) {
+      this._tabs = getTabs(this.props.children);
     }
-
-    if (nextProps.location !== this.props.location) {
-      const matchedTab = this.matchedTab(nextProps.location);
+    if (this.props.location !== prevProps.location) {
+      const matchedTab = this.matchedTab(this.props.location);
       const dir =
-        this.state.matchedTab && matchedTab && this.state.matchedTab.index > matchedTab.index
+        prevState.matchedTab && matchedTab && prevState.matchedTab.index > matchedTab.index
           ? "r2l" : "l2r";
       const styles = this.getStyles(matchedTab);
       this.setState({ matchedTab, dir, styles });

--- a/app/components/layout/TabbedPage.js
+++ b/app/components/layout/TabbedPage.js
@@ -65,12 +65,12 @@ class TabbedPage extends React.Component {
 
   willLeave() {
     const pos = this.state.dir === "l2r" ? -1000 : +1000;
-    return { left: spring(pos, {stiffness: 180, damping: 20}), opacity: spring(0)  };
+    return { left: spring(pos, { stiffness: 180, damping: 20 }), opacity: spring(0)  };
   }
 
   willEnter() {
     const pos = this.state.dir === "l2r" ? +1000 : -1000;
-    return { left: pos,opacity: spring(0), opacity: 1 };
+    return { left: pos, opacity: 1 };
   }
 
   // returns the state.styles in a static container, without animations.

--- a/app/components/layout/TabbedPage.js
+++ b/app/components/layout/TabbedPage.js
@@ -32,18 +32,16 @@ class TabbedPage extends React.Component {
       return;
     }
 
-    if (this.props.location !== prevProps.location) {
-      const matchedTab = this.matchedTab(this.props.location);
-      const haveBoth = prevState.matchedTab && matchedTab;
-
-      if (haveBoth && prevState.matchedTab.index === matchedTab.index) {
-        return;
-      }
-      const dir = haveBoth && prevState.matchedTab.index > matchedTab.index
-        ? "r2l" : "l2r";
-      const styles = this.getStyles(matchedTab);
-      this.setState({ matchedTab, dir, styles });
+    const matchedTab = this.matchedTab(this.props.location);
+    const haveBoth = prevState.matchedTab && matchedTab;
+    if (haveBoth && prevState.matchedTab.index === matchedTab.index) {
+      return;
     }
+
+    const dir = haveBoth && prevState.matchedTab.index > matchedTab.index
+      ? "r2l" : "l2r";
+    const styles = this.getStyles(matchedTab);
+    this.setState({ matchedTab, dir, styles });
   }
 
   matchedTab(location) {

--- a/app/components/layout/TabbedPage.js
+++ b/app/components/layout/TabbedPage.js
@@ -32,16 +32,14 @@ class TabbedPage extends React.Component {
       return;
     }
 
-    if (this.props.children !== prevProps.children) {
-      this._tabs = getTabs(this.props.children);
-    }
     if (this.props.location !== prevProps.location) {
       const matchedTab = this.matchedTab(this.props.location);
       const haveBoth = prevState.matchedTab && matchedTab;
+
       if (haveBoth && prevState.matchedTab.index === matchedTab.index) {
         return;
       }
-      const dir = haveBoth && prevState.matchedTab.index > matchedTab.index 
+      const dir = haveBoth && prevState.matchedTab.index > matchedTab.index
         ? "r2l" : "l2r";
       const styles = this.getStyles(matchedTab);
       this.setState({ matchedTab, dir, styles });
@@ -61,18 +59,18 @@ class TabbedPage extends React.Component {
     return [ {
       key: matchedTab.tab.props.path,
       data: { matchedTab, element },
-      style: { left: spring(0, theme("springs.tab")) }
+      style: { left: spring(0, theme("springs.tab")), opacity: 1 }
     } ];
   }
 
   willLeave() {
     const pos = this.state.dir === "l2r" ? -1000 : +1000;
-    return { left: spring(pos, spring(theme("springs.tab"))) };
+    return { left: spring(pos, {stiffness: 180, damping: 20}), opacity: spring(0)  };
   }
 
   willEnter() {
     const pos = this.state.dir === "l2r" ? +1000 : -1000;
-    return { left: pos };
+    return { left: pos,opacity: spring(0), opacity: 1 };
   }
 
   // returns the state.styles in a static container, without animations.
@@ -103,6 +101,7 @@ class TabbedPage extends React.Component {
                 <div
                   className={"tab-content"}
                   style={{ left: s.style.left, right: -s.style.left,
+                    opacity: s.style.opacity,
                     visibility: Math.abs(s.style.left) > 990 ? "hidden" : "" }}
                   key={s.key}
                 >


### PR DESCRIPTION
This PR improves motion effects on tabbed pages, which I discussed with @alexlyp at slack. 

It fixes the bug when having only 2 tabs;
It removes some unused code; 
It adds opacity into the transitions and makes the effect more stiff
