### PR TITLE
[politeia] Use publishedat for notifications

### DIFF
--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -176,6 +176,8 @@ export const getVettedProposals = () => async (dispatch, getState) => {
       const voteData = parseOptionsResult(voteStatus.optionsresult);
       const oldProposal = oldProposals[p.censorshiprecord.token];
 
+      const publishedTimestamp = p.publishedat || p.timestamp || 0;
+
       const proposal = {
         hasDetails: false,
         ...oldProposal,
@@ -190,7 +192,7 @@ export const getVettedProposals = () => async (dispatch, getState) => {
         files: [],
         hasEligibleTickets: 0,
         eligibleTickets: [],
-        modifiedSinceLastAccess: (p.timestamp*1000) > lastAccessTime,
+        modifiedSinceLastAccess: (publishedTimestamp*1000) > lastAccessTime,
         votingSinceLastAccess: false,
         ...voteData,
       };


### PR DESCRIPTION
This changes the timestamp used for determining notification status from
the original 'timestamp' (last modification timestamp) to 'publishedat'
(publishing timestamp), given that proposals that sit a long time for
vetting might not generate a notification if they haven't been updated.