### PR TITLE
[ln] Fix testnet/mainnet attr

### DIFF
--- a/app/components/views/LNPage/ChannelsTab/index.js
+++ b/app/components/views/LNPage/ChannelsTab/index.js
@@ -88,7 +88,7 @@ class ChannelsTab extends React.Component {
         opening={opening}
         canOpen={canOpen}
         detailedChannel={detailedChannel}
-        testnet={isMainNet}
+        isMainNet={isMainNet}
         onNodeChanged={onNodeChanged}
         onLocalAmtChanged={onLocalAmtChanged}
         onPushAmtChanged={onPushAmtChanged}


### PR DESCRIPTION
Test was using the wrong attribute. The only effect was the push
amount panel was still shown, which is not ideal in mainnet.