### PR TITLE
[launcher] Fix asking for public passphrase

### DIFF
--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -11,7 +11,7 @@ const DaemonLoadingBody = ({
   Form,
   text,
   animationType,
-  isInputRequest,
+  openWalletInputRequest,
   getCurrentBlockCount,
   getWalletReady,
   getDaemonStarted,
@@ -101,7 +101,7 @@ const DaemonLoadingBody = ({
             </div>
           }
         </div>
-        { Form && <Form {...{ ...props, isInputRequest, startupError, getCurrentBlockCount, getDaemonSynced, isSPV }}/> }
+        { Form && <Form {...{ ...props, openWalletInputRequest, startupError, getCurrentBlockCount, getDaemonSynced, isSPV }}/> }
         {syncInput ?
           <div className="advanced-page-form">
             <div className="advanced-daemon-row">

--- a/app/components/views/GetStartedPage/OpenWallet/DecryptForm.js
+++ b/app/components/views/GetStartedPage/OpenWallet/DecryptForm.js
@@ -11,7 +11,6 @@ const messages = defineMessages({
 });
 
 const OpenWalletDecryptFormBodyBase = ({
-  isInputRequest,
   isOpeningWallet,
   publicPassPhrase,
   intl,
@@ -19,7 +18,6 @@ const OpenWalletDecryptFormBodyBase = ({
   onOpenWallet,
   onKeyDown
 }) => (
-  isInputRequest &&
   <div className="advanced-page-form">
     <div className="advanced-daemon-row">
       <T id="getStarted.decrypt.info" m="This wallet is encrypted, please enter the public passphrase to decrypt it." />

--- a/app/components/views/GetStartedPage/OpenWallet/index.js
+++ b/app/components/views/GetStartedPage/OpenWallet/index.js
@@ -18,18 +18,20 @@ class OpenWallet extends React.Component {
   }
 
   render() {
-    const { publicPassPhrase, onKeyDown } = this.state;
+    const { openWalletInputRequest, isOpeningWallet } = this.props;
+    if (!openWalletInputRequest) return null;
+
+    const { publicPassPhrase } = this.state;
     const {
       onSetPublicPassPhrase,
       onOpenWallet,
+      onKeyDown
     } = this;
-    const { isInputRequest, isOpeningWallet } = this.props;
+
     return (
       <OpenWalletDecryptFormBody
         {...{
           ...this.props,
-
-          isInputRequest,
           isOpeningWallet,
           publicPassPhrase,
           onSetPublicPassPhrase,

--- a/app/components/views/GetStartedPage/index.js
+++ b/app/components/views/GetStartedPage/index.js
@@ -95,7 +95,7 @@ class GetStartedPage extends React.Component {
       appVersion,
       updateAvailable,
       isSPV,
-      isInputRequest,
+      openWalletInputRequest,
       syncFetchMissingCfiltersAttempt,
       syncFetchHeadersAttempt,
       syncDiscoverAddressesAttempt,
@@ -238,7 +238,7 @@ class GetStartedPage extends React.Component {
         appVersion,
         updateAvailable,
         isSPV,
-        isInputRequest,
+        openWalletInputRequest,
         syncFetchHeadersAttempt,
       }} />;
   }

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -13,7 +13,7 @@ const mapStateToProps = selectorMap({
   showSpvChoice: sel.showSpvChoice,
   showPrivacy: sel.showPrivacy,
   startStepIndex: sel.startStepIndex,
-  isInputRequest: sel.isInputRequest,
+  openWalletInputRequest: sel.openWalletInputRequest,
   startupError: sel.startupError,
   confirmNewSeed: sel.confirmNewSeed,
   existingOrNew: sel.existingOrNew,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -119,17 +119,7 @@ export const sortedAvailableWallets = createSelector(
 export const previousWallet = get([ "daemon", "previousWallet" ]);
 export const getWalletName = get([ "daemon", "walletName" ]);
 
-const openWalletInputRequest = get([ "walletLoader", "openWalletInputRequest" ]);
-const createWalletInputRequest = get([ "walletLoader", "createWalletInputRequest" ]);
-const advancedDaemonInputRequest = get([ "walletLoader", "advancedDaemonInputRequest" ]);
-const selectCreateWalletInputRequest = get([ "daemon", "selectCreateWalletInputRequest" ]);
-
-export const isInputRequest = or(
-  openWalletInputRequest,
-  createWalletInputRequest,
-  and(openForm, isAdvancedDaemon, advancedDaemonInputRequest),
-  selectCreateWalletInputRequest
-);
+export const openWalletInputRequest = get([ "walletLoader", "openWalletInputRequest" ]);
 
 export const balances = or(get([ "grpc", "balances" ]), () => []);
 export const walletService = get([ "grpc", "walletService" ]);


### PR DESCRIPTION
Fix #1699 

The main issue seems to be that after all the launcher refactorings, the `isInputRequest` selector was left using some superseded state, so the decrypt wallet page was being shown in some wrong situations.

This cleans up and renames the selector to `openWalletInputRequest` so that it's more obvious what it's doing and to make it explicit it's following the corresponding state var.

I tested a bunch of combinations of the startup procedure (spv/rpc/advanced/non-advanced) on existing and new wallets, and with/without the public passphrase.