### PR TITLE
[startup] Better deal with errors

### DIFF
--- a/app/components/views/GetStartedPage/WalletSelection/Form.jsx
+++ b/app/components/views/GetStartedPage/WalletSelection/Form.jsx
@@ -155,7 +155,7 @@ const WalletSelectionForm = ({
                 <>
                   <div
                     className={styles.displayWalletLaunch}
-                    onClick={() => submitChosenWallet(selectedWallet)}>
+                    onClick={() => submitChosenWallet({ selectedWallet })}>
                     <T id="walletselection.launchWallet" m="Launch Wallet " />
                   </div>
                   <span className={styles.launchArrowBounce}>&#8594;</span>

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -76,7 +76,8 @@ export const getStartedMachine = Machine({
                 selectedWallet: (context, event) =>
                   event.selectedWallet
                     ? event.selectedWallet
-                    : context.selectedWallet
+                    : context.selectedWallet,
+                error: (context, event) => event.error
               })
             }
           }
@@ -184,7 +185,8 @@ export const getStartedMachine = Machine({
                 selectedWallet: (context, event) =>
                   event.selectedWallet
                     ? event.selectedWallet
-                    : context.selectedWallet
+                    : context.selectedWallet,
+                error: (context, event) => event.error
               })
             },
             CREATE_WALLET: {
@@ -195,6 +197,12 @@ export const getStartedMachine = Machine({
                     ? event.isNew
                     : context.isCreateNewWallet
               })
+            },
+            ERROR: {
+              target: "choosingWallet",
+              actions: assign({
+                error: (_, event) => event.error
+              })
             }
           }
         },
@@ -203,9 +211,11 @@ export const getStartedMachine = Machine({
           on: {
             SYNC_RPC: "syncingRPC",
             WALLET_PUBPASS_INPUT: "walletPubpassInput",
-            ERROR_STARTING_WALLET: {
+            ERROR: {
               target: "choosingWallet",
-              actions: assign({ error: (context, event) => event.error })
+              actions: assign({
+                error: (context, event) => event.error
+              })
             }
           }
         },


### PR DESCRIPTION
I noticed on startup, if decrediton fails to get available wallets or if it fails to start a wallet, when choosing one, no feedback is given.

This PR fixes it. Example:

![image](https://user-images.githubusercontent.com/15069783/91763728-67681c80-ebac-11ea-972a-50f2b0910959.png)
