### PR TITLE
Restore last address when switching to send to another account

### DIFF
--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -50,7 +50,9 @@ class Send extends React.Component {
       unsignedRawTx,
       isWatchingOnly,
       nextAddress,
-      publishTxResponse
+      publishTxResponse,
+      nextAddressAccount,
+      getNextAddressAttempt
     } = this.props;
     const { isSendSelf, outputs } = this.state;
     let newOutputs;
@@ -58,14 +60,15 @@ class Send extends React.Component {
       publishTxResponse &&
       publishTxResponse !== prevProps.publishTxResponse
     ) {
+      if (isSendSelf) {
+        getNextAddressAttempt(nextAddressAccount.value);
+      }
       newOutputs = [{ key: "output_0", data: this.getBaseOutput() }];
       this.setState({ isSendAll: false });
     }
     if (
       isSendSelf &&
       (prevProps.nextAddress != nextAddress ||
-        (publishTxResponse &&
-          publishTxResponse !== prevProps.publishTxResponse) ||
         (prevState.isSendSelf != isSendSelf && nextAddress))
     ) {
       newOutputs = (newOutputs || outputs).map((o) => ({

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -44,7 +44,7 @@ class Send extends React.Component {
     };
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const {
       constructTxLowBalance,
       unsignedRawTx,
@@ -61,7 +61,13 @@ class Send extends React.Component {
       newOutputs = [{ key: "output_0", data: this.getBaseOutput() }];
       this.setState({ isSendAll: false });
     }
-    if (isSendSelf && prevProps.nextAddress != nextAddress) {
+    if (
+      isSendSelf &&
+      (prevProps.nextAddress != nextAddress ||
+        (publishTxResponse &&
+          publishTxResponse !== prevProps.publishTxResponse) ||
+        (prevState.isSendSelf != isSendSelf && nextAddress))
+    ) {
       newOutputs = (newOutputs || outputs).map((o) => ({
         ...o,
         data: { ...o.data, destination: nextAddress }


### PR DESCRIPTION
Closes https://github.com/decred/decrediton/issues/2495. It ensures that one can use the last generated address just after sending an amount or going back to send page. A new address is generated after transaction.