### PR TITLE
make config singleton

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -6,15 +6,17 @@ import {
   getGlobalCfgPath,
   getWalletPath,
   dcrwalletConf,
-  getDcrdRpcCert
+  getDcrdRpcCert,
+  getBackupDirectory
 } from "./main_dev/paths";
 import * as cfgConstants from "constants/config";
+import { makeFileBackup } from "helpers";
 import { DCR } from "constants";
 
 let config = null;
 export function getGlobalCfg() {
   if (!config) {
-    config = initGlobalCfg()
+    config = initGlobalCfg();
   }
 
   return config;
@@ -157,14 +159,10 @@ export function validateGlobalCfgFile() {
   let fileContents;
   try {
     fileContents = fs.readFileSync(getGlobalCfgPath(), "utf8");
-  } catch (err) {
-    return null;
-  }
-
-  try {
     JSON.parse(fileContents);
+    // make a config.json backup if fileContents is valid.
+    makeFileBackup(getGlobalCfgPath(), getBackupDirectory());
   } catch (err) {
-    console.error(err);
     return err;
   }
 

--- a/app/config.js
+++ b/app/config.js
@@ -11,8 +11,12 @@ import {
 import * as cfgConstants from "constants/config";
 import { DCR } from "constants";
 
+let config = null;
 export function getGlobalCfg() {
-  const config = new Store();
+  if (!config) {
+    config = initGlobalCfg()
+  }
+
   return config;
 }
 
@@ -119,7 +123,10 @@ function cleanWalletCfg(config) {
 }
 
 export function initGlobalCfg() {
-  const config = new Store();
+  if (config) {
+    return config;
+  }
+  config = new Store();
   Object.keys(cfgConstants.INITIAL_VALUES).map((key) => {
     if (!config.has(key)) {
       config.set(key, cfgConstants.INITIAL_VALUES[key]);

--- a/app/helpers/files.js
+++ b/app/helpers/files.js
@@ -37,6 +37,8 @@ export function readFileBackward(path, maxSize, end) {
 
 // makeFileBackup makes a backup of the file on the directory specified.
 // If the directory does not exists, it will be created.
+// @params file - file path string
+// directory - directory path string where backup will be created.
 export function makeFileBackup(file, directory) {
   if (!fs.existsSync(file)) {
     throw "File does not exists";

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -4,7 +4,8 @@ import {
   getExecutablePath,
   dcrdCfg,
   getAppDataDirectory,
-  getDcrdPath
+  getDcrdPath,
+  getBackupDirectory
 } from "./paths";
 import { getWalletCfg, getGlobalCfg } from "config";
 import {
@@ -242,7 +243,7 @@ export function cleanShutdown(mainWindow, app) {
 const upgradeToElectron8 = (rpcCert, rpcKey) => {
   const globalCfg = getGlobalCfg();
   if (!globalCfg.get(UPGD_ELECTRON8)) {
-    const directory = `${getAppDataDirectory()}/backup`;
+    const directory = getBackupDirectory();
 
     if (fs.existsSync(rpcKey)) {
       const backupDone = makeFileBackup(rpcKey, directory);

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -23,6 +23,11 @@ export function getAppDataDirectory() {
   }
 }
 
+// getWalletsDirectoryPath gets the wallets directory.
+export function getBackupDirectory() {
+  return path.join(getAppDataDirectory(), "backup");
+}
+
 // getGlobalCfgPath gets decrediton's config.json file.
 // example of result in unix: ~/.config/decrediton/config.json
 export function getGlobalCfgPath() {


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/decred/decrediton/issues/2636.

I wasn't able to reproduce that bug, but starting a new config store each time getGlobalCfg() is called doesn't seem right to me. This PR changes it so we only start it once