### PR TITLE
Speed up ReceiveTab tooltip transition

### DIFF
--- a/app/components/views/TransactionsPage/ReceiveTab/ReceiveTab.module.css
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceiveTab.module.css
@@ -203,7 +203,7 @@
   z-index: 2;
   opacity: 0;
   transition: opacity 1s;
-  transition-duration: 2s;
+  transition-duration: 0.5s;
 }
 
 .opacity {

--- a/app/components/views/TransactionsPage/ReceiveTab/ReceiveTabPage.jsx
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceiveTabPage.jsx
@@ -36,7 +36,7 @@ const ReceivePage = ({
     setTooltip(true);
     timeout.current = setTimeout(() => {
       setTooltip(false);
-    }, 2500);
+    }, 1000);
   }
 
   return (


### PR DESCRIPTION
Talking to @vctt94 , we concluded that we can speed up the tooltip transition when copying or generating a new address in a receive transaction.
This PR provides it.