### PR TITLE
change polling time for peer count

### DIFF
--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -40,13 +40,13 @@ class Wallet extends React.Component {
         compareInventory();
       }
     }, 60000);
-    // Get peer info every 1 minute, so we can no if there are no available
+    // Get peer info every 10 seconds, so we can no if there are no available
     // peers.
     this.props.setInterval(() => {
       if (politeiaEnabled) {
         getPeerInfo();
       }
-    }, 60000);
+    }, 10000);
   }
 
   render() {


### PR DESCRIPTION
fixes #2759 

Righth now the polling time of the peer count is 1 minute, which probably caused #2759. 

This PR changes it to 10 sec, instead