### PR TITLE
Fix input field size and alignment on `Seed Clipboard Copy Warning` modal

### DIFF
--- a/app/style/Modals.less
+++ b/app/style/Modals.less
@@ -544,6 +544,15 @@
   text-transform: lowercase;
 }
 
+.confirm-seed-copy-modal-content .input-and-unit {
+  margin-left:32px;
+  padding-left:0;
+
+  > input {
+    width: 100%;
+  }
+}
+
 .confirm-seed-copy-warning-text {
   white-space: pre-line;
   margin-bottom: 20px;


### PR DESCRIPTION
closes #2223