### PR TITLE
[main_dev] Make closeDCRD exported again

### DIFF
--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -36,7 +36,7 @@ function closeClis() {
     closeDCRW(dcrwPID);
 }
 
-function closeDCRD() {
+export function closeDCRD() {
   if (isRunning(dcrdPID) && os.platform() != "win32") {
     logger.log("info", "Sending SIGINT to dcrd at pid:" + dcrdPID);
     process.kill(dcrdPID, "SIGINT");


### PR DESCRIPTION
Due to various issues, the exporting of closeDCRD was removed in a previous PR.  This will fix an unexpected error when switching networks in settings.