### PR TITLE
fix treasury balance

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -1297,9 +1297,7 @@ export const getTreasuryBalance = () => (dispatch, getState) => {
       const integerPart = splitedTreasuryInfo[0];
       // dcrdata can send numbers with its decimal part less than 8 decimals, so we manually add it.
       let decimalPart = splitedTreasuryInfo[1];
-      while (decimalPart.length < 8) {
-        decimalPart += "0";
-      }
+      decimalPart += "0".repeat(8 - decimalPart.length);
       const treasuryBalance = integerPart + decimalPart;
       dispatch({ treasuryBalance, type: GETTREASURY_BALANCE_SUCCESS });
     });

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -1293,7 +1293,14 @@ export const getTreasuryBalance = () => (dispatch, getState) => {
   da.getTreasuryInfo(dURL, treasuryAddress)
     .then(treasuryInfo => {
       // Manually convert DCR to atom amounts to avoid floating point multiplication errors (eg. 589926.57667882*1e8 => 58992657667881.99)
-      const treasuryBalance = parseInt(treasuryInfo["data"]["dcr_unspent"].toString().replace(".",""));
+      const splitedTreasuryInfo = treasuryInfo["data"]["dcr_unspent"].toString().split(".");
+      const integerPart = splitedTreasuryInfo[0];
+      // dcrdata can send numbers with its decimal part less than 8 decimals, so we manually add it.
+      let decimalPart = splitedTreasuryInfo[1];
+      while (decimalPart.length < 8) {
+        decimalPart += "0";
+      }
+      const treasuryBalance = integerPart + decimalPart;
       dispatch({ treasuryBalance, type: GETTREASURY_BALANCE_SUCCESS });
     });
 };


### PR DESCRIPTION
fixes #2406 and fixes #2341. 

The reason this bug only happen sometimes, is because dcrdata sends a floating number, so it can send numbers with less than 8 decimal places, sometimes (maybe some rounding, Idk). 

This PR fixes it.