### PR TITLE
Fix ticket naming when saving proposal votes

### DIFF
--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -43,6 +43,11 @@ const ProposalDetails = ({
   goBackHistory,
   eligibleTicketCount
 }) => {
+  walletEligibleTickets = walletEligibleTickets.map((et, i) => {
+    walletEligibleTickets[i].txHash = et.ticket;
+    return walletEligibleTickets[i];
+  });
+
   const { tsDate, hasTickets, isTestnet } = useProposalDetails();
   const { themeName } = useTheme();
   const isDarkTheme = themeName === "theme-dark";


### PR DESCRIPTION
@amassarwi reported to me a bug after voting on latest master. 

After f31cc4b768ee1ff25c5a7ff1e94e34f7bf0f834f, the ticket name was changed to `txHash` before saving it to our politeia directory:
https://github.com/decred/decrediton/commit/f31cc4b768ee1ff25c5a7ff1e94e34f7bf0f834f#diff-c8399d09f1bddd336993b884a3e8d512R623

When opening a proposal with this kind of votes, it would fail to open with the following message, as it is looking for tickets instead of txHash:

![image](https://user-images.githubusercontent.com/15069783/84780568-1b013d80-afbc-11ea-8b85-fecc0e10eb8e.png)


This PR fixes it. 