### PR TITLE
[multi] Small new wallet bugs

### DIFF
--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/index.js
@@ -22,7 +22,8 @@ class StakePools extends React.Component {
   }
 
   componentDidUpdate() {
-    const hasUnconfigured = this.props.unconfiguredStakePools.some(p => p.Host === this.state.selectedUnconfigured.Host );
+    const configuredHost = this.state.selectedUnconfigured ? this.state.selectedUnconfigured.Host : "";
+    const hasUnconfigured = this.props.unconfiguredStakePools.some(p => p.Host ===  configuredHost);
     if (!hasUnconfigured && this.props.unconfiguredStakePools.length) {
       // We just added a stakepool, so it has been removed from the list of
       // unconfigured. Select the next one on the list.

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -131,7 +131,7 @@ export const getNetworkResponse = get([ "grpc", "getNetworkResponse" ]);
 export const getNetworkError = get([ "grpc", "getNetworkError" ]);
 const accounts = createSelector([ getAccountsResponse ], r => r ? r.getAccountsList() : []);
 
-export const isWatchingOnly = get([ "walletLoader", "isWatchingOnly" ]);
+export const isWatchingOnly = bool(get([ "walletLoader", "isWatchingOnly" ]));
 export const accountExtendedKey = createSelector(
   [ get([ "control", "getAccountExtendedKeyResponse" ]) ],
   (response) => response ? response.getAccExtendedPubKey() : null


### PR DESCRIPTION
Fix two small bugs I found while testing previous PRs:

- Fix an error with the tickets page when first creating a wallet. If you access the tickets page fast enough (before the stakepool list has finished loading) you could get a white page error due to not having a previous `selectedUnconfigured` state var set in the page.

- Fix an exception thrown in the accounts page if the `isWatchingOnly` selector didn't store a bool (this could happen if, eg, the `iswatchonly` config var got erased.