### PR TITLE
[control] Prevent gap exhaustion in change generation

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -365,7 +365,8 @@ var initialState = {
     exportingData: false,
     modalVisible: false,
     aboutModalMacOSVisible: false,
-    autobuyerRunningModalVisible: false
+    autobuyerRunningModalVisible: false,
+    changeScriptByAccount: {}
   },
   snackbar: {
     messages: Array()

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -25,6 +25,7 @@ import { GETNEXTADDRESS_ATTEMPT, GETNEXTADDRESS_FAILED, GETNEXTADDRESS_SUCCESS,
   GETACCOUNTEXTENDEDKEY_ATTEMPT, GETACCOUNTEXTENDEDKEY_FAILED, GETACCOUNTEXTENDEDKEY_SUCCESS, HIDE_AUTOBUYER_RUNNING_MODAL, SHOW_AUTOBUYER_RUNNING_MODAL
 } from "../actions/ControlActions";
 import { WALLET_AUTOBUYER_SETTINGS } from "actions/DaemonActions";
+import { CLOSEWALLET_SUCCESS } from "actions/WalletLoaderActions";
 
 import {
   EXPORT_STARTED, EXPORT_COMPLETED, EXPORT_ERROR
@@ -232,7 +233,8 @@ export default function control(state = {}, action) {
       publishTransactionRequestAttempt: false,
       publishTransactionResponse: action.hash,
       constructTxResponse: null,
-      signTxResponse: null
+      signTxResponse: null,
+      changeScriptByAccount: action.changeScriptByAccount
     };
   case PURCHASETICKETS_ATTEMPT:
     return { ...state,
@@ -397,6 +399,7 @@ export default function control(state = {}, action) {
     };
   case CONSTRUCTTX_SUCCESS:
     return { ...state,
+      changeScriptByAccount: action.changeScriptByAccount,
       constructTxRequestAttempt: false,
       constructTxResponse: action.constructTxResponse
     };
@@ -483,6 +486,10 @@ export default function control(state = {}, action) {
     return { ...state,
       getAccountExtendedKeyRequest: false,
       getAccountExtendedKeyResponse: action.getAccountExtendedKeyResponse
+    };
+  case CLOSEWALLET_SUCCESS:
+    return { ...state,
+      changeScriptByAccount: {}
     };
   default:
     return state;

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -17,11 +17,11 @@ export const getMessageVerificationService = promisify(client.getMessageVerifica
 export const getDecodeService = promisify(client.getDecodeMessageService);
 export const getSeedService = promisify(client.getSeedService);
 
-export const getNextAddress = log((walletService, accountNum) =>
+export const getNextAddress = log((walletService, accountNum, kind) =>
   new Promise((resolve, reject) => {
     const request = new api.NextAddressRequest();
     request.setAccount(accountNum);
-    request.setKind(0);
+    request.setKind(kind ? kind : 0);
     request.setGapPolicy(api.NextAddressRequest.GapPolicy.GAP_POLICY_WRAP);
     walletService
       .nextAddress(request, (error, response) => error ? reject(error) : resolve(response));


### PR DESCRIPTION
This prevents address exhaustion due to generating more than the gap limit
addresses by storing the most recently generated change address and reusing
it for all future transactions (for that account) until the transaction is
published.

Work around https://github.com/decred/dcrwallet/issues/1622