### PR TITLE
Add warn when upgrading to new dcrd database version

### DIFF
--- a/app/components/views/GetStartedPage/DaemonLoading/Form.js
+++ b/app/components/views/GetStartedPage/DaemonLoading/Form.js
@@ -101,19 +101,18 @@ const DaemonLoadingBody = ({
             </div>
           }
         </div>
-        {daemonWarning && getCurrentBlockCount <= 0 ?
+        {daemonWarning && getCurrentBlockCount <= 0  && (
           <>
             <div className="get-started-last-log-lines">
               <div className="last-dcrwallet-log-line">{daemonWarning}</div>
             </div>
             <div className="advanced-page-form">
               <div className="advanced-daemon-row">
-                <T id="getStarted.longWaitWarning" m="You are currently upgrading to a new dcrd version.  Typically, this one-time reindexing will take 30-45 minutes on an average machine."/>
+                <T id="getStarted.longWaitWarning" m="You are currently upgrading to a new dcrd version.  Typically, this one-time update will take 10-15 minutes on an average machine."/>
               </div>
             </div>
-          </>:
-          <div/>
-        }
+          </>
+        )}
         { Form && <Form {...{ ...props, openWalletInputRequest, startupError, getCurrentBlockCount, getDaemonSynced, isSPV }}/> }
         {syncInput ?
           <div className="advanced-page-form">

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -195,7 +195,7 @@ ipcMain.on("get-available-wallets", (event, network) => {
 });
 
 ipcMain.on("start-daemon", async (event, params, testnet) => {
-  const startedCredentials = await startDaemon(params, testnet);
+  const startedCredentials = await startDaemon(params, testnet, reactIPC);
   event.returnValue = startedCredentials;
 });
 

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -49,7 +49,7 @@ export const deleteDaemon = (appData, testnet) => {
   }
 };
 
-export const startDaemon = async (params, testnet) => {
+export const startDaemon = async (params, testnet, reactIPC) => {
   if (GetDcrdPID() && GetDcrdPID() !== -1) {
     logger.log("info", "Skipping restart of daemon as it is already running " + GetDcrdPID());
     const appdata = params ? params.appdata : null;
@@ -60,7 +60,7 @@ export const startDaemon = async (params, testnet) => {
   }
 
   try {
-    const started = await launchDCRD(params, testnet);
+    const started = await launchDCRD(params, testnet, reactIPC);
     return started;
   } catch (e) {
     logger.log("error", "error launching dcrd: " + e);

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -1,7 +1,7 @@
 import { dcrwalletCfg, getWalletPath, getExecutablePath, dcrdCfg, getDcrdPath } from "./paths";
 import { getWalletCfg, readDcrdConfig } from "config";
 import { createLogger, AddToDcrdLog, AddToDcrwalletLog, AddToDcrlndLog, GetDcrdLogs,
-  GetDcrwalletLogs, lastErrorLine, lastPanicLine, ClearDcrwalletLogs } from "./logging";
+  GetDcrwalletLogs, lastErrorLine, lastPanicLine, ClearDcrwalletLogs, CheckDaemonLogs } from "./logging";
 import parseArgs from "minimist";
 import { OPTIONS } from "constants";
 import os from "os";
@@ -147,7 +147,7 @@ export async function cleanShutdown(mainWindow, app) {
   });
 }
 
-export const launchDCRD = (params, testnet) => new Promise((resolve,reject) => {
+export const launchDCRD = (params, testnet, reactIPC) => new Promise((resolve,reject) => {
   let rpcCreds, appdata;
 
   rpcCreds = params && params.rpcCreds;
@@ -233,6 +233,9 @@ export const launchDCRD = (params, testnet) => new Promise((resolve,reject) => {
 
   dcrd.stdout.on("data", (data) => {
     AddToDcrdLog(process.stdout, data, debug);
+    if (CheckDaemonLogs(data.toString("utf-8"))) {
+      reactIPC.send("warning-received", true, data.toString("utf-8"));
+    }
     resolve(data.toString("utf-8"));
   });
 

--- a/app/main_dev/logging.js
+++ b/app/main_dev/logging.js
@@ -141,10 +141,15 @@ export function ClearDcrwalletLogs() {
 }
 
 const reindexCheck = "Reindexing to height";
+const upgradeDatabase = "Upgrading database to version 6";
 
 export function CheckDaemonLogs(data) {
   if (data.indexOf(reindexCheck) > 0) {
     return true;
   }
+  if (data.indexOf(upgradeDatabase) > 0) {
+    return true;
+  }
+
   return false;
 }


### PR DESCRIPTION
When updating dcrd to its latest version, decrediton will throw a timeout error when updating its database.

This PR avoid a timeout error and warns the user about it.

I updated the message to the following: `You are currently upgrading to a new dcrd version.  Typically, this one-time update will take 10-15 minutes on an average machine.`

On my computer it took less then 10 minutes to upgrade the database, no ssd. 

If you guys expect a longer or shorter time to update, let me know.  