### PR TITLE
[advanced daemon mode] Use P-256 curve for generating TLS keypairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ to start the node for your respective system.
 
 CLI options (including ```--advanced```) when running `yarn dev` are currently not supported.
 
+When generating the TLS keypairs for the rpc endpoint you should use the P-256 curve by starting the daemon with `--tlscurve=P-256`. Note that the rpccert/rpckey files need to be deleted before this.
+
 ## Platform-specific instructions
 
 ### macOS 


### PR DESCRIPTION
When the TLS keypairs for dcrd's rpc endpoint are generated using the default P-521 curve the decrediton can not connect to it. It receives this error message:

```Error: write EPROTO 10328117885128:error:10000410:SSL routines:OPENSSL_internal:SSLV3_ALERT_HANDSHAKE_FAILURE:../../third_party/boringssl/src/ssl/tls_record.cc:592:SSL alert number 40\n10328117885128:error:1000009a:SSL routines:OPENSSL_internal:HANDSHAKE_FAILURE_ON_CLIENT_HELLO:../../third_party/boringssl/src/ssl/handshake.cc:589:\n```

This diff expands the README to inform users that they should use P-256 curve for generating the TLS keypairs.