### PR TITLE
[transactions] fix: receive transaction page visual adjustments

### DIFF
--- a/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.module.css
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.module.css
@@ -2,8 +2,9 @@
   background-color: var(--background-back-color);
   padding-top: 20px;
   padding-left: 28px;
-  width: 740px;
-  box-sizing: border-box;
+  max-width: 740px;
+  width: 100%;
+  box-sizing: border-box !important;
   display: flex;
   flex-direction: column;
 }
@@ -204,8 +205,9 @@
 .generateButton {
   position: relative;
   margin-top: 20px;
-  margin-left: 600px;
-  width: 185px;
+  text-align: right;
+  width: 100%;
+  max-width: 740px;
   height: 45px;
 }
 
@@ -244,7 +246,7 @@
   }
 
   .generateButton {
-    margin-left: 216px;
+    width: 355px;
   }
 
   .copyParent {


### PR DESCRIPTION
This minor diff fixes some styles and responsiveness on receive transactions page. Closes #2751.

**Before:**
![img](https://user-images.githubusercontent.com/22639213/96578116-0e169280-12ab-11eb-8bcd-598f8f7c8460.png)

**After:**
<img width="773" alt="Screen Shot 2020-10-20 at 11 33 25 AM" src="https://user-images.githubusercontent.com/22639213/96601122-14ffce00-12c8-11eb-91d2-ba7c723340c5.png">
