### PR TITLE
[ticketbuyer] Stop on close wallet

### DIFF
--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -3,7 +3,7 @@ import {
   getLoader, getWalletExists, createWallet, openWallet, closeWallet, getStakePoolInfo, rescanPoint
 } from "wallet";
 import * as wallet from "wallet";
-import { rescanCancel } from "./ControlActions";
+import { rescanCancel, ticketBuyerCancel } from "./ControlActions";
 import { getWalletServiceAttempt, startWalletServices, getBestBlockHeightAttempt,
   cancelPingAttempt } from "./ClientActions";
 import { getVersionServiceAttempt } from "./VersionActions";
@@ -194,6 +194,7 @@ export const closeWalletRequest = () => async(dispatch, getState) => {
     await dispatch(rescanCancel());
     await dispatch(trezorClearDeviceSession());
     await dispatch(stopDcrlnd());
+    await dispatch(ticketBuyerCancel());
     if (walletReady) {
       await closeWallet(getState().walletLoader.loader);
     }


### PR DESCRIPTION
This fixes a bug where re-opening the wallet afterwards made it seem the
ticketbuyer was still running.

close #2344 