### PR TITLE
[accounts] fix: small improvements on privacy accounts flow

### DIFF
--- a/app/components/views/AccountsPage/Privacy/ConfigMixer/ConfigMixer.jsx
+++ b/app/components/views/AccountsPage/Privacy/ConfigMixer/ConfigMixer.jsx
@@ -5,39 +5,34 @@ import style from "../Privacy.module.css";
 import { usePrivacy } from "../hooks";
 import CreateDefaultAccounts from "./CreateDefaultAccounts";
 import CreateNeededAccounts from "./CreateNeededAccounts";
-import { useMountEffect } from "hooks";
 import { useEffect, useState } from "react";
 import { MIXED_ACCOUNT, CHANGE_ACCOUNT } from "constants";
 
+const checkAvailableAccounts = (accounts) => {
+  const mixedExists = accounts.find(
+    ({ accountName }) => accountName === MIXED_ACCOUNT
+  );
+  const changeExists = accounts.find(
+    ({ accountName }) => accountName === CHANGE_ACCOUNT
+  );
+
+  return !(mixedExists || changeExists);
+};
+
 const ConfigMixer = ({ isCreateAccountDisabled, accounts }) => {
-  const [mixedAccountName, setMixedAccountName] = useState("");
-  const [changeAccountName, setChangeAccountName] = useState("");
-  const [areAccountsAvailable, setAreAvailable] = useState(false);
+  const areAccountsAvailable = checkAvailableAccounts(accounts);
+  const [mixedAccountName, setMixedAccountName] = useState(
+    areAccountsAvailable && MIXED_ACCOUNT
+  );
+  const [changeAccountName, setChangeAccountName] = useState(
+    areAccountsAvailable && CHANGE_ACCOUNT
+  );
   const [isValid, setIsValid] = useState(false);
 
   const { createNeededAccounts } = usePrivacy();
 
-  const checkAvailableAccounts = () => {
-    const mixedExists = accounts.find(
-      ({ accountName }) => accountName === MIXED_ACCOUNT
-    );
-    const changeExists = accounts.find(
-      ({ accountName }) => accountName === CHANGE_ACCOUNT
-    );
-
-    return !(mixedExists || changeExists);
-  };
-
-  useMountEffect(() => {
-    if (checkAvailableAccounts()) {
-      setAreAvailable(true);
-      setMixedAccountName(MIXED_ACCOUNT);
-      setChangeAccountName(CHANGE_ACCOUNT);
-    }
-  });
-
   useEffect(() => {
-    setIsValid(mixedAccountName  && changeAccountName);
+    setIsValid(mixedAccountName && changeAccountName);
   }, [mixedAccountName, changeAccountName]);
 
   const onSubmit = (passphrase) =>

--- a/app/components/views/AccountsPage/Privacy/ConfigMixer/ConfigMixer.jsx
+++ b/app/components/views/AccountsPage/Privacy/ConfigMixer/ConfigMixer.jsx
@@ -5,31 +5,36 @@ import style from "../Privacy.module.css";
 import { usePrivacy } from "../hooks";
 import CreateDefaultAccounts from "./CreateDefaultAccounts";
 import CreateNeededAccounts from "./CreateNeededAccounts";
+import { useMountEffect } from "hooks";
 import { useEffect, useState } from "react";
 import { MIXED_ACCOUNT, CHANGE_ACCOUNT } from "constants";
 
-const checkAvailableAccounts = (accounts) => {
-  const mixedExists = accounts.find(
-    ({ accountName }) => accountName === MIXED_ACCOUNT
-  );
-  const changeExists = accounts.find(
-    ({ accountName }) => accountName === CHANGE_ACCOUNT
-  );
-
-  return !(mixedExists || changeExists);
-};
-
 const ConfigMixer = ({ isCreateAccountDisabled, accounts }) => {
-  const areAccountsAvailable = checkAvailableAccounts(accounts);
-  const [mixedAccountName, setMixedAccountName] = useState(
-    areAccountsAvailable && MIXED_ACCOUNT
-  );
-  const [changeAccountName, setChangeAccountName] = useState(
-    areAccountsAvailable && CHANGE_ACCOUNT
-  );
+  const [mixedAccountName, setMixedAccountName] = useState("");
+  const [changeAccountName, setChangeAccountName] = useState("");
+  const [areAccountsAvailable, setAreAvailable] = useState(false);
   const [isValid, setIsValid] = useState(false);
 
   const { createNeededAccounts } = usePrivacy();
+
+  const checkAvailableAccounts = () => {
+    const mixedExists = accounts.find(
+      ({ accountName }) => accountName === MIXED_ACCOUNT
+    );
+    const changeExists = accounts.find(
+      ({ accountName }) => accountName === CHANGE_ACCOUNT
+    );
+
+    return !(mixedExists || changeExists);
+  };
+
+  useMountEffect(() => {
+    if (checkAvailableAccounts()) {
+      setAreAvailable(true);
+      setMixedAccountName(MIXED_ACCOUNT);
+      setChangeAccountName(CHANGE_ACCOUNT);
+    }
+  });
 
   useEffect(() => {
     setIsValid(mixedAccountName && changeAccountName);

--- a/app/components/views/AccountsPage/Privacy/hooks.js
+++ b/app/components/views/AccountsPage/Privacy/hooks.js
@@ -1,12 +1,11 @@
 import { useDispatch, useSelector } from "react-redux";
-import { useCallback } from "react";
 import * as act from "actions/AccountMixerActions";
 import * as sel from "selectors";
 
 export function usePrivacy() {
   const dispatch = useDispatch();
-  const runAccountMixer = useCallback((request) => dispatch(act.runAccountMixer(request)), [dispatch]);
-  const stopAccountMixer = useCallback(() => dispatch(act.stopAccountMixer()), [dispatch]);
+  const runAccountMixer = (request) => dispatch(act.runAccountMixer(request));
+  const stopAccountMixer = () => dispatch(act.stopAccountMixer());
   const accountMixerRunning = useSelector(sel.getAccountMixerRunning);
   const mixedAccount = useSelector(sel.getMixedAccount);
   const changeAccount = useSelector(sel.getChangeAccount);
@@ -15,20 +14,24 @@ export function usePrivacy() {
   const mixedAccountBranch = useSelector(sel.getMixedAccountBranch);
   const accounts = useSelector(sel.sortedAccounts);
   const accountMixerError = useSelector(sel.getAccountMixerError);
-  const createNeededAccounts = useCallback((passphrase, mixedAccountName, changeAccountName) =>
-    dispatch(act.createNeededAccounts(passphrase, mixedAccountName, changeAccountName)),
-    [dispatch]
-  );
+  const createNeededAccounts = (
+    passphrase,
+    mixedAccountName,
+    changeAccountName
+  ) =>
+    dispatch(
+      act.createNeededAccounts(passphrase, mixedAccountName, changeAccountName)
+    );
 
-  const getAccountName = useCallback((n) => {
+  const getAccountName = (n) => {
     const account = accounts.find(({ accountNumber }) => accountNumber === n);
     return account ? account.accountName : null;
-  }, [accounts]);
+  };
 
   const mixedAccountName = getAccountName(mixedAccount);
   const changeAccountName = getAccountName(changeAccount);
 
-  const onStartMixerAttempt = useCallback((passphrase) => {
+  const onStartMixerAttempt = (passphrase) => {
     const request = {
       passphrase,
       mixedAccount,
@@ -36,15 +39,10 @@ export function usePrivacy() {
       mixedAccountBranch,
       csppServer: `${csppServer}:${csppPort}`
     };
-    runAccountMixer(request).then(r => r).catch(err => err);
-  }, [
-    mixedAccount,
-    changeAccount,
-    mixedAccountBranch,
-    csppServer,
-    csppPort,
-    runAccountMixer
-  ]);
+    runAccountMixer(request)
+      .then((r) => r)
+      .catch((err) => err);
+  };
 
   return {
     stopAccountMixer,
@@ -61,4 +59,4 @@ export function usePrivacy() {
     onStartMixerAttempt,
     createNeededAccounts
   };
-};
+}


### PR DESCRIPTION
Noticed that after creating the default accounts required for mixing, there are no changes on the UI. This Diff redirects it to the correct privacy view, and removes some useless `useCallback` hooks.