### PR TITLE
[ln] Prevent using with SPV

### DIFF
--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1021,7 +1021,7 @@ export const trezorDevice = get([ "trezor", "device" ]);
 export const trezorDeviceList = get([ "trezor", "deviceList" ]);
 export const trezorWalletCreationMasterPubkeyAttempt = get([ "trezor", "walletCreationMasterPubkeyAttempt" ]);
 
-export const lnEnabled = bool(and(get([ "ln", "enabled" ]), not(isWatchingOnly), not(isTrezor)));
+export const lnEnabled = bool(and(get([ "ln", "enabled" ]), not(isWatchingOnly), not(isTrezor), not(isSPV)));
 export const lnActive = bool(get([ "ln", "active" ]));
 export const lnConnectAttempt = bool(get([ "ln", "connectAttempt" ]));
 export const lnWalletExists = bool(get([ "ln", "exists" ]));


### PR DESCRIPTION
dcrlnd does not currently support SPV mode so we need to disable the ability
to use LN when the wallet is configured as SPV.