### PR TITLE
[Startup] Fix advanced mode after rebase

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -158,7 +158,6 @@ export const finishPrivacy = () => (dispatch) => {
 };
 
 export const startDaemon = (params) => (dispatch, getState) => new Promise ((resolve, reject) => {
-  const appdata = params && params.appdata;
   dispatch({ type: DAEMONSTART_ATTEMPT });
   const { daemonStarted } = getState().daemon;
   if (daemonStarted) {
@@ -166,7 +165,15 @@ export const startDaemon = (params) => (dispatch, getState) => new Promise ((res
   }
 
   return wallet.startDaemon(params, isTestNet(getState()))
-    .then(rpcCreds => {
+    .then(started => {
+      const rpcCreds = {
+        rpc_user: started.rpc_user,
+        rpc_pass: started.rpc_pass,
+        rpc_cert: started.rpc_cert,
+        rpc_host: started.rpc_host,
+        rpc_port: started.rpc_port
+      };
+      const appdata = started.appdata;
       dispatch({ type: DAEMONSTART_SUCCESS, credentials: rpcCreds, appdata });
       resolve({ appdata, credentials: rpcCreds });
     })

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -223,7 +223,7 @@ export const startRpcRequestFunc = (privPass, isRetry) =>
     }
     const { daemon: { walletName }, walletLoader: { discoverAccountsComplete,isWatchingOnly } }= getState();
 
-    const credentials = ipcRenderer.sendSync("get-daemon-credentials");
+    const credentials = ipcRenderer.sendSync("get-dcrd-rpc-credentials");
     const { rpc_user, rpc_cert, rpc_pass, rpc_host, rpc_port } = credentials;
 
     var request = new RpcSyncRequest();

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -10,7 +10,7 @@ import { installSessionHandlers, reloadAllowedExternalRequests, allowStakepoolRe
 import { setupProxy } from "./main_dev/proxy";
 import {
   getDaemonInfo, cleanShutdown, GetDcrdPID, GetDcrwPID, getBlockChainInfo, connectRpcDaemon,
-  setHeightSynced, getHeightSynced, getDaemonCredentials, setSelectedWallet, getSelectedWallet, setDaemonCredentials,
+  setHeightSynced, getHeightSynced, getDcrdRpcCredentials, setSelectedWallet, getSelectedWallet,
   GetDcrlndPID, GetDcrlndCreds
 } from "./main_dev/launch";
 import { getAvailableWallets, startDaemon, createWallet, removeWallet, stopDaemon, stopWallet, startWallet,
@@ -340,12 +340,8 @@ ipcMain.on("set-selected-wallet", (event, wallet) => {
   event.returnValue = true;
 });
 
-ipcMain.on("get-daemon-credentials", (event) => {
-  event.returnValue = getDaemonCredentials();
-});
-
-ipcMain.on("set-daemon-credentials", (event, credentials) => {
-  setDaemonCredentials(credentials);
+ipcMain.on("get-dcrd-rpc-credentials", (event) => {
+  event.returnValue = getDcrdRpcCredentials();
 });
 
 ipcMain.on("set-previous-wallet", (event, cfg) => {

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -1,9 +1,9 @@
 import fs from "fs-extra";
 import path from "path";
 import { createLogger } from "./logging";
-import { getWalletPath, getWalletDb, getDcrdPath, getDcrdRpcCert } from "./paths";
-import { initWalletCfg, newWalletConfigCreation, getWalletCfg, readDcrdConfig } from "config";
-import { launchDCRD, launchDCRWallet, GetDcrdPID, GetDcrwPID, closeDCRD, closeDCRW, GetDcrwPort,
+import { getWalletPath, getWalletDb, getDcrdPath } from "./paths";
+import { initWalletCfg, newWalletConfigCreation, getWalletCfg } from "config";
+import { launchDCRD, launchDCRWallet, GetDcrwPID, closeDCRD, closeDCRW, GetDcrwPort,
   launchDCRLnd, GetDcrlndPID, GetDcrlndCreds, closeDcrlnd, setDcrdRpcCredentials } from "./launch";
 import { MAINNET } from "constants";
 

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -4,11 +4,12 @@ import { createLogger } from "./logging";
 import { getWalletPath, getWalletDb, getDcrdPath, getDcrdRpcCert } from "./paths";
 import { initWalletCfg, newWalletConfigCreation, getWalletCfg, readDcrdConfig } from "config";
 import { launchDCRD, launchDCRWallet, GetDcrdPID, GetDcrwPID, closeDCRD, closeDCRW, GetDcrwPort,
-  launchDCRLnd, GetDcrlndPID, GetDcrlndCreds, closeDcrlnd } from "./launch";
+  launchDCRLnd, GetDcrlndPID, GetDcrlndCreds, closeDcrlnd, setDcrdRpcCredentials } from "./launch";
 import { MAINNET } from "constants";
 
 const logger = createLogger();
 let watchingOnlyWallet;
+let dcrdIsRemote;
 
 export const getAvailableWallets = (network) => {
   // Attempt to find all currently available wallet.db's in the respective network direction in each wallets data dir
@@ -49,19 +50,31 @@ export const deleteDaemon = (appData, testnet) => {
   }
 };
 
+// startDaemon checks for rpc credentials parameters, which are
+// { rpcuser, rpcpass, rpccert, rpchost, rpcport }, if they are defined
+// dcrdIsRemote is set to true. Otherwise startDaemon checks for appdata
+// parameter and if it is defined startDaemon launches dcrd with appdata's
+// value if it is valid.
+// startDaemon returns an object of format:
+// { appdata, rpc_user, rpc_pass, rpc_cert, rpc_host, rpc_port }
 export const startDaemon = async (params, testnet, reactIPC) => {
-  if (GetDcrdPID() && GetDcrdPID() !== -1) {
-    logger.log("info", "Skipping restart of daemon as it is already running " + GetDcrdPID());
-    const appdata = params ? params.appdata : null;
-    const newConfig = readDcrdConfig(appdata, testnet);
-
-    newConfig.pid =  GetDcrdPID();
-    newConfig.rpc_cert = getDcrdRpcCert(appdata);
-    return newConfig;
+  if (dcrdIsRemote) {
+    logger.log("info", "Skipping restart of daemon as it is connected as remote");
+    return;
   }
 
   try {
-    const started = await launchDCRD(params, testnet, reactIPC);
+    let rpcCreds, appdata;
+    rpcCreds = params && params.rpcCreds;
+    if (rpcCreds) {
+      setDcrdRpcCredentials(rpcCreds);
+      dcrdIsRemote = true;
+      logger.log("info", "dcrd is connected as remote");
+      return rpcCreds;
+    }
+
+    appdata = params && params.appdata;
+    const started = await launchDCRD(reactIPC, testnet, appdata);
     return started;
   } catch (err) {
     logger.log("error", "error launching dcrd: " + err);

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -26,7 +26,6 @@ let dcrwPipeRx, dcrwPipeTx, dcrdPipeRx, dcrwTxStream;
 
 let dcrwPort;
 let rpcuser, rpcpass, rpccert, rpchost, rpcport;
-let appdata;
 let dcrlndCreds;
 
 let dcrdSocket, heightIsSynced, selectedWallet = null;

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -26,6 +26,7 @@ let dcrwPipeRx, dcrwPipeTx, dcrdPipeRx, dcrwTxStream;
 
 let dcrwPort;
 let rpcuser, rpcpass, rpccert, rpchost, rpcport;
+let appdata;
 let dcrlndCreds;
 
 let dcrdSocket, heightIsSynced, selectedWallet = null;
@@ -48,7 +49,7 @@ export const setHeightSynced = (isSynced) => {
 
 export const getHeightSynced = () => heightIsSynced;
 
-export const setDaemonCredentials = ({ rpc_user, rpc_pass, rpc_cert, rpc_host, rpc_port }) => {
+export const setDcrdRpcCredentials = ({ rpc_user, rpc_pass, rpc_cert, rpc_host, rpc_port }) => {
   rpcuser = rpc_user;
   rpcpass = rpc_pass;
   rpccert = rpc_cert;
@@ -57,7 +58,7 @@ export const setDaemonCredentials = ({ rpc_user, rpc_pass, rpc_cert, rpc_host, r
   return true;
 };
 
-export const getDaemonCredentials = () => ({
+export const getDcrdRpcCredentials = () => ({
   rpc_user: rpcuser,
   rpc_pass: rpcpass,
   rpc_cert: rpccert,
@@ -190,42 +191,31 @@ export async function cleanShutdown(mainWindow, app) {
   });
 }
 
-export const launchDCRD = (params, testnet, reactIPC) => new Promise((resolve,reject) => {
-  let rpcCreds, appdata;
-
-  rpcCreds = params && params.rpcCreds;
-  appdata = params && params.appdata;
-
-  if (rpcCreds) {
-    setDaemonCredentials(rpcCreds);
-    dcrdPID = -1;
-    AddToDcrdLog(process.stdout, "dcrd is connected as remote", debug);
-    return resolve(rpcCreds);
-  }
-  if (dcrdPID === -1) {
-    return resolve(getDaemonCredentials());
-  }
-
-  if (!appdata) appdata = getDcrdPath();
-
-  let args = [ "--nolisten" ];
-  const newConfig = readDcrdConfig(appdata, testnet);
-  newConfig.appdata = appdata;
-
-  if (fs.existsSync(dcrdCfg(appdata))) {
-    args.push(`--configfile=${dcrdCfg(appdata)}`);
-  }
-  args.push(`--appdata=${appdata}`);
-
-  if (testnet) {
-    args.push("--testnet");
-  }
-  setDaemonCredentials(newConfig);
-
+// launchDCRD checks launches dcrd
+export const launchDCRD = (reactIPC, testnet, appdata) => new Promise((resolve,reject) => {
   const dcrdExe = getExecutablePath("dcrd", argv.custombinpath);
   if (!fs.existsSync(dcrdExe)) {
     logger.log("error", "The dcrd executable does not exist. Expected to find it at " + dcrdExe);
     return;
+  }
+
+  const args = [ "--nolisten" ];
+
+  // we read dcrd config before setting appdata because if appdata is not defined
+  // we use dcrd.conf file from decrediton's config folder, so appdata needs to be undefined.
+  const newConfig = readDcrdConfig(testnet, appdata);
+
+  if (!appdata) appdata = getDcrdPath();
+  // After reading dcrd.conf we can set rpc.cert, as we are going to use it from getDcrdPath() if
+  // appdata is not defined.
+  newConfig.rpc_cert = `${appdata}/rpc.cert`;
+  newConfig.appdata = appdata;
+  args.push(`--appdata=${appdata}`);
+  if (fs.existsSync(dcrdCfg(appdata))) {
+    args.push(`--configfile=${dcrdCfg(appdata)}`);
+  }
+  if (testnet) {
+    args.push("--testnet");
   }
 
   if (os.platform() == "win32") {
@@ -572,7 +562,7 @@ export const connectRpcDaemon = async (mainWindow, rpcCreds) => {
   let rpc_user, rpc_pass, rpc_cert, rpc_host, rpc_port;
 
   if (rpcCreds) {
-    setDaemonCredentials(rpcCreds);
+    setDcrdRpcCredentials(rpcCreds);
     rpc_user = rpcCreds.rpc_user;
     rpc_pass = rpcCreds.rpc_pass;
     rpc_cert = rpcCreds.rpc_cert;


### PR DESCRIPTION
As we had 1.5 release, this branch code got outdated, and after rebasing it against master, some functionalities on advanced startup mode stopped working.

This PR fixes it. To test it, it is needed to run `yarn` as it needs to install `xstate`

Right now, only advanced options works: connect as remote and start dcrd with different appdata. 

Regular mode is started at: https://github.com/decred/decrediton/pull/2198 but not yet merged. 