### PR TITLE
Fix misspelled `consistently` in 1.5.0 release information

### DIFF
--- a/app/i18n/docs/en/ReleaseNotes/v1.5.0.md
+++ b/app/i18n/docs/en/ReleaseNotes/v1.5.0.md
@@ -30,7 +30,7 @@ team, bgptr.  Many thanks to them for their hard work on this release.
   daemon had some fatal error that it would never recover from.  This allows 
   the user to recover from such a situation more gracefully.
 
-  - Update Politeia proposal fetching to reduce amount of data that is consistantly
+  - Update Politeia proposal fetching to reduce amount of data that is consistently
   requested.  Previously, every load of decrediton would cause an unnecessary 
   amount of data to be requested.
 


### PR DESCRIPTION
closes #2399