### PR TITLE
[pi-ui] Use pi-ui's classnames instead of external lib

### DIFF
--- a/app/components/SideBar/Bar.js
+++ b/app/components/SideBar/Bar.js
@@ -7,7 +7,7 @@ import LastBlockTime from "./LastBlockTime";
 import { Balance } from "shared";
 import { RescanButton, RescanCancelButton } from "buttons";
 import "style/SideBar.less";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 
 const isImported = (accountNumber) => accountNumber === Math.pow(2, 31) - 1;
 const Bar = ({
@@ -30,7 +30,7 @@ const Bar = ({
   accountMixerRunning
 }) => (
   <div
-    className={cx(
+    className={classNames(
       "sidebar",
       !expandSideBar && "sidebar-reduced",
       !expandSideBar && sidebarOnBottom && "sidebar-on-bottom"
@@ -58,7 +58,7 @@ const Bar = ({
             ({ hidden, total, accountName, accountNumber }) =>
               !hidden && (
                 <div
-                  className={cx(
+                  className={classNames(
                     "sidebar-menu-total-balance-extended-bottom-account",
                     isImported(accountNumber) && "imported"
                   )}
@@ -90,7 +90,7 @@ const Bar = ({
           onMouseEnter={rescanRequest ? null : onShowAccounts}
           onMouseLeave={rescanRequest ? null : onHideAccounts}>
           <div
-            className={cx(
+            className={classNames(
               "sidebar-menu-bottom-total-balance-short-separator",
               isShowingAccounts && "showAccounts"
             )}></div>

--- a/app/components/modals/Modal.js
+++ b/app/components/modals/Modal.js
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import EventListener from "react-event-listener";
 import "style/Modals.less";
 import Draggable from "react-draggable";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 import { useRef } from "react";
 import { useSelector } from "react-redux";
 import * as sel from "selectors";
@@ -31,7 +31,7 @@ function Modal({ children, className, draggable, onCancelModal }) {
   const innerView = (
     <div
       ref={modalRef}
-      className={cx(
+      className={classNames(
         showingSidebarMenu
           ? expandSideBar
             ? "app-modal "

--- a/app/components/shared/Balance.js
+++ b/app/components/shared/Balance.js
@@ -2,7 +2,7 @@ import "style/Balance.less";
 import { FormattedNumber } from "react-intl";
 import { balance } from "connectors";
 import { DCR, UNIT_DIVISOR } from "constants";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 
 export const Balance = ({
   currencyDisplay,
@@ -40,7 +40,7 @@ export const Balance = ({
     return (
       <div className={classNameWrapper}>
         <span {...{ onClick }}>
-          <span className={cx(classNameAmount, bold && "bold")}>
+          <span className={classNames(classNameAmount, bold && "bold")}>
             {negativeZero ? "-" : ""}
             <FormattedNumber
               value={head}

--- a/app/components/shared/TxHistory/StakeTxRow.js
+++ b/app/components/shared/TxHistory/StakeTxRow.js
@@ -3,7 +3,7 @@ import { FormattedMessage as T } from "react-intl";
 import { Balance, Tooltip } from "shared";
 import { diffBetweenTwoTs } from "helpers/dateFormat";
 import * as txTypes from "constants/Decrediton";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 
 const messageByType = {
   [txTypes.TICKET]: <T id="transaction.type.ticket" m="Purchased" />,
@@ -79,7 +79,11 @@ export const StakeTxRow = ({
     <Row {...{ className, overview, pending, ...props }}>
       <div className="is-row">
         <span className="icon" />
-        <span className={cx("transaction-stake-type", overview && "overview")}>
+        <span
+          className={classNames(
+            "transaction-stake-type",
+            overview && "overview"
+          )}>
           {typeMsg}
         </span>
         {!pending && (
@@ -94,7 +98,7 @@ export const StakeTxRow = ({
         </Tooltip>
         <Tooltip text={ticketRewardMessage}>
           <Balance
-            classNameWrapper={cx(
+            classNameWrapper={classNames(
               "stake-transaction-ticket-reward",
               overview && "overview"
             )}

--- a/app/components/views/AccountsPage/Privacy/Page.js
+++ b/app/components/views/AccountsPage/Privacy/Page.js
@@ -2,7 +2,7 @@ import { FormattedMessage as T } from "react-intl";
 import { TextInput, NumericInput } from "inputs";
 import { Subtitle } from "shared";
 import { PassphraseModalSwitch, AutoBuyerSwitch } from "buttons";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 import "style/Privacy.less";
 
 const PrivacyPage = ({
@@ -20,8 +20,8 @@ const PrivacyPage = ({
     <Subtitle title={<T id="privacy.subtitle" m="Privacy" />} />
 
     <div className="privacy-page-wrapper is-column">
-      <div className={cx("is-row", "privacy-row")}>
-        <div className={cx("is-row", "privacy-item")}>
+      <div className={classNames("is-row", "privacy-row")}>
+        <div className={classNames("is-row", "privacy-item")}>
           <div className="">
             <T id="privacy.mixing.account" m="Mixing Account" />:
           </div>
@@ -38,8 +38,8 @@ const PrivacyPage = ({
         </div>
       </div>
 
-      <div className={cx("is-row", "privacy-row")}>
-        <div className={cx("is-row", "privacy-item")}>
+      <div className={classNames("is-row", "privacy-row")}>
+        <div className={classNames("is-row", "privacy-item")}>
           <div className="">
             <T id="privacy.change.account" m="Change Account" />:
           </div>
@@ -47,15 +47,15 @@ const PrivacyPage = ({
         </div>
       </div>
 
-      <div className={cx("is-row", "privacy-row")}>
-        <div className={cx("is-row", "privacy-item")}>
+      <div className={classNames("is-row", "privacy-row")}>
+        <div className={classNames("is-row", "privacy-item")}>
           <div className="">
             <T id="privacy.mixing.server" m="Shuffle Server" />:
           </div>
           <TextInput required disabled value={csppServer} />
         </div>
 
-        <div className={cx("is-row", "privacy-item")}>
+        <div className={classNames("is-row", "privacy-item")}>
           <div className="">
             <T id="privacy.mixing.server.port" m="Shuffle Port" />:
           </div>

--- a/app/components/views/GetStartedPage/LanguageSelectPage/Page.js
+++ b/app/components/views/GetStartedPage/LanguageSelectPage/Page.js
@@ -2,7 +2,7 @@ import { KeyBlueButton } from "buttons";
 import "style/LanguageSelect.less";
 import { LanguageSelect } from "inputs";
 import { FormattedMessage as T } from "react-intl";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 
 const LanguageSelectPage = ({
   availableLanguages,
@@ -12,7 +12,11 @@ const LanguageSelectPage = ({
   isTestNet
 }) => {
   return (
-    <div className={cx("page-body getstarted", isTestNet && "testnet-body")}>
+    <div
+      className={classNames(
+        "page-body getstarted",
+        isTestNet && "testnet-body"
+      )}>
       <div className="getstarted-new">
         <div className="language-select-title">
           <T id="selectLang.title" m={"Welcome to Decrediton Wallet"} />

--- a/app/components/views/GetStartedPage/Page.js
+++ b/app/components/views/GetStartedPage/Page.js
@@ -6,7 +6,7 @@ import {
   AboutModalButton
 } from "./messages";
 import { LoaderBarBottom } from "indicators";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 import "style/GetStarted.less";
 
 const DaemonLoadingBody = ({
@@ -20,7 +20,8 @@ const DaemonLoadingBody = ({
   getEstimatedTimeLeft,
   isTestNet
 }) => (
-  <div className={cx("page-body getstarted", isTestNet && "testnet-body")}>
+  <div
+    className={classNames("page-body getstarted", isTestNet && "testnet-body")}>
     <div className="getstarted loader">
       <div className="loader-settings-logs">
         {updateAvailable && (

--- a/app/components/views/GetStartedPage/PrivacyPage/Page.js
+++ b/app/components/views/GetStartedPage/PrivacyPage/Page.js
@@ -1,9 +1,10 @@
 import TopLevelPrivacyOptions from "./TopLevelOptions";
 import CustomPrivacyOptions from "./CustomPrivacyOptions";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 
 export default ({ showCustomPrivacy, isTestNet, ...props }) => (
-  <div className={cx("page-body getstarted", isTestNet && "testnet-body")}>
+  <div
+    className={classNames("page-body getstarted", isTestNet && "testnet-body")}>
     <div className="getstarted-new">
       {!showCustomPrivacy ? (
         <TopLevelPrivacyOptions {...props} />

--- a/app/components/views/GetStartedPage/SpvChoicePage/Page.js
+++ b/app/components/views/GetStartedPage/SpvChoicePage/Page.js
@@ -1,8 +1,9 @@
 import TopLevelPrivacyOptions from "./TopLevelOptions";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 
 export default ({ isTestNet, ...props }) => (
-  <div className={cx("page-body getstarted", isTestNet && "testnet-body")}>
+  <div
+    className={classNames("page-body getstarted", isTestNet && "testnet-body")}>
     <div className="getstarted-new">
       <TopLevelPrivacyOptions {...props} />
     </div>

--- a/app/components/views/SecurityPage/ValidateAddress/Form.js
+++ b/app/components/views/SecurityPage/ValidateAddress/Form.js
@@ -1,7 +1,7 @@
 import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
 import { TextInput } from "inputs";
 import { Subtitle } from "shared";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 
 const messages = defineMessages({
   addressFieldPlaceholder: {
@@ -67,7 +67,7 @@ const ValidateAddressForm = ({
         <T id="securitycenter.validate.field.address.label" m="Address" />
       </div>
       <div
-        className={cx(
+        className={classNames(
           "validate-address-form-address",
           address && validateAddressSuccess && "valid-address"
         )}>

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTicketsAdvanced.js
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTicketsAdvanced.js
@@ -6,7 +6,7 @@ import {
   StakePoolSelect
 } from "inputs";
 import { FormattedMessage as T, defineMessages } from "react-intl";
-import cx from "classnames";
+import { classNames } from "pi-ui";
 
 const messages = defineMessages({
   txFeePlaceholder: {
@@ -30,13 +30,15 @@ const PurchaseTicketAdvancedInfo = ({
   children
 }) => (
   <>
-    <div className={cx("purchase-ticket-advanced-info-label", className)}>
+    <div
+      className={classNames("purchase-ticket-advanced-info-label", className)}>
       {label}:
     </div>
-    <div className={cx("purchase-ticket-advanced-info-value", className)}>
+    <div
+      className={classNames("purchase-ticket-advanced-info-value", className)}>
       {children}
       <div
-        className={cx("stakepool-info-icon", className)}
+        className={classNames("stakepool-info-icon", className)}
         onClick={onIconClick}
       />
     </div>


### PR DESCRIPTION
This diff uses piui's exposed `classNames` function instead of (external?) library.
Note: No need to delete any entry from `package.json` as we don't have "classnames" as direct dep in `package.json` it appears only in yarn.lock as a dep of a dep.

Closes #2513 