### PR TITLE
fix revoked icon

### DIFF
--- a/app/style/TxHistory.less
+++ b/app/style/TxHistory.less
@@ -91,6 +91,9 @@
   &.Revocation .icon {
     background-image: @ticket-revoked-icon;
   }
+  &.revoked .icon {
+    background-image: @ticket-revoked-icon;
+  }
   &.immature .icon {
     background-image: @ticket-immature-icon;
   }


### PR DESCRIPTION
I noticed the revoked icon is missing at overview

![image](https://user-images.githubusercontent.com/15069783/63053202-9cc59d80-beb7-11e9-8868-abe22f3088da.png)

This PR fixes it.