### PR TITLE
[stats] Fix startup stats regression and ticketless wallets

### DIFF
--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -518,7 +518,6 @@ const prepDataToCalcStats = async (startBlock, endBlock, currentDate, endDate, p
   // grab transactions in batches of (roughly) `pageSize` transactions, so
   // that if we can stop in the middle of the process (say, because we're
   // interested in only the first 10 days worth of balances)
-  let i = 0;
   while (continueGetting) {
     const { mined } = await wallet.getTransactions(walletService, currentBlock,
       endBlock, pageSize);
@@ -537,11 +536,6 @@ const prepDataToCalcStats = async (startBlock, endBlock, currentDate, endDate, p
         (endDate && !backwards && currentDate < endDate) ||
         (endDate && backwards && currentDate > endDate )
       ) ;
-    i++;
-    if (i % 10 === 0) {
-      console.log("getting txs on range", currentBlock, endBlock, toProcess.length,
-        endDate, currentDate);
-    }
   }
 
   // grab all txs that are ticket/coinbase maturity blocks from the last tx
@@ -555,7 +549,6 @@ const prepDataToCalcStats = async (startBlock, endBlock, currentDate, endDate, p
     }
   }
 
-  console.log("finished preparing");
   return toProcess;
 };
 
@@ -577,7 +570,7 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
 
   const tsDate = sel.tsDate(getState());
 
-  const pageSize = 20;
+  const pageSize = 200;
   const maxMaturity = Math.max(chainParams.CoinbaseMaturity, chainParams.TicketMaturity);
   let currentDate = new Date();
   let toProcess = [];
@@ -609,8 +602,6 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
         height: currentBlockHeight }));
       toProcess.push(...fixedUnmined);
 
-      console.log("got unmined");
-
       // on backwards stats, we find vote txs before finding ticket txs, so
       // pre-process tickets from all grabbed txs to avoid making the separate
       // getTransaction calls in voteRevokeInfo()
@@ -620,8 +611,6 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
           recordTicket(maturingTxs, liveTickets, tx, commitAmount, isWallet, chainParams);
         }
       });
-
-      console.log("recorded tickets");
 
       await txDataCbBackwards({ mined: toProcess, maturingTxs, liveTickets, walletService, currentBalance,
         chainParams, currentBlockHeight, tsDate, progressFunction, recentBlockTimestamp, balances, maxMaturity });

--- a/app/reducers/statistics.js
+++ b/app/reducers/statistics.js
@@ -47,12 +47,10 @@ export default function statistics(state = {}, action) {
   case CLOSEWALLET_SUCCESS:
     return {
       ...state,
-      statistics: {
-        dailyBalances: Array(),
-        fullDailyBalances: Array(),
-        voteTime: null,
-        getMyTicketsStatsRequest: false,
-      },
+      dailyBalances: Array(),
+      fullDailyBalances: Array(),
+      voteTime: null,
+      getMyTicketsStatsRequest: false,
     };
   default:
     return state;


### PR DESCRIPTION
3 fixes rolled up:

- Fix small regression for large wallet startup introduced in #1839 (backwards stats wasn't being stopped after the 14 day window)
- Fix close state not correctly clearing stats daily stats
- Fix stats calc when the wallet doesn't have the ticket transaction associated with a given vote/revocation.

This last one will usually happen in pool fee wallets, which only record the reward received via a vote/revocation. The easiest way to test this (if you don't have easy access to a pool fee wallet) is to create a wallet, grab an address, then go back to a ticket buying wallet and manually change (in the corresponding `config.json`) the pool fee address so that you buy a ticket paying into the new wallet.

Obviously you need to wait for the purchased ticket to vote or be revoked, so it might take a while to functionally test this.
