### PR TITLE
[ln] Add choice to create LN account during setup

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -102,6 +102,7 @@ export const getNextAccountAttempt = (passphrase, accountName) => (dispatch, get
       setTimeout( () => dispatch({
         getNextAccountResponse, type: GETNEXTACCOUNT_SUCCESS
       }), 1000);
+      return getNextAccountResponse;
     })
     .catch(error => dispatch({ error, type: GETNEXTACCOUNT_FAILED }));
 };
@@ -525,4 +526,3 @@ export const getAccountExtendedKeyAttempt = (accountNumber) => (dispatch, getSta
     })
     .catch(error => dispatch({ error, type: GETACCOUNTEXTENDEDKEY_FAILED }));
 };
-

--- a/app/components/views/LNPage/ConnectPage.js
+++ b/app/components/views/LNPage/ConnectPage.js
@@ -1,8 +1,11 @@
+import { spring } from "react-motion";
 import { StandalonePage, StandaloneHeader } from "layout";
 import { FormattedMessage as T } from "react-intl";
 import { ReceiveAccountsSelect } from "inputs";
-import { PassphraseModalButton } from "buttons";
+import { PassphraseModalButton, TextToggle } from "buttons";
+import { TransitionMotionWrapper } from "shared";
 import { lnPage } from "connectors";
+import { CREATE_LN_ACCOUNT } from "actions/LNActions";
 
 const ConnectPageHeader = () => <StandaloneHeader
   title={<T id="ln.connectPage.title" m="Connect" />}
@@ -10,14 +13,20 @@ const ConnectPageHeader = () => <StandaloneHeader
   iconClassName="accounts"
 />;
 
+const wrapperComponent = props => <div className="account-list" { ...props } />;
+
+// The below constant MUST match what TextToggle expects/uses.
+const NEW_ACCOUNT = "left";
+
 @autobind
 class ConnectPage extends React.Component {
-  constructor(props)  {
+  constructor(props) {
     super(props);
     this.state = {
       launching: this.props.connectAttempt || this.props.startAttempt,
       autopilotEnabled: false,
       account: this.props.defaultAccount,
+      accountOption: NEW_ACCOUNT,
     };
   }
 
@@ -27,9 +36,15 @@ class ConnectPage extends React.Component {
 
   onLaunch(passphrase) {
     this.setState({ launching: true });
-    const account = !this.props.lightningWalletExists
-      ? this.state.account.value
-      : null;
+    let account = null;
+    if (!this.props.lightningWalletExists) {
+      if (this.state.accountOption === NEW_ACCOUNT) {
+        account = CREATE_LN_ACCOUNT;
+      } else {
+        account = this.state.account.value;
+      }
+    }
+
     this.props.startDcrlnd(passphrase, this.state.autopilotEnabled, account)
       .catch(() => this.setState({ launching: false }));
   }
@@ -38,9 +53,81 @@ class ConnectPage extends React.Component {
     this.setState({ autopilotEnabled: !this.state.autopilotEnabled });
   }
 
+  onAccountOptionClick(value) {
+    this.setState({ accountOption: value });
+  }
+
+  getAccountsListComponent() {
+    const { onChangeAccount } = this;
+    const { account } = this.state;
+
+    return [ {
+      data: <>
+        <ReceiveAccountsSelect
+          account={account}
+          onChange={onChangeAccount}
+          showAccountsButton={false}
+          hideSpendable={false}
+        />
+        <div className="existing-account-warning"><T id="ln.connectPage.useExistingAccountWarning"
+          m={`Attention: note that a running LN wallet maintains unencrypted keys
+          in memory while it's running and also takes control of all funds of the
+          given account. It's recommended to have an account dedicated to LN
+          operations and only transfer the funds you intend to use in LN to it.`} />
+        </div>
+      </>,
+      key: "output_0",
+      style: {
+        height: spring(140, { stiffness: 100, damping: 14 }),
+        opacity: spring(1, { stiffness: 100, damping: 20 }),
+      }
+    } ];
+  }
+
+  getNullStyles() {
+    return [ {
+      data: null,
+      key: "output_0",
+      style: {
+        height: spring(0, { stiffness: 100, damping: 14 }),
+        opacity: spring(0, { stiffness: 100, damping: 20 }),
+      }
+    } ];
+  }
+
+  renderSelectLNAccount() {
+    const { onAccountOptionClick, getNullStyles, getAccountsListComponent } = this;
+    const { accountOption } = this.state;
+
+    return (
+      <div className="ln-connect-opt">
+        <div className="label">
+          <T id="ln.connectPage.account" m="Account to use" />
+        </div>
+        <div className="account-selection">
+          <div>
+            <TextToggle
+              leftText={<T id="ln.connectPage.createAccount" m="Create new" />}
+              rightText={<T id="ln.connectPage.useAccount" m="Use existing" />}
+              activeButton={accountOption}
+              toggleAction={onAccountOptionClick}
+            />
+          </div>
+          <TransitionMotionWrapper {...{
+            styles: accountOption === NEW_ACCOUNT ? getNullStyles() : getAccountsListComponent(),
+            wrapperComponent,
+          }} />
+        </div>
+        <div className="description">
+          <T id="ln.connectPage.accountDescr" m="The wallet account to use for LN operations." />
+        </div>
+      </div>
+    );
+  }
+
   render() {
-    const { onLaunch, onChangeEnableAutopilot, onChangeAccount } = this;
-    const { launching, autopilotEnabled, account } = this.state;
+    const { onLaunch, onChangeEnableAutopilot } = this;
+    const { launching, autopilotEnabled } = this.state;
     const { lightningWalletExists } = this.props;
 
     return (
@@ -52,33 +139,14 @@ class ConnectPage extends React.Component {
                 <T id="ln.connectPage.enableAutopilot" m="Enable Automatic Channel Creation" />
               </div>
               <div className="checkbox">
-                <input type="checkbox" checked={autopilotEnabled} onChange={onChangeEnableAutopilot}/>
+                <input type="checkbox" checked={autopilotEnabled} onChange={onChangeEnableAutopilot} />
               </div>
               <div className="description">
                 <T id="ln.connectPage.enableAutopilotDescr" m="This enables the 'autopilot' feature, which tries to automatically open channels for up to 60% of the account's spendable amounts." />
               </div>
             </div>
 
-            { !lightningWalletExists
-              ? <div className="ln-connect-opt">
-                <div className="label">
-                  <T id="ln.connectPage.account" m="Account to use" />
-                </div>
-                <div className="account-list">
-                  <ReceiveAccountsSelect
-                    account={account}
-                    onChange={onChangeAccount}
-                    showAccountsButton={false}
-                    hideSpendable={false}
-                  />
-                </div>
-                <div className="description">
-                  <T id="ln.connectPage.accountDescr" m="The account to use for LN operations." />
-                </div>
-              </div>
-              : null
-            }
-
+            {!lightningWalletExists ? this.renderSelectLNAccount() : null}
           </div>
 
           <PassphraseModalButton

--- a/app/style/LN.less
+++ b/app/style/LN.less
@@ -294,8 +294,22 @@
     margin-top: 2px;
   }
 
+  .account-selection {
+    display: grid;
+    grid-row: 2;
+    grid-row-gap: 10px;
+    justify-items: right;
+  }
+
   .account-list {
-    width: 255px;
+    width: 210px;
+  }
+
+  .existing-account-warning {
+    color: var(--error-text-color);
+    font-size: 11px;
+    line-height: 15px;
+    margin-top: 5px;
   }
 
   .description {


### PR DESCRIPTION
This adds a toggle that lets users choose whether to create a new LN-specific
wallet account when first initializing an LN wallet.

This way users are incentived to not use their default wallet account which
is likely to have the majority of their funds, which could cause many channels
to be automatically opened if the autopilot feature was selected.