### PR TITLE
[mytickets] Allow cancelation when listing tickets

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -501,6 +501,24 @@ const getTicketsFromTransactions = async (walletService, startIdx, endIdx, maxCo
         const txIsTicket = tx.type === TransactionDetails.TransactionType.TICKET_PURCHASE;
         const ticketWasSpent = [ "voted", "revoked" ].indexOf(ticket.status) > -1;
 
+        if (!txIsTicket && !ticketWasSpent) {
+          // This is a limitation in wallet.getTicket() when the wallet does not
+          // have the voting rights (output 0) for the ticket. The status of the
+          // original ticket is obviously bogus, given that it doesn't return
+          // the ticket's status as voted/revoked, even though we have found its
+          // corresponding vote/revocation tx. For the moment, we hack around
+          // the returned data to simulate as if the ticket's spend status was
+          // actually returned correctly, but we need to be careful to filter
+          // for duplicate occurrences of the ticket later on the code flow.
+          const statusByTxType = {
+            [TransactionDetails.TransactionType.VOTE]: "voted",
+            [TransactionDetails.TransactionType.REVOCATION]: "revoked",
+          };
+          ticket.status = statusByTxType[tx.type];
+          ticket.spender = tx.tx;
+          return ticket;
+        }
+
         if (desc && txIsTicket && ticketWasSpent) {
           // fetching backwards, we ignore data from voted/revoked tickets given
           // that we should have seen the spender tx already, so this ticket has
@@ -563,6 +581,7 @@ export const getTickets = () => async (dispatch, getState) => {
     currentBlockHeight } = getState().grpc;
   let { noMoreTickets, getTicketsStartRequestHeight, minedTickets } = getState().grpc;
   const pageCount = maximumTransactionCount;
+  const ticketsNormalizer = sel.ticketsNormalizer(getState());
 
   // List of transactions found after filtering
   let filtered = [];
@@ -571,7 +590,7 @@ export const getTickets = () => async (dispatch, getState) => {
   // have been mined
   let { tickets } = await getTicketsFromTransactions(walletService, -1, -1, 0, currentBlockHeight);
   const unminedFiltered = filterTickets(tickets, ticketsFilter);
-  const unminedTickets = sel.ticketsNormalizer(getState())(unminedFiltered);
+  const unminedTickets = ticketsNormalizer(unminedFiltered);
 
   let startRequestHeight, endRequestHeight, desc;
   if ( ticketsFilter.listDirection === "desc" ) {
@@ -605,7 +624,9 @@ export const getTickets = () => async (dispatch, getState) => {
         lastReportedHeight = startRequestHeight;
       }
 
-      filtered.push(...filterTickets(tickets, ticketsFilter));
+      const thisFiltered = filterTickets(tickets, ticketsFilter);
+      const normalized = ticketsNormalizer(thisFiltered);
+      filtered.push(...normalized);
 
       if (getState().grpc.getTicketsCancel) {
         noMoreTickets = true;
@@ -616,10 +637,32 @@ export const getTickets = () => async (dispatch, getState) => {
     }
   }
 
-  const normalized = sel.ticketsNormalizer(getState())(filtered);
-  minedTickets = [ ...minedTickets, ...normalized ];
+  // This next bit is required due to wallet.getTicket() not correctly showing
+  // the status of tickets when the wallet doesn't have the voting rights for
+  // it. Without this duplicate filtering, we'd see two transactions (the ticket
+  // and a vote/revocation) shown as the same expired or missed status.
+  const newMinedTickets = [];
 
-  dispatch({ unminedTickets, minedTickets, noMoreTickets,
+  if (desc) {
+    // When iterating in desc mode, we add the first found (most recent) ticket
+    // tx (which should have the correct status) and ignore the next one (the
+    // purchase, which would show as missed/expired)
+    newMinedTickets.push(...minedTickets);
+    const ticketsMap = minedTickets.reduce((m, t) => { m[t.hash] = t; return m; }, {});
+    newMinedTickets.push(...filtered.filter(t => !ticketsMap[t.hash]));
+  } else {
+    // When iterating in asc mode, we unshift the newly found (most recent)
+    // tickets first, then ignore the previous (older) one, as the most recent
+    // one will have the correct status.
+    // This provokes a small UI issue in that the older ticket disappears from
+    // the list, causing a "jump" and if the user backtracks it won't be
+    // there anymore.
+    newMinedTickets.push(...filtered);
+    const ticketsMap = filtered.reduce((m, t) => { m[t.hash] = t; return m; }, {});
+    newMinedTickets.unshift(...minedTickets.filter(t => !ticketsMap[t.hash]));
+  }
+
+  dispatch({ unminedTickets, minedTickets: newMinedTickets, noMoreTickets,
     getTicketsStartRequestHeight: startRequestHeight,
     type: GETTICKETS_COMPLETE });
 };

--- a/app/components/indicators/LoadingMoreTickets.js
+++ b/app/components/indicators/LoadingMoreTickets.js
@@ -1,10 +1,49 @@
 import StakeyBounceXs from "./StakeyBounceExtraSmall";
+import { loadingTickets } from "connectors";
 import { FormattedMessage as T } from "react-intl";
+import { Tooltip } from "shared";
 import "style/Loading.less";
 
-const LoadingMoreTicketsIndicator = () =>
-  <div className="loading-more-transactions-indicator">
-    <StakeyBounceXs /><T id="myTickets.loadingMoreTickets" m="Loading more tickets..." />
+const DescMessage = ({ startRequestHeight, currentBlockHeight }) =>
+  <T id="myTickets.loadingMoreTicketsProgressDesc"
+    m="Down to block {block} ({blockPerc, number, percent})"
+    values={{
+      block: startRequestHeight,
+      blockPerc: (currentBlockHeight - startRequestHeight) / currentBlockHeight
+    }}
+  />;
+
+const AscMessage = ({ startRequestHeight, currentBlockHeight }) =>
+  <T id="myTickets.loadingMoreTicketsProgressAsc"
+    m="Up to block {block} ({blockPerc, number, percent})"
+    values={{
+      block: startRequestHeight,
+      blockPerc: (startRequestHeight / currentBlockHeight)
+    }}
+  />;
+
+const CancelLoadingTicketsButton = ({ cancelGetTickets }) => (
+  <Tooltip text={ <T id="mytickets.loadingMoreTickets.cancelBtn" m={"Cancel listing tickets"} /> }>
+    <button
+      className={"gettickets-cancel-button"}
+      onClick={cancelGetTickets} />
+  </Tooltip>
+);
+
+const LoadingTicketsProgress = ({ startRequestHeight, ticketsFilter, currentBlockHeight, cancelGetTickets }) =>
+  <div className="loading-more-tickets-progress-line">
+    {
+      ticketsFilter.listDirection === "desc"
+        ? <DescMessage {...{ startRequestHeight, currentBlockHeight }} />
+        : <AscMessage {...{ startRequestHeight, currentBlockHeight }} />
+    }
+    <CancelLoadingTicketsButton cancelGetTickets={cancelGetTickets} />
   </div>;
 
-export default LoadingMoreTicketsIndicator;
+const LoadingMoreTicketsIndicator = ({ startRequestHeight, ...props }) =>
+  <div className="loading-more-transactions-indicator">
+    <StakeyBounceXs /><T id="myTickets.loadingMoreTickets" m="Loading more tickets..." />
+    { startRequestHeight && <LoadingTicketsProgress { ...{ startRequestHeight, ...props }} /> }
+  </div>;
+
+export default loadingTickets(LoadingMoreTicketsIndicator);

--- a/app/components/views/TicketsPage/MyTicketsTab/Page.js
+++ b/app/components/views/TicketsPage/MyTicketsTab/Page.js
@@ -9,6 +9,14 @@ import "style/MyTickets.less";
 @autobind
 class TicketListPage extends React.Component {
 
+  componentDidMount() {
+    if ((window.innerWidth > 1500) && (!this.props.noMoreTickets)) {
+      // hack to load more items in large-width displays, so that the scroll
+      // doesn't get stuck and can actually get triggered.
+      this.props.onLoadMoreTickets();
+    }
+  }
+
   render() {
     const {
       tickets, noMoreTickets,

--- a/app/connectors/index.js
+++ b/app/connectors/index.js
@@ -57,3 +57,4 @@ export { default as network } from "./network";
 export { default as treasuryInfo } from "./treasuryInfo";
 export { default as trezor } from "./trezor";
 export { default as importScript } from "./importScript";
+export { default as loadingTickets } from "./loadingTickets";

--- a/app/connectors/loadingTickets.js
+++ b/app/connectors/loadingTickets.js
@@ -1,0 +1,17 @@
+import { connect } from "react-redux";
+import { selectorMap } from "../fp";
+import { bindActionCreators } from "redux";
+import * as sel from "../selectors";
+import * as ca from "actions/ClientActions";
+
+const mapStateToProps = selectorMap({
+  startRequestHeight: sel.getTicketsProgressStartRequestHeight,
+  ticketsFilter: sel.ticketsFilter,
+  currentBlockHeight: sel.currentBlockHeight
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  cancelGetTickets: ca.cancelGetTickets,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps);

--- a/app/index.js
+++ b/app/index.js
@@ -187,6 +187,8 @@ var initialState = {
       status: [], // desired ticket status (code). All if blank.
     },
     getTicketsStartRequestHeight: null,
+    getTicketsCancel: false, // user requested cancelation (but it hasn't happened yet)
+    getTicketsProgressStartRequestHeight: null,
 
     // Agenda/VoteChoices
     getAgendasResponse: null,

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -12,6 +12,7 @@ import {
   NEW_TRANSACTIONS_RECEIVED, CHANGE_TRANSACTIONS_FILTER,
   UPDATETIMESINCEBLOCK,
   GETTICKETS_ATTEMPT, GETTICKETS_FAILED, GETTICKETS_COMPLETE, CLEAR_TICKETS,
+  GETTICKETS_PROGRESS, GETTICKETS_CANCEL,
   GETAGENDASERVICE_ATTEMPT, GETAGENDASERVICE_FAILED, GETAGENDASERVICE_SUCCESS,
   RAWTICKETTRANSACTIONS_DECODED, CHANGE_TICKETS_FILTER,
   GETMESSAGEVERIFICATIONSERVICE_ATTEMPT, GETMESSAGEVERIFICATIONSERVICE_FAILED, GETMESSAGEVERIFICATIONSERVICE_SUCCESS,
@@ -274,12 +275,15 @@ export default function grpc(state = {}, action) {
     return {
       ...state,
       getTicketsRequestAttempt: true,
+      getTicketsCancel: false,
     };
   case GETTICKETS_FAILED:
     return {
       ...state,
       getTicketsRequestError: String(action.error),
       getTicketsRequestAttempt: false,
+      getTicketsCancel: false,
+      getTicketsProgressStartRequestHeight: null,
     };
   case GETTICKETS_COMPLETE:
     var tickets = [ ...action.unminedTickets, ...action.minedTickets ];
@@ -292,6 +296,18 @@ export default function grpc(state = {}, action) {
       getTicketsRequestError: "",
       getTicketsRequestAttempt: false,
       getTicketsStartRequestHeight: action.getTicketsStartRequestHeight,
+      getTicketsCancel: false,
+      getTicketsProgressStartRequestHeight: null,
+    };
+  case GETTICKETS_PROGRESS:
+    return {
+      ...state,
+      getTicketsProgressStartRequestHeight: action.startRequestHeight,
+    };
+  case GETTICKETS_CANCEL:
+    return {
+      ...state,
+      getTicketsCancel: true
     };
   case CLEAR_TICKETS:
     return { ...state,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -307,6 +307,7 @@ export const ticketNormalizer = createSelector(
 
 export const noMoreTickets = get([ "grpc", "noMoreTickets" ]);
 export const ticketsFilter = get([ "grpc", "ticketsFilter" ]);
+export const getTicketsProgressStartRequestHeight = get([ "grpc", "getTicketsProgressStartRequestHeight" ]);
 export const ticketsNormalizer = createSelector([ ticketNormalizer ], map);
 export const tickets = get([ "grpc", "tickets" ]);
 export const numTicketsToBuy = get([ "control", "numTicketsToBuy" ]);

--- a/app/style/Loading.less
+++ b/app/style/Loading.less
@@ -33,6 +33,18 @@
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
   display: inline-block;
   margin-top: 2em;
+
+  .loading-more-tickets-progress-line {
+
+    color: var(--disabled-color);
+
+    .gettickets-cancel-button {
+      display: inline-block;
+      vertical-align: middle;
+      margin-left: 10px;
+      margin-top: -2px;
+    }
+  }
 }
 
 .new-logo-animation {

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -587,6 +587,7 @@
   float: right;
 }
 
+.gettickets-cancel-button,
 .rescan-cancel-button {
   width: 16px;
   height: 16px;
@@ -598,6 +599,7 @@
   cursor: pointer;
 }
 
+.gettickets-cancel-button:hover,
 .rescan-cancel-button:hover {
   opacity: 0.7;
 }

--- a/app/style/Themes.less
+++ b/app/style/Themes.less
@@ -9,7 +9,7 @@
     --input-color-focused: #091140;
     --input-color-disabled: #dadfe2;
     --input-color-shadow: rgba(9, 20, 64, 0.21);
-    --stroke-color-default: #a9b4bf; 
+    --stroke-color-default: #a9b4bf;
     --button-text: #48566e;
     --white-button-text: #fff;
     --title-text-and-button-background: #b5bbc5;
@@ -57,7 +57,7 @@
     --title-text-and-button-background: #48566e;
     --title-text-and-button-background-hovered: rgba(72, 86, 110, 0.7);
     --title-text-and-button-background-drop-shadow: rgba(72, 86, 110, 0.34);
-    --stroke-color-default: #a9b4bf; 
+    --stroke-color-default: #a9b4bf;
     --stroke-color-hovered: #596d81;
     --stroke-color-focused: #2970ff;
     --input-color: #2970ff;
@@ -85,4 +85,3 @@
     --display-wallet-gradient-selected-right: #6ed3f3;
     --tx-history-background-hover: rgba(212, 240, 253, 0.5);
   }
-  


### PR DESCRIPTION
This allows cancelation of the whole getTickets process mid-way through,
when problems or delays are noticed.

Decrediton's getTickets current scans the whole transaction set for
tickets of the specified filter status, so some combinations may be slow
to fulfill.

close #1958 