### PR TITLE
[settings] Fix enabling external politeia requests

### DIFF
--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -64,6 +64,31 @@ export const saveSettings = (settings) => (dispatch, getState) => {
 
 };
 
+export const ALLOWEDEXTERNALREQUESTS_ADDED = "ALLOWEDEXTERNALREQUESTS_ADDED";
+export const addAllowedExternalRequest = (requestType) => (dispatch, getState) => {
+  const config = getGlobalCfg();
+  const allowed = config.get("allowed_external_requests");
+  if (allowed.indexOf(requestType) > -1) return;
+
+  allowed.push(requestType);
+  config.set("allowed_external_requests", allowed);
+  wallet.allowExternalRequest(requestType);
+
+  const { settings: { currentSettings, tempSettings } } = getState();
+  const newSettings = { ...currentSettings };
+  newSettings.allowedExternalRequests = allowed;
+
+  // Also modify temp settings, given that it may be different than the current
+  // settings.
+  const newTempSettings = { ...tempSettings };
+  newTempSettings.allowedExternalRequests = [ ...newTempSettings.allowedExternalRequests ];
+  if (newTempSettings.allowedExternalRequests.indexOf(requestType) === -1) {
+    newTempSettings.allowedExternalRequests.push(requestType);
+  }
+
+  dispatch({ newSettings, newTempSettings, type: ALLOWEDEXTERNALREQUESTS_ADDED });
+};
+
 export function updateStateSettingsChanged(settings, norestart) {
   return (dispatch, getState) => {
     const { tempSettings, currentSettings } = getState().settings;

--- a/app/components/buttons/EnableExternalRequestButton.js
+++ b/app/components/buttons/EnableExternalRequestButton.js
@@ -1,16 +1,10 @@
 import { settings } from "connectors";
 import KeyBlueButton from "./KeyBlueButton";
 
-const EnableExternalRequestButton = ({ children, requestType, tempSettings,
-  onSaveSettings }) => {
+const EnableExternalRequestButton = ({ children, requestType,
+  onAddAllowedRequestType }) => {
 
-  const onClick = () => {
-    const allowedExternalRequests = [ ...tempSettings.allowedExternalRequests ];
-    if (allowedExternalRequests.indexOf(requestType) === -1) {
-      allowedExternalRequests.push(requestType);
-      onSaveSettings({ ...tempSettings, allowedExternalRequests });
-    }
-  };
+  const onClick = () => onAddAllowedRequestType(requestType);
 
   return <KeyBlueButton onClick={onClick}>{children}</KeyBlueButton>;
 };

--- a/app/connectors/settings.js
+++ b/app/connectors/settings.js
@@ -23,6 +23,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onChangeTempSettings: sa.updateStateSettingsChanged,
   onSaveSettings: sa.saveSettings,
   onCloseWallet: wla.closeWalletRequest,
+  onAddAllowedRequestType: sa.addAllowedExternalRequest,
   toggleTheme: sa.toggleTheme,
 }, dispatch);
 

--- a/app/reducers/settings.js
+++ b/app/reducers/settings.js
@@ -1,4 +1,5 @@
-import { SETTINGS_SAVE, SETTINGS_CHANGED, SETTINGS_UNCHANGED, SETTINGS_TOGGLE_THEME } from "../actions/SettingsActions";
+import { SETTINGS_SAVE, SETTINGS_CHANGED, SETTINGS_UNCHANGED, SETTINGS_TOGGLE_THEME,
+  ALLOWEDEXTERNALREQUESTS_ADDED } from "../actions/SettingsActions";
 import { WALLET_SETTINGS, SELECT_LANGUAGE } from "actions/DaemonActions";
 export default function settings(state = {}, action) {
   switch (action.type) {
@@ -25,6 +26,11 @@ export default function settings(state = {}, action) {
     return { ...state,
       tempSettings: action.tempSettings,
       settingsChanged: false,
+    };
+  case ALLOWEDEXTERNALREQUESTS_ADDED:
+    return { ...state,
+      currentSettings: action.newSettings,
+      tempSettings: action.newTempSettings,
     };
   case WALLET_SETTINGS:
     currentSettings = state.currentSettings;


### PR DESCRIPTION
Close #1887 

The main motivation for being an individual action instead of reusing the saveSettings action is so that the current temp settings can be preserved if it's changed (eg: go to the settings page, change language and check politeia, then go to the governance page and enable politeia - the changed language will be preserved in the changed settings but not will not be applied yet).