### PR TITLE
Return array on notification when error is object

### DIFF
--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -77,7 +77,7 @@ const fillVotes = async (proposal, propVotes, walletService) => {
   // This assumes the wallet will cast all available votes the same way.
   propVotes.data.castvotes.some(vote => {
     const choiceID = voteBitToChoice[parseInt(vote.votebit)];
-    if (!choiceID) { throw "ERRRRR: choiceID not found on vote", vote; }
+    if (!choiceID) { throw "Error: choiceID not found on vote when getting proposal votes" };
     // proposal.voteCounts.abstain -= 1; // TODO: support abstain
     if (eligibleTicketsByHash[vote.ticket]) {
       proposal.currentVoteChoice = choiceID;

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -77,7 +77,7 @@ const fillVotes = async (proposal, propVotes, walletService) => {
   // This assumes the wallet will cast all available votes the same way.
   propVotes.data.castvotes.some(vote => {
     const choiceID = voteBitToChoice[parseInt(vote.votebit)];
-    if (!choiceID) { throw "Error: choiceID not found on vote when getting proposal votes" };
+    if (!choiceID) { throw "Error: choiceID not found on vote when getting proposal votes"; }
     // proposal.voteCounts.abstain -= 1; // TODO: support abstain
     if (eligibleTicketsByHash[vote.ticket]) {
       proposal.currentVoteChoice = choiceID;


### PR DESCRIPTION
I noticed when notification error  are objects, they do not show at the snackbar.

![image](https://user-images.githubusercontent.com/15069783/57949438-c4a66480-78ba-11e9-9145-2153cc8f338c.png)

This PR transforms the error message to array, so we can show it. 