### PR TITLE
Fix missing import scripts with passphrase

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -317,7 +317,7 @@ export const purchaseTicketsAttempt = (
       // If we need to sign the tx, we re-import the script to ensure the
       // wallet will control the ticket.
       const importScriptResponse = await dispatch(
-        importScriptAttempt(passphrase, stakepool.Script)
+        importScriptAttempt(stakepool.Script)
       );
       if (importScriptResponse.getP2shAddress() !== stakepool.TicketAddress) {
         throw new Error(

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -174,7 +174,7 @@ export const setStakePoolInformation = (
     // import the script and verify whether the imported address matches what the
     // stakepool has sent us
     const importScriptResponse = await dispatch(
-      importScriptAttempt(privpass, response.data.data.Script)
+      importScriptAttempt(response.data.data.Script)
     );
     if (
       importScriptResponse.getP2shAddress() !== response.data.data.TicketAddress


### PR DESCRIPTION
After https://github.com/decred/decrediton/pull/2616, some import scripts methods were missed. 

This PR remove passphrase from them, as well