### PR TITLE
[trezor] Send sequence for prevtx inputs

### DIFF
--- a/app/actions/TrezorActions.js
+++ b/app/actions/TrezorActions.js
@@ -455,10 +455,6 @@ export const walletTxToBtcjsTx = (tx, changeIndex, inputTxs) => async (dispatch,
       address_n: addressPath(addrIndex, addrBranch, WALLET_ACCOUNT,
         chainParams.HDCoinType),
       decred_tree: inp.getTree()
-
-      // FIXME: this needs to be supported on trezor.js.
-      // decredTree: inp.getTree(),
-      // decredScriptVersion: 0,
     });
   }
 
@@ -509,11 +505,8 @@ export function walletTxToRefTx(tx) {
     amount: inp.getAmountIn(),
     prev_hash: rawHashToHex(inp.getPreviousTransactionHash()),
     prev_index: inp.getPreviousTransactionIndex(),
-    decred_tree: inp.getTree()
-
-    // TODO: this needs to be supported on trezor.js
-    // decredTree: inp.getTree(),
-    // decredScriptVersion: 0,
+    decred_tree: inp.getTree(),
+    sequence: inp.getSequence()
   }));
 
   const bin_outputs = tx.getOutputsList().map(outp => ({


### PR DESCRIPTION
The sequence field for inputs of prevtxs was not being sent to the device,
causing a failure to verify that the hash of the previous transaction and its
contents matched.

This error could be triggered if the trezor wallet received funds from a
non-dcrwallet sender that did not set the Sequence field of the authored
transaction to MaxTxInSequenceNum.