### PR TITLE
[stakepools] Refactor actions and apikey entry ux

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -4,7 +4,7 @@ import * as sel from "selectors";
 import eq from "lodash/fp/eq";
 import { getNextAddressAttempt, publishUnminedTransactionsAttempt } from "./ControlActions";
 import { transactionNtfnsStart, accountNtfnsStart } from "./NotificationActions";
-import { updateStakepoolPurchaseInformation, setStakePoolVoteChoices, getStakepoolStats } from "./StakePoolActions";
+import { refreshStakepoolPurchaseInformation, setStakePoolVoteChoices, getStakepoolStats } from "./StakePoolActions";
 import { getDecodeMessageServiceAttempt, decodeRawTransactions } from "./DecodeMessageActions";
 import { push as pushHistory, goBack } from "react-router-redux";
 import { getWalletCfg, getGlobalCfg } from "../config";
@@ -51,7 +51,7 @@ const startWalletServicesTrigger = () => (dispatch, getState) => new Promise((re
       await dispatch(getTicketPriceAttempt());
       await dispatch(getPingAttempt());
       await dispatch(getNetworkAttempt());
-      await dispatch(updateStakepoolPurchaseInformation());
+      await dispatch(refreshStakepoolPurchaseInformation());
       await dispatch(getDecodeMessageServiceAttempt());
       await dispatch(getVotingServiceAttempt());
       await dispatch(getAgendaServiceAttempt());

--- a/app/actions/StakePoolActions.js
+++ b/app/actions/StakePoolActions.js
@@ -1,10 +1,7 @@
 // @flow
 import Promise from "promise";
-import {
-  getPurchaseInfo, setStakePoolAddress, setVoteChoices, getNextAddress, getStakePoolInfo, getAllStakePoolStats,
-} from "wallet";
 import { getWalletCfg, updateStakePoolConfig } from "../config";
-import { importScriptAttempt } from "./ControlActions";
+import { importScriptAttempt, rescanAttempt } from "./ControlActions";
 import * as sel from "../selectors";
 import * as wallet from "wallet";
 
@@ -14,7 +11,7 @@ export const GETSTAKEPOOLSTATS_SUCCESS = "GETSTAKEPOOLSTATS_SUCCESS";
 
 export const getStakepoolStats = () => (dispatch) => {
   dispatch({ type: GETSTAKEPOOLSTATS_ATTEMPT });
-  getAllStakePoolStats()
+  wallet.getAllStakePoolStats()
     .then((allStakePoolStats) =>
       dispatch({ type: GETSTAKEPOOLSTATS_SUCCESS, allStakePoolStats })
       // TODO: add error notification after global snackbar is merged
@@ -43,83 +40,101 @@ const updateSavedConfig = (newPoolInfo, poolHost, apiKey, accountNum) =>
     const { daemon: { walletName } } = getState();
     const walletCfg = getWalletCfg(sel.isTestNet(getState()), walletName);
     walletCfg.set("stakepools", stakePoolConfigs);
-    let selectedStakePool = stakePoolConfigs.filter(p => p.Host === poolHost)[0] || null;
-    dispatch({
-      selectedStakePool,
-      currentStakePoolConfig: stakePoolConfigs,
-      type: UPDATESTAKEPOOLCONFIG_SUCCESS
-    });
+    return stakePoolConfigs;
   };
 
-const setStakePoolAddressAction = (privpass, poolHost, apiKey, accountNum) =>
-  (dispatch, getState) => {
+// setStakePoolAddressAction links the local wallet to a remote stakepool by
+// deriving a new address from a given account, then requesting that the
+// stakepool create the multisig script.
+const setStakePoolAddressAction = (poolHost, apiKey, accountNum) =>
+  async (dispatch, getState) => {
     const walletService = sel.walletService(getState());
-    getNextAddress(walletService, accountNum)
-      .then(({ publicKey }) => {
-        wallet.allowStakePoolHost(poolHost);
-        setStakePoolAddress({ apiUrl: poolHost, apiToken: apiKey, pKAddress: publicKey })
-          .then(response => {
-            if (response.data.status == "success") {
-              dispatch(setStakePoolInformation(privpass, poolHost, apiKey, accountNum, true));
-            } else if (response.data.status == "error") {
-              dispatch({ error: response.data.message, type: UPDATESTAKEPOOLCONFIG_FAILED });
-            } else {
-              dispatch({ error:"shouldn't be here set address:", type: UPDATESTAKEPOOLCONFIG_FAILED });
-            }
-          })
-          .catch(error => dispatch({ error, type: UPDATESTAKEPOOLCONFIG_FAILED }));
-      })
-      .catch(error => dispatch({
-        error: `${error}. Error setting stakepool address, please try again later.`,
-        type: UPDATESTAKEPOOLCONFIG_FAILED
-      }));
+    const { publicKey } = await wallet.getNextAddress(walletService, accountNum);
+    wallet.allowStakePoolHost(poolHost);
+    const response = await wallet.setStakePoolAddress({ apiUrl: poolHost, apiToken: apiKey, pKAddress: publicKey });
+    if (response.data.status == "success") {
+      return response.data;
+    } else {
+      throw new Error(response.data.message);
+    }
   };
 
-export const updateStakepoolPurchaseInformation = () => (dispatch, getState) =>
+export const REFRESHSTAKEPOOLPURCHASEINFORMATION_FAILED = "REFRESHSTAKEPOOLPURCHASEINFORMATION_FAILED";
+
+// refreshStakepoolPurchaseInformation is used during wallet startup to grab
+// fresh information (eg: latest pool fee) from all configured stakepools.
+export const refreshStakepoolPurchaseInformation = () => (dispatch, getState) =>
   Promise.all(sel.configuredStakePools(getState()).map(
     ({ Host, ApiKey }) => {
       wallet.allowStakePoolHost(Host);
-      getPurchaseInfo({ apiUrl: Host, apiToken: ApiKey })
+      wallet.getPurchaseInfo({ apiUrl: Host, apiToken: ApiKey })
         .then( response =>
           response.data.status === "success"
             ? dispatch(updateSavedConfig(response.data.data, Host))
             : null)
         .catch(error => dispatch({
-          error: `Unable to contact stakepool: ${error} please try again later`,
-          type: UPDATESTAKEPOOLCONFIG_FAILED
+          error, host: Host, type: REFRESHSTAKEPOOLPURCHASEINFORMATION_FAILED
         }));
     }
   ));
 
-export const setStakePoolInformation = (privpass, poolHost, apiKey, accountNum, internal, creatingWallet) =>
-  (dispatch) => {
+// setStakePoolInformation links a new stakepool to the wallet. This
+// will contact the given stakepool, link it with an address from the wallet in
+// the given account (if it hasn't already), import the multisig script and
+// rescan the wallet for old transactions.
+//
+// This is meant to be used when setting up a new stakepool.
+export const setStakePoolInformation = (privpass, poolHost, apiKey, rescan) =>
+  async (dispatch) => {
+    let extraErrorData;
+
+    // we currently only support linking to new stakepools from the default
+    // account for address discovery reasons.
+    const accountNum = 0;
+
     wallet.allowStakePoolHost(poolHost);
-    if (!internal) dispatch({ type: UPDATESTAKEPOOLCONFIG_ATTEMPT });
-    getPurchaseInfo({ apiUrl:poolHost, apiToken: apiKey })
-      .then( response => {
-        if (response.data.status === "success") {
-          dispatch(
-            importScriptAttempt(
-              privpass, response.data.data.Script, !creatingWallet, 0, response.data.data.TicketAddress, false,
-              (error) => error
-                ? dispatch({ error, type: UPDATESTAKEPOOLCONFIG_FAILED })
-                : dispatch(updateSavedConfig(response.data.data, poolHost, apiKey, accountNum))
-            )
-          );
-        } else if (response.data.status === "error") {
-          if (response.data.message == "purchaseinfo error - no address submitted") {
-            dispatch(setStakePoolAddressAction(privpass, poolHost, apiKey, accountNum));
-          } else {
-            dispatch({ error: response.data.message, type: UPDATESTAKEPOOLCONFIG_FAILED });
-          }
+    dispatch({ type: UPDATESTAKEPOOLCONFIG_ATTEMPT });
+    try {
+      let response = await wallet.getPurchaseInfo({ apiUrl: poolHost, apiToken: apiKey });
+
+      if (response.data.status == "error" && response.data.message === "purchaseinfo error - no address submitted") {
+        // this error happens when setting up a pool connection for the first
+        // time. We need to generate and send a wallet address to the stakepool,
+        // so that it will bind it with a stakepool address and create the
+        // multisig voting script.
+        await dispatch(setStakePoolAddressAction(poolHost, apiKey, accountNum));
+
+        // remake the remote getPurchaseInfo call to get the newly configured
+        // script
+        // TODO: this should really be returned in the setStakePoolAddress call
+        response = await wallet.getPurchaseInfo({ apiUrl: poolHost, apiToken: apiKey });
+        if (response.data.status !== "success") {
+          // there shouldn't be any errors at this stage anymore
+          throw new Error(response.data.message);
         }
-      })
-      .catch(error =>
-        dispatch({
-          error: `Unable to contact stakepool: ${error} please try again later`,
-          type: UPDATESTAKEPOOLCONFIG_FAILED
-        })
-      );
+      } else if (response.data.status != "success") {
+        throw new Error(response.data.message);
+      }
+
+      // import the script and verify whether the imported address matches what the
+      // stakepool has sent us
+      const importScriptResponse = await dispatch(importScriptAttempt(privpass, response.data.data.Script));
+      if (importScriptResponse.getP2shAddress() !== response.data.data.TicketAddress) {
+        extraErrorData = { incongruentP2shAddress: true,
+          poolP2shAddress: importScriptResponse.getP2shAddress(),
+          scriptAddress: response.data.data.TicketAddress };
+        throw new Error("Incongruent p2sh address returned by stakepool");
+      }
+
+      // All set. Update the config, dispatch the success and start a rescan.
+      const currentStakePoolConfig = await dispatch(updateSavedConfig(response.data.data, poolHost, apiKey, accountNum));
+      let selectedStakePool = currentStakePoolConfig.filter(p => p.Host === poolHost)[0] || null;
+      dispatch({ selectedStakePool, currentStakePoolConfig, type: UPDATESTAKEPOOLCONFIG_SUCCESS });
+      rescan && dispatch(rescanAttempt(0));
+    } catch (error) {
+      dispatch({ error, ...extraErrorData, type: UPDATESTAKEPOOLCONFIG_FAILED });
+      throw (error);
+    }
   };
 
 export const SETSTAKEPOOLVOTECHOICES_ATTEMPT = "SETSTAKEPOOLVOTECHOICES_ATTEMPT";
@@ -150,7 +165,7 @@ const updateStakePoolVoteChoicesConfig = (stakePool, voteChoices) => (dispatch, 
 
 export const setStakePoolVoteChoices = (stakePool, voteChoices) => (dispatch) => {
   wallet.allowStakePoolHost(stakePool.Host);
-  setVoteChoices({
+  wallet.setVoteChoices({
     apiUrl: stakePool.Host, apiToken: stakePool.ApiKey, voteChoices: voteChoices.getVotebits(),
   })
     .then(response => {
@@ -168,7 +183,7 @@ export const setStakePoolVoteChoices = (stakePool, voteChoices) => (dispatch) =>
 
 export const DISCOVERAVAILABLESTAKEPOOLS_SUCCESS = "DISCOVERAVAILABLESTAKEPOOLS_SUCCESS";
 export const discoverAvailableStakepools = () => (dispatch, getState) =>
-  getStakePoolInfo()
+  wallet.getStakePoolInfo()
     .then((foundStakepoolConfigs) => {
       if (foundStakepoolConfigs) {
         const { daemon: { walletName } } = getState();
@@ -190,7 +205,7 @@ export const removeStakePoolConfig = (host) => (dispatch, getState) => {
   let pool = existingPools.filter(p => p.Host === host)[0];
   if (!pool) { return; }
 
-  // Instead of simply deleting from exstingPools we blank all non-default
+  // Instead of simply deleting from exsting pools we blank all non-default
   // fields so the stakepool can be reconfigured without needing to re-fetch
   // the stakepool list from the remote api.
 

--- a/app/components/views/GetStartedPage/StakePools/index.js
+++ b/app/components/views/GetStartedPage/StakePools/index.js
@@ -73,7 +73,7 @@ class StakePoolsBody extends React.Component {
     const host = pool.Host;
     const privPass = passPhrase ? passPhrase : walletPrivatePassphrase;
 
-    onSetStakePoolInfo(privPass, host, apiKey, 0, false, true);
+    onSetStakePoolInfo(privPass, host, apiKey, false);
     this.setState({ apiKey: "" });
   }
 

--- a/app/components/views/TicketsPage/PurchaseTab/Page.js
+++ b/app/components/views/TicketsPage/PurchaseTab/Page.js
@@ -4,15 +4,13 @@ import Tickets from "./Tickets";
 import "style/StakePool.less";
 
 const PurchasePage = ({
-  isSavingStakePoolConfig,
   isPurchasingTickets,
-  isImportingScript,
   stakePool,
   isShowingStakePools,
   onHideStakePoolConfig,
   ...props
 }) => (
-  (isSavingStakePoolConfig || isPurchasingTickets || isImportingScript)
+  (isPurchasingTickets)
     ? <StakeyBounce center/>
     : (isShowingStakePools)
       ? <StakePools {...{ onHideStakePoolConfig }} />

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/AddForm.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/AddForm.js
@@ -24,6 +24,7 @@ const StakePoolsAddForm = ({
   unconfiguredStakePools,
   configuredStakePools,
   apiKey,
+  isSavingStakePoolConfig,
   intl,
   onChangeSelectedUnconfigured,
   onChangeApiKey,
@@ -86,7 +87,8 @@ const StakePoolsAddForm = ({
     <div className="stakepool-add-toolbar">
       <PassphraseModalButton
         modalTitle={<T id="stake.addPoolConfirmation" m="Stakepool Confirmation" />}
-        disabled={!apiKey}
+        loading={isSavingStakePoolConfig}
+        disabled={!apiKey || isSavingStakePoolConfig}
         className="stakepool-confirm-button"
         onSubmit={onSetStakePoolInfo}
         buttonLabel={<T id="stake.addPool.addBtn" m="Continue" />}

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
@@ -21,6 +21,19 @@ class StakePools extends React.Component {
     }
   }
 
+  componentDidUpdate() {
+    const hasUnconfigured = this.props.unconfiguredStakePools.some(p => p.Host === this.state.selectedUnconfigured.Host );
+    if (!hasUnconfigured && this.props.unconfiguredStakePools.length) {
+      // We just added a stakepool, so it has been removed from the list of
+      // unconfigured. Select the next one on the list.
+      this.setState({
+        selectedUnconfigured: this.props.unconfiguredStakePools[0],
+        apiKey: "",
+        hasFailedAttempt: false
+      });
+    }
+  }
+
   componentDidMount() {
     if(!this.state.selectedUnconfigured) {
       this.setState({ selectedUnconfigured: this.props.unconfiguredStakePools[0] });
@@ -137,7 +150,12 @@ class StakePools extends React.Component {
   onSetStakePoolInfo(privpass) {
     const { apiKey } = this.state;
     const onSetInfo = this.props.onSetStakePoolInfo;
-    apiKey ? (onSetInfo && onSetInfo(privpass, this.getSelectedUnconfigured().Host, apiKey, 0)) : this.setState({ hasFailedAttempt: true });
+    if (!onSetInfo) return;
+    if (!apiKey) {
+      this.setState({ hasFailedAttempt: true });
+      return;
+    }
+    onSetInfo(privpass, this.getSelectedUnconfigured().Host, apiKey, true);
   }
 
   onRemoveStakePool(host) {

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
@@ -30,22 +30,30 @@ class StakePools extends React.Component {
     }
   }
 
-  render() {
-    return this.getNoAvailableStakepools() && !this.getStakepoolListingEnabled() ? (
+  renderStakepoolListingDisabled() {
+    return (
       <div>
         <p><T id="stake.enableStakePoolListing.description" m="StakePool listing from external API endpoint is currently disabled. Please enable the access to this third party service or manually configure the stakepool." /></p>
         <EnableExternalRequestButton requestType={EXTERNALREQUEST_STAKEPOOL_LISTING}>
           <T id="stake.enableStakePoolListing.button" m="Enable StakePool Listing" />
         </EnableExternalRequestButton>
       </div>
-    ) : this.getNoAvailableStakepools() ? (
+    );
+  }
+
+  renderNoAvailableStakepools() {
+    return (
       <T
         id="stake.noAvailableStakepools"
         m="No stakepool found. Check your internet connection or {link} to see if the StakePool API is down."
         values={{
           link: (<a className="stakepool-link" onClick={() => shell.openExternal("https://api.decred.org/?c=gsd")}><T id="stake.discoverStakeOoolsAPILink" m="this link" /></a>)
         }} />
-    ) : this.getIsAdding() ? (
+    );
+  }
+
+  renderAddForm() {
+    return (
       <StakePoolsAddForm
         {...{
           ...this.props,
@@ -62,7 +70,21 @@ class StakePools extends React.Component {
           }, this),
         }}
       />
-    ) : (
+    );
+  }
+
+  render() {
+    if (this.getNoAvailableStakepools() && !this.getStakepoolListingEnabled()) {
+      return this.renderStakepoolListingDisabled();
+    }
+    if (this.getNoAvailableStakepools()) {
+      return this.renderNoAvailableStakepools();
+    }
+    if (this.getIsAdding()) {
+      return this.renderAddForm();
+    }
+
+    return (
       <StakePoolsList
         {...{
           ...this.props,
@@ -75,7 +97,9 @@ class StakePools extends React.Component {
   }
 
   getIsAdding() {
-    return this.state.isAdding || this.props.configuredStakePools.length <= 0;
+    return this.state.isAdding
+      || this.props.configuredStakePools.length <= 0
+      || this.props.isImportingScript;
   }
 
   getNoAvailableStakepools() {

--- a/app/components/views/TicketsPage/PurchaseTab/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/index.js
@@ -93,7 +93,7 @@ class Purchase extends React.Component {
 
   onImportScript(privpass, script) {
     const { onImportScript } = this.props;
-    onImportScript && onImportScript(privpass, script, true, 0, false, null);
+    onImportScript && onImportScript(privpass, script);
   }
 
   onRevokeTickets(privpass) {

--- a/app/connectors/stakePools.js
+++ b/app/connectors/stakePools.js
@@ -13,6 +13,7 @@ const mapStateToProps = selectorMap({
   stakePoolListingEnabled: sel.stakePoolListingEnabled,
   updatedStakePoolList: sel.updatedStakePoolList,
   isSavingStakePoolConfig: sel.isSavingStakePoolConfig,
+  isImportingScript: sel.isImportingScript,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/app/connectors/ticketsPage.js
+++ b/app/connectors/ticketsPage.js
@@ -35,7 +35,7 @@ const mapStateToProps = selectorMap({
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   onRevokeTickets: ca.revokeTicketsAttempt,
-  onImportScript: ca.importScriptAttempt,
+  onImportScript: ca.manualImportScriptAttempt,
   onClearRevokeTicketsError: ca.clearRevokeTicketsError,
   onClearRevokeTicketsSuccess: ca.clearRevokeTicketsSuccess,
   onClearImportScriptError: ca.clearImportScriptError,


### PR DESCRIPTION
Close #1773 

This changes the interaction of stakepool api key entry to preserve the api key and host selection if an error (such as wrong passphrase or wrong api key) is triggered. 

It also refactors the stakepool actions in the following ways:

- Use async/await calls to reduce code/indentation depth
- The importScriptAttempt() function now no longer triggers success/error snackbars (which removes the need for many conditionals and parameters throughout stakepool import/ticket purchasing actions)
- A manualImportScriptAttempt() function was added for manual script import (which does trigger snackbar messages and rescans)
- the setStakepoolInfo() call now does some of the checks that were done deeper in the call stack (removing the need to propagate arguments)
- The snackbar has been changed to intercept the error signature of wrong passphrase errors and show a standard message on that case (instead of requiring parsing all over the place)

There are some outstanding snackbar issues and improvements that I can see, but I'll leave them for a second PR.