### PR TITLE
[governance] Fix proposal not scrolling on small height

### DIFF
--- a/app/style/Governance.less
+++ b/app/style/Governance.less
@@ -363,8 +363,9 @@
 }
 
 .proposal-details-text {
-  overflow: auto;
+  min-height:100%;
   margin-top: 20px;
+  margin-bottom: 80px;
   p {
     word-wrap: break-word;
   }

--- a/app/style/Governance.less
+++ b/app/style/Governance.less
@@ -90,6 +90,10 @@
   padding: 1em;
 }
 
+.proposal-list-wrapper {
+  height: 100%;
+}
+
 .proposal-list {
   margin-top: 20px;
   margin-left: 38px;

--- a/app/style/Layout.less
+++ b/app/style/Layout.less
@@ -161,6 +161,7 @@
 }
 
 .tabbed-page-body.governance .tabbed-page-header > .tabs {
+  overflow-y: auto;
   left: unset;
   padding-left: 100px;
   margin-left: -63px;
@@ -176,6 +177,10 @@
       }
     }
   }
+}
+
+.tab-content .proposal-list {
+  margin-bottom: 60px;
 }
 
 .tabbed-page-header > .tabs {


### PR DESCRIPTION
Right now, on governance page, if the height is small, it is not possible to see all the proposals because it is not possible to scroll till the end. 

Also, if the text is long enough, it will not show the whole text, making it impossible to read the whole proposal.

This PR fix those.