### PR TITLE
[governance] Use short proposal urls

### DIFF
--- a/app/components/buttons/InvisibleButton.js
+++ b/app/components/buttons/InvisibleButton.js
@@ -1,3 +1,5 @@
+import { classNames } from "pi-ui";
+
 const InvisibleButton = ({
   className,
   style,
@@ -8,9 +10,9 @@ const InvisibleButton = ({
   children
 }) => (
   <div
-    className={"invisible-button" + (className ? " " + className : "")}
+    className={classNames("invisible-button", className && className)}
     style={{ ...style, display: block ? "block" : undefined }}
-    onClick={() => !disabled && onClick && onClick()}
+    onClick={() => (!disabled && onClick ? onClick() : undefined)}
     {...{ type, disabled }}>
     {children}
   </div>

--- a/app/components/buttons/InvisibleButton.js
+++ b/app/components/buttons/InvisibleButton.js
@@ -10,7 +10,7 @@ const InvisibleButton = ({
   children
 }) => (
   <div
-    className={classNames("invisible-button", className && className)}
+    className={classNames("invisible-button", className)}
     style={{ ...style, display: block ? "block" : undefined }}
     onClick={() => (!disabled && onClick ? onClick() : undefined)}
     {...{ type, disabled }}>

--- a/app/components/modals/Modal.jsx
+++ b/app/components/modals/Modal.jsx
@@ -27,7 +27,7 @@ const Modal = showCheck(({ children, className, draggable, onCancelModal }) => {
             ? style.modal
             : style.reducedBar
           : style.standalone,
-        className && className,
+        className,
         draggable && style.draggable
       )}>
       {children}

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -51,6 +51,7 @@ const ProposalDetails = ({
   const { tsDate, hasTickets, isTestnet } = useProposalDetails();
   const { themeName } = useTheme();
   const isDarkTheme = themeName === "theme-dark";
+  const proposalPath = `/proposals/${token.substring(0, 7)}`;
   return (
     <div>
       <div className={styles.overview}>
@@ -58,7 +59,7 @@ const ProposalDetails = ({
           <div className={styles.overviewInfo}>
             <div className={styles.title}>{name}</div>
             <div className={styles.token}>
-              <PoliteiaLink isTestnet={isTestnet} path={"/proposals/" + token}>
+              <PoliteiaLink isTestnet={isTestnet} path={proposalPath}>
                 {token}
               </PoliteiaLink>
             </div>
@@ -150,7 +151,7 @@ const ProposalDetails = ({
         <div className={styles.links}>
           <PoliteiaLink
             className={styles.politeiaButton}
-            path={`/proposals/${token}`}
+            path={proposalPath}
             CustomComponent={Button}
             isTestnet={isTestnet}>
             <T

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -51,7 +51,8 @@ const ProposalDetails = ({
   const { tsDate, hasTickets, isTestnet } = useProposalDetails();
   const { themeName } = useTheme();
   const isDarkTheme = themeName === "theme-dark";
-  const proposalPath = `/proposals/${token.substring(0, 7)}`;
+  const shortToken = token.substring(0, 7);
+  const proposalPath = `/proposals/${shortToken}`;
   return (
     <div>
       <div className={styles.overview}>
@@ -60,7 +61,7 @@ const ProposalDetails = ({
             <div className={styles.title}>{name}</div>
             <div className={styles.token}>
               <PoliteiaLink isTestnet={isTestnet} path={proposalPath}>
-                {token}
+                {shortToken}
               </PoliteiaLink>
             </div>
             <div className={styles.fields}>

--- a/app/components/views/ProposalDetailsPage/helpers/EligibleTickets/EligibleTickets.jsx
+++ b/app/components/views/ProposalDetailsPage/helpers/EligibleTickets/EligibleTickets.jsx
@@ -12,7 +12,7 @@ const EligibleTickets = ({ tickets, tsDate, voteChoice }) => {
   return (
     <div
       className={styles.wrapper}
-      onClick={hasTickets && toggleExapndedHandler}>
+      onClick={hasTickets ? toggleExapndedHandler : undefined}>
       <div
         className={classNames(
           styles.header,


### PR DESCRIPTION
This diff adds support for short proposal urls which are supported since last politeia release.

In addition, it fixes a console error which was thrown because of `false` being used as `onClick`, when using `onClick={condition && value}` syntax, this commit resolves it by using `onClick={condition ? value : undefined}` instead.

Closes #2601