### PR TITLE
Background colour for "No more transactions" panel

### DIFF
--- a/app/style/Loading.less
+++ b/app/style/Loading.less
@@ -44,6 +44,7 @@
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
   display: inline-block;
   margin-top: 2em;
+  background-color: var(--background-back-color);
 
   .loading-more-tickets-progress-line {
     color: var(--disabled-color);


### PR DESCRIPTION
This also fixes the "Loading more transactions" panel.

## Before

![Screenshot from 2020-10-30 15-09-27](https://user-images.githubusercontent.com/6762864/97722440-8dce0980-1ac2-11eb-90b4-ea70d6ca59dd.png)

![Screenshot from 2020-10-30 15-11-11](https://user-images.githubusercontent.com/6762864/97722424-8a3a8280-1ac2-11eb-9ae6-0a64cd125538.png)

## After

![Screenshot from 2020-10-30 15-11-57](https://user-images.githubusercontent.com/6762864/97722433-8c044600-1ac2-11eb-9d39-eed95a4e72e0.png)
