### PR TITLE
[trezor] Disable trezor integration when creating wallet

### DIFF
--- a/app/actions/TrezorActions.js
+++ b/app/actions/TrezorActions.js
@@ -59,6 +59,15 @@ export const enableTrezor = () => (dispatch, getState) => {
   }
 };
 
+export const TRZ_TREZOR_DISABLED = "TRZ_TREZOR_DISABLED";
+// disableTrezor disables trezor integration for the current wallet. Note
+// that it does **not** disable in the config, so the wallet will restart as a
+// trezor wallet next time it's opened.
+export const disableTrezor = () => (dispatch) => {
+  dispatch(clearDeviceSession());
+  dispatch({ type: TRZ_TREZOR_DISABLED });
+};
+
 export const TRZ_CLEAR_DEVICELIST = "TRZ_CLEAR_DEVICELIST";
 
 export const reloadTrezorDeviceList = () => (dispatch) => {

--- a/app/components/views/GetStartedPage/WalletSelection/index.js
+++ b/app/components/views/GetStartedPage/WalletSelection/index.js
@@ -118,8 +118,19 @@ class WalletSelectionBody extends React.Component {
   showCreateWalletForm(createNewWallet) {
     this.setState({ createNewWallet, createWalletForm: true });
   }
-  hideCreateWalletForm(createNewWallet) {
-    this.setState({ hasFailedAttemptName: false, hasFailedAttemptPubKey: false, createNewWallet, createWalletForm: false });
+  hideCreateWalletForm() {
+    if (this.state.isTrezor) {
+      this.props.trezorDisable();
+    }
+
+    this.setState({ hasFailedAttemptName: false,
+      hasFailedAttemptPubKey: false,
+      createWalletForm: false,
+      newWalletName: "",
+      isWatchingOnly: false,
+      isTrezor: false,
+      walletMasterPubKey: "",
+    });
   }
   onChangeAvailableWallets(selectedWallet) {
     this.setState({ selectedWallet });
@@ -183,6 +194,8 @@ class WalletSelectionBody extends React.Component {
     this.setState({ isTrezor, isWatchingOnly: false });
     if (isTrezor) {
       this.props.trezorEnable();
+    } else {
+      this.props.trezorDisable();
     }
   }
   async onChangeCreateWalletMasterPubKey(walletMasterPubKey) {

--- a/app/connectors/createWallet.js
+++ b/app/connectors/createWallet.js
@@ -29,6 +29,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   decodeSeed: wla.decodeSeed,
   trezorLoadDeviceList: trza.loadDeviceList,
   trezorEnable: trza.enableTrezor,
+  trezorDisable: trza.disableTrezor,
   trezorAlertNoConnectedDevice: trza.alertNoConnectedDevice,
   trezorGetWalletCreationMasterPubKey: trza.getWalletCreationMasterPubKey
 }, dispatch);

--- a/app/reducers/trezor.js
+++ b/app/reducers/trezor.js
@@ -1,5 +1,5 @@
 import {
-  TRZ_TREZOR_ENABLED,
+  TRZ_TREZOR_ENABLED, TRZ_TREZOR_DISABLED,
   TRZ_LOADDEVICELIST_ATTEMPT, TRZ_LOADDEVICELIST_FAILED, TRZ_LOADDEVICELIST_SUCCESS,
   TRZ_DEVICELISTTRANSPORT_LOST,
   TRZ_SELECTEDDEVICE_CHANGED,
@@ -30,6 +30,10 @@ export default function trezor(state = {}, action) {
   case TRZ_TREZOR_ENABLED:
     return { ...state,
       enabled: true,
+    };
+  case TRZ_TREZOR_DISABLED:
+    return { ...state,
+      enabled: false,
     };
   case TRZ_CLEAR_DEVICELIST:
     return { ...state,


### PR DESCRIPTION
Fix #1881 

This changes the wallet create page so that when leaving it or disabling the trezor switch, trezor integration is correctly disabled.