### PR TITLE
[governance] fix: add validator for empty eligible tickets list

### DIFF
--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -81,7 +81,8 @@ const fillVoteSummary = (proposal, voteSummary, blockTimestampFromNow) => {
   proposal.totalVotes = totalVotes;
 };
 
-const ticketHashesToByte = (hashes) => hashes.map(hexReversedHashToArray);
+const ticketHashesToByte = (hashes) =>
+  hashes && hashes.map(hexReversedHashToArray);
 
 // getProposalEligibleTickets gets the wallet eligible tickets from a specific proposal.
 // if the proposal directory already exists it only returns the cached information,


### PR DESCRIPTION
This diff fixes a minor bug on proposal details when no eligible tickets are available.

Before:
<img width="1020" alt="Screen Shot 2020-07-09 at 6 43 09 PM" src="https://user-images.githubusercontent.com/22639213/87093860-3c002b80-c214-11ea-964d-d3bb9d8b9dd2.png">

after:
<img width="966" alt="Screen Shot 2020-07-09 at 6 41 40 PM" src="https://user-images.githubusercontent.com/22639213/87093846-386ca480-c214-11ea-8712-2cc3dbf65943.png">