### PR TITLE
[stats] Fix locked balance and vote time stats

### DIFF
--- a/app/actions/StatisticsActions.js
+++ b/app/actions/StatisticsActions.js
@@ -600,7 +600,7 @@ export const balancesStats = (opts) => async (dispatch, getState) => {
       const { unmined } = await wallet.getTransactions(walletService, -1, -1, 0);
       const fixedUnmined = unmined.map(tx => ({ ...tx, timestamp: currentDate.getTime(),
         height: currentBlockHeight }));
-      toProcess.push(...fixedUnmined);
+      toProcess.unshift(...fixedUnmined);
 
       // on backwards stats, we find vote txs before finding ticket txs, so
       // pre-process tickets from all grabbed txs to avoid making the separate

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -867,6 +867,7 @@ export const averageVoteTime = createSelector(
   (voteTimeStats) => {
     if (!voteTimeStats || !voteTimeStats.data.length) return 0;
     const ticketCount = voteTimeStats.data.reduce((s, v) => s + v.series.count, 0);
+    if (ticketCount === 0) return 0;
     let sum = 0;
     for (let i = 0; i < voteTimeStats.data.length; i++) {
       sum += voteTimeStats.data[i].series.count * i;
@@ -879,6 +880,7 @@ export const medianVoteTime = createSelector(
   (voteTimeStats) => {
     if (!voteTimeStats || !voteTimeStats.data.length) return 0;
     const ticketCount = voteTimeStats.data.reduce((s, v) => s + v.series.count, 0);
+    if (ticketCount === 0) return 0;
     const ticketLimit = ticketCount * 0.5;
     let sum = 0;
     for (let i = 0; i < voteTimeStats.data.length; i++) {
@@ -892,6 +894,7 @@ export const ninetyFifthPercentileVoteTime = createSelector(
   (voteTimeStats) => {
     if (!voteTimeStats || !voteTimeStats.data.length) return 0;
     const ticketCount = voteTimeStats.data.reduce((s, v) => s + v.series.count, 0);
+    if (ticketCount === 0) return 0;
     const ticketLimit = ticketCount * 0.95;
     let sum = 0;
     for (let i = 0; i < voteTimeStats.data.length; i++) {
@@ -911,8 +914,8 @@ export const stakeRewardsStats = createSelector(
     stakeRewards: s.series.stakeRewards / unitDivisor,
     stakeFees: s.series.stakeFees / unitDivisor,
     totalStake: s.series.totalStake / unitDivisor,
-    stakeRewardPerc: (s.series.stakeRewards / s.series.totalStake),
-    stakeFeesPerc: (s.series.stakeFees / s.series.totalStake),
+    stakeRewardPerc: (s.series.stakeRewards / (s.series.totalStake || 1)),
+    stakeFeesPerc: (s.series.stakeFees / (s.series.totalStake || 1)),
   })));
 
 export const modalVisible = get([ "control", "modalVisible" ]);


### PR DESCRIPTION
Fix #1933 

#1933 was caused by appending unmined transactions at the end of the transaction list for processing, when the correct (in backwards mode) is to prepend it to the start of the list.

Fix #1930 

#1930 was caused by a division by 0 when there are tickets but no votes yet.