### PR TITLE
Remove extra setSeconds call

### DIFF
--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -29,10 +29,9 @@ export function dateToUTC(timestamp) {
 export function endOfDay(dt) {
   const res = new Date(dt);
   res.setMilliseconds(0);
-  res.setSeconds(0);
+  res.setSeconds(-1);
   res.setMinutes(0);
   res.setHours(0);
-  res.setSeconds(-1);
   res.setDate(res.getDate()+1);
   return res;
 }

--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -29,9 +29,10 @@ export function dateToUTC(timestamp) {
 export function endOfDay(dt) {
   const res = new Date(dt);
   res.setMilliseconds(0);
-  res.setSeconds(-1);
+  res.setSeconds(0);
   res.setMinutes(0);
   res.setHours(0);
+  res.setSeconds(-1);
   res.setDate(res.getDate()+1);
   return res;
 }

--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -24,7 +24,7 @@ export function dateToUTC(timestamp) {
     date.getUTCHours(), date.getUTCMinutes(),  date.getUTCSeconds());
 }
 
-// Returns a new date pointing to the last microsecond of the day of the given date
+// Returns a new date pointing to the last millisecond of the day of the given date
 export function endOfDay(date) {
   const result = new Date(date);
   result.setHours(23,59,59,999);

--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -24,17 +24,11 @@ export function dateToUTC(timestamp) {
     date.getUTCHours(), date.getUTCMinutes(),  date.getUTCSeconds());
 }
 
-// endOfDay returns a new date pointing to the end of the day (last second)
-// of the day stored in the given date.
-export function endOfDay(dt) {
-  const res = new Date(dt);
-  res.setMilliseconds(0);
-  res.setSeconds(0);
-  res.setMinutes(0);
-  res.setHours(0);
-  res.setSeconds(-1);
-  res.setDate(res.getDate()+1);
-  return res;
+// Returns a new date pointing to the last microsecond of the day of the given date
+export function endOfDay(date) {
+  const result = new Date(date);
+  result.setHours(23,59,59,999);
+  return result;
 }
 
 // formatLocalISODate formats the given Date object d in an ISO8601 format, using

--- a/test/unit/helpers/date.spec.js
+++ b/test/unit/helpers/date.spec.js
@@ -1,6 +1,6 @@
 import tzmock from "timezone-mock";
 import { dateToLocal } from "helpers";
-import { dateToUTC } from "../../../app/helpers/dateFormat";
+import { dateToUTC, endOfDay } from "../../../app/helpers/dateFormat";
 
 afterEach(() => tzmock.unregister());
 
@@ -8,6 +8,18 @@ function localTime(d) {
   return [ d.getFullYear(), d.getMonth()+1, d.getDate(), d.getHours(),
     d.getMinutes(), d.getSeconds(), d.getMilliseconds() ];
 }
+
+test("endOfDay works as expected", () => {
+  expect(localTime(endOfDay("2019-02-10 12:23"))).toEqual([ 2019, 2, 10, 23, 59, 59, 999 ]);
+  expect(localTime(endOfDay("2019-02-01 23:59:40"))).toEqual([ 2019, 2, 1, 23, 59, 59, 999 ]);
+  expect(localTime(endOfDay("2019-02-01 23:59:59"))).toEqual([ 2019, 2, 1, 23, 59, 59, 999 ]);
+  expect(localTime(endOfDay("2019-02-02 00:00"))).toEqual([ 2019, 2, 2, 23, 59, 59, 999 ]);
+
+  expect(localTime(endOfDay(new Date("2019-02-10 12:23")))).toEqual([ 2019, 2, 10, 23, 59, 59, 999 ]);
+  expect(localTime(endOfDay(new Date("2019-02-01 23:59:40")))).toEqual([ 2019, 2, 1, 23, 59, 59, 999 ]);
+  expect(localTime(endOfDay(new Date("2019-02-01 23:59:59")))).toEqual([ 2019, 2, 1, 23, 59, 59, 999 ]);
+  expect(localTime(endOfDay(new Date("2019-02-02 00:00")))).toEqual([ 2019, 2, 2, 23, 59, 59, 999 ]);
+});
 
 test("dateToLocal works as expected", () => {
   tzmock.register("UTC");


### PR DESCRIPTION
It seems like the first setSeconds call has no use, because it's called again with `-1` a bit later. 