### PR TITLE
[governance] Add proposal text padding

### DIFF
--- a/app/style/Governance.less
+++ b/app/style/Governance.less
@@ -342,6 +342,11 @@
   a {
     color:var(--link-color);
   }
+
+  div:not(.links) {
+    padding-right: 30px;
+    padding-bottom: 20px;
+  }
 }
 
 .proposal-details-voting-progress-counts {


### PR DESCRIPTION
User mentioned that the proposal text on 1.5.0-rc1 didn't have any proper padding on the right or the bottom of the text area.