### PR TITLE
Fix dark mode heading colours on Settings tab.

### DIFF
--- a/app/components/views/GetStartedPage/Settings/Settings.jsx
+++ b/app/components/views/GetStartedPage/Settings/Settings.jsx
@@ -52,9 +52,9 @@ const SetttingsForm = ({ onSendBack }) => {
         <Subtitle title={<T id="settings.subtitle" m="Settings" />} />
         <div className={styles.wrapper}>
           <div className={styles.group}>
-            <div className={styles.groupTitle}>
+            <Subtitle title={
               <T id="settings.group-title.connectivity" m="Connectivity" />
-            </div>
+            } />
             <div className={styles.columnWrapper}>
               <div className={styles.column}>
                 <NetworkSettings
@@ -71,9 +71,9 @@ const SetttingsForm = ({ onSendBack }) => {
           </div>
 
           <div className={classNames(styles.group, styles.general)}>
-            <div className={styles.groupTitle}>
+            <Subtitle title={
               <T id="settings.group-title.general" m="General" />
-            </div>
+            } />
             <div className={styles.columnWrapper}>
               <div className={styles.column}>
                 <UISettings
@@ -87,12 +87,12 @@ const SetttingsForm = ({ onSendBack }) => {
           </div>
 
           <div className={classNames(styles.group, styles.privacy)}>
-            <div className={styles.groupTitle}>
+            <Subtitle title={
               <T
                 id="settings.group-title.privacy-and-security"
                 m="Privacy and Security"
               />
-            </div>
+            } />
             <div className={styles.columnWrapper}>
                 <PrivacySettings
                   {...{

--- a/app/components/views/SettingsPage/Settings.jsx
+++ b/app/components/views/SettingsPage/Settings.jsx
@@ -14,6 +14,7 @@ import PrivacySettings from "./PrivacySettings";
 import UISettings from "./UISettings";
 import MiscSettings from "./MiscSettings";
 import TimezoneSettings from "./TimezoneSettings";
+import { Subtitle } from "shared";
 import "style/StakePool.less"; // TODO: delete this as well!
 import styles from "./Settings.module.css";
 import * as configConstants from "constants/config";
@@ -103,12 +104,12 @@ const SettingsPage = ({
       className="settings-standalone-page">
       <div className={styles.wrapper}>
         <div className={styles.group}>
-          <div className={styles.groupTitle}>
+          <Subtitle title={
             <T
               id="settings.getstartpage.group-title.connectivity"
               m="Connectivity"
             />
-          </div>
+          } />
           <div className={styles.columnWrapper}>
             <div className={styles.column}>
               <NetworkSettings
@@ -125,9 +126,9 @@ const SettingsPage = ({
         </div>
 
         <div className={classNames(styles.group, styles.general)}>
-          <div className={styles.groupTitle}>
+          <Subtitle title={
             <T id="settings.getstartpage.group-title.general" m="General" />
-          </div>
+          } />
           <div className={styles.columnWrapper}>
             <div className={styles.column}>
               <UISettings
@@ -153,12 +154,12 @@ const SettingsPage = ({
         </div>
 
         <div className={classNames(styles.group, styles.privacy)}>
-          <div className={styles.groupTitle}>
+          <Subtitle title={
             <T
               id="settings.getstartpage.group-title.privacy-and-security"
               m="Privacy and Security"
             />
-          </div>
+          } />
           <div className={styles.columnWrapper}>
               <PrivacySettings
                 {...{

--- a/app/components/views/SettingsPage/Settings.module.css
+++ b/app/components/views/SettingsPage/Settings.module.css
@@ -66,13 +66,6 @@
   padding: 40px 40px 10px 40px;
 }
 
-.groupTitle {
-  font-size: 20px;
-  line-height: 28px;
-  color: var(--vote-abstain-color);
-  margin-bottom: 14px;
-}
-
 .columnWrapper {
   padding: 20px 40px;
   display: flex;


### PR DESCRIPTION
Remove .css which is no longer required.

Fixes #2724 