### PR TITLE
Bump required dcrwallet api version to 7.0.0

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -88,7 +88,7 @@ var initialState = {
   },
   version: {
     // RequiredVersion
-    requiredVersion: "6.0.0",
+    requiredVersion: "7.0.0",
     versionInvalid: false,
     versionInvalidError: null,
     // VersionService


### PR DESCRIPTION
Per Slack discussion dcrwallet api version 7.0.0 is compatible with 6.0.0
https://decred.slack.com/archives/C0NRMDVMJ/p1562949621352700

This resolves an issue where decrediton cannot be built with the latest release of dcrwallet v2.1.1