### PR TITLE
[governance] show eligible tickets only when voting is active or finished

### DIFF
--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -53,6 +53,9 @@ const ProposalDetails = ({
   const isDarkTheme = themeName === "theme-dark";
   const shortToken = token.substring(0, 7);
   const proposalPath = `/proposals/${shortToken}`;
+  const votingActiveOrFinished =
+    voteStatus === VOTESTATUS_ACTIVEVOTE ||
+    voteStatus === VOTESTATUS_FINISHEDVOTE;
   return (
     <div>
       <div className={styles.overview}>
@@ -116,8 +119,7 @@ const ProposalDetails = ({
             />
           </div>
         </div>
-        {(voteStatus === VOTESTATUS_ACTIVEVOTE ||
-          voteStatus === VOTESTATUS_FINISHEDVOTE) && (
+        {votingActiveOrFinished && (
           <StatusBar
             className={styles.voteStatusBar}
             max={quorumMinimumVotes}
@@ -141,7 +143,7 @@ const ProposalDetails = ({
           />
         )}
       </div>
-      {walletEligibleTickets && (
+      {votingActiveOrFinished && walletEligibleTickets && (
         <EligibleTickets
           tickets={walletEligibleTickets}
           tsDate={tsDate}

--- a/app/components/views/ProposalDetailsPage/ProposalDetailsPage.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetailsPage.jsx
@@ -79,4 +79,3 @@ const ProposalDetailsPage = () => {
 };
 
 export default ProposalDetailsPage;
-

--- a/app/components/views/ProposalDetailsPage/ProposalDetailsPage.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetailsPage.jsx
@@ -79,3 +79,4 @@ const ProposalDetailsPage = () => {
 };
 
 export default ProposalDetailsPage;
+


### PR DESCRIPTION
This diff closes #2610, it ensures eligible tickets section is displayed only when 
proposal voting is active or finished.

Also, this diff includes changes related to prettifying, as I ran `yarn prettify`.