### PR TITLE
[launcher] Only check network info once

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -52,6 +52,7 @@ var initialState = {
     addCustomStakePoolAttempt: false,
   },
   daemon: {
+    networkMatch: false,
     appVersion: pkg.version,
     daemonRemote: false,
     locale: locale,

--- a/app/reducers/daemon.js
+++ b/app/reducers/daemon.js
@@ -19,6 +19,7 @@ import {
   FATAL_DAEMON_ERROR,
   FATAL_WALLET_ERROR,
   CLOSEDAEMON_ATTEMPT, CLOSEDAEMON_FAILED, CLOSEDAEMON_SUCCESS, NOT_SAME_CONNECTION,
+  NETWORK_MATCH
 } from "../actions/DaemonActions";
 import {
   CREATEWALLET_GOBACK,
@@ -30,6 +31,10 @@ import {
 
 export default function version(state = {}, action) {
   switch (action.type) {
+  case NETWORK_MATCH:
+    return { ... state,
+      networkMatch: true,
+    };
   case DECREDITON_VERSION:
     return { ...state,
       updateAvailable: action.msg,


### PR DESCRIPTION
The check to make sure that the network chosen and the daemon match should only need to occur once.  Rather than every time we check the synced block height.