### PR TITLE
[launcher] Show logs on launcher

### DIFF
--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -51,12 +51,9 @@ const DaemonLoadingBody = ({
               <SettingsLinkMsg />
             </InvisibleButton>
           }
-          {(getDaemonStarted && !isDaemonRemote) || getWalletReady ?
-            <InvisibleButton onClick={onShowLogs}>
-              <LogsLinkMsg />
-            </InvisibleButton> :
-            <div/>
-          }
+          <InvisibleButton onClick={onShowLogs}>
+            <LogsLinkMsg />
+          </InvisibleButton>
         </Aux>
       </div>
       <Aux>

--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -25,7 +25,6 @@ const DaemonLoadingBody = ({
   startupError,
   updateAvailable,
   appVersion,
-  isDaemonRemote,
   isSPV,
   syncInput,
   passPhrase,

--- a/app/components/views/GetStartedPage/SpvSync/Form.js
+++ b/app/components/views/GetStartedPage/SpvSync/Form.js
@@ -43,15 +43,13 @@ const SpvSyncBody = ({
             <Aux>
               <AboutModalButton { ...{ appVersion, updateAvailable } } />
               {getWalletReady &&
-                <Aux>
-                  <InvisibleButton onClick={onShowSettings}>
-                    <SettingsLinkMsg />
-                  </InvisibleButton>
-                  <InvisibleButton onClick={onShowLogs}>
-                    <LogsLinkMsg />
-                  </InvisibleButton>
-                </Aux>
+                <InvisibleButton onClick={onShowSettings}>
+                  <SettingsLinkMsg />
+                </InvisibleButton>
               }
+              <InvisibleButton onClick={onShowLogs}>
+                <LogsLinkMsg />
+              </InvisibleButton>
             </Aux>
           </div>
           <LoaderTitleMsg />


### PR DESCRIPTION
Close #1921 

This will make it so the logs button is always shown.  Then depending on what logs are available they will be shown there.