### PR TITLE
[Governance] Cast vote fixes at proposal details page

### DIFF
--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -428,7 +428,6 @@ export const updateVoteChoice = (proposal, newVoteChoiceID, passphrase) => async
 
   const voteChoice = proposal.voteOptions.find(o => o.id === newVoteChoiceID);
   if (!voteChoice) throw "Unknown vote choice for proposal";
-  proposal.currentVoteChoice = voteChoice;
 
   const messages = walletEligibleTickets.map(t => {
     // msg here needs to follow the same syntax as what is defined on
@@ -447,6 +446,7 @@ export const updateVoteChoice = (proposal, newVoteChoiceID, passphrase) => async
         return p.token === token;
       });
       if (proposal) {
+        newProposal.currentVoteChoice = voteChoice;
         return proposals[key][j] = { ...newProposal };
       }
     }

--- a/app/components/views/GovernancePage/Proposals/Details/helpers.js
+++ b/app/components/views/GovernancePage/Proposals/Details/helpers.js
@@ -36,7 +36,7 @@ export const NoElligibleTicketsVotingInfo = ({ showPurchaseTicketsPage }) => (
 );
 
 const VoteOption = ({ value, description, onClick, checked }) => (
-  <div className="proposal-vote-option" onClick={onClick ? () => onClick(value) : null}>
+  <div className="proposal-vote-option">
     <input className={value} type="radio" id={value} name="proposalVoteChoice" readOnly={!onClick} onChange={onClick ? () => onClick(value) : null}
       value={value} checked={checked} />
     <label className={"radio-label " + value} htmlFor={value}/>{description}

--- a/app/components/views/GovernancePage/Proposals/Details/helpers.js
+++ b/app/components/views/GovernancePage/Proposals/Details/helpers.js
@@ -50,7 +50,7 @@ export const ChooseVoteOption = ({ voteOptions, onUpdateVoteChoice, onVoteOption
       <div className="proposal-details-current-choice-box">
         {voteOptions.map(o => (
           <VoteOption value={o.id} description={o.id.charAt(0).toUpperCase()+o.id.slice(1)} key={o.id} checked={currentVoteChoice !== "abstain" ? o.id === currentVoteChoice.id : null }
-            onClick={!votingComplete ? onVoteOptionSelected : null}/>
+            onClick={ (currentVoteChoice === "abstain" && !votingComplete) ? onVoteOptionSelected : null }/>
         ))}
       </div>
     </div>

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -60,7 +60,8 @@ import {
 
 import {
   GETACTIVEVOTE_FAILED, GETVETTED_FAILED, GETPROPOSAL_FAILED,
-  UPDATEVOTECHOICE_FAILED, GETVETTED_UPDATEDVOTERESULTS_FAILED
+  UPDATEVOTECHOICE_SUCCESS, UPDATEVOTECHOICE_FAILED,
+  GETVETTED_UPDATEDVOTERESULTS_FAILED
 } from "actions/GovernanceActions";
 
 import {
@@ -371,6 +372,10 @@ const messages = defineMessages({
   LNWALLET_STARTDCRLND_FAILED: {
     id: "ln.ntf.startDcrlndFailed",
     defaultMessage: "{originalError}"
+  },
+  UPDATEVOTECHOICE_SUCCESS: {
+    id: "governance.ntf.updateVoteChoiceSuccess",
+    defaultMessage: "Your vote has been casted with success!\n Thanks for participating in decred's governance"
   }
 });
 
@@ -440,6 +445,7 @@ export default function snackbar(state = {}, action) {
   case LNWALLET_CLOSECHANNEL_CHANCLOSE:
   case LNWALLET_FUNDWALLET_SUCCESS:
   case LNWALLET_WITHDRAWWALLET_SUCCESS:
+  case UPDATEVOTECHOICE_SUCCESS:
     type = "Success";
     message = messages[action.type] || messages.defaultSuccessMessage;
 


### PR DESCRIPTION
This PR closes #2329, closes #2330, closes #2331

I also added a success message after casting vote, so the user can have a better feedback.

This is the message I added: 
`"Your vote has been casted with success!\n Thanks for participating in decred's governance"`

If someone has a better suggestions or phrase, I am open to discussion. 