### PR TITLE
[transactions] fix: align transaction history page items

### DIFF
--- a/app/components/shared/TxHistory/RegularTxRow.jsx
+++ b/app/components/shared/TxHistory/RegularTxRow.jsx
@@ -6,21 +6,19 @@ import {
   TRANSACTION_DIR_TRANSFERRED
 } from "constants";
 import styles from "./TxHistory.module.css";
-import { classNames, Text } from "pi-ui";
+import { classNames } from "pi-ui";
 
-const TxDirection = ({ account, isCred, flat }) => (
-  <span className={"is-row"}>
+const TxDirection = ({ account, isCred }) => (
+  <span className="is-row">
     {isCred ? (
       <T
         id="txHistory.out.tx"
         m="To {acc}"
         values={{
-          acc: !flat ? (
+          acc: (
             <div className={styles.status}>
               <div className={styles.accountName}>{account}</div>
             </div>
-          ) : (
-            account
           )
         }}
       />
@@ -29,12 +27,10 @@ const TxDirection = ({ account, isCred, flat }) => (
         id="txHistory.in.tx"
         m="From {acc}"
         values={{
-          acc: !flat ? (
+          acc: (
             <div className={styles.status}>
               <div className={styles.accountName}>{account}</div>
             </div>
-          ) : (
-            account
           )
         }}
       />
@@ -66,53 +62,25 @@ const RegularTxRow = ({
           }
         />
       </span>
-      {!overview &&
-        (txDirection === TRANSACTION_DIR_TRANSFERRED ? (
-          <div className={classNames("is-row", styles.txDirection)}>
-            <TxDirection account={txAccountNameDebited} />
-            <TxDirection account={txAccountNameCredited} isCred />
-          </div>
-        ) : txDirection !== TRANSACTION_DIR_RECEIVED ? (
-          <div className={classNames("is-row", styles.txDirection)}>
-            <TxDirection account={txAccountName} />
-            <TxDirection account={txOutputAddresses} isCred />
-          </div>
-        ) : (
-          <div className={classNames("is-row", styles.txDirection)}>
-            <TxDirection account={txAccountName} isCred />
-          </div>
-        ))}
+      {txDirection === TRANSACTION_DIR_TRANSFERRED ? (
+        <div className={classNames("is-row", styles.txDirection)}>
+          <TxDirection account={txAccountNameDebited} />
+          <TxDirection account={txAccountNameCredited} isCred />
+        </div>
+      ) : txDirection !== TRANSACTION_DIR_RECEIVED ? (
+        <div className={classNames("is-row", styles.txDirection)}>
+          <TxDirection account={txAccountName} />
+          <TxDirection account={txOutputAddresses} isCred />
+        </div>
+      ) : (
+        <div className={classNames("is-row", styles.txDirection)}>
+          <TxDirection account={txAccountName} isCred />
+        </div>
+      )}
       {!pending && (
         <div className={styles.timeDateSpacer}>{timeMessage(txTs)}</div>
       )}
     </div>
-    {overview && (
-      <div className={styles.amountHash}>
-        <Text id={`fromto-${(txTs || new Date()).getTime()}`} truncate>
-          {txDirection === TRANSACTION_DIR_TRANSFERRED ? (
-            <>
-              <TxDirection account={txAccountNameDebited} flat />
-              <TxDirection account={txAccountNameDebited} flat isCred />
-            </>
-          ) : txDirection !== TRANSACTION_DIR_RECEIVED ? (
-            <T
-              id="txHistory.overview.tx"
-              m="From {debAcc} To {credAcc}"
-              values={{
-                debAcc: txAccountName,
-                credAcc: txOutputAddresses
-              }}
-            />
-          ) : (
-            <T
-              id="txHistory.overview.in.tx"
-              m="To {credAcc}"
-              values={{ credAcc: txAccountName }}
-            />
-          )}
-        </Text>
-      </div>
-    )}
   </Row>
 );
 

--- a/app/components/shared/TxHistory/RegularTxRow.jsx
+++ b/app/components/shared/TxHistory/RegularTxRow.jsx
@@ -8,6 +8,40 @@ import {
 import styles from "./TxHistory.module.css";
 import { classNames, Text } from "pi-ui";
 
+const TxDirection = ({ account, isCred, flat }) => (
+  <span className={"is-row"}>
+    {isCred ? (
+      <T
+        id="txHistory.out.tx"
+        m="To {acc}"
+        values={{
+          acc: !flat ? (
+            <div className={styles.status}>
+              <div className={styles.accountName}>{account}</div>
+            </div>
+          ) : (
+            account
+          )
+        }}
+      />
+    ) : (
+      <T
+        id="txHistory.in.tx"
+        m="From {acc}"
+        values={{
+          acc: !flat ? (
+            <div className={styles.status}>
+              <div className={styles.accountName}>{account}</div>
+            </div>
+          ) : (
+            account
+          )
+        }}
+      />
+    )}
+  </span>
+);
+
 const RegularTxRow = ({
   txAmount,
   txDirection,
@@ -23,7 +57,7 @@ const RegularTxRow = ({
   ...props
 }) => (
   <Row {...{ ...props, txAccountName, pending, overview }}>
-    <div className="is-row">
+    <div className={classNames(styles.info, overview && styles.overviewInfo)}>
       <span className={classNames(styles[className], styles.icon)} />
       <span className={styles.amountValue}>
         <Balance
@@ -34,62 +68,18 @@ const RegularTxRow = ({
       </span>
       {!overview &&
         (txDirection === TRANSACTION_DIR_TRANSFERRED ? (
-          <div className={classNames("is-row", styles.info)}>
-            <T
-              id="txHistory.transfer.tx"
-              m="From {debAcc} To {credAcc}"
-              values={{
-                debAcc: (
-                  <div className={styles.status}>
-                    <div className={styles.accountName}>
-                      {txAccountNameDebited}
-                    </div>
-                  </div>
-                ),
-                credAcc: (
-                  <div className={styles.status}>
-                    <div className={styles.accountName}>
-                      {txAccountNameCredited}
-                    </div>
-                  </div>
-                )
-              }}
-            />
+          <div className={classNames("is-row", styles.txDirection)}>
+            <TxDirection account={txAccountNameDebited} />
+            <TxDirection account={txAccountNameCredited} isCred />
           </div>
         ) : txDirection !== TRANSACTION_DIR_RECEIVED ? (
-          <div className={classNames("is-row", styles.info)}>
-            <T
-              id="txHistory.out.tx"
-              m="From {debAcc} To {credAcc}"
-              values={{
-                debAcc: (
-                  <div className={styles.status}>
-                    <div className={styles.accountName}>{txAccountName}</div>
-                  </div>
-                ),
-                credAcc: (
-                  <div className={styles.status}>
-                    <div className={styles.accountName}>
-                      {txOutputAddresses}
-                    </div>
-                  </div>
-                )
-              }}
-            />
+          <div className={classNames("is-row", styles.txDirection)}>
+            <TxDirection account={txAccountName} />
+            <TxDirection account={txOutputAddresses} isCred />
           </div>
         ) : (
-          <div className={classNames("is-row", styles.info)}>
-            <T
-              id="txHistory.in.tx"
-              m="To {credAcc}"
-              values={{
-                credAcc: (
-                  <div className={styles.status}>
-                    <div className={styles.accountName}>{txAccountName}</div>
-                  </div>
-                )
-              }}
-            />
+          <div className={classNames("is-row", styles.txDirection)}>
+            <TxDirection account={txAccountName} isCred />
           </div>
         ))}
       {!pending && (
@@ -100,17 +90,13 @@ const RegularTxRow = ({
       <div className={styles.amountHash}>
         <Text id={`fromto-${(txTs || new Date()).getTime()}`} truncate>
           {txDirection === TRANSACTION_DIR_TRANSFERRED ? (
-            <T
-              id="txHistory.transfer.tx"
-              m="From {debAcc} To {credAcc}"
-              values={{
-                debAcc: txAccountNameDebited,
-                credAcc: txAccountNameCredited
-              }}
-            />
+            <>
+              <TxDirection account={txAccountNameDebited} flat />
+              <TxDirection account={txAccountNameDebited} flat isCred />
+            </>
           ) : txDirection !== TRANSACTION_DIR_RECEIVED ? (
             <T
-              id="txHistory.out.tx"
+              id="txHistory.overview.tx"
               m="From {debAcc} To {credAcc}"
               values={{
                 debAcc: txAccountName,
@@ -119,7 +105,7 @@ const RegularTxRow = ({
             />
           ) : (
             <T
-              id="txHistory.in.tx"
+              id="txHistory.overview.in.tx"
               m="To {credAcc}"
               values={{ credAcc: txAccountName }}
             />

--- a/app/components/shared/TxHistory/StakeTxRow.jsx
+++ b/app/components/shared/TxHistory/StakeTxRow.jsx
@@ -63,10 +63,13 @@ const StakeTxRow = ({
   // If txType equals ticket, we use the message bype by the tx status, so we
   // can show the proper icon (Revoked, Voted). Although we show the message
   // as Purchased, to avoid confusion.
-  const typeMsg = txType === "ticket" ? messageByType[status] : messageByType[txType] || "(unknown type)";
+  const typeMsg =
+    txType === "ticket"
+      ? messageByType[status]
+      : messageByType[txType] || "(unknown type)";
   return overview ? (
     <Row {...{ className, overview, pending, ...props }}>
-      <div className="is-row">
+      <div className={styles.overviewInfo}>
         <span className={classNames(styles[className], styles.icon)} />
         <span
           className={classNames(styles.stakeType, overview && styles.overview)}>

--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -99,13 +99,25 @@
 }
 
 .info {
-  margin-left: auto;
+  display: grid;
+  grid-template-columns: 0.5fr 3fr 10fr 3fr;
+  width: 100%;
+}
+
+.overviewInfo {
+  display: grid;
+  grid-template-columns: 1fr 8fr 8fr;
 }
 
 .status {
   padding-top: 1px;
   text-align: right;
-  flex-grow: 2;
+  margin-left: 5px;
+  max-width: 210px;
+}
+
+.txDirection {
+  justify-self: right;
 }
 
 .accountName {
@@ -123,7 +135,7 @@
 
 .timeDateSpacer {
   font-size: 11px;
-  margin-right: 20px;
+  text-align: right;
 }
 
 .overviewPending .txInfo {
@@ -245,6 +257,7 @@
 
 .historyRow .txInfo .txRowWrapper {
   padding: 16px 20px;
+  width: 90%;
 }
 
 .eligibleRow {
@@ -266,6 +279,27 @@
     width: 355px;
   }
   .accountName {
-    display: none;
+    background: transparent;
+    padding: 0 3px;
+    height: 20px;
+  }
+  .status {
+    padding-top: 0px;
+  }
+  .txDirection {
+    align-self: center;
+    order: 4;
+    grid-column-start: 1;
+    justify-self: left;
+    grid-column-end: 4;
+    font-size: 11px;
+    padding-bottom: 3px;
+  }
+  .txRowWrapper {
+    padding: 5px 20px 27px 20px !important;
+  }
+  .info {
+    grid-template-columns: 0.5fr 3fr 3fr;
+    padding-bottom: 1rem;
   }
 }

--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -84,20 +84,6 @@
   margin-left: 10px;
 }
 
-.amountHash {
-  font-family: var(--font-family-monospace);
-  margin-left: 34px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.amountHash > span {
-  color: var(--overview-balance-label) !important;
-  font-size: 11px !important;
-  line-height: 11px !important;
-}
-
 .info {
   display: grid;
   grid-template-columns: 0.5fr 3fr 10fr 3fr;
@@ -109,8 +95,25 @@
   grid-template-columns: 1fr 8fr 8fr;
 }
 
+.overviewInfo .txDirection {
+  align-self: center;
+  order: 4;
+  grid-column-start: 1;
+  justify-self: left;
+  grid-column-end: 4;
+  font-size: 11px;
+  padding-bottom: 3px;
+  color: var(--overview-balance-label) !important;
+  font-family: var(--font-family-monospace);
+}
+
+.overviewInfo .txDirection .accountName {
+  background: transparent;
+  padding: 0 3px;
+  height: 20px;
+}
+
 .status {
-  padding-top: 1px;
   text-align: right;
   margin-left: 5px;
   max-width: 210px;
@@ -294,6 +297,8 @@
     grid-column-end: 4;
     font-size: 11px;
     padding-bottom: 3px;
+    color: var(--overview-balance-label) !important;
+    font-family: var(--font-family-monospace);
   }
   .txRowWrapper {
     padding: 5px 20px 27px 20px !important;


### PR DESCRIPTION
This diff closes #2690 by adding some CSS tweaks to improve the fields organization in the TxHistory row.

### Before

**Regular view:**
    <img width="1535" alt="Screen Shot 2020-10-10 at 9 26 35 AM" src="https://user-images.githubusercontent.com/22639213/95655014-bc1b8300-0ada-11eb-8d60-3256e3403768.png">

**Small-width view:**
    <img width="648" alt="Screen Shot 2020-10-10 at 9 33 20 AM" src="https://user-images.githubusercontent.com/22639213/95655151-ab1f4180-0adb-11eb-8199-a362acf0ff1e.png">

### After
**Regular view:**
    <img width="1535" alt="Screen Shot 2020-10-10 at 9 26 14 AM" src="https://user-images.githubusercontent.com/22639213/95655012-b9b92900-0ada-11eb-8357-df8ff436e2d8.png">

**Small-width view:**
    <img width="647" alt="Screen Shot 2020-10-10 at 9 32 25 AM" src="https://user-images.githubusercontent.com/22639213/95655153-ac506e80-0adb-11eb-8191-ba0a7fe0ae18.png">