### PR TITLE
Fix unmined tx showing twice

### DIFF
--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -403,12 +403,12 @@ export default function grpc(state = {}, action) {
         recentRegularTransactions: action.recentRegularTransactions,
         recentStakeTransactions: action.recentStakeTransactions,
         stakeTransactions: {
-          ...state.stakeTransactions,
-          ...action.stakeTransactions
+          ...action.stakeTransactions,
+          ...state.stakeTransactions
         },
         regularTransactions: {
-          ...state.regularTransactions,
-          ...action.regularTransactions
+          ...action.regularTransactions,
+          ...state.regularTransactions
         }
       };
     case CHANGE_TRANSACTIONS_FILTER:


### PR DESCRIPTION
This PR fixes a bug on transactions overview and history page.

Right now after buying a ticket, after the split tx getting mined, it will mine the ticket tx again, making it show duplicated at our overview. 

Also, after making a tx, it is not showing at history transactions or my tickets page. 

This PR fixes these both cases. fixes #2520