### PR TITLE
[pi-ui][settings] Use pi-ui's Checkbox component instead of custom one

### DIFF
--- a/app/components/views/SettingsPage/PrivacySettings.jsx
+++ b/app/components/views/SettingsPage/PrivacySettings.jsx
@@ -6,10 +6,9 @@ import {
   EXTERNALREQUEST_POLITEIA,
   EXTERNALREQUEST_DCRDATA
 } from "main_dev/externalRequests";
-
 import { ChangePassphraseButton } from "buttons";
 import { WatchOnlyWarnNotification } from "shared";
-import { classNames } from "pi-ui";
+import { classNames, Checkbox } from "pi-ui";
 import styles from "./Settings.module.css";
 
 const propTypes = {
@@ -19,23 +18,6 @@ const propTypes = {
   changePassphraseRequestAttempt: PropTypes.bool.isRequired,
   onChangeTempSettings: PropTypes.func.isRequired
 };
-
-const AllowableRequestType = ({
-  id,
-  label,
-  description,
-  checked,
-  onChange
-}) => (
-  <div className={classNames(styles.row, styles.rowChecklist)}>
-    <div className={styles.label}>{label}</div>
-    <div className={styles.privacyCheckbox}>
-      <input id={id} type="checkbox" checked={checked} onChange={onChange} />
-      <label htmlFor={id}></label>
-    </div>
-    <div className={styles.checklistDescription}>{description}</div>
-  </div>
-);
 
 const PrivacySettings = ({
   tempSettings,
@@ -88,104 +70,117 @@ const PrivacySettings = ({
               </WatchOnlyWarnNotification>
             </div>
           </div>
-          <AllowableRequestType
-            label={
-              <T
-                id="settings.privacy.networkStatus.label"
-                m="Network Information"
-              />
-            }
-            id="networking"
-            description={
-              <T
-                id="settings.privacy.networkStatus.description"
-                m="General network information (block height, etc) from decred.org"
-              />
-            }
-            checked={
-              tempSettings.allowedExternalRequests.indexOf(
-                EXTERNALREQUEST_NETWORK_STATUS
-              ) > -1
-            }
-            onChange={toggle(EXTERNALREQUEST_NETWORK_STATUS)}
-          />
-          <AllowableRequestType
-            label={
-              <T id="settings.privacy.stakepoolListing.label" m="VSP Listing" />
-            }
-            id="stakepool"
-            description={
-              <T
-                id="settings.privacy.stakepoolListing.description"
-                m="List of currently available VSPs from decred.org"
-              />
-            }
-            checked={
-              tempSettings.allowedExternalRequests.indexOf(
-                EXTERNALREQUEST_STAKEPOOL_LISTING
-              ) > -1
-            }
-            onChange={toggle(EXTERNALREQUEST_STAKEPOOL_LISTING)}
-          />
+          <div className={classNames(styles.row, styles.rowChecklist)}>
+            <Checkbox
+              label={
+                <T
+                  id="settings.privacy.networkStatus.label"
+                  m="Network Information"
+                />
+              }
+              id="networking"
+              description={
+                <T
+                  id="settings.privacy.networkStatus.description"
+                  m="General network information (block height, etc) from decred.org"
+                />
+              }
+              checked={
+                tempSettings.allowedExternalRequests.indexOf(
+                  EXTERNALREQUEST_NETWORK_STATUS
+                ) > -1
+              }
+              onClick={toggle(EXTERNALREQUEST_NETWORK_STATUS)}
+            />
+          </div>
+          <div className={classNames(styles.row, styles.rowChecklist)}>
+            <Checkbox
+              label={
+                <T
+                  id="settings.privacy.stakepoolListing.label"
+                  m="VSP Listing"
+                />
+              }
+              id="stakepool"
+              description={
+                <T
+                  id="settings.privacy.stakepoolListing.description"
+                  m="List of currently available VSPs from decred.org"
+                />
+              }
+              checked={
+                tempSettings.allowedExternalRequests.indexOf(
+                  EXTERNALREQUEST_STAKEPOOL_LISTING
+                ) > -1
+              }
+              onClick={toggle(EXTERNALREQUEST_STAKEPOOL_LISTING)}
+            />
+          </div>
         </div>
       </div>
       <div className={styles.column}>
         <div>
-          <AllowableRequestType
-            label={
-              <T id="settings.privacy.updateCheck.label" m="Update Check" />
-            }
-            id="update"
-            description={
-              <T
-                id="settings.privacy.updateCheck.description"
-                m="Get latest released version from github.org"
-              />
-            }
-            checked={
-              tempSettings.allowedExternalRequests.indexOf(
-                EXTERNALREQUEST_UPDATE_CHECK
-              ) > -1
-            }
-            onChange={toggle(EXTERNALREQUEST_UPDATE_CHECK)}
-          />
-          <AllowableRequestType
-            label={<T id="settings.privacy.politeia.label" m="Politeia" />}
-            id="politeia"
-            description={
-              <T
-                id="settings.privacy.politeia.description"
-                m="List and vote on proposals on proposals.decred.org"
-              />
-            }
-            checked={
-              tempSettings.allowedExternalRequests.indexOf(
-                EXTERNALREQUEST_POLITEIA
-              ) > -1
-            }
-            onChange={toggle(EXTERNALREQUEST_POLITEIA)}
-          />
-          <AllowableRequestType
-            label={
-              <T
-                id="settings.privacy.dcrdata.label"
-                m="Decred Block Explorer"
-              />
-            }
-            id="dcrdata"
-            description={
-              <T
-                id="settings.privacy.dcrdata.description"
-                m="Access chain information from dcrdata.decred.org"
-              />
-            }
-            checked={
-              tempSettings.allowedExternalRequests.indexOf(
-                EXTERNALREQUEST_DCRDATA
-              ) > -1
-            }
-            onChange={toggle(EXTERNALREQUEST_DCRDATA)}
-          />
+          <div className={classNames(styles.row, styles.rowChecklist)}>
+            <Checkbox
+              label={
+                <T id="settings.privacy.updateCheck.label" m="Update Check" />
+              }
+              id="update"
+              description={
+                <T
+                  id="settings.privacy.updateCheck.description"
+                  m="Get latest released version from github.org"
+                />
+              }
+              checked={
+                tempSettings.allowedExternalRequests.indexOf(
+                  EXTERNALREQUEST_UPDATE_CHECK
+                ) > -1
+              }
+              onClick={toggle(EXTERNALREQUEST_UPDATE_CHECK)}
+            />
+          </div>
+          <div className={classNames(styles.row, styles.rowChecklist)}>
+            <Checkbox
+              label={<T id="settings.privacy.politeia.label" m="Politeia" />}
+              id="politeia"
+              description={
+                <T
+                  id="settings.privacy.politeia.description"
+                  m="List and vote on proposals on proposals.decred.org"
+                />
+              }
+              checked={
+                tempSettings.allowedExternalRequests.indexOf(
+                  EXTERNALREQUEST_POLITEIA
+                ) > -1
+              }
+              onClick={toggle(EXTERNALREQUEST_POLITEIA)}
+            />
+          </div>
+          <div className={classNames(styles.row, styles.rowChecklist)}>
+            <Checkbox
+              label={
+                <T
+                  id="settings.privacy.dcrdata.label"
+                  m="Decred Block Explorer"
+                />
+              }
+              id="dcrdata"
+              description={
+                <T
+                  id="settings.privacy.dcrdata.description"
+                  m="Access chain information from dcrdata.decred.org"
+                />
+              }
+              checked={
+                tempSettings.allowedExternalRequests.indexOf(
+                  EXTERNALREQUEST_DCRDATA
+                ) > -1
+              }
+              onClick={toggle(EXTERNALREQUEST_DCRDATA)}
+            />
+          </div>
         </div>
       </div>
     </>

--- a/app/components/views/SettingsPage/Settings.module.css
+++ b/app/components/views/SettingsPage/Settings.module.css
@@ -48,16 +48,6 @@
   margin-right: 0;
 }
 
-.checklistDescription {
-  font-style: italic;
-  text-align: left;
-  margin-left: 22px;
-  color: var(--settings-desc);
-  font-size: 11px;
-  line-height: 15px;
-  width: 175px;
-}
-
 .label {
   display: inline-block;
   margin-right: 14px;
@@ -135,10 +125,6 @@
   background-image: var(--info-icon);
   background-size: 16px;
   margin-right: 5px;
-}
-
-.privacy .columnContent .row .checklistDescription {
-  width: 220px;
 }
 
 .changePasswordDefaultIcon {
@@ -235,11 +221,6 @@
   max-width: 400px;
 }
 
-.privacyCheckbox {
-  margin-top: 2px;
-  order: -1;
-}
-
 .closeModalButton {
   height: 23px;
   background-color: var(--wallet-close-button-bg);
@@ -275,46 +256,6 @@ div.radioButtonsWrapper > * {
 .timezoneOption > label > span:nth-child(2) {
   background-color: var(--input-color);
 }
-
-/* REPLACE ALLL THIS WITH PI-UI's CHECKBOX */
-.wrapper input[type="checkbox"] {
-  display: none;
-}
-
-.wrapper input[type="checkbox"]:disabled + label {
-  display: inline-block;
-  background-color: var(--disabled-background-color);
-  border: 1px solid var(--disabled-color);
-}
-
-.wrapper input[type="checkbox"]:checked:disabled + label {
-  display: inline-block;
-  border: 1px solid var(--disabled-color);
-  background-color: var(--disabled-background-color);
-  background-image: var(--checkmark-grey-icon);
-  background-repeat: no-repeat;
-  background-size: 10px;
-}
-
-.wrapper input[type="checkbox"] + label {
-  display: inline-block;
-  border: 1px solid var(--home-content-link);
-  background-color: none;
-  width: 12px;
-  height: 12px;
-  background-position: 1px;
-}
-
-.wrapper input[type="checkbox"]:checked + label {
-  display: inline-block;
-  border: 1px solid var(--input-color);
-  background-color: none;
-  background-image: var(--checkmark-blue-icon);
-  background-repeat: no-repeat;
-  background-size: 10px;
-}
-
-/* END REPLACE WITH PI-UI */
 
 @media screen and (min-width: 1680px) and (max-width: 1919px) {
   .wrapper {

--- a/package.json
+++ b/package.json
@@ -283,7 +283,7 @@
     "node-abi": "^2.15.0",
     "node-addon-loader": "decred/node-addon-loader#master",
     "nouislider": "^12.0.0",
-    "pi-ui": "https://github.com/decred/pi-ui",
+    "pi-ui": "https://github.com/amassarwi/pi-ui#rbDescription",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -283,7 +283,7 @@
     "node-abi": "^2.15.0",
     "node-addon-loader": "decred/node-addon-loader#master",
     "nouislider": "^12.0.0",
-    "pi-ui": "https://github.com/amassarwi/pi-ui#rbDescription",
+    "pi-ui": "https://github.com/amassarwi/pi-ui#checkboxAdj",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -283,7 +283,7 @@
     "node-abi": "^2.15.0",
     "node-addon-loader": "decred/node-addon-loader#master",
     "nouislider": "^12.0.0",
-    "pi-ui": "https://github.com/amassarwi/pi-ui#checkboxAdj",
+    "pi-ui": "https://github.com/decred/pi-ui",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",
     "raw-loader": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9319,9 +9319,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/decred/pi-ui":
+"pi-ui@https://github.com/amassarwi/pi-ui#rbDescription":
   version "1.0.0"
-  resolved "https://github.com/decred/pi-ui#c9741462323ab7d7c30059827f8b618f7bfc5b8d"
+  resolved "https://github.com/amassarwi/pi-ui#ed5cb576390d40c117b2f4cc9ef7249e69a29fcd"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9319,9 +9319,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/amassarwi/pi-ui#checkboxAdj":
+"pi-ui@https://github.com/decred/pi-ui":
   version "1.0.0"
-  resolved "https://github.com/amassarwi/pi-ui#b124cc03cc5087a533a86850dd9f5a96b092250b"
+  resolved "https://github.com/decred/pi-ui#7b9e38f8964cd504245846fcf92f45871bcbab46"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9319,9 +9319,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/amassarwi/pi-ui#rbDescription":
+"pi-ui@https://github.com/amassarwi/pi-ui#checkboxAdj":
   version "1.0.0"
-  resolved "https://github.com/amassarwi/pi-ui#ed5cb576390d40c117b2f4cc9ef7249e69a29fcd"
+  resolved "https://github.com/amassarwi/pi-ui#b124cc03cc5087a533a86850dd9f5a96b092250b"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"


### PR DESCRIPTION
This diff replaces custom checkbox used in privacy settings with pi-ui's component.
Closes #2661 
Needs decred/pi-ui#294
~~Based on #2662~~

---

<img width="776" alt="image" src="https://user-images.githubusercontent.com/10324528/92574313-99097380-f28f-11ea-9854-5c296a04ce94.png">
