### PR TITLE
Polish tx row pending indicator

### DIFF
--- a/app/components/shared/TxHistory/RegularTxRow.jsx
+++ b/app/components/shared/TxHistory/RegularTxRow.jsx
@@ -6,7 +6,7 @@ import {
   TRANSACTION_DIR_TRANSFERRED
 } from "constants";
 import styles from "./TxHistory.module.css";
-import { classNames } from "pi-ui";
+import { classNames, Text } from "pi-ui";
 
 const RegularTxRow = ({
   txAmount,
@@ -98,31 +98,33 @@ const RegularTxRow = ({
     </div>
     {overview && (
       <div className={styles.amountHash}>
-        {txDirection === TRANSACTION_DIR_TRANSFERRED ? (
-          <T
-            id="txHistory.transfer.tx"
-            m="From {debAcc} To {credAcc}"
-            values={{
-              debAcc: txAccountNameDebited,
-              credAcc: txAccountNameCredited
-            }}
-          />
-        ) : txDirection !== TRANSACTION_DIR_RECEIVED ? (
-          <T
-            id="txHistory.out.tx"
-            m="From {debAcc} To {credAcc}"
-            values={{
-              debAcc: txAccountName,
-              credAcc: txOutputAddresses
-            }}
-          />
-        ) : (
-          <T
-            id="txHistory.in.tx"
-            m="To {credAcc}"
-            values={{ credAcc: txAccountName }}
-          />
-        )}
+        <Text id={`fromto-${(txTs || new Date()).getTime()}`} truncate>
+          {txDirection === TRANSACTION_DIR_TRANSFERRED ? (
+            <T
+              id="txHistory.transfer.tx"
+              m="From {debAcc} To {credAcc}"
+              values={{
+                debAcc: txAccountNameDebited,
+                credAcc: txAccountNameCredited
+              }}
+            />
+          ) : txDirection !== TRANSACTION_DIR_RECEIVED ? (
+            <T
+              id="txHistory.out.tx"
+              m="From {debAcc} To {credAcc}"
+              values={{
+                debAcc: txAccountName,
+                credAcc: txOutputAddresses
+              }}
+            />
+          ) : (
+            <T
+              id="txHistory.in.tx"
+              m="To {credAcc}"
+              values={{ credAcc: txAccountName }}
+            />
+          )}
+        </Text>
       </div>
     )}
   </Row>

--- a/app/components/shared/TxHistory/Row.jsx
+++ b/app/components/shared/TxHistory/Row.jsx
@@ -11,13 +11,7 @@ const Row = ({ pending, onClick, className, children, overview, eligible }) => (
       eligible && styles.eligibleRow
     )}>
     <div className={classNames(styles.txInfo, className)} onClick={onClick}>
-      <div
-        class={classNames(
-          styles.txRowWrapper,
-          pending && styles.txPeningRowWrapper
-        )}>
-        {children}
-      </div>
+      <div class={styles.txRowWrapper}>{children}</div>
       {pending && (
         <Tooltip content={<T id="txHistory.Pending" m="Pending" />}>
           <div className={styles.pendingOverviewDetails} onClick={onClick} />

--- a/app/components/shared/TxHistory/Row.jsx
+++ b/app/components/shared/TxHistory/Row.jsx
@@ -19,7 +19,7 @@ const Row = ({ pending, onClick, className, children, overview, eligible }) => (
         {children}
       </div>
       {pending && (
-        <Tooltip conent={<T id="txHistory.Pending" m="Pending" />}>
+        <Tooltip content={<T id="txHistory.Pending" m="Pending" />}>
           <div className={styles.pendingOverviewDetails} onClick={onClick} />
         </Tooltip>
       )}

--- a/app/components/shared/TxHistory/Row.jsx
+++ b/app/components/shared/TxHistory/Row.jsx
@@ -1,6 +1,5 @@
-import { Tooltip } from "shared";
 import { FormattedMessage as T } from "react-intl";
-import { classNames } from "pi-ui";
+import { classNames, Tooltip } from "pi-ui";
 import styles from "./TxHistory.module.css";
 
 const Row = ({ pending, onClick, className, children, overview, eligible }) => (
@@ -12,13 +11,19 @@ const Row = ({ pending, onClick, className, children, overview, eligible }) => (
       eligible && styles.eligibleRow
     )}>
     <div className={classNames(styles.txInfo, className)} onClick={onClick}>
-      {children}
+      <div
+        class={classNames(
+          styles.txRowWrapper,
+          pending && styles.txPeningRowWrapper
+        )}>
+        {children}
+      </div>
+      {pending && (
+        <Tooltip conent={<T id="txHistory.Pending" m="Pending" />}>
+          <div className={styles.pendingOverviewDetails} onClick={onClick} />
+        </Tooltip>
+      )}
     </div>
-    {pending && (
-      <Tooltip text={<T id="txHistory.Pending" m="Pending" />}>
-        <div className={styles.pendingOverviewDetails} onClick={onClick} />
-      </Tooltip>
-    )}
   </div>
 );
 

--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -205,10 +205,6 @@
   text-overflow: ellipsis;
 }
 
-.overviewRow .txInfo .txPeningRowWrapper {
-  flex-basis: auto;
-}
-
 .pendingOverviewDetails {
   background-color: var(--disabled-background-color-lighter);
   background-image: var(--pending-animation);

--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -86,13 +86,16 @@
 
 .amountHash {
   font-family: var(--font-family-monospace);
-  color: var(--overview-balance-label);
-  font-size: 11px;
-  line-height: 11px;
   margin-left: 34px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.amountHash > span {
+  color: var(--overview-balance-label) !important;
+  font-size: 11px !important;
+  line-height: 11px !important;
 }
 
 .info {
@@ -125,19 +128,6 @@
 
 .overviewPending .txInfo {
   width: 100%;
-}
-
-.pendingOverviewDetails {
-  background-color: var(--disabled-background-color-lighter);
-  background-image: var(--pending-animation);
-  background-size: 14px;
-  background-position: 50%;
-  background-repeat: no-repeat;
-  width: 32px;
-  height: 54px;
-  cursor: pointer;
-  text-align: center;
-  margin-left: -32px;
 }
 
 .myTickets {
@@ -201,8 +191,35 @@
   cursor: pointer;
 }
 
-.overviewRow .txInfo {
-  padding: 16px 20px 9px 10px;
+.txInfo {
+  display: flex;
+}
+
+.overviewRow .txInfo .txRowWrapper {
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  flex-basis: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.overviewRow .txInfo .txPeningRowWrapper {
+  flex-basis: auto;
+}
+
+.pendingOverviewDetails {
+  background-color: var(--disabled-background-color-lighter);
+  background-image: var(--pending-animation);
+  background-size: 14px;
+  background-position: 50%;
+  background-repeat: no-repeat;
+  width: 40px;
+  flex-basis: 40px;
+  height: 54px;
+  cursor: pointer;
+  text-align: center;
 }
 
 .overviewRow .timeDateSpacer {
@@ -226,8 +243,12 @@
 }
 
 .historyRow .txInfo {
-  padding: 16px 20px;
   width: 100%;
+  justify-content: space-between;
+}
+
+.historyRow .txInfo .txRowWrapper {
+  padding: 16px 20px;
 }
 
 .eligibleRow {


### PR DESCRIPTION
This diff improves the pending indicator which is displayed in both txs history & overview lists.
It includes the following changes:
 - Use flex to align content of the row.
 - Use pi-ui's `Tooltip`.
 - Use pi-ui's `Text` component with `truncate` prop to ellipsis too wide text. 

Closes #2544 

After:

![image](https://user-images.githubusercontent.com/10324528/85927457-7548ab00-b8a6-11ea-8b76-d427950444d9.png)


![image](https://user-images.githubusercontent.com/10324528/85927451-6e219d00-b8a6-11ea-978c-770fbaf0a9b5.png)


![image](https://user-images.githubusercontent.com/10324528/85927451-6e219d00-b8a6-11ea-978c-770fbaf0a9b5.png)
