### PR TITLE
[settings] Submit passphrase change on enter

### DIFF
--- a/app/components/modals/ChangePassphraseModal/Modal.js
+++ b/app/components/modals/ChangePassphraseModal/Modal.js
@@ -9,14 +9,17 @@ const Modal = ({
   updateConfirmPrivatePassphrase,
   confirmPrivPassError,
   hasFailedAttempt,
+  triggerPassphraseModalSubmit,
   onSubmit,
+  onTriggerPassphraseModalSubmit,
   ...props
 }) => (
   <PassphraseModal
     {...{
       ...props,
       onSubmit,
-      prependPassphraseRow: true
+      prependPassphraseRow: true,
+      triggerSubmit: triggerPassphraseModalSubmit,
     }}
   >
     <PassphraseModalField
@@ -29,6 +32,7 @@ const Modal = ({
         placeholder=""
         value={privPass}
         onChange={(e) => updatePrivatePassphrase(e.target.value)}
+        onKeyDownSubmit={onTriggerPassphraseModalSubmit}
       />
     </PassphraseModalField>
 
@@ -43,6 +47,7 @@ const Modal = ({
         placeholder=""
         value={confirmPrivPass}
         onChange={(e) => updateConfirmPrivatePassphrase(e.target.value)}
+        onKeyDownSubmit={onTriggerPassphraseModalSubmit}
       />
     </PassphraseModalField>
   </PassphraseModal>

--- a/app/components/modals/ChangePassphraseModal/index.js
+++ b/app/components/modals/ChangePassphraseModal/index.js
@@ -21,7 +21,8 @@ class ChangePassphraseModal extends React.Component {
       privPass: "",
       confirmPrivPass: "",
       confirmPrivPassError: false,
-      hasFailedAttempt: false
+      hasFailedAttempt: false,
+      triggerPassphraseModalSubmit: false,
     };
   }
 
@@ -46,12 +47,16 @@ class ChangePassphraseModal extends React.Component {
 
   updatePrivatePassphrase(privPass) {
     if (privPass == "" ) this.setState({ hasFailedAttempt: true });
-    this.setState({ privPass });
+    this.setState({ privPass, triggerPassphraseModalSubmit: false });
   }
 
   updateConfirmPrivatePassphrase(confirmPrivPass) {
     if (confirmPrivPass == "" ) this.setState({ hasFailedAttempt: true });
-    this.setState({ confirmPrivPass, confirmPrivPassError: false });
+    this.setState({ confirmPrivPass, confirmPrivPassError: false, triggerPassphraseModalSubmit: false });
+  }
+
+  onTriggerPassphraseModalSubmit() {
+    this.setState({ triggerPassphraseModalSubmit: true });
   }
 
   render() {
@@ -61,7 +66,8 @@ class ChangePassphraseModal extends React.Component {
       onSubmit,
       onCancelModal,
       isValid,
-      validationFailed
+      validationFailed,
+      onTriggerPassphraseModalSubmit,
     } = this;
 
     return (
@@ -73,7 +79,8 @@ class ChangePassphraseModal extends React.Component {
           onSubmit,
           onCancelModal,
           isValid,
-          validationFailed
+          validationFailed,
+          onTriggerPassphraseModalSubmit
         }}
       />
     );

--- a/app/components/modals/PassphraseModal/PassphraseModal.js
+++ b/app/components/modals/PassphraseModal/PassphraseModal.js
@@ -11,6 +11,12 @@ class PassphraseModal extends React.Component {
     this.state = this.getInitialState();
   }
 
+  componentDidUpdate(prevProps) {
+    if ((prevProps.triggerSubmit !== this.props.triggerSubmit) && this.props.triggerSubmit) {
+      this.onSubmit();
+    }
+  }
+
   onCancelModal() {
     this.resetState();
     this.props.onCancelModal && this.props.onCancelModal();


### PR DESCRIPTION
This changes the ChangePassphraseModal to submit the form when the user
presses the enter key with one of the inputs on focus.

This is slightly tricky due to how modals are currently structured.

Fix #1909 