### PR TITLE
Remove travis packaging for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 
 os:
   - linux
+  - osx
 
 language: node_js
 node_js:
@@ -21,4 +22,3 @@ script:
   - yarn test || travis_terminate 1
   - yarn build || travis_terminate 1
   - yarn i18n-check-dupes || travis_terminate 1
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis_wait yarn package-dev-linux; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 
 os:
   - linux
-  - osx
 
 language: node_js
 node_js:
@@ -23,4 +22,3 @@ script:
   - yarn build || travis_terminate 1
   - yarn i18n-check-dupes || travis_terminate 1
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis_wait yarn package-dev-linux; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_wait yarn package-mac; fi

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     ]
   },
   "build": {
+    "publish": "null",
     "appId": "com.Electron.Decrediton",
     "dmg": {
-      "publish": "null",
       "contents": [
         {
           "x": 130,

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     ]
   },
   "build": {
-    "publish": ["never"],
     "appId": "com.Electron.Decrediton",
     "dmg": {
+      "publish": "null",
       "contents": [
         {
           "x": 130,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     ]
   },
   "build": {
-    "publish": "null",
     "appId": "com.Electron.Decrediton",
     "dmg": {
       "contents": [

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     ]
   },
   "build": {
+    "publish": ["never"],
     "appId": "com.Electron.Decrediton",
     "dmg": {
-      "publish": "never",
       "contents": [
         {
           "x": 130,

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "build": {
     "appId": "com.Electron.Decrediton",
     "dmg": {
+      "publish": "never",
       "contents": [
         {
           "x": 130,


### PR DESCRIPTION
Currently we are having travis package for linux and osx, but realistically there isn't much worth to do this since the packages themselves won't be usable since they don't include dcr* binaries.  I'll be opening a new issue that will cover the changes that we need for travis to properly include packaging.