### PR TITLE
Ask for passphrase if account discovery is needed

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -333,7 +333,7 @@ export const closeDaemonRequest = () => async (dispatch, getState) => {
   }
 };
 
-export const startWallet = (selectedWallet) => (dispatch, getState) =>
+export const startWallet = (selectedWallet, hasPassPhrase) => (dispatch, getState) =>
   new Promise((resolve, reject) => {
     const start = async () => {
       const { currentSettings } = getState().settings;
@@ -412,9 +412,11 @@ export const startWallet = (selectedWallet) => (dispatch, getState) =>
         currentStakePoolConfig,
         dismissBackupRedeemScript
       });
+      const needsPassPhrase = !discoverAccountsComplete && !hasPassPhrase;
       dispatch({
         type: WALLET_LOADER_SETTINGS,
         discoverAccountsComplete,
+        needsPassPhrase,
         enablePrivacy,
         mixedAccount,
         changeAccount,

--- a/app/components/views/GetStartedPage/OpenWallet/DiscoverAccounts.jsx
+++ b/app/components/views/GetStartedPage/OpenWallet/DiscoverAccounts.jsx
@@ -1,0 +1,38 @@
+import { useState, useCallback } from "react";
+import PassphraseForm from "./PassphraseForm";
+
+const DiscoverAccounts = ({ onSendSetPassphrase }) => {
+  const [passPhrase, setPassPhrase] = useState("");
+
+  const onContinueHandler = useCallback(() => {
+    if (passPhrase == "") {
+      return;
+    }
+
+    onSendSetPassphrase(passPhrase);
+  }, [onSendSetPassphrase, passPhrase]);
+
+
+  const onKeyDown = useCallback(
+    (e) => {
+      if (e.keyCode == 13) {
+        e.preventDefault();
+        onContinueHandler();
+      }
+    },
+    [onContinueHandler]
+  );
+
+  return (
+    <PassphraseForm
+      {...{
+        passPhrase,
+        onSetPassPhrase: setPassPhrase,
+        onOpenWallet: onContinueHandler,
+        onKeyDown
+      }}
+    />
+  );
+};
+
+export default DiscoverAccounts;

--- a/app/components/views/GetStartedPage/OpenWallet/OpenWallet.jsx
+++ b/app/components/views/GetStartedPage/OpenWallet/OpenWallet.jsx
@@ -1,9 +1,9 @@
 import { useState, useCallback } from "react";
 import OpenWalletDecryptFormBody from "./DecryptForm";
 import { FormattedMessage as T } from "react-intl";
-import { OPENWALLET_FAILED_INPUT } from "actions/WalletLoaderActions";
+import { OPENWALLET_FAILED_INPUT, OPENWALLET_INPUTPRIVPASS } from "actions/WalletLoaderActions";
 
-const OpenWallet = ({ onOpenWallet, onSendContinue, onSendError }) => {
+const OpenWallet = ({ onOpenWallet, onSendContinue, onSendError, onSendDiscoverAccountsPassInput }) => {
   const [publicPassPhrase, setPublicPassPhrase] = useState("");
 
   const onOpenWalletHandler = useCallback(() => {
@@ -13,6 +13,11 @@ const OpenWallet = ({ onOpenWallet, onSendContinue, onSendError }) => {
     onOpenWallet(publicPassPhrase, true)
       .then(() => onSendContinue())
       .catch((error) => {
+        if (error === OPENWALLET_INPUTPRIVPASS) {
+          onSendError(null);
+          return onSendDiscoverAccountsPassInput();
+        }
+
         if (error === OPENWALLET_FAILED_INPUT) {
           return onSendError(
             <T
@@ -24,7 +29,7 @@ const OpenWallet = ({ onOpenWallet, onSendContinue, onSendError }) => {
         onSendError(error);
       })
       .finally(() => setPublicPassPhrase(""));
-  }, [onOpenWallet, onSendContinue, onSendError, publicPassPhrase]);
+  }, [onOpenWallet, onSendContinue, onSendError, publicPassPhrase, onSendDiscoverAccountsPassInput]);
 
   const onKeyDown = useCallback(
     (e) => {

--- a/app/components/views/GetStartedPage/OpenWallet/PassphraseForm.jsx
+++ b/app/components/views/GetStartedPage/OpenWallet/PassphraseForm.jsx
@@ -1,0 +1,50 @@
+import { KeyBlueButton } from "buttons";
+import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
+import { PasswordInput } from "inputs";
+import styles from "../GetStarted.module.css";
+
+const messages = defineMessages({
+  privatePassphrasePlaceholder: {
+    id: "getStarted.decrypt.passphrasePlaceholder",
+    defaultMessage: "Private Passphrase"
+  }
+});
+
+const PassphraseFormBase = ({
+  passPhrase,
+  intl,
+  onSetPassPhrase,
+  onOpenWallet,
+  onKeyDown
+}) => (
+  <div className={styles.pageForm}>
+    <div className={styles.daemonRow}>
+      <T
+        id="getStarted.passphrase.info"
+        m="The accounts for this wallet haven't been discovered yet. Please enter the wallet's private passphrase to perform account discovery."
+      />
+    </div>
+    <div className={styles.deamonRow}>
+      <div className={styles.daemonLabel}>
+        <T id="getStarted.discoverAccounts.passphrase" m="Private Passphrase" />
+      </div>
+      <div className={styles.daemonInput}>
+        <PasswordInput
+          autoFocus
+          className={styles.inputPrivatePassword}
+          placeholder={intl.formatMessage(messages.privatePassphrasePlaceholder)}
+          value={passPhrase}
+          onChange={(e) => onSetPassPhrase(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+      </div>
+    </div>
+    <div className={styles.loaderBarButtons}>
+      <KeyBlueButton onClick={onOpenWallet} disabled={passPhrase == ""}>
+        <T id="passphraseForm.continueBtn" m="Continue" />
+      </KeyBlueButton>
+    </div>
+  </div>
+);
+
+export default injectIntl(PassphraseFormBase);

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -160,7 +160,7 @@ export const useGetStarted = () => {
       isSyncingRPC: async (context) => {
         const { passPhrase, isPrivacy } = context;
         if (context.isSPV) {
-          return startSPVSync()
+          return startSPVSync(passPhrase)
             .then(() => send({ type: "GO_TO_HOME_VIEW" }))
             .catch((error) =>
               send({ type: "ERROR_SYNCING_WALLET", payload: { error } })

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -66,7 +66,11 @@ export default function walletLoader(state = {}, action) {
     case WALLET_SELECTED:
       return { ...state, selectedWallet: action.selectedWallet };
     case OPENWALLET_SUCCESS:
-      return { ...state, isWatchingOnly: action.isWatchingOnly };
+      return {
+        ...state,
+        isWatchingOnly: action.isWatchingOnly,
+        needsPassPhrase: false
+      };
     case CLOSEWALLET_FAILED:
       return {
         ...state,
@@ -88,7 +92,8 @@ export default function walletLoader(state = {}, action) {
         syncAttemptRequest: false,
         syncError: null,
         synced: false,
-        syncLastFetchedHeaderTime: null
+        syncLastFetchedHeaderTime: null,
+        needsPassPhrase: false
       };
     case UPDATEDISCOVERACCOUNTS:
       return { ...state, discoverAccountsComplete: action.complete };
@@ -96,6 +101,7 @@ export default function walletLoader(state = {}, action) {
       return {
         ...state,
         discoverAccountsComplete: action.discoverAccountsComplete,
+        needsPassPhrase: action.needsPassPhrase,
         privacyEnabled: action.enablePrivacy,
         mixedAccount: action.mixedAccount,
         changeAccount: action.changeAccount,

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -211,6 +211,7 @@ export const getStartedMachine = Machine({
           on: {
             SYNC_RPC: "syncingRPC",
             WALLET_PUBPASS_INPUT: "walletPubpassInput",
+            WALLET_DISCOVERACCOUNTS_PASS: "walletDiscoverAccountsPassInput",
             ERROR: {
               target: "choosingWallet",
               actions: assign({
@@ -222,6 +223,7 @@ export const getStartedMachine = Machine({
         walletPubpassInput: {
           onEntry: "isAtWalletPubpassInput",
           on: {
+            WALLET_DISCOVERACCOUNTS_PASS: "walletDiscoverAccountsPassInput",
             CONTINUE: "syncingRPC",
             ERROR: {
               target: "walletPubpassInput",
@@ -231,9 +233,27 @@ export const getStartedMachine = Machine({
             }
           }
         },
+        walletDiscoverAccountsPassInput: {
+          onEntry: "isAtWalletDiscoverAccountsPassInput",
+          on: {
+            SETPASSPHRASE: {
+              target: "syncingRPC",
+              actions: assign({
+                passPhrase: (context, event) => event.passPhrase
+              })
+            },
+            ERROR: {
+              target: "walletDiscoverAccountsPassInput",
+              actions: assign({
+                error: (context, event) => event.error && event.error
+              })
+            }
+          }
+        },
         syncingRPC: {
           onEntry: "isSyncingRPC",
           on: {
+            WALLET_DISCOVERACCOUNTS_PASS: "walletDiscoverAccountsPassInput",
             ERROR_SYNCING_WALLET: {
               target: "choosingWallet",
               actions: assign({


### PR DESCRIPTION
This fixes a bug in SPV wallets where account discovery was broken on restored wallets which had more than one account. Discovery wasn't happening due to the passphrase not being passed along to the SpvSync.

It also modifies the get started sequence to ask for the private passphrase if account discovery hasn't completed yet, so that restarting a wallet restore after some blocks have been synced but before accounts have been discovered correctly finds the additional accounts.

Testing the passphrase request can be done by starting a wallet restore, then closing Decrediton during the initial block sync.

There are four different combinations for being presented the passphrase request view: 

- SPV Sync vs RPC Sync
- Wallet with vs without public passphrase
