### PR TITLE
Fix minor bugs in modal components

### DIFF
--- a/app/components/modals/PassphraseModal/hooks.js
+++ b/app/components/modals/PassphraseModal/hooks.js
@@ -15,10 +15,6 @@ function usePassphraseModal(
     setHasFailedAttempt(false);
   }, []);
 
-  useEffect(() => {
-    if (triggerSubmit) onSubmit();
-  }, [triggerSubmit, onSubmit]);
-
   const onCancelModalCallback = useCallback(() => {
     resetState();
     onCancelModal && onCancelModal();
@@ -43,6 +39,10 @@ function usePassphraseModal(
     onSubmit(passPhrase);
     resetState();
   }, [passPhrase, validationFailed, isValidCallback, onSubmit, resetState]);
+
+  useEffect(() => {
+    if (triggerSubmit) onSubmitCallback();
+  }, [triggerSubmit, onSubmitCallback]);
 
   return {
     passPhrase,

--- a/app/components/modals/PassphraseModal/hooks.js
+++ b/app/components/modals/PassphraseModal/hooks.js
@@ -41,7 +41,7 @@ function usePassphraseModal(
   }, [passPhrase, validationFailed, isValidCallback, onSubmit, resetState]);
 
   useEffect(() => {
-    if (triggerSubmit) onSubmitCallback();
+    triggerSubmit && onSubmitCallback();
   }, [triggerSubmit, onSubmitCallback]);
 
   return {

--- a/app/hooks/useSettings.js
+++ b/app/hooks/useSettings.js
@@ -24,7 +24,8 @@ const useSettings = () => {
   const walletReady = useSelector(sel.getWalletReady);
 
   const onAttemptChangePassphrase = useCallback(
-    () => dispatch(ca.changePassphraseAttempt()),
+    (oldPass, newPass, priv) =>
+      dispatch(ca.changePassphraseAttempt(oldPass, newPass, priv)),
     [dispatch]
   );
 


### PR DESCRIPTION
This PR fixes two minor bugs I've just checked in modal components:
1. ``PassphraseModal`` sometimes does not reset the passphrase input content.
2. ``ChangePasswordModal`` never works properly.

They were probably generated during refactoring.