### PR TITLE
[home] Fix active ticket count in SPV wallets

### DIFF
--- a/app/components/views/HomePage/tabs/Balance.js
+++ b/app/components/views/HomePage/tabs/Balance.js
@@ -15,7 +15,7 @@ const HomePage = ({
       <div className="overview-spendable-locked-wrapper">
         <div className="overview-spendable-locked-wrapper-area">
           <Balance
-            classNameWrapper="overview-balance-spendable-locked available"
+            classNameWrapper="overview-balance-spendable-locked available amount"
             classNameUnit="overview-balance-spendable-locked-unit"
             amount={spendableTotalBalance} />
           <div className="overview-balance-spendable-locked-label">
@@ -24,7 +24,7 @@ const HomePage = ({
         </div>
         <div className="overview-spendable-locked-wrapper-area">
           <Balance
-            classNameWrapper="overview-balance-spendable-locked locked"
+            classNameWrapper="overview-balance-spendable-locked locked amount"
             classNameUnit="overview-balance-spendable-locked-unit"
             amount={lockedTotalBalance} />
           <div className="overview-balance-spendable-locked-label">

--- a/app/components/views/HomePage/tabs/Tickets.js
+++ b/app/components/views/HomePage/tabs/Tickets.js
@@ -8,7 +8,7 @@ import "style/HomePage.less";
 const HomePage = ({
   totalValueOfLiveTickets,
   earnedStakingReward,
-  liveTicketsCount,
+  activeTicketsCount,
   votedTicketsCount,
   ticketDataChart
 }) => {
@@ -17,40 +17,46 @@ const HomePage = ({
       <div className="overview-spendable-locked-wrapper">
         <div className="overview-spendable-locked-wrapper-area tickets">
           <div className="is-row">
-            <div className="overview-balance-spendable-locked active">{liveTicketsCount}</div>
-            <div className="overview-balance-spendable-locked-top-label">
-              <T id="home.liveTicketsCount" m="active tickets" />
+            <div className="overview-balance-spendable-locked active">
+              <T id="home.activeTicketsCount" m="{count, plural, one {{fmtCount} active ticket} other {{fmtCount} active tickets}}"
+                values={{
+                  count: activeTicketsCount,
+                  fmtCount: <span className="count">{activeTicketsCount}</span>
+                }} />
             </div>
           </div>
           <div className="is-row">
             <div className="overview-balance-spendable-locked-text">
-              <T id="home.totalValueOfLiveTickets" m="With a total value of" />
+              <T id="home.totalValueOfActiveTickets" m="With a total value of {value}"
+                values={{ value: <Balance
+                  flat
+                  classNameWrapper="header-small-balance overview-balance-spendable-locked"
+                  classNameUnit="overview-balance-spendable-locked-unit"
+                  amount={totalValueOfLiveTickets} />
+                }} />
             </div>
-            <Balance
-              flat
-              classNameWrapper="header-small-balance overview-balance-spendable-locked"
-              classNameUnit="overview-balance-spendable-locked-unit"
-              amount={totalValueOfLiveTickets} />
           </div>
         </div>
         <div className="overview-spendable-locked-wrapper-area">
           <div className="is-row">
-            <div className="overview-balance-spendable-locked voted">{votedTicketsCount}</div>
-            <div className="overview-balance-spendable-locked-top-label">
-              <T id="home.votedTicketsCount" m="voted tickets" />
+            <div className="overview-balance-spendable-locked voted">
+              <T id="home.votedTicketsCount" m="{count, plural, one {{fmtCount} voted ticket} other {{fmtCount} voted tickets}}"
+                values={{
+                  count: votedTicketsCount,
+                  fmtCount: <span className="count">{votedTicketsCount}</span>
+                }} />
             </div>
           </div>
           <div className="is-row">
             <div className="overview-balance-spendable-locked-text">
-              <T id="home.earned" m="Earned" />
-            </div>
-            <Balance
-              flat
-              classNameWrapper="header-small-balance overview-balance-spendable-locked"
-              classNameUnit="overview-balance-spendable-locked-unit"
-              amount={earnedStakingReward} />
-            <div className="overview-balance-spendable-locked-text back">
-              <T id="home.stakingRewards" m="in staking rewards" />
+              <T id="home.earned" m="Earned {value} in staking rewards"
+                values={{
+                  value: <Balance
+                    flat
+                    classNameWrapper="header-small-balance overview-balance-spendable-locked"
+                    classNameUnit="overview-balance-spendable-locked-unit"
+                    amount={earnedStakingReward} />
+                }} />
             </div>
           </div>
         </div>

--- a/app/components/views/HomePage/tabs/Transactions.js
+++ b/app/components/views/HomePage/tabs/Transactions.js
@@ -15,7 +15,7 @@ const HomePage = ({
       <div className="overview-spendable-locked-wrapper">
         <div className="overview-spendable-locked-wrapper-area">
           <Balance
-            classNameWrapper="overview-balance-spendable-locked received"
+            classNameWrapper="overview-balance-spendable-locked received amount"
             classNameUnit="overview-balance-spendable-locked-unit"
             amount={balanceReceived} />
           <div className="overview-balance-spendable-locked-label">
@@ -24,7 +24,7 @@ const HomePage = ({
         </div>
         <div className="overview-spendable-locked-wrapper-area">
           <Balance
-            classNameWrapper="overview-balance-spendable-locked sent"
+            classNameWrapper="overview-balance-spendable-locked sent amount"
             classNameUnit="overview-balance-spendable-locked-unit"
             amount={balanceSent} />
           <div className="overview-balance-spendable-locked-label">

--- a/app/connectors/ticketHome.js
+++ b/app/connectors/ticketHome.js
@@ -6,7 +6,7 @@ const mapStateToProps = selectorMap({
   sentAndReceivedTransactions: sel.sentAndReceivedTransactions,
   totalValueOfLiveTickets: sel.totalValueOfLiveTickets,
   earnedStakingReward: sel.totalSubsidy,
-  liveTicketsCount: sel.liveTicketsCount,
+  activeTicketsCount: sel.activeTicketsCount,
   votedTicketsCount: sel.votedTicketsCount,
   ticketDataChart: sel.ticketDataChart
 });

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -711,6 +711,13 @@ export const immatureTicketsCount = compose(r => r ? r.getImmature() : 0, getSta
 export const expiredTicketsCount = compose(r => r ? r.getExpired() : 0, getStakeInfoResponse);
 export const liveTicketsCount = compose(r => r ? r.getLive() : 0, getStakeInfoResponse);
 export const unspentTicketsCount = compose(r => r ? r.getUnspent() : 0, getStakeInfoResponse);
+export const activeTicketsCount = createSelector(
+  [ isSPV, getStakeInfoResponse ],
+  (isSPV, r) =>
+    isSPV
+      ? r.getUnspent() + r.getImmature()
+      : r.getLive() + r.getImmature()
+);
 export const totalSubsidy = compose(r => r ? r.getTotalSubsidy() : 0, getStakeInfoResponse);
 export const hasTicketsToRevoke = compose(
   r => r ? r.getRevoked() !== r.getExpired() + r.getMissed() : 0,

--- a/app/style/HomePage.less
+++ b/app/style/HomePage.less
@@ -3,7 +3,7 @@
 
 .overview-header {
   padding-left: 63px;
-  padding-top: 47px; 
+  padding-top: 47px;
   padding-right: 56px;
   justify-content: space-between;
   background-color: var(--background-back-color);
@@ -66,24 +66,30 @@
 }
 
 .overview-balance-spendable-locked {
-  font-size: 17px;
+  font-family: var(--font-family-regular);
+  line-height: 13px;
   color: var(--input-color-default);
-  font-family: var(--font-family-monospaced);
-  line-height: 18px;
   padding-left: 10px;
   margin-right: 2px;
   background-repeat: no-repeat;
   background-position: 0 50%;
   background-size: 7px;
 
+  > .count,
+  &.amount {
+  font-size: 17px;
+  font-family: var(--font-family-monospaced);
+  line-height: 18px;
+  }
+
   &.active {
     background-image: @legend-active;
   }
-  
+
   &.voted {
     background-image: @legend-voted;
   }
-  
+
   &.received {
     background-image: @legend-received;
   }
@@ -185,7 +191,7 @@
   .overview-transactions-ticket {
     padding: 30px 20px;
   }
-  
+
   .overview-header {
     padding-top: 60px;
     padding-left: 20px;
@@ -229,8 +235,8 @@
     padding-right: 0;
 
     .overview-header-wrapper {
-      width: 394px;  
-      min-width: 394px;  
+      width: 394px;
+      min-width: 394px;
     }
 
     .tabs > .tab > a {
@@ -242,7 +248,7 @@
 
       .overview-tab {
         border: 1px solid var(--home-content-link);
-        border-radius: 3px;        
+        border-radius: 3px;
       }
     }
   }


### PR DESCRIPTION
SPV wallets don't track the live and missed ticket count only the unspent.
Therefore we introduce a new selector to track the active ticket count as
intended for display purposes in the home page.

This correctly tracks the immature+unspent count in SPV wallets and
immature+live in RPC wallets.

This fixes an issue reported in the support channel.