### PR TITLE
[trezor] Disable integration when closing wallet

### DIFF
--- a/app/reducers/trezor.js
+++ b/app/reducers/trezor.js
@@ -21,6 +21,9 @@ import {
 import {
   SIGNTX_ATTEMPT, SIGNTX_FAILED, SIGNTX_SUCCESS
 } from "actions/ControlActions";
+import {
+  CLOSEWALLET_SUCCESS,
+} from "actions/WalletLoaderActions";
 
 export default function trezor(state = {}, action) {
   switch (action.type) {
@@ -157,6 +160,10 @@ export default function trezor(state = {}, action) {
   case TRZ_UPDATEFIRMWARE_SUCCESS:
     return { ...state,
       performingOperation: false,
+    };
+  case CLOSEWALLET_SUCCESS:
+    return { ...state,
+      enabled: false,
     };
   default:
     return state;


### PR DESCRIPTION
This disables trezor integration once a trezor-enabled wallet is closed.

Without this, you would still see the trezor sidebar menu item after closing a trezor wallet and opening a non-trezor one.