### PR TITLE
Use decrediton own rpc.cert and rpc.key instead of the ones from dcrd

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -171,7 +171,7 @@ export const startDaemon = (params) => (dispatch, getState) =>
           rpc_host: started.rpc_host,
           rpc_port: started.rpc_port
         };
-        const appdata = started.appdata;
+        const appdata = started.dcrdAppdata;
         dispatch({ type: DAEMONSTART_SUCCESS, credentials: rpcCreds, appdata });
         resolve({ appdata, credentials: rpcCreds });
       })

--- a/app/constants/config.js
+++ b/app/constants/config.js
@@ -22,7 +22,7 @@ export const APPDATA = "appdata_path";
 export const DISABLE_HARDWARE_ACCEL = "disable_hardware_accel";
 export const LN_ENABLED = "ln_enabled";
 export const TREZOR_DEBUG = "trezor_debug";
-export const UPGD_ELECTRON8 = "upgd_electron8";
+export const UPGD_ELECTRON8 = "is_electron8";
 
 export const RPCUSER = "rpc_user";
 export const RPCPASS = "rpc_pass";

--- a/app/helpers/byteActions.js
+++ b/app/helpers/byteActions.js
@@ -41,40 +41,6 @@ export function hexReversedHashToArray(hexStr) {
   return res;
 }
 
-// readFileBackward reads a file backward and if maxSize is specified it will
-// only read until reach that size in bytes.
-export function readFileBackward(path, maxSize, end) {
-  fs.open(path, "r", function (error, descriptor) {
-    if (error) return end(error);
-    fs.fstat(descriptor, function (error, stats) {
-      if (error) return end(error);
-      let buffer, position;
-      if (stats.size > maxSize) {
-        buffer = Buffer.alloc(maxSize);
-        position = stats.size - maxSize;
-      } else {
-        buffer = Buffer.alloc(stats.size);
-        position = 0;
-      }
-      let offset = 0;
-      let length = buffer.length;
-      const read = function () {
-        fs.read(descriptor, buffer, offset, length, position, function (
-          error,
-          copied
-        ) {
-          if (error) return end(error);
-          offset += copied;
-          length -= copied;
-          if (length === 0) return end(undefined, buffer);
-          read();
-        });
-      };
-      read();
-    });
-  });
-}
-
 // str2utf8hex converts a (js, utf-16) string into (utf-8 encoded) hex.
 export function str2utf8hex(str) {
   return Buffer.from(str).toString("hex");

--- a/app/helpers/byteActions.js
+++ b/app/helpers/byteActions.js
@@ -1,5 +1,3 @@
-import fs from "fs-extra";
-
 // @flow
 export function reverseHash(s) {
   s = s.replace(/^(.(..)*)$/, "0$1"); // add a leading zero if needed

--- a/app/helpers/files.js
+++ b/app/helpers/files.js
@@ -1,3 +1,4 @@
+import fs from "fs-extra";
 
 // readFileBackward reads a file backward and if maxSize is specified it will
 // only read until reach that size in bytes.
@@ -36,29 +37,22 @@ export function readFileBackward(path, maxSize, end) {
 // makeFileBackup makes a backup of the file on the directory specified.
 // If the directory does not exists, it will be created.
 export function makeFileBackup(file, directory) {
-  try {
-    if (!fs.existsSync(file)) {
-      throw "File does not exists";
-    }
-    // get file name. Which probably is everything after the last /
-    // ex: /home/.dcrd/rpc.cert
-    const fileName = file.substr(file.lastIndexOf('/') + 1);
-    console.log(fileName)
-    // if directory does not exists, create it.
-    if (!fs.existsSync(directory)) {
-      fs.mkdirSync(directory);
-    }
-    // copy it to directory specified
-    fs.copyFileSync(file, `${directory}/${fileName}`, err => {
-      if (err) {
-        throw err;
-        return;
-      };
-    });
-
-    return true;
-  } catch (err) {
-    throw err;
-    return false;
+  if (!fs.existsSync(file)) {
+    throw "File does not exists";
   }
+  // get file name. Which probably is everything after the last /
+  // ex: /home/.dcrd/rpc.cert
+  const fileName = file.substr(file.lastIndexOf("/") + 1);
+  // if directory does not exists, create it.
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory);
+  }
+  // copy it to directory specified
+  fs.copyFileSync(file, `${directory}/${fileName}`, err => {
+    if (err) {
+      throw err;
+    };
+  });
+
+  return true;
 }

--- a/app/helpers/files.js
+++ b/app/helpers/files.js
@@ -1,0 +1,64 @@
+
+// readFileBackward reads a file backward and if maxSize is specified it will
+// only read until reach that size in bytes.
+export function readFileBackward(path, maxSize, end) {
+  fs.open(path, "r", function (error, descriptor) {
+    if (error) return end(error);
+    fs.fstat(descriptor, function (error, stats) {
+      if (error) return end(error);
+      let buffer, position;
+      if (stats.size > maxSize) {
+        buffer = Buffer.alloc(maxSize);
+        position = stats.size - maxSize;
+      } else {
+        buffer = Buffer.alloc(stats.size);
+        position = 0;
+      }
+      let offset = 0;
+      let length = buffer.length;
+      const read = function () {
+        fs.read(descriptor, buffer, offset, length, position, function (
+          error,
+          copied
+        ) {
+          if (error) return end(error);
+          offset += copied;
+          length -= copied;
+          if (length === 0) return end(undefined, buffer);
+          read();
+        });
+      };
+      read();
+    });
+  });
+}
+
+// makeFileBackup makes a backup of the file on the directory specified.
+// If the directory does not exists, it will be created.
+export function makeFileBackup(file, directory) {
+  try {
+    if (!fs.existsSync(file)) {
+      throw "File does not exists";
+    }
+    // get file name. Which probably is everything after the last /
+    // ex: /home/.dcrd/rpc.cert
+    const fileName = file.substr(file.lastIndexOf('/') + 1);
+    console.log(fileName)
+    // if directory does not exists, create it.
+    if (!fs.existsSync(directory)) {
+      fs.mkdirSync(directory);
+    }
+    // copy it to directory specified
+    fs.copyFileSync(file, `${directory}/${fileName}`, err => {
+      if (err) {
+        throw err;
+        return;
+      };
+    });
+
+    return true;
+  } catch (err) {
+    throw err;
+    return false;
+  }
+}

--- a/app/helpers/files.js
+++ b/app/helpers/files.js
@@ -1,4 +1,5 @@
 import fs from "fs-extra";
+import path from "path";
 
 // readFileBackward reads a file backward and if maxSize is specified it will
 // only read until reach that size in bytes.
@@ -40,9 +41,8 @@ export function makeFileBackup(file, directory) {
   if (!fs.existsSync(file)) {
     throw "File does not exists";
   }
-  // get file name. Which probably is everything after the last /
-  // ex: /home/.dcrd/rpc.cert
-  const fileName = file.substr(file.lastIndexOf("/") + 1);
+  // get file name so we can use it to make the backup.
+  const fileName = path.basename(file);
   // if directory does not exists, create it.
   if (!fs.existsSync(directory)) {
     fs.mkdirSync(directory);

--- a/app/helpers/index.js
+++ b/app/helpers/index.js
@@ -7,6 +7,7 @@ export * from "./arrays";
 export * from "./dom.js";
 export * from "./transactions";
 export * from "./msgTx";
+export * from "./files";
 
 // kidCheck takes a component and returns a component that only renders if it has children
 export const kidCheck = (C) => {

--- a/app/helpers/strings.js
+++ b/app/helpers/strings.js
@@ -55,3 +55,16 @@ export function limitFractionalDigits(s, maxFracDigits) {
   if (match[2].length <= maxFracDigits) return s;
   return match[1] + "." + match[2].substr(0, maxFracDigits);
 }
+
+// makeRandomString makes a random string. We use it as a generator to
+// rpcuser and rpcpass when starting dcrd with no conf file.
+export function makeRandomString(length) {
+  let text = "";
+  const possible =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  for (let i = 0; i < length; i++)
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+  return text;
+}

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -66,7 +66,7 @@ import {
   inputMenu,
   selectionMenu
 } from "./main_dev/templates";
-import { readFileBackward } from "./helpers/byteActions";
+import { readFileBackward } from "./helpers";
 import electron from "electron";
 import { isString } from "./fp";
 import {

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -279,6 +279,12 @@ export const launchDCRD = (reactIPC, testnet, appdata) =>
       dcrdAppdata,
       configFile
     } = readDcrdConfig(testnet, appdata);
+
+    // upgradeToElectron8 will remove the rpc_cert and rpc_key in case they
+    // exist and an upgrade to electron 8 is necessary.
+    // If an appdata was passed, it will remove its rpc.cert and rpc.key
+    // which can be annoying. We should do a backup or warn the user about it,
+    // but right now it will silently remove them.
     upgradeToElectron8(rpc_cert, rpc_key);
 
     const args = [
@@ -400,6 +406,7 @@ function readDcrdConfig(testnet, appdata) {
     if (appdata) {
       dcrdAppdata = appdata;
       rpc_cert = `${appdata}/rpc.cert`;
+      rpc_key = `${appdata}/rpc.key`;
       // if conf file of the appdata informed exists, we use it, otherwise
       // we use decrediton's own dcrd.conf file.
       if (fs.existsSync(dcrdCfg(appdata))) {

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -238,7 +238,6 @@ export function cleanShutdown(mainWindow, app) {
 const upgradeToElectron8 = (rpcCert, rpcKey) => {
   const globalCfg = getGlobalCfg();
   if (!globalCfg.get(UPGD_ELECTRON8)) {
-    const files = [rpcCert, rpcKey];
     const directory = `${getAppDataDirectory()}/backup`;
 
     if (fs.existsSync(rpcKey)) {


### PR DESCRIPTION
This PR fixes #2463 

With this change we are going to use the rpc.cert and rpc.key from decrediton's config directory, instead of the ones at dcrd, when starting decrediton with regular mode. 

If it is an advanced start and a different appdata, it will still need to update the rpc.cert and rpc.key, as we can't start dcrd with electron 8 as it doesn't support curve P-521.

~~Right now we are silently removing the files, as explained here https://github.com/decred/decrediton/pull/2599/files#diff-2c2e316b04b5e082a42f1340fc886b19R283~~

~~But I believe we can have a better approach for that. I believe we can make some kind of warn for the user so he makes a backup of his rpc.cert and rpc.key before removing them, what do you guys think?~~

Now, I am saving the rpc.cert and rpc.key at a directory called backup located at decrediton's config directory (on linux: `.config/decrediton/backup`)

I am also changing the config name from `upgd_electron8` to `is_electron8`, because I think `upgd_electron8` can be confusing as if we should upgrade it to electron 8 or if it is already updated
