### PR TITLE
[launcher] Fix SPV choice triggering daemon launch

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -95,18 +95,18 @@ export const showPrivacy = () => (dispatch) => {
   dispatch(pushHistory("/getstarted/privacy"));
 };
 
-export const enableSpv = () => (dispatch, getState) => {
+export const enableSpv = () => async (dispatch, getState) => {
   dispatch(updateStateSettingsChanged({ spvMode: true }, true));
   const tempSettings = getState().settings.tempSettings;
-  dispatch(saveSettings(tempSettings));
-  dispatch(finishSpvChoice());
+  await dispatch(saveSettings(tempSettings));
+  dispatch(finishSpvChoice(true));
 };
 
 export const disableSpv = () => (dispatch, getState) => {
   dispatch(updateStateSettingsChanged({ spvMode: false }, true));
   const tempSettings = getState().settings.tempSettings;
   dispatch(saveSettings(tempSettings));
-  dispatch(finishSpvChoice());
+  dispatch(finishSpvChoice(false));
 };
 
 export const setupStandardPrivacy = () => (dispatch, getState) => {
@@ -131,11 +131,13 @@ export const selectLanguage = (selectedLanguage) => (dispatch) => {
   dispatch(pushHistory("/getstarted"));
 };
 
-export const finishSpvChoice = () => (dispatch) => {
+export const finishSpvChoice = (isSPV) => (dispatch) => {
   const config = getGlobalCfg();
   config.set("show_spvchoice", false);
   dispatch({ type: FINISH_SPVCHOICE });
-  dispatch(startDaemon());
+  if (!isSPV) {
+    dispatch(startDaemon());
+  }
   dispatch(goBack());
 };
 


### PR DESCRIPTION
This fixes an instance where selecting to use SPV for the first time on a new
install would cause the dcrd full node to run.

The problem was that to speed up the blockchain download, the node was started
after SPV choice and before the wallet tutorial but it was started
unconditionally, without considering the previous choice to only run in SPV
mode.

How to reproduce the issue (without this commit):

- Rename/remove `~/.dcrd/data/testnet3` (so that it's more obvious the daemon is running and performing IBD)
- Edit `~/.config/decrediton/config.json`:
  - `show_tutorial: true`
  - `spv_mode: false`
  - `show_spvchoice: true`

Start decrediton, select SPV and the daemon is started.