### PR TITLE
Fix stream error

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -241,12 +241,9 @@ export const startRpcRequestFunc = (isRetry, privPass) =>
     return new Promise(() => {
       if (!isRetry) dispatch({ type: SYNC_ATTEMPT });
       const { loader } = getState().walletLoader;
-      var rpcSyncCall = loader.rpcSync(request);
+      const rpcSyncCall = loader.rpcSync(request);
+      dispatch({ syncCall: rpcSyncCall, type: SYNC_UPDATE });
       rpcSyncCall.on("data", function(response) {
-        const { syncCall } = getState().walletLoader;
-        if (!syncCall) {
-          dispatch({ syncCall: rpcSyncCall, type: SYNC_UPDATE });
-        }
         dispatch(syncConsumer(response));
       });
       rpcSyncCall.on("end", function() {
@@ -386,12 +383,9 @@ export const spvSyncAttempt = (privPass) => (dispatch, getState) => {
   }
   return new Promise(() => {
     const { loader } = getState().walletLoader;
-    var spvSyncCall = loader.spvSync(request);
+    const spvSyncCall = loader.spvSync(request);
+    dispatch({ syncCall: spvSyncCall, type: SYNC_UPDATE });
     spvSyncCall.on("data", function(response) {
-      const { syncCall } = getState().walletLoader;
-      if (!syncCall) {
-        dispatch({ syncCall: spvSyncCall, type: SYNC_UPDATE });
-      }
       dispatch(syncConsumer(response));
     });
     spvSyncCall.on("end", function() {

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -15,7 +15,7 @@ import {
   SYNC_PEER_CONNECTED, SYNC_PEER_DISCONNECTED, SYNC_FETCHED_MISSING_CFILTERS_STARTED,
   SYNC_FETCHED_MISSING_CFILTERS_PROGRESS, SYNC_FETCHED_MISSING_CFILTERS_FINISHED,
   SYNC_DISCOVER_ADDRESSES_STARTED, SYNC_DISCOVER_ADDRESSES_FINISHED,
-  SYNC_RESCAN_STARTED, SYNC_RESCAN_PROGRESS, SYNC_RESCAN_FINISHED,
+  SYNC_RESCAN_STARTED, SYNC_RESCAN_PROGRESS, SYNC_RESCAN_FINISHED, SYNC_CANCEL,
   GENERATESEED_ATTEMPT
 } from "actions/WalletLoaderActions";
 import {
@@ -274,11 +274,18 @@ export default function walletLoader(state = {}, action) {
       syncInput: false,
       syncAttemptRequest: false,
       synced: false,
+      syncCall: null,
     };
   case SYNC_UPDATE:
     return { ...state,
       syncError: null,
       syncCall: action.syncCall,
+    };
+  case SYNC_CANCEL:
+    return { ...state,
+      syncError: null,
+      synced: false,
+      syncCall: null,
     };
   case SYNC_SUCCESS:
     return { ...state,


### PR DESCRIPTION
Fix #1698 

Tracked down the issue to the `syncCall` state var not being correctly cleared when closing the wallet and not being replaced on a subsequent invocation.