### PR TITLE
Responsive close button on settings page

### DIFF
--- a/app/style/Layout.less
+++ b/app/style/Layout.less
@@ -109,10 +109,13 @@
 .standalone-page-header-container {
   width: 750px;
   position: relative;
+  justify-content: space-between;
+  align-items: center; 
+  flex-wrap: wrap;   
 }
 
 .standalone-page.settings-standalone-page .standalone-page-header-container {
-  width: 740px;
+  width: 1240px;
 } 
 
 .tabbed-page-body {
@@ -151,8 +154,7 @@
   margin-top: 1px;
 }
 
-.tabbed-page-header > .standalone-page-header-container > .title-header-button,
-.standalone-page-header > .standalone-page-header-container > .title-header-button {
+.tabbed-page-header > .standalone-page-header-container > .title-header-button {
   margin-left: auto;
 }
 
@@ -357,8 +359,28 @@
   float: left;
   margin-bottom: 10px;
 }
+@media screen and (max-width: 1919px) {
+  .standalone-page.settings-standalone-page .standalone-page-header-container {
+    width: 1240px;
+  } 
+}
+
+@media screen and (max-width: 1679px) {
+  .standalone-page.settings-standalone-page .standalone-page-header-container {
+    width: 1000px;
+  } 
+}
+
+@media screen and (max-width: 1439px) { 
+  .standalone-page.settings-standalone-page .standalone-page-header-container {
+    width: 740px;
+  }   
+}
 
 @media screen and (max-width: 1179px) {
+  .standalone-page.settings-standalone-page .standalone-page-header-container {
+    width: 649px;
+  }   
   .tabbed-page .tab-content {
     padding: 38px 20px 30px 20px;
   }
@@ -380,17 +402,16 @@
 }
 
 @media screen and (max-width: 1106px) {
-  .standalone-page-header-container {
+  .standalone-page-header-container,
+  .standalone-page.settings-standalone-page .standalone-page-header-container {
     width: 649px;
   }  
 }
 
 @media screen and (max-width: 768px) {
-  .standalone-page-header-container {
-    width: 355px;
-    &.is-row {
-      flex-direction: column;
-    }
+  .standalone-page-header-container, 
+  .standalone-page.settings-standalone-page .standalone-page-header-container {
+    width: 345px;
   }  
 
   .standalone-page-body {
@@ -450,7 +471,6 @@
   .standalone-page.settings-standalone-page {
     .title-header-button {
       margin-left: 0;
-      margin-top: 10px;
     }
     .standalone-page-body {
       position: relative;

--- a/app/style/Settings.less
+++ b/app/style/Settings.less
@@ -338,11 +338,9 @@
   background-image: @close-wallet-icon;
   background-repeat: no-repeat;
   background-size: 13px;
-  width: 134px;
   background-position: 10px 8px;
   border-radius: 10px;
-  padding: 0;
-  padding-top: 6px;
+  padding: 6px 15px 0 30px;
 }
 
 .privacy-buttons {
@@ -481,7 +479,7 @@
   }
 }
 
-@media screen and (max-width: 1180px) {
+@media screen and (max-width: 1179px) {
   .settings-wrapper {
     .settings-group { 
       width: 649px;


### PR DESCRIPTION
This is a follow-up PR of #2412 and fixes the responsiveness of the close button. 
Also fixes the first issue of #2390 (Close button copy overlap)