### PR TITLE
[walletselection] Show trezor wallets with correct label

### DIFF
--- a/app/components/views/GetStartedPage/WalletSelection/Form.js
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.js
@@ -21,6 +21,13 @@ const CreateRestoreButtons = ({ showCreateWalletForm }) => (
   </>
 );
 
+const WalletTypeLabel = ({ isWatchingOnly, finished, isTrezor }) => {
+  if (isTrezor) return <T id="walletselection.trezor" m="Trezor" />;
+  if (isWatchingOnly) return <T id="walletselection.watchOnly" m="Watch Only"/>;
+  if (!finished) return <T id="walletselection.setupIncomplete" m="Setup incomplete"/>;
+  return null;
+};
+
 const WalletSelectionBodyBase = ({
   availableWallets,
   createWallet,
@@ -66,7 +73,11 @@ const WalletSelectionBodyBase = ({
                       </Tooltip>
                     </div>}
                   <div className={selected && !editWallets ? "display-wallet-complete selected" : "display-wallet-complete"}>
-                    {!wallet.isWatchingOnly ? !wallet.finished && <T id="walletselection.setupIncomplete" m="Setup incomplete"/> : <T id="walletselection.watchOnly" m="Watch Only"/>}
+                    <WalletTypeLabel
+                      isWatchingOnly={wallet.isWatchingOnly}
+                      isTrezor={wallet.value.isTrezor}
+                      finished={wallet.finished}
+                    />
                   </div>
                   <div className={selected && !editWallets ? "wallet-icon selected" : "wallet-icon wallet"}/>
                   <div className={selected && !editWallets ? "display-wallet-name selected" : "display-wallet-name"}>


### PR DESCRIPTION
This improves an UI issue where users are confused by the "watching-only" label in their trezor-based wallets.