### PR TITLE
Fix log and no id message

### DIFF
--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -129,6 +129,7 @@ export const launchDCRD = (params, testnet) => new Promise((resolve,reject) => {
     rpchost = rpcCreds.rpc_host;
     rpcport = rpcCreds.rpc_port;
     dcrdPID = -1;
+    AddToDcrdLog(process.stdout, "dcrd is connected as remote", debug);
     return resolve(rpcCreds);
   }
   if (dcrdPID === -1) {

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -187,6 +187,10 @@ const messages = defineMessages({
     id: "daemonSyncingTimeout.errors",
     defaultMessage: "Daemon connection timeout exceded.\n That Probably means you filled your parameters wrong. Please review it."
   },
+  DAEMONCONNECTING_ERROR: {
+    id: "daemon.connect.error",
+    defaultMessage: "Error connecting to daemon",
+  },
   REMOVESTAKEPOOLCONFIG: {
     id: "stakepools.removedStakePoolConfig",
     defaultMessage: "Successfully removed StakePool config"
@@ -460,7 +464,8 @@ export default function snackbar(state = {}, action) {
     break;
   case CONNECTDAEMON_FAILURE:
     type = "Error";
-    action.daemonTimeout ? message = messages["DAEMONCONNECTING_TIMEOUT"] : message = action.error;
+    action.daemonTimeout ? message = messages["DAEMONCONNECTING_TIMEOUT"] : message = messages["DAEMONCONNECTING_ERROR"];
+    action.error && action.error.code ? message.defaultMessage = action.error.code : null;
     break;
   }
 


### PR DESCRIPTION
This PR fixes #2136 

I noticed logs are only not showing when connected as remote, which is expected. But I added a line to the logs informing that, to be more descriptive. 

I also noticed when failing to connect, decrediton is crashing due to a missing id on the notification message. This PR also fixes it. 

Here is an image of the crash: 

![image](https://user-images.githubusercontent.com/15069783/60446803-878efb00-9bf8-11e9-819e-93fa47f4a9c1.png)

