### PR TITLE
[politeia] Ignore listing after wallet closed

### DIFF
--- a/app/reducers/governance.js
+++ b/app/reducers/governance.js
@@ -1,5 +1,5 @@
 import {
-  GETVETTED_ATTEMPT, GETVETTED_FAILED, GETVETTED_SUCCESS,
+  GETVETTED_ATTEMPT, GETVETTED_FAILED, GETVETTED_SUCCESS, GETVETTED_CANCELED,
   GETVETTED_UPDATEDVOTERESULTS_SUCCESS,
   GETPROPOSAL_ATTEMPT, GETPROPOSAL_FAILED, GETPROPOSAL_SUCCESS,
   UPDATEVOTECHOICE_ATTEMPT, UPDATEVOTECHOICE_SUCCESS, UPDATEVOTECHOICE_FAILED,
@@ -13,6 +13,8 @@ export default function governance(state = {}, action) {
   case GETVETTED_ATTEMPT:
     return { ...state, getVettedAttempt: true };
   case GETVETTED_FAILED:
+    return { ...state, getVettedAttempt: false };
+  case GETVETTED_CANCELED:
     return { ...state, getVettedAttempt: false };
   case GETVETTED_SUCCESS:
     return { ...state,


### PR DESCRIPTION
This changes the logic for fetching Politeia data such that, if the
wallet is detected as closed (or changed) then the results or any errors
are ignored.

This is necessary because the external access to Politeia can be slow
(due to server load) or the call to the wallets CommittedTickets grpc
endpoint may take some time to complete if the wallet has many tickets.

An user closing the wallet while the results are still being fetched
would cause an undersirable snackbar error message without this fix.

close #1964 