### PR TITLE
Fix transaction wrong path

### DIFF
--- a/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfoDisplay.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfoDisplay.jsx
@@ -167,7 +167,7 @@ const StakeInfoDisplay = ({
             foot={
               lastVotedTicket && (
                 <Link
-                  to={`/transactions/history/${lastVotedTicket.txHash}`}
+                  to={`/transaction/history/${lastVotedTicket.txHash}`}
                   className={styles.foot}>
                   <span className={styles.purchaseTicketFoot}>
                     {lastVotedTicket.txHash.substr(0, 6) + "... "}


### PR DESCRIPTION
This PR corrects the path of the last ticket transaction, setting it to redirect to the right location. This bug has been found in https://github.com/decred/decrediton/pull/2594 as well. After this PR, there will be no further occurrence of ``transactions/history/txHash``.