### PR TITLE
fix proposal details stop rendering

### DIFF
--- a/app/components/views/GovernancePage/Proposals/Details/Page.js
+++ b/app/components/views/GovernancePage/Proposals/Details/Page.js
@@ -6,26 +6,18 @@ import {
   NoElligibleTicketsVotingInfo, UpdatingVoteChoice, TimeValue,
   ChosenVoteOption, ProposalText, ProposalAbandoned
 } from "./helpers";
-import { politeiaMarkdownIndexMd } from "helpers";
 import {
   VOTESTATUS_ACTIVEVOTE, VOTESTATUS_VOTED, VOTESTATUS_ABANDONED
 } from "actions/GovernanceActions";
 
 export default ({ viewedProposalDetails,
   showPurchaseTicketsPage, hasTickets, onVoteOptionSelected, onUpdateVoteChoice,
-  newVoteChoice, updateVoteChoiceAttempt, tsDate }) =>
+  newVoteChoice, updateVoteChoiceAttempt, tsDate, text }) =>
 {
   const { name, token, hasEligibleTickets, voteStatus, voteOptions,
     voteCounts, creator, timestamp, endTimestamp, currentVoteChoice,
     version } = viewedProposalDetails;
   const eligibleTicketCount = viewedProposalDetails.eligibleTickets.length;
-
-  let text = "";
-  viewedProposalDetails.files.forEach(f => {
-    if (f.name === "index.md") {
-      text = politeiaMarkdownIndexMd(f.payload);
-    }
-  });
 
   const voted = voteStatus === VOTESTATUS_VOTED;
   const voting = voteStatus === VOTESTATUS_ACTIVEVOTE;

--- a/app/components/views/GovernancePage/Proposals/Details/helpers.js
+++ b/app/components/views/GovernancePage/Proposals/Details/helpers.js
@@ -126,3 +126,12 @@ export const ProposalText = ({ text }) => (
     }}
   />
 );
+
+// politeiaMarkdownIndexMd returns markdown text from the payload of a politeia
+// proposal file that corresponds to its index.md). This was extracted from the
+// helpers.js file of politeia. Assumes the payload has been converted from
+// base64 into bytes.
+export function politeiaMarkdownIndexMd(payload) {
+  let text = decodeURIComponent(escape(payload));
+  return text.substring(text.indexOf("\n") + 1);
+}

--- a/app/components/views/GovernancePage/Proposals/Details/index.js
+++ b/app/components/views/GovernancePage/Proposals/Details/index.js
@@ -1,13 +1,29 @@
 import { proposals } from "connectors";
 import Page from "./Page";
-import { LoadingProposal, ProposalError } from "./helpers";
+import { LoadingProposal, ProposalError, politeiaMarkdownIndexMd } from "./helpers";
 
 @autobind
 class ProposalDetails extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { newVoteChoice: null };
+    this.state = {
+      newVoteChoice: null,
+      text: null,
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    const { viewedProposalDetails } = this.props;
+    let text = "";
+    if (prevProps.viewedProposalDetails !== viewedProposalDetails && viewedProposalDetails.files.length) {
+      viewedProposalDetails.files.forEach(f => {
+        if (f.name === "index.md") {
+          text = politeiaMarkdownIndexMd(f.payload);
+        }
+      });
+      this.setState({ text });
+    }
   }
 
   onVoteOptionSelected(opt) {

--- a/app/helpers/strings.js
+++ b/app/helpers/strings.js
@@ -55,12 +55,3 @@ export function limitFractionalDigits(s, maxFracDigits) {
   if (match[2].length <= maxFracDigits) return s;
   return match[1] + "." + match[2].substr(0, maxFracDigits);
 }
-
-// politeiaMarkdownIndexMd returns markdown text from the payload of a politeia
-// proposal file that corresponds to its index.md). This was extracted from the
-// helpers.js file of politeia. Assumes the payload has been converted from
-// base64 into bytes.
-export function politeiaMarkdownIndexMd(payload) {
-  let text = decodeURIComponent(escape(payload));
-  return text.substring(text.indexOf("\n") + 1);
-}


### PR DESCRIPTION
I noticed a run condition at governance Pages. If you open a proposal details, before `GETVETTED_UPDATEDVOTERESULTS_SUCCESS` is dispatched, the proposal stop showing at the governance page when it is dispatched.

This PR fixes it. 