### PR TITLE
[sidebar] Have sidebar leave bottom more aggresively

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -95,6 +95,7 @@ class App extends React.Component {
         this.props.onSidebarLeaveBottom();
         this.props.onReduceSideBar();
       } else {
+        this.props.onSidebarLeaveBottom();
         this.props.onExpandSideBar();
       }
     };


### PR DESCRIPTION
This fixes an issue with the sidebar showing as the
bottom bar when first loading the app in developer mode.