### PR TITLE
Show ticket vote time instead of purchase time on overview screen

### DIFF
--- a/app/components/shared/TxHistory/StakeTxRow.jsx
+++ b/app/components/shared/TxHistory/StakeTxRow.jsx
@@ -18,6 +18,7 @@ const StakeTxRow = ({
   enterTimestamp,
   pending,
   txTs,
+  txLeaveTs,
   accountName,
   txType,
   status,
@@ -109,7 +110,9 @@ const StakeTxRow = ({
           {accountName}
         </div>
         {!pending && (
-          <div className={styles.timeDateSpacer}>{timeMessage(txTs)}</div>
+          <div className={styles.timeDateSpacer}>
+            {overview ? timeMessage(txLeaveTs) : timeMessage(txTs)}
+          </div>
         )}
       </div>
     </Row>

--- a/app/components/shared/TxHistory/StakeTxRow.jsx
+++ b/app/components/shared/TxHistory/StakeTxRow.jsx
@@ -17,7 +17,6 @@ const StakeTxRow = ({
   leaveTimestamp,
   enterTimestamp,
   pending,
-  txTs,
   txLeaveTs,
   accountName,
   txType,
@@ -110,7 +109,9 @@ const StakeTxRow = ({
           {accountName}
         </div>
         {!pending && (
-          <div className={styles.timeDateSpacer}>{timeMessage(txLeaveTs)}</div>
+          <div className={styles.timeDateSpacer}>
+            {txLeaveTs && timeMessage(txLeaveTs)}
+          </div>
         )}
       </div>
     </Row>

--- a/app/components/shared/TxHistory/StakeTxRow.jsx
+++ b/app/components/shared/TxHistory/StakeTxRow.jsx
@@ -110,9 +110,7 @@ const StakeTxRow = ({
           {accountName}
         </div>
         {!pending && (
-          <div className={styles.timeDateSpacer}>
-            {overview ? timeMessage(txLeaveTs) : timeMessage(txTs)}
-          </div>
+          <div className={styles.timeDateSpacer}>{timeMessage(txLeaveTs)}</div>
         )}
       </div>
     </Row>

--- a/app/components/shared/TxHistory/TxHistory.jsx
+++ b/app/components/shared/TxHistory/TxHistory.jsx
@@ -57,9 +57,7 @@ const TxHistory = ({
       {transactions.map((tx, index) => {
         if (limit && index >= limit) return;
         if (!tx) return;
-        const txTimestamp = tx && tx.enterTimestamp
-          ? tx.enterTimestamp
-          : tx.timestamp;
+        const txTimestamp = tx.enterTimestamp || tx.timestamp;
         // we define the transaction icon by its rowType, so we pass it as a
         // className props
         let rowType = tx.status || tx.txType;
@@ -90,6 +88,7 @@ const TxHistory = ({
               className: rowType,
               intl,
               txTs: txTimestamp && tsDate(txTimestamp),
+              txLeaveTs: tx.leaveTimestamp && tsDate(tx.leaveTimestamp),
               overview,
               pending: tx.isPending,
               onClick: () => history.push(`/transaction/history/${tx.txHash}`),

--- a/app/components/views/TicketsPage/MyTicketsTab/Page.jsx
+++ b/app/components/views/TicketsPage/MyTicketsTab/Page.jsx
@@ -17,32 +17,32 @@ const subtitleMenu = ({
   onChangeSelectedType,
   onChangeSortType
 }) => (
-    <div className={style.ticketsButtons}>
-      <Tooltip
-        tipWidth={300}
-        text={<T id="tickets.sortby.tooltip" m="Sort By" />}>
-        <EyeFilterMenu
-          labelKey="label"
-          keyField="value"
-          options={sortTypes}
-          selected={selectedSortOrderKey}
-          onChange={onChangeSortType}
-          type="sortBy"
-        />
-      </Tooltip>
-      <Tooltip
-        tipWidth={300}
-        text={<T id="tickets.tickettypes.tooltip" m="Ticket Status" />}>
-        <EyeFilterMenu
-          labelKey="label"
-          keyField="key"
-          options={ticketTypes}
-          selected={selectedTicketTypeKey}
-          onChange={onChangeSelectedType}
-        />
-      </Tooltip>
-    </div>
-  );
+  <div className={style.ticketsButtons}>
+    <Tooltip
+      tipWidth={300}
+      text={<T id="tickets.sortby.tooltip" m="Sort By" />}>
+      <EyeFilterMenu
+        labelKey="label"
+        keyField="value"
+        options={sortTypes}
+        selected={selectedSortOrderKey}
+        onChange={onChangeSortType}
+        type="sortBy"
+      />
+    </Tooltip>
+    <Tooltip
+      tipWidth={300}
+      text={<T id="tickets.tickettypes.tooltip" m="Ticket Status" />}>
+      <EyeFilterMenu
+        labelKey="label"
+        keyField="key"
+        options={ticketTypes}
+        selected={selectedTicketTypeKey}
+        onChange={onChangeSelectedType}
+      />
+    </Tooltip>
+  </div>
+);
 
 const TicketListPage = ({
   tickets,
@@ -95,7 +95,7 @@ const TicketListPage = ({
               <T id="tickets.table.header.account" m="Account" />
             </div>
             <div>
-              <T id="tickets.table.header.purchased" m="Purchased" />
+              <T id="tickets.table.header.purchased" m="Voted" />
             </div>
           </div>
           <TxHistory
@@ -113,8 +113,8 @@ const TicketListPage = ({
       ) : tickets.length > 0 ? (
         <NoMoreTicketsIndicator />
       ) : (
-            <NoTicketsIndicator />
-          )}
+        <NoTicketsIndicator />
+      )}
     </InfiniteScroll>
   );
 };


### PR DESCRIPTION
This PR fixes staked tickets displaying their ``enterTimestamp`` instead of ``leaveTimestamp`` on overview screen.

Closes https://github.com/decred/decrediton/issues/2760.