### PR TITLE
Deal with error in case no tx details is found

### DIFF
--- a/app/actions/TransactionActions.js
+++ b/app/actions/TransactionActions.js
@@ -613,6 +613,9 @@ const getMissingStakeTxData = async (
     // transaction
     try {
       const ticket = await wallet.getTransaction(walletService, ticketTxHash);
+      // tx which come from the gRPC call
+      // walletService.getTransactions().getMinedTransactions().getTransactionsList()
+      // at our wallet/service.js
       ticketTx = ticket.tx;
     } catch (error) {
       if (String(error).indexOf("NOT_FOUND") > -1) {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -421,8 +421,16 @@ export const ticketNormalizer = createSelector(
         .reduce((s, c) => (s + isTicketChange(c) ? c.getAmount() : 0), 0);
 
       // ticket investment is the full amount paid by the wallet on the ticket purchase
+      let accountName = "";
       const debitList = ticketTx.getDebitsList();
-      const accountName = getAccountName(debitList[0].getPreviousAccount());
+      if (debitList.length > 0) {
+        accountName = getAccountName(debitList[0].getPreviousAccount());
+      } else {
+        // Mixer is set to ignore gap limit. If a wallet does not know tx
+        // details for some reason, can be due that or some other reason which
+        // needs to be investigated.
+        throw "Tx debit list is empty. Something is wrong.";
+      }
       const ticketInvestment =
         debitList.reduce((a, v) => a + v.getPreviousAmount(), 0) - ticketChange;
 


### PR DESCRIPTION
I noticed if a wallet does not know some tx details it will crash decrediton when starting. This may happen for many reasons, one we discussed at matrix is that, mixer is set to ignore gap limit. So if someone mixes his outputs with a different wallet.db, decrediton may not recognize it. 

This PR deals with this case, so decrediton can still starts and we can further investigate the cause. 