### PR TITLE
[security] fix: improve sign message and address validation handlers

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -151,10 +151,7 @@ export const IMPORTSCRIPT_SUCCESS = "IMPORTSCRIPT_SUCCESS";
 
 // importScriptAttempt tries to import the given script into the wallet. It will
 // throw an exception in case of errors.
-export const importScriptAttempt = (script) => async (
-  dispatch,
-  getState
-) => {
+export const importScriptAttempt = (script) => async (dispatch, getState) => {
   dispatch({ type: IMPORTSCRIPT_ATTEMPT });
   const walletService = sel.walletService(getState());
   try {
@@ -181,9 +178,7 @@ export const IMPORTSCRIPT_MANUAL_FAILED = "IMPORTSCRIPT_MANUAL_FAILED";
 // meant as a step during some other operation (eg: linking to a stakepool).
 //
 // This function always initiates a complete wallet rescan in case of success.
-export const manualImportScriptAttempt = (script) => async (
-  dispatch
-) => {
+export const manualImportScriptAttempt = (script) => async (dispatch) => {
   try {
     await dispatch(importScriptAttempt(script));
     dispatch({ type: IMPORTSCRIPT_MANUAL_SUCCESS });
@@ -544,9 +539,6 @@ export const constructTransactionAttempt = (
   });
 };
 
-export const VALIDATEADDRESS_ATTEMPT = "VALIDATEADDRESS_ATTEMPT";
-export const VALIDATEADDRESS_FAILED = "VALIDATEADDRESS_FAILED";
-export const VALIDATEADDRESS_SUCCESS = "VALIDATEADDRESS_SUCCESS";
 export const VALIDATEADDRESS_CLEANSTORE = "VALIDATEADDRESS_CLEANSTORE";
 
 export const validateAddress = (address) => async (dispatch, getState) => {
@@ -555,7 +547,6 @@ export const validateAddress = (address) => async (dispatch, getState) => {
     const network = currentSettings.network;
     const validationErr = isValidAddress(address, network);
     if (validationErr) {
-      dispatch({ type: VALIDATEADDRESS_FAILED });
       return {
         isValid: false,
         error: validationErr,
@@ -564,13 +555,13 @@ export const validateAddress = (address) => async (dispatch, getState) => {
         }
       };
     }
-    dispatch({ type: VALIDATEADDRESS_ATTEMPT });
     const response = await wallet.validateAddress(
       sel.walletService(getState()),
       address
     );
-    dispatch({ response, type: VALIDATEADDRESS_SUCCESS });
+    const responseObj = response ? response.toObject() : {};
     return {
+      ...responseObj,
       isValid: response.getIsValid(),
       error: null,
       getIsValid() {
@@ -578,7 +569,6 @@ export const validateAddress = (address) => async (dispatch, getState) => {
       }
     };
   } catch (error) {
-    dispatch({ type: VALIDATEADDRESS_FAILED });
     return {
       isValid: false,
       error,
@@ -606,9 +596,6 @@ export const validateMasterPubKey = (masterPubKey) => (dispatch) => {
     return { isValid: false, error };
   }
 };
-
-export const validateAddressCleanStore = (dispatch) =>
-  dispatch({ type: VALIDATEADDRESS_CLEANSTORE });
 
 export const SIGNMESSAGE_ATTEMPT = "SIGNMESSAGE_ATTEMPT";
 export const SIGNMESSAGE_FAILED = "SIGNMESSAGE_FAILED";

--- a/app/components/views/SecurityPage/SignMessage/SignMessage.jsx
+++ b/app/components/views/SecurityPage/SignMessage/SignMessage.jsx
@@ -32,13 +32,17 @@ const SignMessage = ({ location, intl }) => {
 
   const onChangeAddress = async (address) => {
     setAddress(address);
-    if (address == "") {
+    if (address === "") {
       setAddressError("Please enter an address");
       return;
     }
     try {
       const resp = await onValidateAddress(address);
-      setAddressError(!resp.getIsValid() ? "Please enter a valid address" : null);
+      setAddressError(
+        !resp.getIsValid() || !resp.isMine
+          ? "Please enter a valid address owned by you"
+          : null
+      );
     } catch (e) {
       setAddressError("Error: Address validation failed, please try again");
     }
@@ -46,7 +50,7 @@ const SignMessage = ({ location, intl }) => {
 
   const onChangeMessage = (msg) => {
     setMessage(msg);
-    if (msg == "") {
+    if (msg === "") {
       setMessageError("Please enter a message");
     } else {
       setMessageError(null);

--- a/app/components/views/SecurityPage/SignMessage/SignMessageForm.jsx
+++ b/app/components/views/SecurityPage/SignMessage/SignMessageForm.jsx
@@ -29,12 +29,13 @@ const SignMessageForm = ({
   onChangeAddress,
   onChangeMessage
 }) => {
-  const disabled = isSigningMessage
-    || address == ""
-    || message == ""
-    || addressError
-    || messageError
-    || isSignMessageDisabled;
+  const disabled =
+    isSigningMessage ||
+    address === "" ||
+    message === "" ||
+    addressError ||
+    messageError ||
+    isSignMessageDisabled;
   return (
     <>
       <div className={sharedStyles.securityPageForm}>

--- a/app/components/views/SecurityPage/ValidateAddress/ValidateAddress.jsx
+++ b/app/components/views/SecurityPage/ValidateAddress/ValidateAddress.jsx
@@ -1,20 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import ValidateAddressForm from "./ValidateAddressForm";
 import { useValidateAddress } from "./hooks";
 
 const ValidateAddress = () => {
-  const {
-    validateAddressSuccess,
-    onValidateAddress,
-    onValidateAddressCleanStore
-  } = useValidateAddress();
+  const { onValidateAddress, validateAddressSuccess } = useValidateAddress();
   const [address, setAddress] = useState("");
   const [error, setError] = useState(null);
-
-  useEffect(() => {
-    onValidateAddressCleanStore();
-    return () => onValidateAddressCleanStore();
-  }, [onValidateAddressCleanStore]);
 
   const onChangeAddress = async (address) => {
     setAddress(address);

--- a/app/components/views/SecurityPage/ValidateAddress/hooks.js
+++ b/app/components/views/SecurityPage/ValidateAddress/hooks.js
@@ -1,28 +1,22 @@
-import { useCallback } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import * as sel from "selectors";
+import { useCallback, useState } from "react";
+import { useDispatch } from "react-redux";
 import * as ca from "actions/ControlActions";
 
 export function useValidateAddress() {
+  const [validateAddressSuccess, setValidateAddressSuccess] = useState();
   const dispatch = useDispatch();
-  const validateAddressError = useSelector(sel.validateAddressError);
-  const validateAddressSuccess = useSelector(sel.validateAddressSuccess);
-  const validateAddressRequestAttempt = useSelector(sel.validateAddressRequestAttempt);
 
   const onValidateAddress = useCallback(
-    (address) => dispatch(ca.validateAddress(address)),
-    [dispatch]
-  );
-  const onValidateAddressCleanStore = useCallback(
-    () => dispatch(ca.validateAddressCleanStore),
+    async (address) => {
+      const resp = await dispatch(ca.validateAddress(address));
+      setValidateAddressSuccess(resp);
+      return resp;
+    },
     [dispatch]
   );
 
   return {
-    validateAddressError,
     validateAddressSuccess,
-    validateAddressRequestAttempt,
-    onValidateAddress,
-    onValidateAddressCleanStore
+    onValidateAddress
   };
 }

--- a/app/components/views/SecurityPage/ValidateAddress/hooks.js
+++ b/app/components/views/SecurityPage/ValidateAddress/hooks.js
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { useDispatch } from "react-redux";
 import * as ca from "actions/ControlActions";
 
@@ -6,14 +6,11 @@ export function useValidateAddress() {
   const [validateAddressSuccess, setValidateAddressSuccess] = useState();
   const dispatch = useDispatch();
 
-  const onValidateAddress = useCallback(
-    async (address) => {
-      const resp = await dispatch(ca.validateAddress(address));
-      setValidateAddressSuccess(resp);
-      return resp;
-    },
-    [dispatch]
-  );
+  const onValidateAddress = async (address) => {
+    const resp = await dispatch(ca.validateAddress(address));
+    setValidateAddressSuccess(resp);
+    return resp;
+  };
 
   return {
     validateAddressSuccess,

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -62,10 +62,6 @@ import {
   CONSTRUCTTX_SUCCESS,
   CONSTRUCTTX_FAILED_LOW_BALANCE,
   SETBALANCETOMAINTAIN,
-  VALIDATEADDRESS_ATTEMPT,
-  VALIDATEADDRESS_SUCCESS,
-  VALIDATEADDRESS_FAILED,
-  VALIDATEADDRESS_CLEANSTORE,
   MODAL_SHOWN,
   MODAL_HIDDEN,
   SHOW_ABOUT_MODAL_MACOS,
@@ -488,26 +484,6 @@ export default function control(state = {}, action) {
         constructTxRequestAttempt: false,
         constructTxResponse: action.constructTxResponse
       };
-    case VALIDATEADDRESS_ATTEMPT:
-      return {
-        ...state,
-        validateAddressRequestAttempt: true,
-        validateAddressResponse: null
-      };
-    case VALIDATEADDRESS_SUCCESS:
-      return {
-        ...state,
-        validateAddressRequestAttempt: false,
-        validateAddressResponse: action.response
-      };
-    case VALIDATEADDRESS_FAILED:
-      return {
-        ...state,
-        validateAddressRequestAttempt: false,
-        validateAddressResponse: null
-      };
-    case VALIDATEADDRESS_CLEANSTORE:
-      return { ...state, validateAddressResponse: null };
     case WALLET_AUTOBUYER_SETTINGS:
       return { ...state, balanceToMaintain: action.balanceToMaintain };
     case EXPORT_STARTED:

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -320,7 +320,15 @@ export const ticketNormalizer = createSelector(
   [network, accounts, chainParams, txURLBuilder, blockURLBuilder],
   (network, accounts, chainParams, txURLBuilder, blockURLBuilder) => {
     return (ticket) => {
-      const { txType, status, spender, blockHash, rawTx, isStake, timestamp } = ticket;
+      const {
+        txType,
+        status,
+        spender,
+        blockHash,
+        rawTx,
+        isStake,
+        timestamp
+      } = ticket;
       // TODO refactor same code to be used in tickets and regular tx normalizers.
       const findAccount = (num) =>
         accounts.find((account) => account.getAccountNumber() === num);
@@ -1015,19 +1023,6 @@ export const verifyMessageSuccess = compose(
   (r) => (r ? r.toObject() : null),
   verifyMessageResponse
 );
-export const validateAddressRequestAttempt = get([
-  "control",
-  "validateAddressRequestAttempt"
-]);
-export const validateAddressError = get(["control", "validateAddressError"]);
-export const validateAddressResponse = get([
-  "control",
-  "validateAddressResponse"
-]);
-export const validateAddressSuccess = compose(
-  (r) => (r ? r.toObject() : null),
-  validateAddressResponse
-);
 
 const getStakeInfoResponse = get(["grpc", "getStakeInfoResponse"]);
 
@@ -1507,9 +1502,7 @@ export const trezorWalletCreationMasterPubkeyAttempt = get([
   "walletCreationMasterPubkeyAttempt"
 ]);
 
-export const lnEnabled = bool(
-  and(not(isWatchingOnly), not(isTrezor))
-);
+export const lnEnabled = bool(and(not(isWatchingOnly), not(isTrezor)));
 export const lnActive = bool(get(["ln", "active"]));
 export const lnStartupStage = get(["ln", "startupStage"]);
 export const lnStartAttempt = bool(get(["ln", "startAttempt"]));


### PR DESCRIPTION
This diff Closes #2700, which reported an unexpected behavior regarding address validation on security page.

I figured out that the addressValidation stuff was using the redux tree to manage the address validation state. But since we use the `useValidateAddress` on multiple components, each one behaving differently according to the `address`, it makes no sense to store the responses on the redux tree.

I thought of caching those address in the redux tree, but I think it's an overkill fo this feature, since there are not much cases we need to keep the validation responses stored.

Therefore, the solution was to keep the validation response as a state variable, and remove the address validation away from the redux tree.