### PR TITLE
Remove deprecated code

### DIFF
--- a/app/components/inputs/Input.js
+++ b/app/components/inputs/Input.js
@@ -19,9 +19,10 @@ class Input extends React.Component{
       this.input.focus();
     }
   }
-  componentWillReceiveProps(nextProps) {
-    if (this.props.disabled != nextProps.disabled) {
-      this.setState({ divClassName: nextProps.disabled ? this.state.divClassName + " disabled" : "input-and-unit " + (this.props.className || "") });
+  componentDidUpdate(prevProps) {
+    const { className, disabled, } = this.props;
+    if (prevProps.disabled != disabled) {
+      this.setState({ divClassName: disabled ? this.state.divClassName + " disabled" : "input-and-unit " + (className || "") });
     }
   }
   onInputFocus = (e) => {


### PR DESCRIPTION
After commit https://github.com/decred/decrediton/commit/3d399552856aec933b899ac37113dd5adfb630f6 most of the code being deprecated was removed, but this bits were missed or re-added. 

This PR removes it.

Also, these warnings are showing in decrediton despite all deprecated code being removed. So I believe it is from some dependency we are using:

![image](https://user-images.githubusercontent.com/15069783/63172525-45890f80-c014-11e9-9bfd-458cc0bd4b63.png)

When they get updated we can follow, as theses warnings can be annoying.