### PR TITLE
[actions] Always record ticket info for stake txs

### DIFF
--- a/app/selectors.js
+++ b/app/selectors.js
@@ -335,7 +335,7 @@ const txHashToTicket = createSelector(
   }, {})
 );
 
-const transactionNormalizer = createSelector(
+export const transactionNormalizer = createSelector(
   [ accounts, txURLBuilder, blockURLBuilder ],
   (accounts, txURLBuilder, blockURLBuilder) => {
     const findAccount = num => accounts.find(account => account.getAccountNumber() === num);


### PR DESCRIPTION
This changes the getTransactions() action call to always fetch and fill
missing stake info for stake transactions.

This fixes an issue where the ticket price and reward amounts appeared as
zero in the history list for stake transactions.

Fix #2350 