### PR TITLE
[launcher] Add pipetx to wallet on win32 platform

### DIFF
--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -6,6 +6,9 @@ import parseArgs from "minimist";
 import { OPTIONS } from "./constants";
 import os from "os";
 import fs from "fs-extra";
+import util from "util";
+import { spawn } from "child_process";
+import isRunning from "is-running";
 import stringArgv from "string-argv";
 import { concat, isString } from "../fp";
 
@@ -18,7 +21,9 @@ let dcrwPID;
 
 // windows-only stuff
 let dcrwPipeRx;
+let dcrwPipeTx;
 let dcrdPipeRx;
+let dcrwTxStream;
 
 let dcrwPort;
 
@@ -31,8 +36,8 @@ function closeClis() {
     closeDCRW(dcrwPID);
 }
 
-export function closeDCRD() {
-  if (require("is-running")(dcrdPID) && os.platform() != "win32") {
+function closeDCRD() {
+  if (isRunning(dcrdPID) && os.platform() != "win32") {
     logger.log("info", "Sending SIGINT to dcrd at pid:" + dcrdPID);
     process.kill(dcrdPID, "SIGINT");
     dcrdPID = null;
@@ -51,12 +56,14 @@ export function closeDCRD() {
 
 export const closeDCRW = () => {
   try {
-    if (require("is-running")(dcrwPID) && os.platform() != "win32") {
+    if (isRunning(dcrwPID) && os.platform() != "win32") {
       logger.log("info", "Sending SIGINT to dcrwallet at pid:" + dcrwPID);
       process.kill(dcrwPID, "SIGINT");
-    } else if (require("is-running")(dcrwPID)) {
+    } else if (isRunning(dcrwPID)) {
       try {
         const win32ipc = require("../node_modules/win32ipc/build/Release/win32ipc.node");
+        dcrwTxStream.close();
+        win32ipc.closePipe(dcrwPipeTx);
         win32ipc.closePipe(dcrwPipeRx);
       } catch (e) {
         logger.log("error", "Error closing dcrwallet piperx: " + e);
@@ -86,7 +93,7 @@ export async function cleanShutdown(mainWindow, app) {
     logger.log("info", "Closing decrediton.");
 
     let shutdownTimer = setInterval(function () {
-      const stillRunning = (require("is-running")(dcrdPID) && os.platform() != "win32");
+      const stillRunning = (isRunning(dcrdPID) && os.platform() != "win32");
 
       if (!stillRunning) {
         logger.log("info", "Final shutdown pause. Quitting app.");
@@ -106,7 +113,6 @@ export async function cleanShutdown(mainWindow, app) {
 }
 
 export const launchDCRD = (mainWindow, daemonIsAdvanced, daemonPath, appdata, testnet, reactIPC) => {
-  const spawn = require("child_process").spawn;
   let args = [ "--nolisten" ];
   let newConfig = {};
   if (appdata) {
@@ -130,7 +136,6 @@ export const launchDCRD = (mainWindow, daemonIsAdvanced, daemonPath, appdata, te
 
   if (os.platform() == "win32") {
     try {
-      const util = require("util");
       const win32ipc = require("../node_modules/win32ipc/build/Release/win32ipc.node");
       dcrdPipeRx = win32ipc.createPipe("out");
       args.push(util.format("--piperx=%d", dcrdPipeRx.readEnd));
@@ -188,7 +193,7 @@ export const launchDCRD = (mainWindow, daemonIsAdvanced, daemonPath, appdata, te
 // dcrwallet using their internal IPC protocol.
 // NOTE: very simple impl for the moment, will break if messages get split
 // between data calls.
-const DecodeDaemonIPCData = (logger, data, cb) => {
+const DecodeDaemonIPCData = (data, cb) => {
   let i = 0;
   while (i < data.length) {
     if (data[i++] !== 0x01) throw "Wrong protocol version when decoding IPC data";
@@ -204,7 +209,6 @@ const DecodeDaemonIPCData = (logger, data, cb) => {
 };
 
 export const launchDCRWallet = (mainWindow, daemonIsAdvanced, walletPath, testnet, reactIPC) => {
-  const spawn = require("child_process").spawn;
   let args = [ "--configfile=" + dcrwalletCfg(getWalletPath(testnet, walletPath)) ];
 
   const cfg = getWalletCfg(testnet, walletPath);
@@ -219,12 +223,40 @@ export const launchDCRWallet = (mainWindow, daemonIsAdvanced, walletPath, testne
     return;
   }
 
+  const notifyGrpcPort = (port) => {
+    dcrwPort = port;
+    logger.log("info", "wallet grpc running on port", port);
+    mainWindow.webContents.send("dcrwallet-port", port);
+  };
+
+  const decodeDcrwIPC = data => DecodeDaemonIPCData(data, (mtype, payload) => {
+    if (mtype === "grpclistener") {
+      const intf = payload.toString("utf-8");
+      const matches = intf.match(/^.+:(\d+)$/);
+      if (matches) {
+        notifyGrpcPort(matches[1]);
+      } else {
+        logger.log("error", "GRPC port not found on IPC channel to dcrwallet: " + intf);
+      }
+    }
+  });
+
   if (os.platform() == "win32") {
     try {
-      const util = require("util");
       const win32ipc = require("../node_modules/win32ipc/build/Release/win32ipc.node");
       dcrwPipeRx = win32ipc.createPipe("out");
       args.push(util.format("--piperx=%d", dcrwPipeRx.readEnd));
+
+      dcrwPipeTx = win32ipc.createPipe("in");
+      args.push(util.format("--pipetx=%d", dcrwPipeTx.writeEnd));
+      args.push("--rpclistenerevents");
+      const pipeTxReadFd = win32ipc.getPipeEndFd(dcrwPipeTx.readEnd);
+      dcrwPipeTx.readEnd = -1; // -1 == INVALID_HANDLE_VALUE
+
+      dcrwTxStream = fs.createReadStream("", { fd: pipeTxReadFd });
+      dcrwTxStream.on("data", decodeDcrwIPC);
+      dcrwTxStream.on("error", (e) => e && e.code && e.code != "EOF" && logger.log("error", "tx stream error", e));
+      dcrwTxStream.on("close", () => logger.log("info", "dcrwallet tx stream closed"));
     } catch (e) {
       logger.log("error", "can't find proper module to launch dcrwallet: " + e);
     }
@@ -245,23 +277,9 @@ export const launchDCRWallet = (mainWindow, daemonIsAdvanced, walletPath, testne
     stdio: [ "ignore", "pipe", "pipe", "ignore", "pipe" ]
   });
 
-  const notifyGrpcPort = (port) => {
-    dcrwPort = port;
-    logger.log("info", "wallet grpc running on port", port);
-    mainWindow.webContents.send("dcrwallet-port", port);
-  };
-
-  dcrwallet.stdio[4].on("data", (data) => DecodeDaemonIPCData(logger, data, (mtype, payload) => {
-    if (mtype === "grpclistener") {
-      const intf = payload.toString("utf-8");
-      const matches = intf.match(/^.+:(\d+)$/);
-      if (matches) {
-        notifyGrpcPort(matches[1]);
-      } else {
-        logger.log("error", "GRPC port not found on IPC channel to dcrwallet: " + intf);
-      }
-    }
-  }));
+  if (os.platform() !== "win32") {
+    dcrwallet.stdio[4].on("data", decodeDcrwIPC);
+  }
 
   dcrwallet.on("error", function (err) {
     logger.log("error", "Error running dcrwallet.  Check logs and restart! " + err);
@@ -287,23 +305,7 @@ export const launchDCRWallet = (mainWindow, daemonIsAdvanced, walletPath, testne
 
   const addStdoutToLogListener = (data) => AddToDcrwalletLog(process.stdout, data, debug);
 
-  // waitForGrpcPortListener is added as a stdout on("data") listener only on
-  // win32 because so far that's the only way we found to get back the grpc port
-  // on that platform. For linux/macOS users, the --pipetx argument is used to
-  // provide a pipe back to decrediton, which reads the grpc port in a secure and
-  // reliable way.
-  const waitForGrpcPortListener = (data) => {
-    const matches = /DCRW: gRPC server listening on [^ ]+:(\d+)/.exec(data);
-    if (matches) {
-      notifyGrpcPort(matches[1]);
-      // swap the listener since we don't need to keep looking for the port
-      dcrwallet.stdout.removeListener("data", waitForGrpcPortListener);
-      dcrwallet.stdout.on("data", addStdoutToLogListener);
-    }
-    AddToDcrwalletLog(process.stdout, data, debug);
-  };
-
-  dcrwallet.stdout.on("data", os.platform() == "win32" ? waitForGrpcPortListener : addStdoutToLogListener);
+  dcrwallet.stdout.on("data", addStdoutToLogListener);
   dcrwallet.stderr.on("data", (data) => {
     AddToDcrwalletLog(process.stderr, data, debug);
   });
@@ -322,7 +324,6 @@ export const GetDcrdPID = () => dcrdPID;
 export const GetDcrwPID = () => dcrwPID;
 
 export const readExesVersion = (app, grpcVersions) => {
-  let spawn = require("child_process").spawnSync;
   let args = [ "--version" ];
   let exes = [ "dcrd", "dcrwallet", "dcrctl" ];
   let versions = {

--- a/app/modules/win32ipc/module.cc
+++ b/app/modules/win32ipc/module.cc
@@ -1,6 +1,8 @@
 #include <node.h>
 #include <v8.h>
 #include <cstring>
+#include <io.h>
+#include <uv.h>
 
 #include "pipe_wrapper.h"
 
@@ -20,7 +22,7 @@ void CreatePipe(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
     pipe_wrapper::pipe_direction direction;
 
-    v8::String::Utf8Value const arg0(args[0]->ToString());
+    v8::String::Utf8Value const arg0(isolate, args[0]);
     if (arg0.length() == 2 && !std::strcmp("in", *arg0)) {
         direction = pipe_wrapper::pipe_direction::IN;
     } else if (arg0.length() == 3 && !std::strcmp("out", *arg0)) {
@@ -53,6 +55,7 @@ void CreatePipe(v8::FunctionCallbackInfo<v8::Value> const& args) {
         v8::Number::New(isolate, (double)pipe.read_end_handle));
     obj->Set(v8::String::NewFromUtf8(isolate, "writeEnd"),
         v8::Number::New(isolate, (double)pipe.write_end_handle));
+
     args.GetReturnValue().Set(obj);
 }
 
@@ -101,6 +104,26 @@ void ClosePipe(v8::FunctionCallbackInfo<v8::Value> const& args) {
     }
 }
 
+void GetPipeEndFd(v8::FunctionCallbackInfo<v8::Value> const& args) {
+    auto isolate = v8::Isolate::GetCurrent();
+
+    if (args.Length() != 1) {
+        isolate->ThrowException(v8::Exception::TypeError(
+            v8::String::NewFromUtf8(isolate, "Wrong number of arguments")));
+        return;
+    }
+
+    if (!args[0]->IsNumber()) {
+        isolate->ThrowException(v8::Exception::TypeError(
+            v8::String::NewFromUtf8(isolate, "Argument type error")));
+        return;
+    }
+
+    uv_os_fd_t fhandle = (uv_os_fd_t) args[0]->IntegerValue();
+    int fd = uv_open_osfhandle(fhandle);
+
+    args.GetReturnValue().Set(v8::Number::New(isolate, (double) fd));
+}
 
 void Init(v8::Handle<v8::Object> exports) {
     auto isolate = v8::Isolate::GetCurrent();
@@ -108,6 +131,8 @@ void Init(v8::Handle<v8::Object> exports) {
         v8::FunctionTemplate::New(isolate, CreatePipe)->GetFunction());
     exports->Set(v8::String::NewFromUtf8(isolate, "closePipe"),
         v8::FunctionTemplate::New(isolate, ClosePipe)->GetFunction());
+    exports->Set(v8::String::NewFromUtf8(isolate, "getPipeEndFd"),
+        v8::FunctionTemplate::New(isolate, GetPipeEndFd)->GetFunction());
 }
 
 NODE_MODULE(win32ipc, Init)

--- a/app/modules/win32ipc/moduleTestWallet.js
+++ b/app/modules/win32ipc/moduleTestWallet.js
@@ -6,6 +6,7 @@ const childProcess = require("child_process");
 const addon = require("./build/Release/win32ipc");
 const path = require("path");
 const os = require("os");
+const fs = require("fs");
 
 //const pipeFname = "\\\\.\\pipe\\dcrwallet-test";
 const walletConfPath = path.join(os.homedir(), "AppData", "Local", "Decrediton",
@@ -15,19 +16,61 @@ function sleep(milli) {
   return new Promise(resolve => setTimeout(resolve, milli));
 }
 
+function DecodeDaemonIPCData(data, cb) {
+  let i = 0;
+  while (i < data.length) {
+    if (data[i++] !== 0x01) throw "Wrong protocol version when decoding IPC data";
+    const mtypelen = data[i++];
+    const mtype = data.slice(i, i+mtypelen).toString("utf-8");
+    i += mtypelen;
+    const psize = data.readUInt32LE(i);
+    i += 4;
+    const payload = data.slice(i, i+psize);
+    i += psize;
+    cb(mtype, payload);
+  }
+}
+
 async function test() {
   try {
-    const pipe = addon.createPipe("out");
+    console.log("\nCreating pipes");
+
+    const pipeRx = addon.createPipe("out");
+    const pipeTx = addon.createPipe("in");
+    const pipeTxReadFd = addon.getPipeEndFd(pipeTx.readEnd);
+    console.log(pipeRx, pipeTx, pipeTxReadFd);
+
+    const txStream = fs.createReadStream("", { fd: pipeTxReadFd });
+    txStream.on("data", data => {
+      DecodeDaemonIPCData(data, (mtype, payload) => {
+        console.log("Got message", mtype, payload.toString("utf-8"));
+      });
+    });
+    txStream.on("error", (e) => console.log("tx stream error", e));
+    txStream.on("close", () => console.log("tx stream closed"));
+    txStream.on("end", () => console.log("tx stream ended"));
+
+    console.log("Launching wallet");
     childProcess.spawn("dcrwallet", [
       `-C ${walletConfPath}`,
-      `--piperx ${pipe.readEnd}`, "--debuglevel DCRW=TRACE"
+      `--piperx ${pipeRx.readEnd}`,
+      `--pipetx ${pipeTx.writeEnd}`,
+      "--rpclistenerevents",
+      "--debuglevel DCRW=TRACE"
     ], { "detached": true, "shell": true });
 
-    console.log(pipe);
     await sleep(7000);
     console.log("Slept to test some. Will try to close the pipe.");
-    console.log(addon.closePipe(pipe));
-    console.log("Closed the pipe!");
+
+    // txStream has taken control of pipeTx.readEnd, so we have to
+    // close this end normally and not via the the native module
+    txStream.close();
+    pipeTx.readEnd = -1; // -1 == INVALID_HANDLE_VALUE
+    addon.closePipe(pipeTx);
+
+    addon.closePipe(pipeRx);
+
+    console.log("Closed the pipes!");
   } catch (error) {
     console.log("Error");
     console.log(error);
@@ -35,6 +78,12 @@ async function test() {
   }
 }
 
-setTimeout(test, 3000);
+async function testMulti() {
+  for (let i = 0; i < 10; i++) {
+    await test();
+  }
+}
 
-setTimeout(function () { process.exit(0); }, 15000);
+setTimeout(testMulti, 3000);
+
+setTimeout(function () { process.exit(0); }, 150000);

--- a/app/modules/win32ipc/pipe_wrapper.cc
+++ b/app/modules/win32ipc/pipe_wrapper.cc
@@ -50,13 +50,20 @@ err:
 }
 
 char const* close_pipe_end(uintptr_t read_end_handle, uintptr_t write_end_handle) {
-    if (!CloseHandle((HANDLE) read_end_handle)) {
-        return "Close(read_end_handle)";
+    HANDLE h_rd = (HANDLE) read_end_handle;
+    HANDLE h_wr = (HANDLE) write_end_handle;
+    
+    if (h_rd != INVALID_HANDLE_VALUE) {
+        if (!CloseHandle(h_rd)) {
+            return "Close(read_end_handle)";
+        }
     }
 
 
-    if (!CloseHandle((HANDLE) write_end_handle)) {
-        return "Close(write_end_handle)";
+    if (h_wr != INVALID_HANDLE_VALUE) {
+        if (!CloseHandle(h_wr)) {
+            return "Close(write_end_handle)";
+        }
     }
 
     return nullptr;

--- a/app/modules/win32ipc/pipe_wrapper.h
+++ b/app/modules/win32ipc/pipe_wrapper.h
@@ -2,6 +2,15 @@
 
 #include <cstdint>
 
+#ifdef IN
+#undef IN
+#endif
+
+#ifdef OUT
+#undef OUT
+#endif
+
+
 namespace pipe_wrapper {
 
 template <typename T>


### PR DESCRIPTION
~**Requires #2009**~

This adds the pipetx flag to wallet initialization when running on the windows platform, so that the app can perform correct fetching of the grpc port during wallet startup and allows us to get rid of port detection via logs, which is brittle.

This requires the app to be compiled with an electron version 4 or higher, due to the correct function only being available on libuv 1.23+.

When testing this you might need to remove the entire `node_modules` and `app/node_modules` for the correct version of the module to be compiled. The win32ipc module does **not** work when using `yarn build && yarn start`, only with either `yarn dev` or `yarn package`.

Close #1712.