### PR TITLE
[inputs] Improve DcrInput usage

### DIFF
--- a/app/components/inputs/DcrInput.js
+++ b/app/components/inputs/DcrInput.js
@@ -2,7 +2,7 @@ import FloatInput from "./FloatInput";
 import IntegerInput from "./IntegerInput";
 import { strToDcrAtoms } from "helpers/strings";
 import balanceConnector from "connectors/balance";
-import { DCR, MAX_DCR_AMOUNT } from "constants";
+import { MAX_DCR_AMOUNT } from "constants";
 
 /**
  * FixedDcrInput is a simple numeric input that is assumed to **always** hold
@@ -21,29 +21,53 @@ export const FixedDcrInput = ({ currencyDisplay, ...props }) =>
  * DcrInput provides a way to receive decred amount inputs. Instead of the usual
  * value/onChange pair, it uses amount/onChangeAmount to track values in decred
  * atoms, correctly accounting for the currently used currencyDisplay, floating
- * convertions, etc.
+ * conversions, etc.
  *
- * It tracks 2 different values: the typed input in the text box (which may
- * contain decimal and eventually thousands separator) and the actual input
- * amount in **ATOMS** (as required by various wallet operations).
+ * While the typed value is tracked in the internal state of this component,
+ * users should ordinarily only use amount/onChangeAmount so that storing
+ * and later re-displaying the value is consistent.
  */
 @autobind
 class DcrInput extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      decimal: false
+    };
+  }
+
+  // amountToDisplayStr converts the given amount in atoms to the appropriate
+  // string to display given the current config of this input.
+  amountToDisplayStr(amount) {
+    if (!amount && !this.state.decimal) return amount;
+    if (!amount) return "0.";
+    const { unitDivisor } = this.props;
+    let scaled = amount / unitDivisor;
+    if (this.state.decimal) {
+      scaled += ".";
+    }
+    return scaled;
+  }
+
+  // typedValueToAmount converts the given string value typed into the input to
+  // the appropriate atom amount.
+  typedValueToAmount(value) {
+    return strToDcrAtoms(value, this.props.unitDivisor);
   }
 
   onChange(e) {
-    const { unitDivisor, currencyDisplay, onChange } = this.props;
+    const { onChangeAmount } = this.props;
     let amount;
     const value = e.target.value;
+    const decimal = value && value.length > 0 && value[value.length-1] == ".";
     if (value) {
-      // pre-validate if <= max supply
-      amount = currencyDisplay === DCR ? value*unitDivisor : strToDcrAtoms(value, unitDivisor);
+      amount = this.typedValueToAmount(value);
 
+      // Pre-validate if <= max supply
       if (amount > MAX_DCR_AMOUNT) return;
     }
-    if (onChange) onChange({ ...e, value, atomValue: amount });
+    if (onChangeAmount) onChangeAmount({ ...e, value, atomValue: amount });
+    this.setState({ decimal });
   }
 
   render() {
@@ -54,7 +78,7 @@ class DcrInput extends React.Component {
     return <Comp
       {...this.props}
       unit={currencyDisplay}
-      value={this.props.amount}
+      value={this.amountToDisplayStr(this.props.amount)}
       onChange={this.onChange}
       maxFracDigits={maxFracDigits}
     />;

--- a/app/components/views/LNPage/ChannelsTab/Page.js
+++ b/app/components/views/LNPage/ChannelsTab/Page.js
@@ -49,12 +49,12 @@ export default ({
       </div>
       <div className="local-amt">
         <T id="ln.openChannel.localAmt" m="Total Funding Amount" />
-        <DcrInput amount={localAmt} onChange={onLocalAmtChanged} />
+        <DcrInput amount={localAmt} onChangeAmount={onLocalAmtChanged} />
       </div>
       { isMainNet ? null : // Not allowing to push atoms in mainnet as a precaution from inadvertent user action for the moment.
         <div className="push-amt">
           <T id="ln.openChannel.pushAmt" m="Push Amount (optional)" />
-          <DcrInput amount={pushAmt} onChange={onPushAmtChanged} />
+          <DcrInput amount={pushAmt} onChangeAmount={onPushAmtChanged} />
         </div>
       }
       <KeyBlueButton className="open-btn" onClick={onOpenChannel} loading={opening} disabled={opening || !canOpen}>

--- a/app/components/views/LNPage/ChannelsTab/index.js
+++ b/app/components/views/LNPage/ChannelsTab/index.js
@@ -14,9 +14,7 @@ class ChannelsTab extends React.Component {
     super(props);
     this.state = {
       node: "",
-      localAmt: 0,
       localAmtAtoms: 0,
-      pushAmt: 0,
       pushAmtAtoms: 0,
       canOpen: false,
       opening: false
@@ -24,17 +22,17 @@ class ChannelsTab extends React.Component {
   }
 
   onNodeChanged(e) {
-    const canOpen = e.target.value && this.state.localAmt > 0;
+    const canOpen = e.target.value && this.state.localAmtAtoms > 0;
     this.setState({ node: (""+e.target.value).trim(), canOpen });
   }
 
-  onLocalAmtChanged({ value, atomValue }) {
+  onLocalAmtChanged({ atomValue }) {
     const canOpen = atomValue > 0 && this.state.node;
-    this.setState({ localAmt: value, localAmtAtoms: atomValue, canOpen });
+    this.setState({ localAmtAtoms: atomValue, canOpen });
   }
 
-  onPushAmtChanged({ value, atomValue }) {
-    this.setState({ pushAmt: value, pushAmtAtoms: atomValue });
+  onPushAmtChanged({ atomValue }) {
+    this.setState({ pushAmtAtoms: atomValue });
   }
 
   onOpenChannel() {
@@ -44,8 +42,8 @@ class ChannelsTab extends React.Component {
     }
     this.setState({ opening: true });
     this.props.openChannel(node, localAmtAtoms, pushAmtAtoms).then(() => {
-      this.setState({ opening: false, node: "", localAmt: 0, pushAmt: 0,
-        localAmtAtoms: 0, pushAmtAtoms: 0 });
+      this.setState({ opening: false, node: "", localAmtAtoms: 0,
+        pushAmtAtoms: 0, canOpen: false });
     }).catch(() => {
       this.setState({ opening: false });
     });
@@ -68,7 +66,7 @@ class ChannelsTab extends React.Component {
       maxOutboundAmount } = this.props.channelBalances;
 
     const { channels, pendingChannels, closedChannels, isMainNet } = this.props;
-    const { node, localAmt, pushAmt, opening, canOpen,
+    const { node, localAmtAtoms, pushAmtAtoms, opening, canOpen,
       detailedChannel } = this.state;
     const { onNodeChanged, onLocalAmtChanged, onPushAmtChanged,
       onOpenChannel, onCloseChannel, onToggleChannelDetails } = this;
@@ -83,8 +81,8 @@ class ChannelsTab extends React.Component {
         pendingChannels={pendingChannels}
         closedChannels={closedChannels}
         node={node}
-        localAmt={localAmt}
-        pushAmt={pushAmt}
+        localAmt={localAmtAtoms}
+        pushAmt={pushAmtAtoms}
         opening={opening}
         canOpen={canOpen}
         detailedChannel={detailedChannel}

--- a/app/components/views/LNPage/InvoicesTab/Page.js
+++ b/app/components/views/LNPage/InvoicesTab/Page.js
@@ -55,7 +55,7 @@ export default ({
       </div>
       <div className="value">
         <T id="ln.invoicesTab.addInvoice.value" m="Value" />
-        <DcrInput amount={value} onChange={onValueChanged} />
+        <DcrInput amount={value} onChangeAmount={onValueChanged} />
       </div>
       <KeyBlueButton onClick={onAddInvoice} disabled={addInvoiceAttempt}>+</KeyBlueButton>
       { !lastPayRequest

--- a/app/components/views/LNPage/InvoicesTab/index.js
+++ b/app/components/views/LNPage/InvoicesTab/index.js
@@ -14,15 +14,14 @@ class InvoicesTab extends React.Component {
   constructor(props)  {
     super(props);
     this.state = {
-      value: 0,
       atomValue: 0,
       memo: "",
       lastPayRequest: ""
     };
   }
 
-  onValueChanged({ value, atomValue }) {
-    this.setState({ value, atomValue });
+  onValueChanged({ atomValue }) {
+    this.setState({ atomValue });
   }
 
   onMemoChanged(e) {
@@ -46,14 +45,14 @@ class InvoicesTab extends React.Component {
 
   render() {
     const { invoices, tsDate, addInvoiceAttempt } = this.props;
-    const { memo, value, lastPayRequest, lastError } = this.state;
+    const { memo, atomValue, lastPayRequest, lastError } = this.state;
     const { onValueChanged, onMemoChanged, onAddInvoice } = this;
 
     return (
       <Page
         invoices={invoices}
         tsDate={tsDate}
-        value={value}
+        value={atomValue}
         memo={memo}
         addInvoiceAttempt={addInvoiceAttempt}
         lastPayRequest={lastPayRequest}

--- a/app/components/views/LNPage/PaymentsTab/Page.js
+++ b/app/components/views/LNPage/PaymentsTab/Page.js
@@ -39,7 +39,7 @@ const DecodedPayRequest = ({ decoded, tsDate, expired, sendValue, onSendValueCha
   <div className="decoded-payreq">
     { decoded.numAtoms
       ? <div className="num-atoms"><Balance amount={decoded.numAtoms} /></div>
-      : <DcrInput amount={sendValue} onChange={onSendValueChanged} />
+      : <DcrInput amount={sendValue} onChangeAmount={onSendValueChanged} />
     }
     { decoded.description
       ? <div className="description">{decoded.description}</div>

--- a/app/components/views/LNPage/PaymentsTab/index.js
+++ b/app/components/views/LNPage/PaymentsTab/index.js
@@ -14,7 +14,6 @@ class PaymentsTab extends React.Component {
   constructor(props)  {
     super(props);
     this.state = {
-      sendValue: 0,
       sendValueAtom: 0,
       payRequest: "",
       decodedPayRequest: null,
@@ -62,8 +61,8 @@ class PaymentsTab extends React.Component {
     this.lastDecodeTimer = this.props.setTimeout(this.decodePayRequest, 1000);
   }
 
-  onSendValueChanged({ value, atomValue }) {
-    this.setState({ sendValue: value, sendValueAtom: atomValue });
+  onSendValueChanged({ atomValue }) {
+    this.setState({ sendValueAtom: atomValue });
   }
 
   onSendPayment() {
@@ -84,7 +83,7 @@ class PaymentsTab extends React.Component {
   render() {
     const { payments, tsDate } = this.props;
     const { payRequest, decodedPayRequest, decodingError,
-      expired, sending, sendValue } = this.state;
+      expired, sending, sendValueAtom } = this.state;
     const { onPayRequestChanged, onSendPayment, onSendValueChanged } = this;
 
     return (
@@ -96,7 +95,7 @@ class PaymentsTab extends React.Component {
         decodingError={decodingError}
         expired={expired}
         sending={sending}
-        sendValue={sendValue}
+        sendValue={sendValueAtom}
         onPayRequestChanged={onPayRequestChanged}
         onSendPayment={onSendPayment}
         onSendValueChanged={onSendValueChanged}

--- a/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/index.js
@@ -116,17 +116,9 @@ class TicketAutoBuyer extends React.Component {
       : null;
   }
 
-  onChangeBalanceToMaintain(balanceToMaintain) {
-    const balanceToMaintainInAtoms = this.getValueInAtoms(balanceToMaintain);
-
-    const balanceToMaintainError = (
-      isNaN(balanceToMaintainInAtoms) ||
-      balanceToMaintainInAtoms < 0
-    ) || !balanceToMaintain;
-
+  onChangeBalanceToMaintain({ atomValue }) {
     this.setState({
-      balanceToMaintain: balanceToMaintain,
-      balanceToMaintainError: balanceToMaintainError
+      balanceToMaintain: atomValue
     });
   }
 

--- a/app/components/views/TransactionsPage/SendTab/OutputRow.js
+++ b/app/components/views/TransactionsPage/SendTab/OutputRow.js
@@ -42,7 +42,7 @@ const getSendSelfIcon = ({ isSendSelf, onShowSendSelf, onShowSendOthers }) => !i
   </Tooltip>;
 
 const SendOutputRow = ({
-  index, destination, value, onAddOutput, onRemoveOutput,
+  index, destination, amount, onAddOutput, onRemoveOutput,
   onValidateAmount, onValidateAddress, isSendAll, onKeyDown, sendAllAmount, error, intl,
   onShowSendAll, onHideSendAll, isSendSelf, outputs, onChangeAccount, onShowSendSelf,
   account, onShowSendOthers
@@ -90,9 +90,9 @@ const SendOutputRow = ({
             showErrors={error && error.amount}
             invalid={error && error.amount}
             invalidMessage={error && error.amount}
-            amount={value}
+            amount={amount}
             placeholder={intl.formatMessage(messages.amountPlaceholder)}
-            onChange={ e => onValidateAmount({ value: e.value , index, atomValue: e.atomValue })}
+            onChangeAmount={ e => onValidateAmount({ index, atomValue: e.atomValue })}
             onKeyDown={onKeyDown}
           />
         }

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -32,11 +32,15 @@ class Send extends React.Component {
   componentDidUpdate(prevProps) {
     const { constructTxLowBalance, unsignedRawTx, isWatchingOnly, nextAddress, publishTxResponse } = this.props;
     const { isSendSelf, outputs } = this.state;
+    let newOutputs;
     if (publishTxResponse && publishTxResponse !== prevProps.publishTxResponse) {
-      this.setState({ outputs: [ { key: "output_0", data: this.getBaseOutput() } ] });
+      newOutputs = [ { key: "output_0", data: this.getBaseOutput() } ];
+      this.setState({ isSendAll: false });
     }
     if (isSendSelf && (prevProps.nextAddress != nextAddress)) {
-      let newOutputs = outputs.map(o => ({ ...o, data:{ ...o.data, destination: nextAddress } }));
+      newOutputs = (newOutputs || outputs).map(o => ({ ...o, data:{ ...o.data, destination: nextAddress } }));
+    }
+    if (newOutputs) {
       this.setState({ outputs: newOutputs }, this.onAttemptConstructTransaction);
     }
     if (constructTxLowBalance !== prevProps.constructTxLowBalance) {
@@ -103,7 +107,7 @@ class Send extends React.Component {
   }
 
   getBaseOutput() {
-    return { destination: "", amount: null, value: null, error: { address: null, amount: null } };
+    return { destination: "", amount: null, error: { address: null, amount: null } };
   }
 
   getDefaultStyles() {
@@ -232,18 +236,15 @@ class Send extends React.Component {
   }
 
   onValidateAmount(data) {
-    // value represents the value to be showed on the component and amount
-    // represents its value in atoms so we can calculate transaction data.
-    const { value, atomValue, index } = data;
+    const { atomValue, index } = data;
     let error;
-    if (!value || isNaN(value)) {
+    if (!atomValue || isNaN(atomValue)) {
       error = <T id="send.errors.invalidAmount" m="Please enter a valid amount" />;
     }
-    if (value <= 0) {
+    if (atomValue <= 0) {
       error = <T id="send.errors.negativeAmount" m="Please enter a valid amount (> 0)" />;
     }
     const ref = this.state.outputs[index];
-    ref.data.value = value;
     ref.data.amount = atomValue;
 
     ref.data.error.amount = error;

--- a/app/style/SendPage.less
+++ b/app/style/SendPage.less
@@ -1,7 +1,7 @@
 @import (reference) "./main.less";
 @import (reference) "./Icons.less";
 
-.send-wrapper-area { 
+.send-wrapper-area {
   width: 740px;
   margin-bottom: 20px;
 }
@@ -19,7 +19,7 @@
 
     .total-amount-send-amount-bytes {
       color: var(--account-text);
-    }    
+    }
   }
 }
 
@@ -50,7 +50,7 @@
   background-position: 50% 50%;
   background-size: 19px;
   background-repeat: no-repeat;
-  margin-bottom: 25px;
+  margin-bottom: 23px;
   cursor: pointer;
 
   &.add {
@@ -92,7 +92,7 @@
         background-image: @send-all-disabled;
       }
     }
-  
+
     &:hover {
       background-image: var(--send-all-hover);
     }
@@ -116,7 +116,7 @@
 }
 
 .details-label-column {
-  white-space: nowrap; 
+  white-space: nowrap;
   .total-amount-sending-text {
     margin-left: 27px;
   }
@@ -154,7 +154,7 @@
 }
 
 .send-input-wrapper {
-  margin-bottom: 25px;
+  margin-bottom: 23px;
 
   .input-errors-area {
     margin-bottom: -14px;
@@ -162,9 +162,14 @@
 }
 
 .send-input {
-  width: 260px;  
+  width: 260px;
   margin-left: 10px;
   margin-right: 10px;
+
+  &.input-and-unit {
+    width: 255px;
+    padding-bottom: 2px;
+  }
 
   &.send-all {
     border-bottom: 1px var(--stroke-color-default) solid;
@@ -238,7 +243,7 @@
   }
 
   .send-input-wrapper {
-    margin-bottom: 22px;  
+    margin-bottom: 22px;
   }
 
   .send-input {


### PR DESCRIPTION
This changes the DcrInput component to require only a single prop as
input ('amount').

Having to track both 'value' and 'amount' as consumer of DcrInput
was cumbersome and led to some mistakes such as in the ticket buyer
input that specifies the balance to maintain.

This improves the component so that only a single set of props
(amount/onChangeAmount) need to be specified and the component behaves
as expected.