### PR TITLE
Fix not updating feeStatus value after registering it successfully

### DIFF
--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -67,7 +67,10 @@ export const SYNCVSPTICKETS_SUCCESS = "SYNCVSPTICKETS_SUCCESS";
 export const syncVSPTicketsRequest = ({ passphrase, vspHost, vspPubkey, account }) => (dispatch, getState) => {
   dispatch({ type: SYNCVSPTICKETS_ATTEMPT });
   wallet.syncVSPTickets(getState().grpc.walletService, passphrase, vspHost, vspPubkey, account)
-    .then(() => dispatch({ type: SYNCVSPTICKETS_SUCCESS }))
+    .then(() => {
+      dispatch({ type: SYNCVSPTICKETS_SUCCESS });
+      dispatch(getVSPTicketsByFeeStatus(VSP_FEE_PROCESS_ERRORED));
+    })
     .catch(err => {
       dispatch({ type: SYNCVSPTICKETS_FAILED, err });
     });

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -36,8 +36,7 @@ class App extends React.Component {
     shutdownApp: PropTypes.func.isRequired,
     shutdownRequested: PropTypes.bool.isRequired,
     daemonStopped: PropTypes.bool.isRequired,
-    autobuyerRunningModalVisible: PropTypes.bool.isRequired,
-    hideCantCloseModal: PropTypes.func.isRequired
+    autobuyerRunningModalVisible: PropTypes.bool.isRequired
   };
 
   constructor(props) {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -800,8 +800,12 @@ export const getVSPTickets = createSelector(
     Object.keys(hashes).forEach((feeStatus) => {
       // fee status hashes
       const fsHashes = hashes[feeStatus];
-      vspTickets[feeStatus] = fsHashes.map((hash) => {
-        if (!hash) return null;
+
+      fsHashes.forEach((hash) => {
+        if (!vspTickets[feeStatus]) {
+          vspTickets[feeStatus] = [];
+        }
+        if (!hash) return;
         // right now we only show fee status for tickets which can be voted.
         if (!txsMap[hash]) {
           // it should not have an uknown tx. If there is, we should get this tx
@@ -815,7 +819,7 @@ export const getVSPTickets = createSelector(
         ) {
           const objCopy = Object.assign({}, txsMap[hash]);
           objCopy.feeStatus = feeStatus;
-          return objCopy;
+          vspTickets[feeStatus] = [objCopy, ...vspTickets[feeStatus]];
         }
         return null;
       });


### PR DESCRIPTION
This PR removes the warning of required props and update ticket fee status value, if vsp sync was successfully. 