### PR TITLE
Governance fix data download

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -109,7 +109,7 @@ export const getStartupWalletInfo = () => (dispatch) => {
           dispatch(getTreasuryBalance());
         }
         if (politeiaEnabled) {
-          await dispatch(getTokenAndInitialBatch());
+          dispatch(getTokenAndInitialBatch());
         }
         if (lnEnabled) {
           dispatch(checkLnWallet());

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -45,7 +45,6 @@ const fillVoteSummary = (proposal, voteSummary, blockTimestampFromNow) => {
   const quorum = voteSummary.quorumpercentage ? voteSummary.quorumpercentage : 20;
   const eligibleVotes = voteSummary.eligibletickets;
   const passPercentage = voteSummary.passpercentage ? voteSummary.passpercentage : 60;
-  proposal.eligibleTicketCount = eligibleVotes;
   proposal.quorumMinimumVotes = eligibleVotes * (quorum / 100);
   proposal.voteStatus = voteSummary.status;
 

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -3,7 +3,7 @@ import * as pi from "middleware/politeiaapi";
 import * as wallet from "wallet";
 import { push as pushHistory } from "react-router-redux";
 import { hexReversedHashToArray, reverseRawHash } from "helpers";
-import { setPoliteiaPath, getEligibleTickets, saveEligibleTickets, savePiVote, getProposalWalletVote } from "main_dev/paths";
+import { setPoliteiaPath, getEligibleTickets, saveEligibleTickets, savePiVote, getProposalWalletVote, removeCachedProposals } from "main_dev/paths";
 
 // Proposal vote status codes from politeiawww's v1.PropVoteStatusT
 // PropVoteStatusInvalid       PropVoteStatusT = 0 // Invalid vote status
@@ -156,10 +156,13 @@ const getInitialBatch = () => async (dispatch, getState) => {
   await dispatch(getProposalsAndUpdateVoteStatus(preVoteBatch));
 };
 
-export const getTokenAndInitialBatch = () => async (dispatch) => {
+export const getTokenAndInitialBatch = () => async (dispatch, getState) => {
   setPoliteiaPath();
   await dispatch(getTokenInventory());
-  dispatch(getInitialBatch());
+  const inventory = sel.inventory(getState());
+  // remove proposals cache which are not in the inventory activeVote
+  removeCachedProposals(inventory.activeVote);
+  await dispatch(getInitialBatch());
 };
 
 export const DISABLE_POLITEIA_SUCCESS = "DISABLE_POLITEIA_SUCCESS";

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -417,8 +417,8 @@ export const updateVoteChoice = (proposal, newVoteChoiceID, passphrase) => async
       const key = keys[i];
       let proposal, j;
       proposal = proposals[key].find( (p, ind) => {
-        p.token === token;
         j = ind;
+        return p.token === token;
       });
       if (proposal) {
         return proposals[key][j] = { ...newProposal };

--- a/app/components/views/GovernancePage/Proposals/Details/Page.js
+++ b/app/components/views/GovernancePage/Proposals/Details/Page.js
@@ -14,8 +14,8 @@ export default ({ viewedProposalDetails, goBackHistory,
   showPurchaseTicketsPage, hasTickets, onVoteOptionSelected, onUpdateVoteChoice,
   newVoteChoice, updateVoteChoiceAttempt, tsDate, text }) =>
 {
-  const { name, token, hasEligibleTickets, voteStatus, voteOptions,
-    voteCounts, creator, timestamp, endTimestamp, currentVoteChoice,
+  const { name, token, voteStatus, proposalStatus, voteOptions, voteCounts,
+    creator, timestamp, endTimestamp, currentVoteChoice, hasEligibleTickets,
     version, quorumMinimumVotes } = viewedProposalDetails;
   const eligibleTicketCount = viewedProposalDetails.eligibleTicketCount;
   const voted = voteStatus === VOTESTATUS_FINISHEDVOTE;
@@ -39,11 +39,9 @@ export default ({ viewedProposalDetails, goBackHistory,
   case VOTESTATUS_FINISHEDVOTE:
     voteInfo = <ChosenVoteOption {...{ voteOptions, currentVoteChoice, votingComplete: true }} />;
     break;
-  case PROPOSALSTATUS_ABANDONED:
-    voteInfo = <ProposalAbandoned />;
-    break;
   default:
-    voteInfo = <ProposalNotVoting />;
+    if (proposalStatus === PROPOSALSTATUS_ABANDONED) voteInfo = <ProposalAbandoned />;
+    else voteInfo = <ProposalNotVoting />;
     break;
   }
 

--- a/app/components/views/GovernancePage/Proposals/Details/Page.js
+++ b/app/components/views/GovernancePage/Proposals/Details/Page.js
@@ -17,9 +17,6 @@ export default ({ viewedProposalDetails, goBackHistory,
   const { name, token, voteStatus, proposalStatus, voteOptions, voteCounts,
     creator, timestamp, endTimestamp, currentVoteChoice, hasEligibleTickets,
     version, quorumMinimumVotes } = viewedProposalDetails;
-  const eligibleTicketCount = viewedProposalDetails.eligibleTicketCount;
-  let voteInfo = null;
-
   const getVoteInfo = ({
     voteStatus, voteOptions, onUpdateVoteChoice, onVoteOptionSelected, newVoteChoice,
     eligibleTicketCount,currentVoteChoice, showPurchaseTicketsPage
@@ -44,6 +41,9 @@ export default ({ viewedProposalDetails, goBackHistory,
     }
     return <ProposalNotVoting />;
   };
+
+  const eligibleTicketCount = viewedProposalDetails.walletEligibleTickets && viewedProposalDetails.walletEligibleTickets.length;
+  let voteInfo = null;
 
   // Check if proposal is abandoned. If it is not we check its vote status
   if (proposalStatus === PROPOSALSTATUS_ABANDONED) {

--- a/app/components/views/GovernancePage/Proposals/Details/Page.js
+++ b/app/components/views/GovernancePage/Proposals/Details/Page.js
@@ -4,7 +4,7 @@ import { PoliteiaLink } from "shared";
 import {
   ProposalNotVoting, NoTicketsVotingInfo, OverviewField, OverviewVotingProgressInfo,
   NoElligibleTicketsVotingInfo, UpdatingVoteChoice, TimeValue,
-  ChosenVoteOption, ProposalText, ProposalAbandoned
+  ChooseVoteOption, ProposalText, ProposalAbandoned
 } from "./helpers";
 import {
   VOTESTATUS_ACTIVEVOTE, VOTESTATUS_FINISHEDVOTE, PROPOSALSTATUS_ABANDONED
@@ -18,31 +18,41 @@ export default ({ viewedProposalDetails, goBackHistory,
     creator, timestamp, endTimestamp, currentVoteChoice, hasEligibleTickets,
     version, quorumMinimumVotes } = viewedProposalDetails;
   const eligibleTicketCount = viewedProposalDetails.eligibleTicketCount;
-  const voted = voteStatus === VOTESTATUS_FINISHEDVOTE;
-  const voting = voteStatus === VOTESTATUS_ACTIVEVOTE;
   let voteInfo = null;
 
-  switch(voteStatus) {
-  case VOTESTATUS_ACTIVEVOTE:
-    if (updateVoteChoiceAttempt) voteInfo = <UpdatingVoteChoice />;
-    else if (!hasTickets) voteInfo = <NoTicketsVotingInfo {...{ showPurchaseTicketsPage }} />;
-    else if (!hasEligibleTickets) voteInfo = <NoElligibleTicketsVotingInfo {...{ showPurchaseTicketsPage }} />;
-    else {
-      voteInfo =
-        <ChosenVoteOption
-          {...{ voteOptions, onUpdateVoteChoice,
-            onVoteOptionSelected, newVoteChoice, eligibleTicketCount,
-            currentVoteChoice, votingComplete: false }}
-        />;
+  const getVoteInfo = ({
+    voteStatus, voteOptions, onUpdateVoteChoice, onVoteOptionSelected, newVoteChoice,
+    eligibleTicketCount,currentVoteChoice, showPurchaseTicketsPage
+  }) => {
+    if (voteStatus === VOTESTATUS_FINISHEDVOTE) {
+      return <ChooseVoteOption {...{ voteOptions, currentVoteChoice, votingComplete: true }} />;
     }
-    break;
-  case VOTESTATUS_FINISHEDVOTE:
-    voteInfo = <ChosenVoteOption {...{ voteOptions, currentVoteChoice, votingComplete: true }} />;
-    break;
-  default:
-    if (proposalStatus === PROPOSALSTATUS_ABANDONED) voteInfo = <ProposalAbandoned />;
-    else voteInfo = <ProposalNotVoting />;
-    break;
+    if (voteStatus === VOTESTATUS_ACTIVEVOTE) {
+      if (updateVoteChoiceAttempt) {
+        return <UpdatingVoteChoice />;
+      }
+      if (!hasTickets) {
+        return <NoTicketsVotingInfo {...{ showPurchaseTicketsPage }} />;
+      }
+      if (!hasEligibleTickets) {
+        return <NoElligibleTicketsVotingInfo {...{ showPurchaseTicketsPage }} />;
+      }
+
+      return <ChooseVoteOption {...{ voteOptions, onUpdateVoteChoice,
+        onVoteOptionSelected, newVoteChoice, eligibleTicketCount,
+        currentVoteChoice, votingComplete: false }} />;
+    }
+    return <ProposalNotVoting />;
+  };
+
+  // Check if proposal is abandoned. If it is not we check its vote status
+  if (proposalStatus === PROPOSALSTATUS_ABANDONED) {
+    voteInfo = <ProposalAbandoned />;
+  } else {
+    voteInfo = getVoteInfo({
+      voteStatus, voteOptions, onUpdateVoteChoice, onVoteOptionSelected, newVoteChoice,
+      eligibleTicketCount,currentVoteChoice, showPurchaseTicketsPage
+    });
   }
 
   return (
@@ -64,16 +74,16 @@ export default ({ viewedProposalDetails, goBackHistory,
               label={<T id="proposal.overview.lastUpdated.label" m="Last Updated" />}
               value={<TimeValue timestamp={timestamp} tsDate={tsDate} />} />
             <OverviewField
-              show={voting && endTimestamp}
+              show={voteStatus === VOTESTATUS_ACTIVEVOTE && endTimestamp}
               label={<T id="proposal.overview.deadline.label" m="Voting Deadline" />}
-              value={voting ? <TimeValue timestamp={endTimestamp} tsDate={tsDate} /> : null } />
+              value={<TimeValue timestamp={endTimestamp} tsDate={tsDate} /> } />
           </div>
         </div>
         <div className="proposal-details-overview-voting">
           <InvisibleButton className="go-back-icon-button" onClick={goBackHistory} />
           {voteInfo}
         </div>
-        {(voting || voted )  &&
+        {(voteStatus === VOTESTATUS_ACTIVEVOTE || voteStatus === VOTESTATUS_FINISHEDVOTE ) &&
           <OverviewVotingProgressInfo {...{ voteCounts, quorumMinimumVotes }} /> }
       </div>
       <div className="proposal-details-text">

--- a/app/components/views/GovernancePage/Proposals/Details/Page.js
+++ b/app/components/views/GovernancePage/Proposals/Details/Page.js
@@ -17,12 +17,11 @@ export default ({ viewedProposalDetails, goBackHistory,
   const { name, token, hasEligibleTickets, voteStatus, voteOptions,
     voteCounts, creator, timestamp, endTimestamp, currentVoteChoice,
     version, quorumMinimumVotes } = viewedProposalDetails;
-  const eligibleTicketCount = viewedProposalDetails.eligibleTickets.length;
-
+  const eligibleTicketCount = viewedProposalDetails.eligibleTicketCount;
   const voted = voteStatus === VOTESTATUS_FINISHEDVOTE;
   const voting = voteStatus === VOTESTATUS_ACTIVEVOTE;
-
   let voteInfo = null;
+
   switch(voteStatus) {
   case VOTESTATUS_ACTIVEVOTE:
     if (updateVoteChoiceAttempt) voteInfo = <UpdatingVoteChoice />;

--- a/app/components/views/GovernancePage/Proposals/Details/Page.js
+++ b/app/components/views/GovernancePage/Proposals/Details/Page.js
@@ -61,7 +61,7 @@ export default ({ viewedProposalDetails, goBackHistory,
         <div className="proposal-details-overview-info">
           <div className="proposal-details-title">{name}</div>
           <div className="proposal-details-token">
-            <PoliteiaLink path={"/proposals/"+token}>{token}</PoliteiaLink>
+            <PoliteiaLink path={"/proposal/"+token}>{token}</PoliteiaLink>
           </div>
           <div className="proposal-details-overview-fields">
             <OverviewField
@@ -88,7 +88,7 @@ export default ({ viewedProposalDetails, goBackHistory,
       </div>
       <div className="proposal-details-text">
         <div className="links">
-          <PoliteiaLink path={"/proposals/"+token}>
+          <PoliteiaLink path={"/proposal/"+token}>
             <T id="proposals.community.goToProposal" m="See proposal comments on Politeia" />
           </PoliteiaLink>
         </div>

--- a/app/components/views/GovernancePage/Proposals/Details/helpers.js
+++ b/app/components/views/GovernancePage/Proposals/Details/helpers.js
@@ -6,9 +6,8 @@ import UpdateVoteChoiceModalButton from "./UpdateVoteChoiceModalButton";
 import { default as ReactMarkdown }  from "react-markdown";
 import { FormattedRelative } from "shared";
 
-export const LoadingProposal = () => (
-  <div className="proposal-loading-page"><PoliteiaLoading /></div>
-);
+export const LoadingProposal = () =>
+  <div className="proposal-loading-page"><PoliteiaLoading /></div>;
 
 export const ProposalError = ( { error } ) => <div><T id="proposalDetails.loadingError" m="Error loading Proposal: {error}" values={{ error }} /></div>;
 
@@ -98,9 +97,9 @@ const renderInternalProposalLink = ({ children }) => {
   return <a onClick={() => {} } href="#">{children}</a>;
 };
 
-const renderProposalImage = ({ alt }) => {
-  return <span>{alt}</span>;
-};
+// This changes images to never open. Debatable whether we want to
+// allow proposals to open images directly from decrediton.
+const renderProposalImage = ({ alt }) => <span>{alt}</span>;
 
 export const ProposalText = ({ text }) => (
   <>
@@ -121,8 +120,8 @@ export const ProposalText = ({ text }) => (
 
         // debatable whether we wanna allow inline image references in proposals
         // in decrediton.
-        imageReference: () => renderProposalImage,
-        image: () => renderProposalImage,
+        imageReference: renderProposalImage,
+        image: renderProposalImage,
 
         html: () => null,
       }}

--- a/app/components/views/GovernancePage/Proposals/Details/helpers.js
+++ b/app/components/views/GovernancePage/Proposals/Details/helpers.js
@@ -43,7 +43,7 @@ const VoteOption = ({ value, description, onClick, checked }) => (
   </div>
 );
 
-export const ChosenVoteOption = ({ voteOptions, onUpdateVoteChoice, onVoteOptionSelected, newVoteChoice, currentVoteChoice, votingComplete, eligibleTicketCount }) => (
+export const ChooseVoteOption = ({ voteOptions, onUpdateVoteChoice, onVoteOptionSelected, newVoteChoice, currentVoteChoice, votingComplete, eligibleTicketCount }) => (
   <>
     <div className="proposal-details-voting-preference">
       <div className="proposal-details-voting-preference-title"><T id="proposalDetails.votingInfo.votingPreferenceTitle" m="My Voting Preference" /></div>

--- a/app/components/views/GovernancePage/Proposals/ProposalList/Page.js
+++ b/app/components/views/GovernancePage/Proposals/ProposalList/Page.js
@@ -6,33 +6,6 @@ import { VOTESTATUS_ACTIVEVOTE, VOTESTATUS_FINISHEDVOTE } from "actions/Governan
 import InfiniteScroll from "react-infinite-scroller";
 import { FormattedRelative } from "shared";
 
-const VoteChoiceText = ({ currentVoteChoice }) => {
-  if (!currentVoteChoice) {
-    return <div>&nbsp;</div>;
-  }
-
-  let voteChoiceString =
-    (currentVoteChoice !== "abstain")
-      ? (<><T id="proposal.voted" m="Voted"/> {currentVoteChoice}</>)
-      : <T id="proposal.noVote" m="No vote cast"/>;
-
-  return <>
-    <div className={"proposal-vote-choice " + currentVoteChoice}/>
-    <div className="proposal-vote-choice-text">{voteChoiceString}</div>
-  </>;
-};
-
-const VoteChoice = ({ currentVoteChoice }) =>
-  <div className={"proposal-vote-choice " + currentVoteChoice}/>;
-const VoteResults = ({ currentVoteChoice, quorumPass, voteResult }) => (
-  <div className="proposal-vote-result">
-    <div className="proposal-vote-choice-area">
-      <VoteChoiceText currentVoteChoice={currentVoteChoice}/>
-    </div>
-    <div className="proposal-vote-passage">{quorumPass ? voteResult : <T id="proposals.quorumNotMet" m="Quorum not met"/>}</div>
-  </div>
-);
-
 const ProposalListItem = ({ name, timestamp, token, voteCounts, tsDate, onClick,
   voteStatus, currentVoteChoice, quorumPass, voteResult, modifiedSinceLastAccess,
   votingSinceLastAccess, quorumMinimumVotes }) => {
@@ -57,42 +30,44 @@ const ProposalListItem = ({ name, timestamp, token, voteCounts, tsDate, onClick,
       </div>
       {( voteStatus === VOTESTATUS_ACTIVEVOTE || voteStatus === VOTESTATUS_FINISHEDVOTE) &&
         <>
-          <VoteChoice currentVoteChoice={currentVoteChoice} />
+          <div className={"proposal-vote-choice " + (currentVoteChoice && currentVoteChoice.id)}/>
           <VotingProgress {...{ voteCounts, quorumMinimumVotes } }  />
         </>}
-      { voteStatus === VOTESTATUS_FINISHEDVOTE &&
-        <VoteResults  {...{ currentVoteChoice, quorumPass, voteResult }}/>}
+      { voteStatus === VOTESTATUS_FINISHEDVOTE && (
+        <div className="proposal-vote-result">
+          <div className="proposal-vote-passage">{quorumPass ? voteResult : <T id="proposals.quorumNotMet" m="Quorum not met"/>}</div>
+        </div>
+      )}
     </div>
   );
 };
 
 const ProposalList = ({
   proposals, loading, viewProposalDetails, tsDate, finishedProposal, noMoreProposals, onLoadMoreProposals
-}) => {
-  return (
-    <>
-      { loading
-        ? <div className="proposal-loading-page"><PoliteiaLoading center /></div>
-        : proposals && proposals.length
-          ? (
-            <InfiniteScroll
-              hasMore={!noMoreProposals}
-              loadMore={onLoadMoreProposals}
-              initialLoad={false}
-              useWindow={false}
-              threshold={0}
-            >
-              <div className={finishedProposal ? "proposal-list ended" : "proposal-list"}>
-                {proposals.map(v => (
-                  <ProposalListItem key={v.token} {...v} tsDate={tsDate} onClick={viewProposalDetails} />
-                ))}
-              </div>
-            </InfiniteScroll>
-          )
-          : <NoProposals />
-      }
-    </>
-  );};
+}) => (
+  <>
+    { loading
+      ? <div className="proposal-loading-page"><PoliteiaLoading center /></div>
+      : proposals && proposals.length
+        ? (
+          <InfiniteScroll
+            hasMore={!noMoreProposals}
+            loadMore={onLoadMoreProposals}
+            initialLoad={false}
+            useWindow={false}
+            threshold={0}
+          >
+            <div className={finishedProposal ? "proposal-list ended" : "proposal-list"}>
+              {proposals.map(v => (
+                <ProposalListItem key={v.token} {...v} tsDate={tsDate} onClick={viewProposalDetails} />
+              ))}
+            </div>
+          </InfiniteScroll>
+        )
+        : <NoProposals />
+    }
+  </>
+);
 
 export const ActiveVoteProposals = activeVoteProposals(ProposalList);
 export const PreVoteProposals = preVoteProposals(ProposalList);

--- a/app/config.js
+++ b/app/config.js
@@ -2,7 +2,7 @@ import fs from "fs";
 import Store from "electron-store";
 import ini from "ini";
 import { stakePoolInfo } from "./middleware/stakepoolapi";
-import { appDataDirectory, getGlobalCfgPath, dcrdCfg, getWalletPath, dcrwalletCfg, getDcrdRpcCert, getDcrdPath } from "./main_dev/paths";
+import { getAppDataDirectory, getGlobalCfgPath, dcrdCfg, getWalletPath, dcrwalletCfg, getDcrdRpcCert, getDcrdPath } from "./main_dev/paths";
 import * as cfgConstants from "constants/config";
 import { DCR, TESTNET, MAINNET } from "constants";
 
@@ -166,8 +166,8 @@ export function readDcrdConfig(configPath, testnet) {
 
     if (fs.existsSync(dcrdCfg(configPath))) {
       readCfg = ini.parse(Buffer.from(fs.readFileSync(dcrdCfg(configPath))).toString());
-    } else if (fs.existsSync(dcrdCfg(appDataDirectory()))) {
-      readCfg = ini.parse(Buffer.from(fs.readFileSync(dcrdCfg(appDataDirectory()))).toString());
+    } else if (fs.existsSync(dcrdCfg(getAppDataDirectory()))) {
+      readCfg = ini.parse(Buffer.from(fs.readFileSync(dcrdCfg(getAppDataDirectory()))).toString());
     } else {
       return newCfg;
     }
@@ -303,7 +303,7 @@ function makeRandomString(length) {
 }
 
 export function createTempDcrdConf(testnet) {
-  if (!fs.existsSync(dcrdCfg(appDataDirectory()))) {
+  if (!fs.existsSync(dcrdCfg(getAppDataDirectory()))) {
     const port = testnet ? "19109" : "9109";
 
     const dcrdConf = {
@@ -315,9 +315,9 @@ export function createTempDcrdConf(testnet) {
         network: testnet ? TESTNET : MAINNET,
       }
     };
-    fs.writeFileSync(dcrdCfg(appDataDirectory()), ini.stringify(dcrdConf));
+    fs.writeFileSync(dcrdCfg(getAppDataDirectory()), ini.stringify(dcrdConf));
   }
-  return appDataDirectory();
+  return getAppDataDirectory();
 }
 
 export function newWalletConfigCreation(testnet, walletPath) {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -3,7 +3,7 @@ import parseArgs from "minimist";
 import { app, BrowserWindow, Menu, dialog } from "electron";
 import { initGlobalCfg, validateGlobalCfgFile, setMustOpenForm } from "./config";
 import { appLocaleFromElectronLocale, default as locales } from "./i18n/locales";
-import { createLogger, lastLogLine, GetDcrdLogs, GetDcrwalletLogs } from "./main_dev/logging";
+import { createLogger, lastLogLine, GetDcrdLogs, GetDcrwalletLogs, GetDcrlndLogs } from "./main_dev/logging";
 import { getWalletsDirectoryPath, getWalletsDirectoryPathNetwork, getAppDataDirectory } from "./main_dev/paths";
 import { getGlobalCfgPath, checkAndInitWalletCfg } from "./main_dev/paths";
 import { installSessionHandlers, reloadAllowedExternalRequests, allowStakepoolRequests, allowExternalRequest } from "./main_dev/externalRequests";

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -3,8 +3,8 @@ import parseArgs from "minimist";
 import { app, BrowserWindow, Menu, dialog } from "electron";
 import { initGlobalCfg, validateGlobalCfgFile, setMustOpenForm } from "./config";
 import { appLocaleFromElectronLocale, default as locales } from "./i18n/locales";
-import { createLogger, lastLogLine, GetDcrdLogs, GetDcrwalletLogs, GetDcrlndLogs } from "./main_dev/logging";
-import { getWalletsDirectoryPath, getWalletsDirectoryPathNetwork, appDataDirectory } from "./main_dev/paths";
+import { createLogger, lastLogLine, GetDcrdLogs, GetDcrwalletLogs } from "./main_dev/logging";
+import { getWalletsDirectoryPath, getWalletsDirectoryPathNetwork, getAppDataDirectory } from "./main_dev/paths";
 import { getGlobalCfgPath, checkAndInitWalletCfg } from "./main_dev/paths";
 import { installSessionHandlers, reloadAllowedExternalRequests, allowStakepoolRequests, allowExternalRequest } from "./main_dev/externalRequests";
 import { setupProxy } from "./main_dev/proxy";
@@ -21,7 +21,7 @@ import { OPTIONS, USAGE_MESSAGE, VERSION_MESSAGE, BOTH_CONNECTION_ERR_MESSAGE, M
 import { DAEMON_ADVANCED, LOCALE } from "constants/config";
 
 // setPath as decrediton
-app.setPath("userData", appDataDirectory());
+app.setPath("userData", getAppDataDirectory());
 
 const argv = parseArgs(process.argv.slice(1), OPTIONS);
 const debug = argv.debug || process.env.NODE_ENV === "development";

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -1,7 +1,7 @@
 import fs from "fs-extra";
 import path from "path";
 import { createLogger } from "./logging";
-import { getWalletPath, getWalletDBPathFromWallets, getDcrdPath } from "./paths";
+import { getWalletPath, getWalletDb, getDcrdPath } from "./paths";
 import { initWalletCfg, newWalletConfigCreation, getWalletCfg, readDcrdConfig } from "config";
 import { launchDCRD, launchDCRWallet, GetDcrdPID, GetDcrwPID, closeDCRD, closeDCRW, GetDcrwPort,
   launchDCRLnd, GetDcrlndPID, GetDcrlndCreds, closeDcrlnd } from "./launch";
@@ -25,7 +25,7 @@ export const getAvailableWallets = (network) => {
     const lastAccess = cfg.get("lastaccess");
     const watchingOnly = cfg.get("iswatchonly");
     const isTrezor = cfg.get("trezor");
-    const walletDbFilePath = getWalletDBPathFromWallets(isTestNet, wallet);
+    const walletDbFilePath = getWalletDb(isTestNet, wallet);
     const finished = fs.pathExistsSync(walletDbFilePath);
     availableWallets.push({ network, wallet, finished, lastAccess, watchingOnly, isTrezor });
   });

--- a/app/main_dev/logging.js
+++ b/app/main_dev/logging.js
@@ -1,7 +1,7 @@
 import winston from "winston";
 import path from "path";
 import { MAX_LOG_LENGTH } from "constants";
-import { appDataDirectory } from "./paths";
+import { getAppDataDirectory } from "./paths";
 import os from "os";
 
 let dcrdLogs = Buffer.from("");
@@ -66,7 +66,7 @@ export function createLogger(debug) {
     transports: [
       new (winston.transports.File)({
         json: false,
-        filename: path.join(appDataDirectory(), "decrediton.log"),
+        filename: path.join(getAppDataDirectory(), "decrediton.log"),
         timestamp: logTimestamp,
         formatter: logFormatter,
       })

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -115,3 +115,65 @@ export function checkAndInitWalletCfg (testnet) {
     newWalletConfigCreation(testnet, "default-wallet");
   }
 }
+
+// getPoliteiaPath gets the politeia path which proposals are cached.
+export function getPoliteiaPath () {
+  return path.join(getAppDataDirectory(), "politeia");
+}
+
+// setPoliteiaPath sets the politeia path which proposals are cached.
+export function setPoliteiaPath () {
+  try {
+    const politeiaPath = getPoliteiaPath();
+    if (fs.pathExistsSync(politeiaPath)) {
+      return;
+    }
+    fs.mkdirSync(politeiaPath);
+  } catch (err) {
+    throw err;
+  }  
+}
+
+// getProposalPathFromPoliteia gets a proposal by its token or return empty string
+// if proposal is not foud.
+export function getProposalPathFromPoliteia (token) {
+  const proposalPath = path.join(getPoliteiaPath(), token);
+  if (fs.pathExistsSync(proposalPath)) {
+    return proposalPath;
+  }
+  return "";
+}
+
+// setPoliteiaProposalPath mkdir if directory of proposal does not exists.
+export function setPoliteiaProposalPath (token) {
+  try {
+    let proposalPath = getProposalPathFromPoliteia(token);
+    if (fs.pathExistsSync(proposalPath)) {
+      return;
+    }
+    proposalPath = path.join(getPoliteiaPath(), token)
+    fs.mkdirSync(proposalPath);
+    return proposalPath;
+  } catch (err) {
+    throw err;
+  }
+}
+
+// saveEligibleTickets receives a proposal token and its eligible tickets object.
+// it checks if proposal path exists, creates it if it does not exist.
+// and write a eligibletickets.json file, with { eligibleTickets: [tickets]) }
+export function saveEligibleTickets (token, eligibleTickets) {
+  let proposalPath = getProposalPathFromPoliteia(token);
+  if (!fs.pathExistsSync(proposalPath)) {
+    proposalPath = setPoliteiaProposalPath(token);
+  }
+  const fullPath = path.join(proposalPath, "eligibletickets.json");
+  fs.writeFile(fullPath, JSON.stringify(eligibleTickets));
+}
+
+// getEligibleTickets get the eligibletickets.json from the proposal Path
+export function getEligibleTickets (proposalPath) {
+  const fullPath = path.join(proposalPath, "eligibletickets.json")
+  const eligibleTickets = fs.readFileSync(fullPath);
+  return JSON.parse(eligibleTickets);
+}

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -126,7 +126,7 @@ export function setPoliteiaPath () {
   if (fs.pathExistsSync(politeiaPath)) {
     return;
   }
-  fs.mkdirSync(politeiaPath);
+  fs.mkdirSync(politeiaPath, { mode: 0o700 });
 }
 
 // getProposalPathFromPoliteia gets a proposal by its token or return empty string
@@ -146,7 +146,7 @@ export function setPoliteiaProposalPath (token) {
     return;
   }
   proposalPath = path.join(getPoliteiaPath(), token);
-  fs.mkdirSync(proposalPath);
+  fs.mkdirSync(proposalPath, { mode: 0o700 });
   return proposalPath;
 }
 
@@ -159,7 +159,7 @@ export function saveEligibleTickets (token, eligibleTickets) {
     proposalPath = setPoliteiaProposalPath(token);
   }
   const fullPath = path.join(proposalPath, "eligibletickets.json");
-  fs.writeFile(fullPath, JSON.stringify(eligibleTickets));
+  fs.writeFile(fullPath, JSON.stringify(eligibleTickets), { mode: 0o600 });
 }
 
 // getEligibleTickets get the eligibletickets.json from the proposal Path
@@ -184,7 +184,7 @@ function getWalletPiPath (testnet, walletName) {
   if (fs.pathExistsSync(walletPiPath)) {
     return walletPiPath;
   }
-  fs.mkdirSync(walletPiPath);
+  fs.mkdirSync(walletPiPath, { mode: 0o700 });
   return walletPiPath;
 }
 
@@ -196,10 +196,10 @@ export function savePiVote (vote, token, testnet, walletName) {
   const walletPath = getWalletPiPath(testnet, walletName);
   const proposalPath = path.join(walletPath, token);
   if (!fs.pathExistsSync(proposalPath)) {
-    fs.mkdirSync(proposalPath);
+    fs.mkdirSync(proposalPath, { mode: 0o700 });
   }
   const fullPath = path.join(proposalPath, "vote.json");
-  fs.writeFile(fullPath, JSON.stringify(vote));
+  fs.writeFile(fullPath, JSON.stringify(vote), { mode: 0o600 });
 }
 
 // getProposalWalletVote returns vote.json file if found or return null

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -8,7 +8,7 @@ import { TESTNET, MAINNET } from "constants";
 // os.homedir() rather than using process.env.LOCALAPPDATA because in my tests
 // that was available when using the standalone node but not there when using
 // electron in production mode.
-export function appDataDirectory() {
+export function getAppDataDirectory() {
   if (os.platform() == "win32") {
     return path.join(os.homedir(), "AppData", "Local", "Decrediton");
   } else if (process.platform === "darwin") {
@@ -18,74 +18,62 @@ export function appDataDirectory() {
   }
 }
 
+// getGlobalCfgPath gets decrediton's config.json file.
+// example of result in unix: ~/.config/decrediton/config.json
 export function getGlobalCfgPath() {
-  return path.resolve(appDataDirectory(), "config.json");
+  return path.resolve(getAppDataDirectory(), "config.json");
 }
 
+// getWalletsDirectoryPath gets the wallets directory.
 export function getWalletsDirectoryPath() {
-  return path.join(appDataDirectory(), "wallets");
+  return path.join(getAppDataDirectory(), "wallets");
 }
 
+// getWalletsDirectoryPathNetwork gets the wallets directory.
+// Example in unix if testnet equals true: ~/.config/decrediton/wallets/testnet
 export function getWalletsDirectoryPathNetwork(testnet) {
-  return path.join(appDataDirectory(), "wallets", testnet ? TESTNET : MAINNET);
+  return path.join(getAppDataDirectory(), "wallets", testnet ? TESTNET : MAINNET);
 }
 
-export function getWalletPath(testnet, walletPath = "", testnet3) {
+// getWalletPath returns the directory of a selected wallet byt its name.
+// a wallet name represent the directory it is located in.
+export function getWalletPath(testnet, walletName = "") {
   const testnetStr = testnet ? TESTNET : MAINNET;
-  const testnet3Str = testnet3 === true ? "testnet3" : testnet3 === false ? MAINNET : "";
-  return path.join(getWalletsDirectoryPath(), testnetStr, walletPath, testnet3Str);
+  return path.join(getWalletsDirectoryPath(), testnetStr, walletName);
 }
 
-export function getDefaultWalletDirectory(testnet, testnet3) {
-  return getWalletPath(testnet, "default-wallet", testnet3);
+// getWalletDb Returns the wallet.db file from a specific wallet.
+// walletPath represents the wallet name decrediton has loaded.
+export function getWalletDb(testnet, walletPath) {
+  return path.join(
+    getWalletsDirectoryPath(), testnet ? TESTNET : MAINNET,
+    walletPath, testnet ? "testnet3" : MAINNET, "wallet.db"
+  );
 }
 
-export function getDefaultWalletFilesPath(testnet, filePath = "") {
-  return path.join(getDefaultWalletDirectory(testnet), filePath);
-}
-
-export function getWalletDBPathFromWallets(testnet, walletPath) {
-  const network = testnet ? TESTNET : MAINNET;
-  const networkFolder = testnet ? "testnet3" : MAINNET;
-  return path.join(getWalletsDirectoryPath(), network, walletPath, networkFolder, "wallet.db");
-}
-
-export function getDecreditonWalletDBPath(testnet) {
-  return path.join(appDataDirectory(), testnet ? "testnet3" : MAINNET, "wallet.db");
-}
-
-export function dcrctlCfg(configPath) {
-  return path.resolve(configPath, "dcrctl.conf");
-}
-
+// dcrdCfg gets the dcrd.conf file from a specified path
 export function dcrdCfg(configPath) {
   return path.resolve(configPath, "dcrd.conf");
 }
 
+// dcrwalletCfg gets the dcrwallet.conf file from a specified path
 export function dcrwalletCfg(configPath) {
   return path.resolve(configPath, "dcrwallet.conf");
 }
 
+// getDcrdPath gets the default dcrd path.
 export function getDcrdPath() {
   if (os.platform() == "win32") {
     return path.join(os.homedir(), "AppData", "Local", "Dcrd");
-  } else if (process.platform === "darwin") {
+  } if (process.platform === "darwin") {
     return path.join(os.homedir(), "Library","Application Support","dcrd");
   } else {
     return path.join(os.homedir(),".dcrd");
   }
 }
 
-export function getDcrwalletPath() {
-  if (os.platform() == "win32") {
-    return path.join(os.homedir(), "AppData", "Local", "Dcrwallet");
-  } else if (process.platform === "darwin") {
-    return path.join(os.homedir(), "Library","Application Support","dcrwallet");
-  } else {
-    return path.join(os.homedir(),".dcrwallet");
-  }
-}
-
+// getDcrdRpcCert gets rpc.cert file from a specified path.
+// if no path is informed it gets from the default path.
 export function getDcrdRpcCert (appDataPath) {
   return path.resolve(appDataPath ? appDataPath : getDcrdPath(), "rpc.cert");
 }
@@ -100,24 +88,26 @@ export function getExecutablePath(name, custombinpath) {
   return path.join(binPath, execName);
 }
 
+// getDirectoryLogs gets the logs directory
 export function getDirectoryLogs(dir) {
   return path.join(dir, "logs");
 }
 
+// checkAndInitWalletCfg checks for existing old wallet.db directories and copy its
+// wallet.db file to the new decrediton wallets path.
+// TODO deprecate this code as most decrediton are updated to 1.4.0 version.
 export function checkAndInitWalletCfg (testnet) {
-  const walletDirectory = getDefaultWalletDirectory(testnet);
+  const walletDirectory = getWalletPath(testnet, "default-wallet");
+  const configJson = path.join(walletDirectory, "config.json");
+  const oldWalletDbPath = path.join(getAppDataDirectory(), testnet ? "testnet3" : MAINNET);
 
-  if (!fs.pathExistsSync(walletDirectory) && fs.pathExistsSync(getDecreditonWalletDBPath(testnet))) {
+  if (!fs.pathExistsSync(walletDirectory) && fs.pathExistsSync(oldWalletDbPath)) {
     fs.mkdirsSync(walletDirectory);
-
-    // check for existing mainnet directories
-    if ( fs.pathExistsSync(getDecreditonWalletDBPath(testnet)) ) {
-      fs.copySync(getDecreditonWalletDBPath(testnet), path.join(getDefaultWalletDirectory(testnet, testnet),"wallet.db"));
-    }
+    fs.copySync(getDecreditonWalletDBPath(testnet), path.join(walletDirectory, testnet ? "testnet3" : MAINNET, "wallet.db"));
 
     // copy over existing config.json if it exists
     if (fs.pathExistsSync(getGlobalCfgPath())) {
-      fs.copySync(getGlobalCfgPath(), getDefaultWalletFilesPath(testnet, "config.json"));
+      fs.copySync(getGlobalCfgPath(), configJson);
     }
 
     // create new configs for default mainnet wallet

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -136,7 +136,7 @@ export function setPoliteiaPath () {
 
 // getProposalPathFromPoliteia gets a proposal by its token or return empty string
 // if proposal is not foud.
-export function getProposalPathFromPoliteia (token) {
+function getProposalPathFromPoliteia (token) {
   const proposalPath = path.join(getPoliteiaPath(), token);
   if (fs.pathExistsSync(proposalPath)) {
     return proposalPath;
@@ -172,8 +172,16 @@ export function saveEligibleTickets (token, eligibleTickets) {
 }
 
 // getEligibleTickets get the eligibletickets.json from the proposal Path
-export function getEligibleTickets (proposalPath) {
+// return null if proposal directory or eligibletickets.json is not found.
+export function getEligibleTickets (token) {
+  const proposalPath = getProposalPathFromPoliteia(token);
+  if (!proposalPath) {
+    return null;
+  }
   const fullPath = path.join(proposalPath, "eligibletickets.json")
+  if (!fs.pathExistsSync(fullPath)) {
+    return null;
+  }
   const eligibleTickets = fs.readFileSync(fullPath);
   return JSON.parse(eligibleTickets);
 }

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -38,8 +38,7 @@ export function getWalletsDirectoryPathNetwork(testnet) {
 // getWalletPath returns the directory of a selected wallet byt its name.
 // a wallet name represent the directory it is located in.
 export function getWalletPath(testnet, walletName = "") {
-  const testnetStr = testnet ? TESTNET : MAINNET;
-  return path.join(getWalletsDirectoryPath(), testnetStr, walletName);
+  return path.join(getWalletsDirectoryPathNetwork(testnet), walletName);
 }
 
 // getWalletDb Returns the wallet.db file from a specific wallet.
@@ -184,4 +183,53 @@ export function getEligibleTickets (token) {
   }
   const eligibleTickets = fs.readFileSync(fullPath);
   return JSON.parse(eligibleTickets);
+}
+
+// getWalletPiPath gets the wallet politeia path if it exists, otherwise
+// it creates its path and returns it.
+function getWalletPiPath (testnet, walletName) {
+  try {
+    const walletPiPath = path.join(getWalletPath(testnet, walletName), "politeia")
+    if (fs.pathExistsSync(walletPiPath)) {
+      return walletPiPath;
+    }
+    fs.mkdirSync(walletPiPath);
+    return walletPiPath;
+  } catch (err) {
+    throw err;
+  }
+}
+
+// savePiVote checks if proposal directory exists, creates it, otherwise and
+// creates the vote.json file with the vote information.
+// we do not delete this directory after, as we use it to check for finished
+// votings with the wallet.
+export function savePiVote (vote, token, testnet, walletName) {
+  try {
+    const walletPath = getWalletPiPath(testnet, walletName);
+    const proposalPath = path.join(walletPath, token);
+    if (!fs.pathExistsSync(proposalPath)) {
+      fs.mkdirSync(proposalPath);
+    }
+    const fullPath = path.join(proposalPath, "vote.json");
+    fs.writeFile(fullPath, JSON.stringify(vote));
+  } catch (error) {
+    throw error;
+  }
+}
+
+// getProposalWalletVote returns vote.json file if found or return null
+export function getProposalWalletVote (token, testnet, walletName) {
+  try {
+    const walletPath = getWalletPiPath(testnet, walletName);
+    const proposalPath = path.join(walletPath, token);
+    if (!fs.pathExistsSync(proposalPath)) {
+      return null;
+    }
+    const fullPath = path.join(proposalPath, "vote.json");
+    const vote = fs.readFileSync(fullPath);
+    return JSON.parse(vote);
+  } catch (error) {
+    throw error;
+  }
 }

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -102,7 +102,7 @@ export function checkAndInitWalletCfg (testnet) {
 
   if (!fs.pathExistsSync(walletDirectory) && fs.pathExistsSync(oldWalletDbPath)) {
     fs.mkdirsSync(walletDirectory);
-    fs.copySync(getDecreditonWalletDBPath(testnet), path.join(walletDirectory, testnet ? "testnet3" : MAINNET, "wallet.db"));
+    fs.copySync(path.join(oldWalletDbPath, "wallet.db"), path.join(walletDirectory, testnet ? "testnet3" : MAINNET, "wallet.db"));
 
     // copy over existing config.json if it exists
     if (fs.pathExistsSync(getGlobalCfgPath())) {
@@ -122,15 +122,11 @@ export function getPoliteiaPath () {
 
 // setPoliteiaPath sets the politeia path which proposals are cached.
 export function setPoliteiaPath () {
-  try {
-    const politeiaPath = getPoliteiaPath();
-    if (fs.pathExistsSync(politeiaPath)) {
-      return;
-    }
-    fs.mkdirSync(politeiaPath);
-  } catch (err) {
-    throw err;
-  }  
+  const politeiaPath = getPoliteiaPath();
+  if (fs.pathExistsSync(politeiaPath)) {
+    return;
+  }
+  fs.mkdirSync(politeiaPath);
 }
 
 // getProposalPathFromPoliteia gets a proposal by its token or return empty string
@@ -145,17 +141,13 @@ function getProposalPathFromPoliteia (token) {
 
 // setPoliteiaProposalPath mkdir if directory of proposal does not exists.
 export function setPoliteiaProposalPath (token) {
-  try {
-    let proposalPath = getProposalPathFromPoliteia(token);
-    if (fs.pathExistsSync(proposalPath)) {
-      return;
-    }
-    proposalPath = path.join(getPoliteiaPath(), token)
-    fs.mkdirSync(proposalPath);
-    return proposalPath;
-  } catch (err) {
-    throw err;
+  let proposalPath = getProposalPathFromPoliteia(token);
+  if (fs.pathExistsSync(proposalPath)) {
+    return;
   }
+  proposalPath = path.join(getPoliteiaPath(), token);
+  fs.mkdirSync(proposalPath);
+  return proposalPath;
 }
 
 // saveEligibleTickets receives a proposal token and its eligible tickets object.
@@ -177,7 +169,7 @@ export function getEligibleTickets (token) {
   if (!proposalPath) {
     return null;
   }
-  const fullPath = path.join(proposalPath, "eligibletickets.json")
+  const fullPath = path.join(proposalPath, "eligibletickets.json");
   if (!fs.pathExistsSync(fullPath)) {
     return null;
   }
@@ -188,16 +180,12 @@ export function getEligibleTickets (token) {
 // getWalletPiPath gets the wallet politeia path if it exists, otherwise
 // it creates its path and returns it.
 function getWalletPiPath (testnet, walletName) {
-  try {
-    const walletPiPath = path.join(getWalletPath(testnet, walletName), "politeia")
-    if (fs.pathExistsSync(walletPiPath)) {
-      return walletPiPath;
-    }
-    fs.mkdirSync(walletPiPath);
+  const walletPiPath = path.join(getWalletPath(testnet, walletName), "politeia");
+  if (fs.pathExistsSync(walletPiPath)) {
     return walletPiPath;
-  } catch (err) {
-    throw err;
   }
+  fs.mkdirSync(walletPiPath);
+  return walletPiPath;
 }
 
 // savePiVote checks if proposal directory exists, creates it, otherwise and
@@ -205,31 +193,23 @@ function getWalletPiPath (testnet, walletName) {
 // we do not delete this directory after, as we use it to check for finished
 // votings with the wallet.
 export function savePiVote (vote, token, testnet, walletName) {
-  try {
-    const walletPath = getWalletPiPath(testnet, walletName);
-    const proposalPath = path.join(walletPath, token);
-    if (!fs.pathExistsSync(proposalPath)) {
-      fs.mkdirSync(proposalPath);
-    }
-    const fullPath = path.join(proposalPath, "vote.json");
-    fs.writeFile(fullPath, JSON.stringify(vote));
-  } catch (error) {
-    throw error;
+  const walletPath = getWalletPiPath(testnet, walletName);
+  const proposalPath = path.join(walletPath, token);
+  if (!fs.pathExistsSync(proposalPath)) {
+    fs.mkdirSync(proposalPath);
   }
+  const fullPath = path.join(proposalPath, "vote.json");
+  fs.writeFile(fullPath, JSON.stringify(vote));
 }
 
 // getProposalWalletVote returns vote.json file if found or return null
 export function getProposalWalletVote (token, testnet, walletName) {
-  try {
-    const walletPath = getWalletPiPath(testnet, walletName);
-    const proposalPath = path.join(walletPath, token);
-    if (!fs.pathExistsSync(proposalPath)) {
-      return null;
-    }
-    const fullPath = path.join(proposalPath, "vote.json");
-    const vote = fs.readFileSync(fullPath);
-    return JSON.parse(vote);
-  } catch (error) {
-    throw error;
+  const walletPath = getWalletPiPath(testnet, walletName);
+  const proposalPath = path.join(walletPath, token);
+  if (!fs.pathExistsSync(proposalPath)) {
+    return null;
   }
+  const fullPath = path.join(proposalPath, "vote.json");
+  const vote = fs.readFileSync(fullPath);
+  return JSON.parse(vote);
 }

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -213,3 +213,33 @@ export function getProposalWalletVote (token, testnet, walletName) {
   const vote = fs.readFileSync(fullPath);
   return JSON.parse(vote);
 }
+
+// removeCachedProposals gets a batch of proposal's token, makes a diff with
+// the values in the directory, and remove the ones that are not in the inventory.
+// We use this method to remove cached proposals from proposals which have finished
+// voting.
+export function removeCachedProposals (inventoryProposals) {
+  const politeiaPath = getPoliteiaPath();
+  const dirProposals = fs.readdirSync(politeiaPath);
+  // we get all values that are in the directory but are not in the inventory
+  // and remove them as the vote has finished.
+  const difference = dirProposals.filter(x => !inventoryProposals.includes(x));
+  difference.forEach(token => {
+    const proposalPath = path.join(politeiaPath, token);
+    deleteFolderRecursive(proposalPath);
+  });
+}
+
+function deleteFolderRecursive (path) {
+  if (fs.existsSync(path)) {
+    fs.readdirSync(path).forEach( file => {
+      const curPath = path + "/" + file;
+      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+        deleteFolderRecursive(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(path);
+  }
+}

--- a/app/reducers/governance.js
+++ b/app/reducers/governance.js
@@ -37,7 +37,7 @@ export default function governance(state = {}, action) {
   case UPDATEVOTECHOICE_SUCCESS:
     return {
       ...state,
-      proposals: action.proposals,
+      proposals: { ...action.proposals },
       updateVoteChoiceAttempt: false };
   case UPDATEVOTECHOICE_FAILED:
     return { ...state, updateVoteChoiceAttempt: false };

--- a/app/reducers/governance.js
+++ b/app/reducers/governance.js
@@ -29,7 +29,8 @@ export default function governance(state = {}, action) {
     return { ...state,
       getProposalAttempt: false,
       proposalsDetails: { ...state.proposalsDetails,
-        [action.token]: { ...action.proposal, ...action.voteResult } },
+        [action.token]: { ...action.proposal }
+      },
       proposals: { ...action.proposals },
     };
   case UPDATEVOTECHOICE_ATTEMPT:
@@ -38,7 +39,12 @@ export default function governance(state = {}, action) {
     return {
       ...state,
       proposals: { ...action.proposals },
-      updateVoteChoiceAttempt: false };
+      updateVoteChoiceAttempt: false,
+      proposalsDetails: { ...state.proposalsDetails,
+        [action.token]: { ...action.proposal },
+      },
+    };
+
   case UPDATEVOTECHOICE_FAILED:
     return { ...state, updateVoteChoiceAttempt: false };
   case CLOSEWALLET_SUCCESS:

--- a/app/style/Governance.less
+++ b/app/style/Governance.less
@@ -154,7 +154,7 @@
       border-radius: 100px;
       background-color: var(--vote-abstain-color);
       position: absolute;
-      right: 280px;
+      right: 240px;
       margin-top: 3px;
       &.yes {
         background-color: var(--vote-yes-color);

--- a/app/style/Governance.less
+++ b/app/style/Governance.less
@@ -164,14 +164,13 @@
       }
     }
     > .proposal-vote-result {
-      margin-top: -3px;
+      margin-top: 10px;
       font-size: 11px;
       line-height: 14px;
       position: absolute;
-      right: 130px;
+      right: 145px;
       text-transform: capitalize;
       display: flex;
-      flex-direction: column;
       .proposal-vote-choice-area {
         display: flex;
       }
@@ -189,13 +188,9 @@
           background-color: var(--vote-no-color);
         }
       }
-      .proposal-vote-choice-text {
-        color: var(--stroke-color-hovered);
-      }
       > .proposal-vote-passage {
         color: var(--stroke-color-default);
         width: 80px;
-        margin-top: 2px;
       }
     }
   }

--- a/app/style/Governance.less
+++ b/app/style/Governance.less
@@ -153,9 +153,9 @@
       height: 6px;
       border-radius: 100px;
       background-color: var(--vote-abstain-color);
-      position: absolute;
-      right: 240px;
-      margin-top: 3px;
+      margin-top: 2px;
+      margin-right: 10px;
+      margin-left: auto;  
       &.yes {
         background-color: var(--vote-yes-color);
       }
@@ -173,20 +173,6 @@
       display: flex;
       .proposal-vote-choice-area {
         display: flex;
-      }
-      .proposal-vote-choice {
-        width: 6px;
-        height: 6px;
-        border-radius: 100px;
-        background-color: var(--vote-abstain-color);
-        margin-top: 4px;
-        margin-right: 5px;
-        &.yes {
-          background-color: var(--vote-yes-color);
-        }
-        &.no {
-          background-color: var(--vote-no-color);
-        }
       }
       > .proposal-vote-passage {
         color: var(--stroke-color-default);

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -734,7 +734,6 @@
   display: flex;
   margin-top: 2px;
   border: 1px solid var(--white-border);
-  margin-left: auto;
   margin-right: 20px;
   border-radius: 10rem;
 


### PR DESCRIPTION
~~This PR is built on top of https://github.com/decred/decrediton/pull/2192.~~

When testing this PR if one wants to cast a vote, it will be necessary to have eligible tickets.

It closes https://github.com/decred/decrediton/issues/2076, closes https://github.com/decred/decrediton/issues/2101, closes https://github.com/decred/decrediton/issues/2047, closes https://github.com/decred/decrediton/issues/2015 (duplicated), and closes https://github.com/decred/decrediton/issues/2166, and closes #1807

I am caching the eligible tickets and as @lukebp suggested we are only showing cast vote options for active voting proposals.

I believe we can also cache the information of other votes (we have this information when querying for the proposal details) and show votes of proposals which we have at the finished vote tab, but I believe this is open to discussion. 

We could also close https://github.com/decred/decrediton/issues/2042, but for that we need commit https://github.com/decred/politeia/commit/8b25fa2f44799c4ee786d04da4bfa450ed255e66 deployed. I left a TODO in the code: https://github.com/decred/decrediton/compare/master...vctt94:governance-fix-data-download?expand=1#diff-c8399d09f1bddd336993b884a3e8d512R31 and after it gets deployed will be no problem fixing that. 

