### PR TITLE
TrezorActions: Allow updating firmware.

### DIFF
--- a/app/actions/TrezorActions.js
+++ b/app/actions/TrezorActions.js
@@ -1,7 +1,7 @@
 import * as wallet from "wallet";
 import * as selectors from "selectors";
 import fs from "fs";
-import { hexToBytes, str2utf8hex } from "helpers";
+import { rawToHex, hexToBytes, str2utf8hex } from "helpers";
 import {
   walletTxToBtcjsTx,
   walletTxToRefTx,
@@ -22,6 +22,7 @@ import {
   SIGNMESSAGE_SUCCESS
 } from "./ControlActions";
 import { getAmountFromTxInputs, getTxFromInputs } from "./TransactionActions";
+import { ipcRenderer } from "electron";
 
 const session = require("connect").default;
 const { TRANSPORT_EVENT, UI, UI_EVENT, DEVICE_EVENT } = require("connect");
@@ -32,6 +33,8 @@ const AQUIRED = "acquired";
 const NOBACKUP = "no-backup";
 const TRANSPORT_ERROR = "transport-error";
 const TRANSPORT_START = "transport-start";
+const BOOTLOADER_MODE = "bootloader";
+const DISCONNECTED_DURING_ACTION = "device disconnected during action";
 
 let setListeners = false;
 
@@ -56,7 +59,7 @@ export const enableTrezor = () => (dispatch, getState) => {
   connect()(dispatch, getState);
 };
 
-async function initTransport(dispatch, debug) {
+export const initTransport = async (session, debug) => {
   await session.init({
     connectSrc: "https://localhost:8088/",
     env: "web",
@@ -71,7 +74,7 @@ async function initTransport(dispatch, debug) {
     .catch(err => {
       throw err;
     });
-}
+};
 
 export const TRZ_CONNECT_ATTEMPT = "TRZ_CONNECT_ATTEMPT";
 export const TRZ_CONNECT_FAILED = "TRZ_CONNECT_FAILED";
@@ -87,7 +90,7 @@ export const connect = () => async (dispatch, getState) => {
   wallet.allowExternalRequest(EXTERNALREQUEST_TREZOR_BRIDGE);
 
   const debug = getState().trezor.debug;
-  await initTransport(dispatch, debug)
+  await initTransport(session, debug)
     .catch(error => {
       dispatch({ error, type: TRZ_CONNECT_FAILED });
       return;
@@ -111,20 +114,26 @@ export const TRZ_SELECTEDDEVICE_CHANGED = "TRZ_SELECTEDDEVICE_CHANGED";
 export const TRZ_NOCONNECTEDDEVICE = "TRZ_NOCONNECTEDDEVICE";
 
 function onChange(dispatch, getState, features) {
-  if (features == null) throw "no features on change";
+  if (features == null) return;
   const currentDevice = selectors.trezorDevice(getState());
-  const device = features.id;
   // No current device handle by connect.
   if (!currentDevice) return;
+  let device = features.id;
+  if (features.mode == BOOTLOADER_MODE) {
+    device = BOOTLOADER_MODE;
+  }
   if (device == currentDevice) return;
   const deviceLabel = features.label;
   dispatch({ deviceLabel, device, type: TRZ_SELECTEDDEVICE_CHANGED });
 };
 
 function onConnect(dispatch, getState, features) {
-  if (features == null) throw "no features on connect";
-  const device = features.id;
+  if (features == null) return;
+  let device = features.id;
   const deviceLabel = features.label;
+  if (features.mode == BOOTLOADER_MODE) {
+    device = BOOTLOADER_MODE;
+  }
   dispatch({ deviceLabel, device, type: TRZ_LOADDEVICE });
   return device;
 };
@@ -175,11 +184,12 @@ function setDeviceListeners(dispatch, getState) {
         break;
     };
   });
+
   session.on(DEVICE_EVENT, (event) => {
     const type = event.type;
     switch (type) {
       case CHANGE:
-        if (event.payload.type == AQUIRED) {
+        if (event.payload && event.payload.type == AQUIRED) {
           onChange(dispatch, getState, event.payload);
         }
         break;
@@ -191,6 +201,7 @@ function setDeviceListeners(dispatch, getState) {
         break;
     };
   });
+
   // TODO: Trezor needs some time to start listening for the responses to its
   // requests. Find a better way than static sleeps to accomplish this.
   session.on(UI_EVENT, async (event) => {
@@ -274,9 +285,8 @@ async function deviceRun(dispatch, getState, fn) {
   if (noDevice(getState)) throw "no trezor device";
   const handleError = (error) => {
     const {
-      trezor: { waitingForPin, waitingForPassphrase, debug }
+      trezor: { waitingForPin, waitingForPassphrase }
     } = getState();
-    debug && console.log("Handle error no deviceRun", error);
     if (waitingForPin) dispatch({ error, type: TRZ_PIN_CANCELED });
     if (waitingForPassphrase)
       dispatch({ error, type: TRZ_PASSPHRASE_CANCELED });
@@ -289,21 +299,11 @@ async function deviceRun(dispatch, getState, fn) {
   };
 
   try {
-    const waitFor = async () => {
-      try {
-        return await fn();
-      } catch (err) {
-        // doesn't seem to be reachable by trezor interruptions, but might be
-        // caused by fn() failing in some other way (even though it's
-        // recommended not to do (non-trezor) lengthy operations inside fn())
-        throw handleError(err);
-      }
-    };
-    const res = await waitFor();
+    const res = await fn();
     if (res && res.error) throw handleError(res.error);
     return res;
-  } catch (outerErr) {
-    throw handleError(outerErr);
+  } catch (error) {
+    throw handleError(error);
   }
 };
 
@@ -776,13 +776,22 @@ export const TRZ_UPDATEFIRMWARE_ATTEMPT = "TRZ_UPDATEFIRMWARE_ATTEMPT";
 export const TRZ_UPDATEFIRMWARE_FAILED = "TRZ_UPDATEFIRMWARE_FAILED";
 export const TRZ_UPDATEFIRMWARE_SUCCESS = "TRZ_UPDATEFIRMWARE_SUCCESS";
 
+// updateFirmware attempts to update the device's firmware. For some reason,
+// possibly the size of the firmware, this action will not complete if called
+// from here. We send the firmware to a higher place in the electron hiearchy
+// to send it for us.
 export const updateFirmware = (path) => async (dispatch, getState) => {
+  // Attempting to update the firmware while already updating will cause the
+  // trezor to lock up.
+  const {
+    trezor: { performingUpdate }
+  } = getState();
+  if (performingUpdate) {
+    console.log("already updating firmware");
+    return;
+  }
+
   dispatch({ type: TRZ_UPDATEFIRMWARE_ATTEMPT });
-  // TODO: Allow firmware installation.
-  dispatch({ error: "firware install currently disabled", type: TRZ_UPDATEFIRMWARE_FAILED });
-  // Strange var to fool linter.
-  const abort = true;
-  if (abort) return;
 
   if (noDevice(getState)) {
     dispatch({
@@ -794,13 +803,11 @@ export const updateFirmware = (path) => async (dispatch, getState) => {
 
   try {
     const rawFirmware = fs.readFileSync(path);
-
-    await deviceRun(dispatch, getState, async () => {
-      const res = await session.firmwareUpdate({
-        binary: rawFirmware.buffer
-      });
-      return res.payload;
-    });
+    const hexFirmware = rawToHex(rawFirmware);
+    // Ask main.development.js to send the firmware for us.
+    const errorStr = await ipcRenderer.invoke("upload-firmware", hexFirmware);
+    // A successful upload will end with the user unplugging the device.
+    if (errorStr != DISCONNECTED_DURING_ACTION) throw errorStr;
     dispatch({ type: TRZ_UPDATEFIRMWARE_SUCCESS });
   } catch (error) {
     dispatch({ error, type: TRZ_UPDATEFIRMWARE_FAILED });

--- a/app/components/views/TrezorPage/ConfigSections.js
+++ b/app/components/views/TrezorPage/ConfigSections.js
@@ -46,6 +46,10 @@ class TrezorConfigSections extends React.Component {
     this.props.backupDevice();
   }
 
+  isUpdating() {
+   return this.props.isPerformingUpdate;
+  }
+
   render() {
     const {
       onTogglePinProtection,
@@ -57,6 +61,7 @@ class TrezorConfigSections extends React.Component {
       onInitDevice,
       onBackupDevice,
       onUpdateFirmware,
+      isUpdating,
       loading
     } = this;
 
@@ -77,7 +82,7 @@ class TrezorConfigSections extends React.Component {
           {...{ onWipeDevice, onRecoverDevice, onInitDevice, onBackupDevice, loading }}
         />
 
-        <FirmwareUpdate {...{ onUpdateFirmware, loading }} />
+        <FirmwareUpdate {...{ onUpdateFirmware, loading, isUpdating }} />
       </>
     );
   }

--- a/app/components/views/TrezorPage/FirmwareUpdate.js
+++ b/app/components/views/TrezorPage/FirmwareUpdate.js
@@ -30,7 +30,7 @@ class FirmwareUpdate extends React.Component {
       </>
     );
 
-    const { loading } = this.props;
+    const { loading, isUpdating } = this.props;
 
     return (
       <VerticalAccordion
@@ -54,8 +54,8 @@ class FirmwareUpdate extends React.Component {
 
         <DangerButton
           onClick={this.onUpdateFirmware}
-          loading={loading}
-          disabled={loading}>
+          loading={loading || isUpdating()}
+          disabled={loading || isUpdating()}>
           <T id="trezorPage.updateFirmwareBtn" m="Update Firmware" />
         </DangerButton>
       </VerticalAccordion>

--- a/app/connectors/trezor.js
+++ b/app/connectors/trezor.js
@@ -6,6 +6,7 @@ import * as trza from "../actions/TrezorActions";
 
 const mapStateToProps = selectorMap({
   isTrezor: sel.isTrezor,
+  isPerformingUpdate: sel.isPerformingTrezorUpdate,
   waitingForPin: sel.trezorWaitingForPin,
   waitingForPassPhrase: sel.trezorWaitingForPassPhrase,
   waitingForWord: sel.trezorWaitingForWord,

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -58,7 +58,8 @@ import {
   startDcrlnd,
   stopDcrlnd,
   removeDcrlnd,
-  lnScbInfo
+  lnScbInfo,
+  updateTrezorFirmware
 } from "./main_dev/ipc";
 import {
   initTemplate,
@@ -296,6 +297,11 @@ ipcMain.on("create-wallet", (event, walletPath, testnet) => {
 
 ipcMain.on("remove-wallet", (event, walletPath, testnet) => {
   event.returnValue = removeWallet(testnet, walletPath);
+});
+
+ipcMain.handle("upload-firmware", async (event, firmware) => {
+  const res = await updateTrezorFirmware(firmware);
+  return res;
 });
 
 ipcMain.on("stop-daemon", (event) => {

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -17,6 +17,8 @@ import {
   setDcrdRpcCredentials
 } from "./launch";
 import { MAINNET } from "constants";
+import { initTransport } from "actions/TrezorActions.js";
+import * as connect from "connect";
 
 const logger = createLogger();
 let watchingOnlyWallet;
@@ -138,6 +140,28 @@ export const removeWallet = (testnet, walletPath) => {
   } catch (e) {
     logger.log("error", "error creating wallet: " + e);
     return false;
+  }
+};
+
+// updateTrezorFirmware attempts to make a temporary connection to a trezor
+// device and update it with the supplied firmware. It returns an error string
+// in case of error.
+export const updateTrezorFirmware = async ( firmware ) => {
+  let session = connect.default;
+  try {
+    await initTransport(session, false);
+    const res = await session.firmwareUpdate({
+       binary: firmware
+    });
+    if (res.payload && res.payload.error) {
+      throw res.payload.error;
+    }
+    return null;
+  } catch (e) {
+    logger.log("error", "error uploading trezor firmware: " + e);
+    return e.toString();
+  } finally {
+    session = null;
   }
 };
 

--- a/app/reducers/trezor.js
+++ b/app/reducers/trezor.js
@@ -180,8 +180,13 @@ export default function trezor(state = {}, action) {
     case TRZ_WIPEDEVICE_ATTEMPT:
     case TRZ_RECOVERDEVICE_ATTEMPT:
     case TRZ_INITDEVICE_ATTEMPT:
-    case TRZ_UPDATEFIRMWARE_ATTEMPT:
       return { ...state, performingOperation: true };
+    case TRZ_UPDATEFIRMWARE_ATTEMPT:
+      return {
+        ...state,
+        performingOperation: true,
+        performingUpdate: true
+      };
     case TRZ_CHANGELABEL_SUCCESS:
       return {
         ...state,
@@ -203,11 +208,16 @@ export default function trezor(state = {}, action) {
     case TRZ_RECOVERDEVICE_SUCCESS:
     case TRZ_INITDEVICE_FAILED:
     case TRZ_INITDEVICE_SUCCESS:
-    case TRZ_UPDATEFIRMWARE_FAILED:
-    case TRZ_UPDATEFIRMWARE_SUCCESS:
     case TRZ_BACKUPDEVICE_FAILED:
     case TRZ_BACKUPDEVICE_SUCCESS:
       return { ...state, performingOperation: false };
+    case TRZ_UPDATEFIRMWARE_FAILED:
+    case TRZ_UPDATEFIRMWARE_SUCCESS:
+      return {
+        ...state,
+        performingOperation: false,
+        performingUpdate: false
+      };
     case CLOSEWALLET_SUCCESS:
       return { ...state, enabled: false };
     default:

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1457,6 +1457,7 @@ export const autobuyerRunningModalVisible = get([
 ]);
 
 export const isTrezor = get(["trezor", "enabled"]);
+export const isPerformingTrezorUpdate = get(["trezor", "performingUpdate"]);
 
 export const isSignMessageDisabled = and(isWatchingOnly, not(isTrezor));
 export const isChangePassPhraseDisabled = isWatchingOnly;


### PR DESCRIPTION
Part of #2681

We are unable to update firmware from TrezorActions.js. This is believed
to be due to the size of the firmware and the limitations of this
electron child process. We send the firmware to the main process to push
to the device. The main process uses a temporary connection to trezor in
order to accomplish this.