### PR TITLE
Update en translations to display values

### DIFF
--- a/app/components/views/HomePage/tabs/Tickets.js
+++ b/app/components/views/HomePage/tabs/Tickets.js
@@ -30,7 +30,7 @@ const HomePage = ({
           <div className="is-row">
             <div className="overview-balance-spendable-locked-text">
               <T
-                id="home.totalValueOfActiveTickets"
+                id="home.totalValueOfLiveTickets"
                 m="With a total value of {value}"
                 values={{
                   value: (


### PR DESCRIPTION
Attempted to fix #2462 because it is an annoyance for me personally, but as I am working on it I realise this is a part of a much wider change, and I am not totally familiar with the i18n workflow for decrediton. I have pushed what I have so far, but it is incomplete because it only fixes two of the affected fields, and only affects English language.

Even if the other fixes are not appropriate, using the correct var name in `Tickets.js` (`totalValueOfActiveTickets` => `totalValueOfLiveTickets`) could possibly be merged in isolation, 

fyi @matheusd 