### PR TITLE
[fonts] Fix Incosolata in wrong places

### DIFF
--- a/app/style/Layout.less
+++ b/app/style/Layout.less
@@ -346,7 +346,7 @@
 }
 
 .fatal-error {
-  font-family: var(--font-family-monospaced);
+  font-family: var(--font-family-regular);
   font-size: 13px;
 }
 

--- a/app/style/Loading.less
+++ b/app/style/Loading.less
@@ -132,7 +132,7 @@
   font-weight: 600;
   padding-left: 46px;
   padding-top: 19px;
-  font-family: var(--font-family-monospaced);
+  font-family: var(--font-family-regular);
   background-image: var(--blockchain-default);
   background-position: 20px 20px;
   background-size: 16px;

--- a/app/style/MyTickets.less
+++ b/app/style/MyTickets.less
@@ -38,7 +38,7 @@
 }
 
 .ticket-overview-header {
-  font-family: var(--font-family-monospaced);
+  font-family: var(--font-family-regular);
   font-weight: bold;
   font-size: 17px;
   text-transform: uppercase;
@@ -79,7 +79,7 @@
   .inline-block-mixin;
 
   color: var(--disabled-color);
-  font-family: var(--font-family-monospaced);
+  font-family: var(--font-family-regular);
   border-right: 1px solid var(--input-color-disabled);
   padding-right: 0.5em;
 }
@@ -88,7 +88,7 @@
   .inline-block-mixin;
 
   color: var(--disabled-color);
-  font-family: var(--font-family-monospaced);
+  font-family: var(--font-family-regular);
   background-image: var(--time-lock-icon);
   background-repeat: no-repeat;
   background-size: 12px 12px;

--- a/app/style/StakePool.less
+++ b/app/style/StakePool.less
@@ -134,7 +134,7 @@ textarea.stakepool-content-nest-content-settings {
 .stakepool-add-not-redeemable {
   display: inline-block;
   margin-top: 5px;
-  font-family: var(--font-family-monospaced);
+  font-family: var(--font-family-regular);
   font-size: 11px;
   color: var(--filter-menu-bg-hover);
   text-decoration: underline;

--- a/app/style/Trezor.less
+++ b/app/style/Trezor.less
@@ -37,7 +37,7 @@
 }
 
 .trezor-label {
-  font-family: var(--font-family-monospaced);
+  font-family: var(--font-family-regular);
 }
 
 .trezor-config-regular-buttons .button {

--- a/app/style/TxHistory.less
+++ b/app/style/TxHistory.less
@@ -122,8 +122,8 @@
 }
 
 .transaction-amount-number {
-  font-size: 18px;
-  font-weight: 600;
+  font-size: 15px;
+  font-family: var(--font-family-regular-semi-bold);
   margin-left: 10px;
 }
 
@@ -148,13 +148,12 @@
   font-family: var(--font-family-regular);
   color: var(--input-color-default);
   font-size: 15px;
-  font-weight: 600;
   margin-left: 10px;
 }
 
 .transaction-info-price-reward {
   display: flex;
-  font-family: var(--font-family-monospaced);
+  font-family: var(--font-family-regular);
   color: var(--settings-desc);
   font-size: 12px;
   margin-left: 30px;


### PR DESCRIPTION
As chatted with @linnutee at Matrix, we only use Incosolata for the overview's larger fonts. 

This PR switches its occurrences in other places. 