### PR TITLE
[purchase ticket] Fix wrong selector name

### DIFF
--- a/app/connectors/spv.js
+++ b/app/connectors/spv.js
@@ -3,7 +3,7 @@ import { selectorMap } from "../fp";
 import * as sel from "../selectors";
 
 const mapStateToProps = selectorMap({
-  spvMode: sel.isSpv,
+  spvMode: sel.isSPV,
   blocksNumberToNextTicket: sel.blocksNumberToNextTicket,
 });
 


### PR DESCRIPTION
This PR fixes the purchase ticket tab crashing due the wrong selector name.