### PR TITLE
Bump to 1.6.0-pre

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decrediton",
   "productName": "decrediton",
-  "version": "1.5.1",
+  "version": "1.6.0-pre",
   "description": "Cross-platform decred gui based on Electron and React",
   "main": "./main.js",
   "author": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decrediton",
   "productName": "decrediton",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Cross-platform decred gui based on Electron and React",
   "main": "./main.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decrediton",
   "productName": "Decrediton",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Decrediton based on React, React Router, Webpack, React Hot Loader for rapid application development",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decrediton",
   "productName": "Decrediton",
-  "version": "1.5.1",
+  "version": "1.6.0-pre",
   "description": "Decrediton based on React, React Router, Webpack, React Hot Loader for rapid application development",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
The matches similar usage in dcrd/dcrwallet. 

From now on. as a new release is put out will will start the next cycle by bumping to 1.X.0-pre.  