### PR TITLE
[launcher] Fix whitescreen in wallet selection

### DIFF
--- a/app/components/views/GetStartedPage/WalletSelection/index.js
+++ b/app/components/views/GetStartedPage/WalletSelection/index.js
@@ -23,12 +23,15 @@ class WalletSelectionBody extends React.Component {
     };
   }
   componentDidUpdate(prevProps) {
-    if (this.props.availableWallets.length > 0 && prevProps.availableWallets.length !== this.props.availableWallets.length) {
+    if (this.props.selectedWallet && this.props.availableWallets.length === 0) {
+      this.setState({ selectedWallet: null });
+    } else if (prevProps.availableWallets.length !== this.props.availableWallets.length) {
       this.setState({ selectedWallet: this.props.availableWallets[0] });
     } else {
       for (var i = 0; i < prevProps.availableWallets.length; i++) {
         if (this.props.availableWallets[i].label !== prevProps.availableWallets[i].label) {
           this.setState({ selectedWallet: this.props.availableWallets[0] });
+          break;
         }
       }
     }


### PR DESCRIPTION
The error was the componentDidUpdate code relying on having a previous
selectedWallet available, when this won't be true if this the very first
wallet which creation was canceled.

Fix #1886 