### PR TITLE
fix: clear tx info when navigating away

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -308,7 +308,7 @@ export const purchaseTicketsAttempt = (
 
     const stakePoolStats = await wallet.getStakePoolStats(stakepool.Host);
 
-    if(stakePoolStats.data.data.PoolStatus == "Closed"){
+    if (stakePoolStats.data.data.PoolStatus == "Closed") {
       throw new Error(
         "Unable to purchase a ticket from a closed VSP (" + stakepool.Host + ")"
       );

--- a/app/components/views/TransactionsPage/SendTab/index.js
+++ b/app/components/views/TransactionsPage/SendTab/index.js
@@ -94,6 +94,10 @@ class Send extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.onClearTransaction();
+  }
+
   render() {
     if (!this.props.walletService) {
       return <ErrorScreen />;


### PR DESCRIPTION
This diff cleans the send transaction tx info on component unmount.
I started by adding new action to cleanup the transaction info, and then noticed
that we already have one which is even dispatched inside `SendTab` but wasn't called
for anywhere, so I just added a `componentWillUnmount` to call `onClearTransaction` 
which was already there ☺️ 

Closes #2533 