### PR TITLE
[tickets] Add import script button to AddStakepool form

### DIFF
--- a/app/components/buttons/ImportScriptIconButton.js
+++ b/app/components/buttons/ImportScriptIconButton.js
@@ -1,0 +1,28 @@
+import { ImportScriptModal } from "modals";
+import { importScript } from "connectors";
+import { Tooltip } from "shared";
+import ModalButton from "./ModalButton";
+import InvisibleButton from "./InvisibleButton";
+import { FormattedMessage as T } from "react-intl";
+import { SimpleLoading } from "indicators";
+
+const ImportScriptIconButton = ({ rescanRequest, isImportingScript, onImportScript }) => (
+  <Tooltip className="stakepool-content-import-script-button-tooltip-container"
+    warning={!!rescanRequest}
+    text={!rescanRequest
+      ? <T id="purchaseTickets.import" m="Manually import a redeem script for tickets." />
+      : <T id="purchaseTickets.importDisabledRescan" m="Importing scripts is disabled during a rescan." />}
+  >
+    <ModalButton
+      buttonComponent={InvisibleButton}
+      buttonLabel={isImportingScript ? <SimpleLoading /> : null}
+      className={"stakepool-content-import-script-button " + (isImportingScript ? "loading" : "")}
+      modalTitle={<T id="tickets.importScriptConfirmation" m="Import Script Confirmation" />}
+      modalComponent={ImportScriptModal}
+      disabled={rescanRequest}
+      onSubmit={onImportScript}
+    />
+  </Tooltip>
+);
+
+export default importScript(ImportScriptIconButton);

--- a/app/components/buttons/index.js
+++ b/app/components/buttons/index.js
@@ -13,6 +13,7 @@ export { default as EnableExternalRequestButton } from "./EnableExternalRequestB
 export { default as SendTransactionButton } from "./SendTransactionButton";
 export { default as SignMessageButton } from "./SignMessageButton";
 export { default as GoBackIconButton } from "./GoBackIconButton";
+export { default as ImportScriptIconButton } from "./ImportScriptIconButton";
 
 import ModalButton from "./ModalButton";
 import KeyBlueButton from "./KeyBlueButton";

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/Form.js
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/Form.js
@@ -1,9 +1,7 @@
-import { ImportScriptModal } from "modals";
 import { TicketsCogs, InfoDocModalButton, PassphraseModalButton,
-  InvisiblePassphraseModalButton } from "buttons";
+  ImportScriptIconButton } from "buttons";
 import { AccountsSelect, NumTicketsInput } from "inputs";
 import { FormattedMessage as T } from "react-intl";
-import { Tooltip } from "shared";
 import { TransitionMotionWrapper } from "shared";
 
 import "style/StakePool.less";
@@ -17,13 +15,11 @@ const PurchaseTicketsForm = ({
   hasTicketsToRevoke,
   numTicketsToBuy,
   canAffordTickets,
-  rescanRequest,
   onIncrementNumTickets,
   onDecrementNumTickets,
   onChangeNumTickets,
   onChangeAccount,
   onPurchaseTickets,
-  onImportScript,
   onRevokeTickets,
   onToggleShowAdvanced,
   account,
@@ -68,21 +64,7 @@ const PurchaseTicketsForm = ({
         <div className="stakepool-purchase-ticket-info">
           <div className="stakepool-purchase-ticket-action-buttons">
             <TicketsCogs opened={!isShowingAdvanced} onClick={onToggleShowAdvanced} />
-
-            <Tooltip className="stakepool-content-import-script-button-tooltip-container"
-              warning={!!rescanRequest}
-              text={!rescanRequest
-                ? <T id="purchaseTickets.import" m="Manually import a redeem script for tickets." />
-                : <T id="purchaseTickets.importDisabledRescan" m="Importing scripts is disabled during a rescan." />}
-            >
-              <InvisiblePassphraseModalButton
-                className="stakepool-content-import-script-button"
-                modalTitle={<T id="tickets.importScriptConfirmation" m="Import Script Confirmation" />}
-                modalComponent={ImportScriptModal}
-                disabled={rescanRequest}
-                onSubmit={onImportScript}
-              />
-            </Tooltip>
+            <ImportScriptIconButton />
           </div>
           <TransitionMotionWrapper {...{
             styles: !isShowingAdvanced ? getQuickBarComponent : getAdvancedComponent,

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/AddForm.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/AddForm.js
@@ -1,5 +1,6 @@
 import { ExternalLink } from "shared";
-import { PassphraseModalButton, ScriptRedeemableButton, SlateGrayButton } from "buttons";
+import { PassphraseModalButton, ScriptRedeemableButton, SlateGrayButton,
+  ImportScriptIconButton } from "buttons";
 import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
 import { TextInput, StakePoolSelect } from "inputs";
 import { Documentation } from "shared";
@@ -81,6 +82,7 @@ const StakePoolsAddForm = ({
             className="stakepool-add-not-redeemable"
             buttonLabel={<T id="stake.notRedeemed" m={"Script not redeemable?"} />}
           />
+          <ImportScriptIconButton />
         </div>
       </div>
     </div>

--- a/app/connectors/importScript.js
+++ b/app/connectors/importScript.js
@@ -1,0 +1,16 @@
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import { selectorMap } from "fp";
+import * as sel from "selectors";
+import * as ca from "actions/ControlActions";
+
+const mapStateToProps = selectorMap({
+  rescanRequest: sel.rescanRequest,
+  isImportingScript: sel.isImportingScript,
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  onImportScript: ca.manualImportScriptAttempt,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/connectors/index.js
+++ b/app/connectors/index.js
@@ -55,3 +55,4 @@ export { default as newProposalCounts } from "./newProposalCounts";
 export { default as network } from "./network";
 export { default as treasuryInfo } from "./treasuryInfo";
 export { default as trezor } from "./trezor";
+export { default as importScript } from "./importScript";

--- a/app/style/StakePool.less
+++ b/app/style/StakePool.less
@@ -235,11 +235,19 @@
   background-size: 25px;
   background-position: center;
   background-image: @importscript-icon;
-  margin-top: 8px;
   width: 20px;
   height: 25px;
   padding: 0px;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 10px;
+}
+
+.stakepool-content-import-script-button.loading {
+  background-image: none;
+  > .spinner > div {
+    background-color: var(--title-text-and-button-background-hovered);
+  }
 }
 
 .stakepool-content-import-script-button:hover {
@@ -247,7 +255,7 @@
 }
 
 .stakepool-content-import-script-button-tooltip-container {
-  display: block;
+  display: inline-block;
 }
 
 .stakepool-content-revoke-button {
@@ -1198,6 +1206,7 @@ textarea.stakepool-content-nest-content-settings {
 }
 
 .stakepool-add-not-redeemable {
+  display: inline-block;
   margin-top: 5px;
   font-family: @font-family-monospaced;
   font-size: 11px;


### PR DESCRIPTION
This allows an user to import a script without having to add a stakepool first (which is necessary to use if the stakepool has disappeared or you're trying to import a script other than ones used by stakepools).

The loading indicator will need some iteration from design, but we can improve it in time.