### PR TITLE
[getstarted] fix crash on startup when `show_tutorial:true` in config.json

### DIFF
--- a/app/components/views/GetStartedPage/TutorialPage/TutorialPage.jsx
+++ b/app/components/views/GetStartedPage/TutorialPage/TutorialPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import TutorialPage from "./Page";
-import { useDaemonStartup } from "connectors";
+import { useDaemonStartup } from "hooks";
 
 const Tutorial = () => {
   const { finishTutorial } = useDaemonStartup();


### PR DESCRIPTION
This diff fixes the following issue which was reported on #2552:

> @matheusd reported when decrediton starting going to tutorial page, decrediton crashes