### PR TITLE
[cspp] not allow small balances to start mixer

### DIFF
--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -3,7 +3,7 @@ import Promise from "promise";
 import * as sel from "selectors";
 import * as wallet from "wallet";
 import { getWalletCfg } from "config";
-import { getAcctSpendebleBalance } from "./ClientActions";
+import { getAcctSpendableBalance } from "./ClientActions";
 import { MIN_RELAY_FEE_ATOMS } from "constants";
 
 export const GETACCOUNTMIXERSERVICE_ATTEMPT = "GETACCOUNTMIXERSERVICE_ATTEMPT";
@@ -45,7 +45,7 @@ export const runAccountMixer = ({
       dispatch({ type: RUNACCOUNTMIXER_ATTEMPT });
       const runMixerAsync = async () => {
         // no start mixer if account balance is less than minimum possible fee.
-        const spendableBal = await dispatch(getAcctSpendebleBalance(changeAccount));
+        const spendableBal = await dispatch(getAcctSpendableBalance(changeAccount));
         if (spendableBal < MIN_RELAY_FEE_ATOMS) {
           return { error: "Account Balance Too Small" };
         }

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -676,7 +676,7 @@ export const abandonTransactionAttempt = (txid) => (dispatch, getState) => {
     .catch((error) => dispatch({ error, type: ABANDONTRANSACTION_FAILED }));
 };
 
-export const getAcctSpendebleBalance = (acctId) => async (dispatch, getState) => {
+export const getAcctSpendableBalance = (acctId) => async (dispatch, getState) => {
   const acct = await wallet.getBalance(sel.walletService(getState()), acctId, 0);
   return acct.getSpendable();
 };

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -675,3 +675,8 @@ export const abandonTransactionAttempt = (txid) => (dispatch, getState) => {
     })
     .catch((error) => dispatch({ error, type: ABANDONTRANSACTION_FAILED }));
 };
+
+export const getAcctSpendebleBalance = (acctId) => async (dispatch, getState) => {
+  const acct = await wallet.getBalance(sel.walletService(getState()), acctId, 0);
+  return acct.getSpendable();
+};

--- a/app/components/views/AccountsPage/Privacy/hooks.js
+++ b/app/components/views/AccountsPage/Privacy/hooks.js
@@ -24,7 +24,7 @@ export function usePrivacy() {
   const mixedAccountName = getAccountName(mixedAccount);
   const changeAccountName = getAccountName(changeAccount);
 
-  const onStartMixerAttempt = useCallback(async (passphrase) => {
+  const onStartMixerAttempt = useCallback((passphrase) => {
     const request = {
       passphrase,
       mixedAccount,
@@ -32,7 +32,7 @@ export function usePrivacy() {
       mixedAccountBranch,
       csppServer: `${csppServer}:${csppPort}`
     };
-    await runAccountMixer(request);
+    runAccountMixer(request).then(r => r).catch(err => err);
   }, [
     mixedAccount,
     changeAccount,

--- a/app/constants/Decred.js
+++ b/app/constants/Decred.js
@@ -1,6 +1,7 @@
 export const MAX_POSSIBLE_FEE_INPUT = 0.1;
 
 export const MIN_RELAY_FEE = 0.0001;
+export const MIN_RELAY_FEE_ATOMS = 10000;
 
 // Constants copied from dcrd/chaincfg/params.go
 


### PR DESCRIPTION
This PR makes the mixer throws an error and not start if the change account balance has its balances smaller than the min rellay fee. 

