### PR TITLE
[ln] Add syncedToChain check at connect

### DIFF
--- a/app/components/views/LNPage/ChannelsTab/PendingChannel.js
+++ b/app/components/views/LNPage/ChannelsTab/PendingChannel.js
@@ -5,8 +5,9 @@ const PendingOpenChannelDetails = ({ channel }) => (
   <>
     <span><T id="ln.pendingOpenDetails.commitFee" m="Commit Fee" /></span>
     <Balance amount={channel.commitFee} />
-    <span><T id="ln.pendingOpenDetails.confirmationHeight" m="Confirmation Height" /></span>
+    {/*     <span><T id="ln.pendingOpenDetails.confirmationHeight" m="Confirmation Height" /></span>
     <span>{channel.confirmationHeight}</span>
+    */}
   </>
 );
 
@@ -22,8 +23,9 @@ const PendingForceCloseChannelDetails = ({ channel }) => (
     <Balance amount={channel.limboBalance} />
     <span><T id="ln.pendingForceCloseDetails.recoveredBalance" m="Recovered Balance" /></span>
     <Balance amount={channel.recoveredBalance} />
-    <span><T id="ln.pendingForceCloseDetails.maturityHeight" m="Maturity Height" /></span>
+    {/*    <span><T id="ln.pendingForceCloseDetails.maturityHeight" m="Maturity Height" /></span>
     <span>{channel.maturityHeight}</span>
+    */}
   </>
 );
 
@@ -68,7 +70,7 @@ export const PendingChannelDetails = ({ channel }) => {
     <div className="ln-pending-channel-details">
       <span><T id="ln.pendingChannelDetails.type" m="Type" /></span>
       <span>{detailsType}</span>
-      <span><T id="ln.pendingChannelDetials.channelPoint" m="Channel Point" /></span>
+      <span><T id="ln.pendingChannelDetails.channelPoint" m="Channel Point" /></span>
       <ExternalLink href={channel.channelPointURL}>{channel.channelPoint}</ExternalLink>
       <span><T id="ln.pendingChannelDetails.remotePubKey" m="Remote Pubkey" /></span>
       <span>{channel.remotePubkey}</span>

--- a/app/components/views/LNPage/ConnectPage.js
+++ b/app/components/views/LNPage/ConnectPage.js
@@ -15,8 +15,7 @@ class ConnectPage extends React.Component {
   constructor(props)  {
     super(props);
     this.state = {
-      connecting: false,
-      launching: false,
+      launching: this.props.connectAttempt,
       autopilotEnabled: false,
       account: this.props.defaultAccount,
     };

--- a/app/connectors/lnPage.js
+++ b/app/connectors/lnPage.js
@@ -6,6 +6,7 @@ import * as sel from "selectors";
 
 const mapStateToProps = selectorMap({
   lnActive: sel.lnActive,
+  connectAttempt: sel.lnConnectAttempt,
   walletBalances: sel.lnWalletBalances,
   channelBalances: sel.lnChannelBalances,
   channels: sel.lnChannels,

--- a/app/index.js
+++ b/app/index.js
@@ -420,6 +420,7 @@ var initialState = {
     enabled: globalCfg.get("ln_enabled"),
     active: false,
     exists: false,
+    connectAttempt: false,
     info: {
       version: null,
       identityPubkey: null,

--- a/app/reducers/ln.js
+++ b/app/reducers/ln.js
@@ -1,6 +1,6 @@
 import {
   LNWALLET_INFO_UPDATED,
-  LNWALLET_CONNECT_ATTEMPT, LNWALLET_CONNECT_SUCCESS,
+  LNWALLET_CONNECT_ATTEMPT, LNWALLET_CONNECT_SUCCESS, LNWALLET_CONNECT_FAILED,
   LNWALLET_BALANCE_UPDATED, LNWALLET_CHANNELBALANCE_UPDATED, LNWALLET_CHANNELLIST_UPDATED,
   LNWALLET_LATESTINVOICES_UPDATED, LNWALLET_LATESTPAYMENTS_UPDATED,
   LNWALLET_ADDINVOICE_ATTEMPT, LNWALLET_ADDINVOICE_SUCCESS, LNWALLET_ADDINVOICE_FAILED,
@@ -39,12 +39,19 @@ export default function ln(state = {}, action) {
       ...state,
       active: false,
       client: null,
+      connectAttempt: true,
+    };
+  case LNWALLET_CONNECT_FAILED:
+    return {
+      ...state,
+      connectAttempt: false,
     };
   case LNWALLET_CONNECT_SUCCESS:
     return {
       ...state,
       active: true,
       client: action.lnClient,
+      connectAttempt: false,
     };
   case LNWALLET_BALANCE_UPDATED:
     return {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1023,6 +1023,7 @@ export const trezorWalletCreationMasterPubkeyAttempt = get([ "trezor", "walletCr
 
 export const lnEnabled = bool(and(get([ "ln", "enabled" ]), not(isWatchingOnly), not(isTrezor)));
 export const lnActive = bool(get([ "ln", "active" ]));
+export const lnConnectAttempt = bool(get([ "ln", "connectAttempt" ]));
 export const lnWalletExists = bool(get([ "ln", "exists" ]));
 export const lnInfo = get([ "ln", "info" ]);
 export const lnWalletBalances = get([ "ln", "walletBalances" ]);


### PR DESCRIPTION
This adds a check during node connection to ensure ln operations are only
performed after the node is synced to chain.

It also fixes a bug where you could go to another page, come back to the
ConnectPage view and try to connect again while a previous connection attempt
was still ongoing.

I'm also hiding the MaturingHeight attribute for the moment, since that's not 
working in the underlying dcrlnd.