### PR TITLE
Move undefined variable to beginning

### DIFF
--- a/app/components/buttons/EyeFilterMenu/index.js
+++ b/app/components/buttons/EyeFilterMenu/index.js
@@ -65,9 +65,9 @@ class EyeFilterMenu extends React.Component {
   }
 
   render() {
+    const { menuOpen } = this.state;
     const className = [ "eye-filter-menu", this.props.className || "",
       (menuOpen ? "menu-open" : "") ].join(" ");
-    const { menuOpen } = this.state;
 
     const menu = menuOpen ? this.getOpenedMenu() : null;
 


### PR DESCRIPTION
after commit https://github.com/decred/decrediton/commit/4b4fd7af41b00478510cc80579e2746fba5ae9e6 decrediton will now crash when going to tx history or my ticket page, saying `menuOpen` is undefined.

This PR fixess it.

The crash: 
![image](https://user-images.githubusercontent.com/15069783/61593544-17e8ac00-abb7-11e9-9a69-7ca88f555676.png)
