### PR TITLE
Remove wallet ping

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -63,7 +63,6 @@ const startWalletServicesTrigger = () => (dispatch, getState) =>
       }
       await dispatch(getNextAddressAttempt(0));
       await dispatch(getTicketPriceAttempt());
-      await dispatch(getPingAttempt());
       await dispatch(getNetworkAttempt());
       await dispatch(refreshStakepoolPurchaseInformation());
       await dispatch(getVotingServiceAttempt());
@@ -326,37 +325,6 @@ export const getNetworkAttempt = () => (dispatch, getState) => {
         dispatch(pushHistory("/walletError"));
       }, 1000);
     });
-};
-
-export const GETPING_ATTEMPT = "GETPING_ATTEMPT";
-export const GETPING_FAILED = "GETPING_FAILED";
-export const GETPING_SUCCESS = "GETPING_SUCCESS";
-export const GETPING_CANCELED = "GETPING_CANCELED";
-
-export const getPingAttempt = () => (dispatch, getState) =>
-  wallet
-    .doPing(sel.walletService(getState()))
-    .then(() => {
-      const pingTimer = setTimeout(() => dispatch(getPingAttempt()), 10000);
-      dispatch({ pingTimer, type: GETPING_SUCCESS });
-    })
-    .catch((error) => {
-      const {
-        daemon: { shutdownRequested, walletError }
-      } = getState();
-      dispatch({ error, type: GETPING_FAILED });
-      if (!shutdownRequested && !walletError)
-        setTimeout(() => {
-          dispatch(pushHistory("/walletError"));
-        }, 1000);
-    });
-
-export const cancelPingAttempt = () => (dispatch, getState) => {
-  const { pingTimer } = getState().grpc;
-  if (pingTimer) {
-    clearTimeout(pingTimer);
-    dispatch({ type: GETPING_CANCELED });
-  }
 };
 
 export const GETSTAKEINFO_ATTEMPT = "GETSTAKEINFO_ATTEMPT";

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -7,7 +7,6 @@ import { getVersionServiceAttempt } from "./VersionActions";
 import { stopNotifcations } from "./NotificationActions";
 import { saveSettings, updateStateSettingsChanged } from "./SettingsActions";
 import { rescanCancel } from "./ControlActions";
-import { cancelPingAttempt } from "./ClientActions";
 import { semverCompatible } from "./VersionActions";
 import * as wallet from "wallet";
 import { push as pushHistory, goBack } from "connected-react-router";
@@ -227,7 +226,6 @@ export const shutdownApp = () => (dispatch, getState) => {
   });
   dispatch(stopNotifcations());
   dispatch(rescanCancel());
-  dispatch(cancelPingAttempt());
   dispatch(syncCancel());
   dispatch(pushHistory("/shutdown"));
 };

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -12,7 +12,7 @@ import { rescanCancel, ticketBuyerCancel } from "./ControlActions";
 import {
   getWalletServiceAttempt,
   startWalletServices,
-  getBestBlockHeightAttempt,
+  getBestBlockHeightAttempt
 } from "./ClientActions";
 import { WALLETREMOVED_FAILED } from "./DaemonActions";
 import { getWalletCfg, getDcrdCert } from "config";

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -13,7 +13,6 @@ import {
   getWalletServiceAttempt,
   startWalletServices,
   getBestBlockHeightAttempt,
-  cancelPingAttempt
 } from "./ClientActions";
 import { WALLETREMOVED_FAILED } from "./DaemonActions";
 import { getWalletCfg, getDcrdCert } from "config";
@@ -233,7 +232,6 @@ export const closeWalletRequest = () => async (dispatch, getState) => {
   const { walletReady } = getState().daemon;
   dispatch({ type: CLOSEWALLET_ATTEMPT });
   try {
-    await dispatch(cancelPingAttempt());
     await dispatch(stopNotifcations());
     await dispatch(syncCancel());
     await dispatch(rescanCancel());

--- a/app/index.js
+++ b/app/index.js
@@ -146,11 +146,6 @@ const initialState = {
     getNetworkError: null,
     getNetworkRequestAttempt: false,
     getNetworkResponse: null,
-    // Ping
-    getPingError: null,
-    getPingRequestAttempt: false,
-    getPingResponse: null,
-    pingTimer: null,
     // StakeInfo
     getStakeInfoError: null,
     getStakeInfoRequestAttempt: false,

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -14,10 +14,6 @@ import {
   GETNETWORK_ATTEMPT,
   GETNETWORK_FAILED,
   GETNETWORK_SUCCESS,
-  GETPING_ATTEMPT,
-  GETPING_FAILED,
-  GETPING_SUCCESS,
-  GETPING_CANCELED,
   GETSTAKEINFO_ATTEMPT,
   GETSTAKEINFO_FAILED,
   GETSTAKEINFO_SUCCESS,
@@ -261,36 +257,6 @@ export default function grpc(state = {}, action) {
         getNetworkError: null,
         getNetworkRequestAttempt: false,
         getNetworkResponse: action.getNetworkResponse
-      };
-    case GETPING_ATTEMPT:
-      return {
-        ...state,
-        getPingError: "",
-        getPingRequestAttempt: true,
-        pingTimer: null
-      };
-    case GETPING_FAILED:
-      return {
-        ...state,
-        getPingError: String(action.error),
-        getPingRequestAttempt: false,
-        pingTimer: null
-      };
-    case GETPING_SUCCESS:
-      return {
-        ...state,
-        getPingError: "",
-        getPingRequestAttempt: false,
-        getPingResponse: action.getPingResponse,
-        pingTimer: action.pingTimer
-      };
-    case GETPING_CANCELED:
-      return {
-        ...state,
-        getPingError: "",
-        getPingRequestAttempt: false,
-        getPingResponse: null,
-        pingTimer: null
       };
     case GETSTAKEINFO_ATTEMPT:
       return {

--- a/app/wallet/client.js
+++ b/app/wallet/client.js
@@ -50,7 +50,6 @@ export const getVoteChoices = promisifyReq(
   "voteChoices",
   api.VoteChoicesRequest
 );
-export const doPing = promisifyReq("ping", api.PingRequest);
 export const loadActiveDataFilters = promisifyReq(
   "loadActiveDataFilters",
   api.LoadActiveDataFiltersRequest


### PR DESCRIPTION
This PR removes decrediton's ping to dcrwallet. 

Right now, most of the calls on decrediton works based on loopback interfaces and the ones which we keep a connection, we can tell when it stopped working, like ticket auto buyer or mixing.

So I am removing this grpc ping to dcrwallet, because it makes decrediton logs polluted 