### PR TITLE
[actions] Fix fetchMissingStakeInfo infinite loop

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -1096,11 +1096,23 @@ export const fetchMissingStakeTxData = tx => async (dispatch, getState) => {
   }
 
   const oldTxs = getState().grpc.transactions;
+  const oldStakeTxs = getState().grpc.recentStakeTransactions;
   const txIdx = oldTxs.findIndex(t => t.txHash === tx.txHash);
-  if (txIdx > -1) {
-    const newTxs = [ ...oldTxs ];
-    newTxs.splice(txIdx, 1, newTx);
-    dispatch({ transactions: newTxs, txHash: tx.txHash, type: FETCHMISSINGSTAKETXDATA_SUCCESS });
+  const stakeTxIdx = oldStakeTxs.findIndex(t => t.txHash === tx.txHash);
+
+  if ((txIdx > -1) || (stakeTxIdx > -1)) {
+    const dispatchState = { txHash: tx.txHash, type: FETCHMISSINGSTAKETXDATA_SUCCESS };
+    if (txIdx > -1) {
+      const newTxs = [ ...oldTxs ];
+      newTxs[txIdx] = newTx;
+      dispatchState["transactions"] = newTxs;
+    }
+    if (stakeTxIdx > -1) {
+      const newStakeTxs = [ ...oldStakeTxs ];
+      newStakeTxs[stakeTxIdx] = newTx;
+      dispatchState["recentStakeTransactions"] = newStakeTxs;
+    }
+    dispatch(dispatchState);
   } else {
     // not supposed to happen in normal usage; this function  should only be
     // entered from a transaction already in the transaction list

--- a/app/components/views/TransactionPage/index.js
+++ b/app/components/views/TransactionPage/index.js
@@ -3,10 +3,16 @@ import TransactionPage from "./Page";
 import { transactionPage } from "connectors";
 
 const Transaction = ({ walletService, viewedTransaction, viewedDecodedTransaction,
-  decodeRawTransactions, tsDate }) => {
+  decodeRawTransactions, tsDate, fetchMissingStakeTxData }) => {
 
   if (!viewedDecodedTransaction) {
     decodeRawTransactions([ viewedTransaction.rawTx ]);
+  }
+
+  const { txType, ticketPrice, leaveTimestamp } = viewedTransaction;
+  if (((txType == "Ticket") && (!ticketPrice)) || ((txType == "Vote") && (!leaveTimestamp))) {
+    // don't have the extended stake info for this transaction yet. Request it.
+    fetchMissingStakeTxData(viewedTransaction);
   }
 
   return !walletService

--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -113,11 +113,6 @@ const TxDetails = ({
 
   var subtitle = <div/>;
 
-  if (((txType == "Ticket") && (!ticketPrice)) || ((txType == "Vote") && (!leaveTimestamp))) {
-    // don't have the extended stake info for this transaction yet. Request it.
-    fetchMissingStakeTxData(tx);
-  }
-
   switch (txType) {
   case "Ticket":
   case "Vote":

--- a/app/components/views/TxDetails.js
+++ b/app/components/views/TxDetails.js
@@ -56,7 +56,6 @@ const TxDetails = ({
   goBackHistory,
   tsDate,
   publishUnminedTransactions,
-  fetchMissingStakeTxData,
 }) => {
   const {
     txHash,

--- a/app/connectors/transactionDetails.js
+++ b/app/connectors/transactionDetails.js
@@ -13,7 +13,6 @@ const mapStateToProps = selectorMap({
 const mapDispatchToProps = dispatch => bindActionCreators({
   goBackHistory: ca.goBackHistory,
   publishUnminedTransactions: cla.publishUnminedTransactionsAttempt,
-  fetchMissingStakeTxData: ca.fetchMissingStakeTxData,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/connectors/transactionPage.js
+++ b/app/connectors/transactionPage.js
@@ -3,6 +3,7 @@ import { selectorMap } from "../fp";
 import { bindActionCreators } from "redux";
 import * as sel from "../selectors";
 import * as dma from "../actions/DecodeMessageActions";
+import * as ca from "../actions/ClientActions";
 
 const mapStateToProps = selectorMap({
   walletService: sel.walletService,
@@ -13,6 +14,7 @@ const mapStateToProps = selectorMap({
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   decodeRawTransactions: dma.decodeRawTransactions,
+  fetchMissingStakeTxData: ca.fetchMissingStakeTxData,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/fp.js
+++ b/app/fp.js
@@ -1,5 +1,5 @@
 export { createSelector } from "reselect";
-export { compose, reduce, find, filter, get, eq, map, keyBy, some } from "lodash/fp";
+export { compose, reduce, find, findIndex, filter, get, eq, map, keyBy, some } from "lodash/fp";
 import compose from "lodash/fp/compose";
 import get from "lodash/fp/get";
 import { isFunction } from "util";

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -401,7 +401,8 @@ export default function grpc(state = {}, action) {
   case FETCHMISSINGSTAKETXDATA_SUCCESS:
     return {
       ...state,
-      transactions: action.transactions,
+      transactions: action.transactions || state.transactions,
+      recentStakeTransactions: action.recentStakeTransactions || state.recentStakeTransactions,
       fetchMissingStakeTxDataAttempt: {
         ...state.fetchMissingStakeTxDataAttempt,
         [action.txHash]: false,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -401,8 +401,8 @@ const transactionNormalizer = createSelector(
         txNumericType: type,
         rawTx: Buffer.from(tx.getTransaction()).toString("hex"),
         originalTx: origTx,
+        ...txDetails,
         ...stakeInfo,
-        ...txDetails
       };
     };
   }
@@ -499,13 +499,13 @@ export const homeHistoryTickets = createSelector(
         // the filter for the moment.
         return null;
       }
-      tx.ticketPrice = ticketDecoded.ticketPrice;
+      if (ticketDecoded.ticketPrice) tx.ticketPrice = ticketDecoded.ticketPrice;
       if (ticketDecoded.status != "voted") {
         tx.status = ticketDecoded.status;
       }
-      tx.enterTimestamp = ticketDecoded.enterTimestamp;
-      tx.leaveTimestamp = ticketDecoded.leaveTimestamp;
-      tx.ticketReward = ticketDecoded.ticketReward;
+      if (ticketDecoded.enterTimestamp) tx.enterTimestamp = ticketDecoded.enterTimestamp;
+      if (ticketDecoded.leaveTimestamp) tx.leaveTimestamp = ticketDecoded.leaveTimestamp;
+      if (ticketDecoded.ticketReward) tx.ticketReward = ticketDecoded.ticketReward;
 
       return tx;
     }).filter(v => !!v);
@@ -522,13 +522,13 @@ export const viewedTransaction = createSelector(
     const ticketDecoded = txHashToTicket[txHash];
     const tx = find({ txHash }, transactions);
     if (ticketDecoded) {
-      tx.ticketPrice = ticketDecoded.ticketPrice;
+      if (ticketDecoded.ticketPrice) tx.ticketPrice = ticketDecoded.ticketPrice;
       if (ticketDecoded.status != "voted") {
         tx.status = ticketDecoded.status;
       }
-      tx.enterTimestamp = ticketDecoded.enterTimestamp;
-      tx.leaveTimestamp = ticketDecoded.leaveTimestamp;
-      tx.ticketReward = ticketDecoded.ticketReward;
+      if (ticketDecoded.enterTimestamp) tx.enterTimestamp = ticketDecoded.enterTimestamp;
+      if (ticketDecoded.leaveTimestamp) tx.leaveTimestamp = ticketDecoded.leaveTimestamp;
+      if (ticketDecoded.ticketReward) tx.ticketReward = ticketDecoded.ticketReward;
     }
     return tx;
   }


### PR DESCRIPTION
This happens on some situations with a ticket transaction continually requesting the missing stake info.

The easiest way to test this is to purchase a ticket, then create a new wallet using the same seed but without importing the stakepool api key, then try to see the tx details. A few other situations (eg: split tickets without voting rights) also trigger this.

There are a couple of things triggering this, bust mostly the issue is that when the normalized transaction data has `!TicketPrice`, it will continually request the stake info. I had to refactor some stuff to allow the correct state to be propagated.
