### PR TITLE
Accept windows break line in lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
     ],
     "linebreak-style": [
       "error",
-      "unix"
+      (process.platform === "win32" ? "windows" : "unix")
     ],
     "quotes": [
       "error",


### PR DESCRIPTION
Right now if developing in windows and run lint, all break line will fail lint 

![image](https://user-images.githubusercontent.com/15069783/68531857-a95e6400-02f5-11ea-8d5b-61877201a782.png)

This PR fixes this so we do not need to switch the rule everytime we test lint.