### PR TITLE
pi-ui: use default themes' names & override toggle bg

### DIFF
--- a/app/components/views/GetStartedPage/Settings/Settings.jsx
+++ b/app/components/views/GetStartedPage/Settings/Settings.jsx
@@ -11,7 +11,11 @@ import { KeyBlueButton } from "buttons";
 import { GoBackMsg } from "../messages";
 import { getGlobalCfg } from "config";
 import * as configConstants from "constants/config";
-import { useTheme } from "pi-ui";
+import {
+  useTheme,
+  DEFAULT_LIGHT_THEME_NAME,
+  DEFAULT_DARK_THEME_NAME
+} from "pi-ui";
 import stylesSettigs from "views/SettingsPage/Settings.module.css";
 import stylesGetStarted from "../GetStarted.module.css";
 import { useSettings } from "hooks";
@@ -33,7 +37,11 @@ const SetttingsForm = ({ onSendBack }) => {
     const config = getGlobalCfg();
     const oldTheme = config.get(configConstants.THEME);
     if (oldTheme != tempSettings.theme) {
-      setThemeName(tempSettings.theme);
+      setThemeName(
+        tempSettings.theme.includes("dark")
+          ? DEFAULT_DARK_THEME_NAME
+          : DEFAULT_LIGHT_THEME_NAME
+      );
     }
     onSaveSettings(tempSettings);
     onSendBack();
@@ -53,9 +61,11 @@ const SetttingsForm = ({ onSendBack }) => {
         <Subtitle title={<T id="settings.subtitle" m="Settings" />} />
         <div className={styles.wrapper}>
           <div className={styles.group}>
-            <Subtitle title={
-              <T id="settings.group-title.connectivity" m="Connectivity" />
-            } />
+            <Subtitle
+              title={
+                <T id="settings.group-title.connectivity" m="Connectivity" />
+              }
+            />
             <div className={styles.columnWrapper}>
               <div className={styles.column}>
                 <NetworkSettings
@@ -72,9 +82,9 @@ const SetttingsForm = ({ onSendBack }) => {
           </div>
 
           <div className={classNames(styles.group, styles.general)}>
-            <Subtitle title={
-              <T id="settings.group-title.general" m="General" />
-            } />
+            <Subtitle
+              title={<T id="settings.group-title.general" m="General" />}
+            />
             <div className={styles.columnWrapper}>
               <div className={styles.column}>
                 <UISettings
@@ -88,27 +98,29 @@ const SetttingsForm = ({ onSendBack }) => {
           </div>
 
           <div className={classNames(styles.group, styles.privacy)}>
-            <Subtitle title={
-              <T
-                id="settings.group-title.privacy-and-security"
-                m="Privacy and Security"
-              />
-            } />
-            <div className={styles.columnWrapper}>
-                <PrivacySettings
-                  {...{
-                    tempSettings,
-                    onAttemptChangePassphrase,
-                    isChangePassPhraseDisabled,
-                    onChangeTempSettings,
-                    walletReady,
-                    changePassphraseRequestAttempt
-                  }}
+            <Subtitle
+              title={
+                <T
+                  id="settings.group-title.privacy-and-security"
+                  m="Privacy and Security"
                 />
-              </div>
+              }
+            />
+            <div className={styles.columnWrapper}>
+              <PrivacySettings
+                {...{
+                  tempSettings,
+                  onAttemptChangePassphrase,
+                  isChangePassPhraseDisabled,
+                  onChangeTempSettings,
+                  walletReady,
+                  changePassphraseRequestAttempt
+                }}
+              />
             </div>
           </div>
         </div>
+      </div>
       <div className={styles.formSaveButtonWrapper}>
         <KeyBlueButton
           disabled={!areSettingsDirty}

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -1,4 +1,12 @@
-import { classNames, Button, StatusBar, Tooltip, Text, useTheme } from "pi-ui";
+import {
+  classNames,
+  Button,
+  StatusBar,
+  Tooltip,
+  Text,
+  useTheme,
+  DEFAULT_DARK_THEME_NAME
+} from "pi-ui";
 import { FormattedMessage as T } from "react-intl";
 import { InvisibleButton } from "buttons";
 import { PoliteiaLink } from "shared";
@@ -50,7 +58,7 @@ const ProposalDetails = ({
 
   const { tsDate, hasTickets, isTestnet } = useProposalDetails();
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "theme-dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const shortToken = token.substring(0, 7);
   const proposalPath = `/proposals/${shortToken}`;
   const votingActiveOrFinished =

--- a/app/components/views/SettingsPage/Settings.jsx
+++ b/app/components/views/SettingsPage/Settings.jsx
@@ -1,5 +1,10 @@
 import { useCallback } from "react";
-import { useTheme, classNames } from "pi-ui";
+import {
+  useTheme,
+  classNames,
+  DEFAULT_DARK_THEME_NAME,
+  DEFAULT_LIGHT_THEME_NAME
+} from "pi-ui";
 import { FormattedMessage as T } from "react-intl";
 import { StandaloneHeader, StandalonePage } from "layout";
 import {
@@ -88,7 +93,11 @@ const SettingsPage = ({
     const config = getGlobalCfg();
     const oldTheme = config.get(configConstants.THEME);
     if (oldTheme != tempSettings.theme) {
-      setThemeName(tempSettings.theme);
+      setThemeName(
+        tempSettings.theme.includes("dark")
+          ? DEFAULT_DARK_THEME_NAME
+          : DEFAULT_LIGHT_THEME_NAME
+      );
     }
     onSaveSettings(tempSettings);
   }, [onSaveSettings, tempSettings, setThemeName]);
@@ -104,12 +113,14 @@ const SettingsPage = ({
       className="settings-standalone-page">
       <div className={styles.wrapper}>
         <div className={styles.group}>
-          <Subtitle title={
-            <T
-              id="settings.getstartpage.group-title.connectivity"
-              m="Connectivity"
-            />
-          } />
+          <Subtitle
+            title={
+              <T
+                id="settings.getstartpage.group-title.connectivity"
+                m="Connectivity"
+              />
+            }
+          />
           <div className={styles.columnWrapper}>
             <div className={styles.column}>
               <NetworkSettings
@@ -126,9 +137,11 @@ const SettingsPage = ({
         </div>
 
         <div className={classNames(styles.group, styles.general)}>
-          <Subtitle title={
-            <T id="settings.getstartpage.group-title.general" m="General" />
-          } />
+          <Subtitle
+            title={
+              <T id="settings.getstartpage.group-title.general" m="General" />
+            }
+          />
           <div className={styles.columnWrapper}>
             <div className={styles.column}>
               <UISettings
@@ -154,26 +167,28 @@ const SettingsPage = ({
         </div>
 
         <div className={classNames(styles.group, styles.privacy)}>
-          <Subtitle title={
-            <T
-              id="settings.getstartpage.group-title.privacy-and-security"
-              m="Privacy and Security"
-            />
-          } />
-          <div className={styles.columnWrapper}>
-              <PrivacySettings
-                {...{
-                  tempSettings,
-                  onAttemptChangePassphrase,
-                  isChangePassPhraseDisabled,
-                  onChangeTempSettings,
-                  walletReady,
-                  changePassphraseRequestAttempt
-                }}
+          <Subtitle
+            title={
+              <T
+                id="settings.getstartpage.group-title.privacy-and-security"
+                m="Privacy and Security"
               />
-            </div>
+            }
+          />
+          <div className={styles.columnWrapper}>
+            <PrivacySettings
+              {...{
+                tempSettings,
+                onAttemptChangePassphrase,
+                isChangePassPhraseDisabled,
+                onChangeTempSettings,
+                walletReady,
+                changePassphraseRequestAttempt
+              }}
+            />
           </div>
         </div>
+      </div>
 
       <div className={styles.saveButtonWrapper}>
         <div className={styles.saveButton}>

--- a/app/index.js
+++ b/app/index.js
@@ -19,7 +19,13 @@ import { DCR, THEME, LOCALE, NETWORK } from "constants";
 import { getSelectedWallet } from "./main_dev/launch";
 import { AppContainer } from "react-hot-loader";
 
-import { defaultLightTheme, ThemeProvider, defaultDarkTheme } from "pi-ui";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  defaultDarkTheme,
+  DEFAULT_DARK_THEME_NAME,
+  DEFAULT_LIGHT_THEME_NAME
+} from "pi-ui";
 import { lightTheme, darkTheme, icons } from "style/themes";
 import SourceSansProLight from "style/fonts/SourceSansPro-Light.ttf";
 import SourceSansProLightItalic from "style/fonts/SourceSansPro-LightItalic.ttf";
@@ -485,19 +491,24 @@ const fonts = [
 ];
 
 const themes = {
-  "theme-light": { ...defaultLightTheme, ...lightTheme, ...icons },
-  "theme-dark": { ...defaultDarkTheme, ...darkTheme, ...icons }
+  [DEFAULT_LIGHT_THEME_NAME]: { ...defaultLightTheme, ...lightTheme, ...icons },
+  [DEFAULT_DARK_THEME_NAME]: { ...defaultDarkTheme, ...darkTheme, ...icons }
 };
 
 const history = createMemoryHistory();
 const store = configureStore(initialState, history);
+
+const currentTheme = currentSettings && currentSettings.theme;
+const defaultThemeName = currentTheme.includes("dark")
+  ? DEFAULT_DARK_THEME_NAME
+  : DEFAULT_LIGHT_THEME_NAME;
 
 const render = () =>
   ReactDOM.render(
     <AppContainer>
       <ThemeProvider
         themes={themes}
-        defaultThemeName={currentSettings.theme}
+        defaultThemeName={defaultThemeName}
         fonts={fonts}>
         <Provider store={store}>
           <ConnectedRouter history={history}>

--- a/app/style/themes/darkTheme.js
+++ b/app/style/themes/darkTheme.js
@@ -90,7 +90,8 @@ const darkTheme = {
   "back-button-text": "#E9F8FE",
   "back-button-dark-text": "#0E152F",
   "tx-detail-text": "#E9F8FE",
-  "tx-detail-raw-shadow": "linear-gradient(to top, rgb(243, 246, 246, 0.25) 10%, rgb(243, 246, 246, 0.20) 20%, rgb(243, 246, 246, 0) 70%)",
+  "tx-detail-raw-shadow":
+    "linear-gradient(to top, rgb(243, 246, 246, 0.25) 10%, rgb(243, 246, 246, 0.20) 20%, rgb(243, 246, 246, 0) 70%)",
   "home-content-link": "#99C1E3",
   "transfer-details-bg": "#152042",
   "filter-menu-arrow": "#99C1E3",
@@ -125,6 +126,9 @@ const darkTheme = {
   "input-copy-hover-color": "#78d9f8",
   "coinjoin-sum-color": "#7DA7D9",
   "coinjoin-sum-text-color": "#fff",
+
+  // override pi-ui's toggle default dark background
+  "toggle-bar-color": "var(--background-copy-color)",
 
   /* icons */
   "menu-settings-default": "url('style/icons/settingsDefaultDark.svg')",

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "node-abi": "^2.15.0",
     "node-addon-loader": "decred/node-addon-loader#master",
     "nouislider": "^12.0.0",
-    "pi-ui": "https://github.com/amassarwi/pi-ui#themesnames",
+    "pi-ui": "https://github.com/decred/pi-ui",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "node-abi": "^2.15.0",
     "node-addon-loader": "decred/node-addon-loader#master",
     "nouislider": "^12.0.0",
-    "pi-ui": "https://github.com/decred/pi-ui",
+    "pi-ui": "https://github.com/amassarwi/pi-ui#themesnames",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",
     "raw-loader": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9441,9 +9441,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/decred/pi-ui":
+"pi-ui@https://github.com/amassarwi/pi-ui#themesnames":
   version "1.0.0"
-  resolved "https://github.com/decred/pi-ui#7b9e38f8964cd504245846fcf92f45871bcbab46"
+  resolved "https://github.com/amassarwi/pi-ui#17b4ba32f1987d65dcb24127d2f10c1bc96583e1"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9441,9 +9441,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/amassarwi/pi-ui#themesnames":
+"pi-ui@https://github.com/decred/pi-ui":
   version "1.0.0"
-  resolved "https://github.com/amassarwi/pi-ui#17b4ba32f1987d65dcb24127d2f10c1bc96583e1"
+  resolved "https://github.com/decred/pi-ui#86083b26ae7925701a73179d70bf7e88d7d67e59"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"


### PR DESCRIPTION
While working on decred/decrediton#2829 I noticed that decrediton is using different theme names as the default ones used in pi-ui & pigui, this is a bit problematic and may cause some styling bugs, as we check internally in pi-ui if default dark theme is used by checking the current theme name: `const isDarkTheme = themeName === "dark"`, and using different theme names as we do in decrediton would cause some pi-ui's components to show wrong styling.

So as solution https://github.com/decred/pi-ui/pull/304 exports two constants for default themes names: `DEFAULT_LIGHT_THEME_NAME` & `DEFAULT_DARK_THEME_NAME`, and uses them when it determines if default dark styling should be used internally in pi-ui's components. After this commit consumers of pi-ui lib would need to provide these default themes names if they are interested in default components' dark/light styling.

This diff adjusts `decrediton` code base to work with the new exported default themes' names & overrides the dark 
toggle bar background color.

### Dependencies

Closes #2829 
Needs https://github.com/decred/pi-ui/pull/304
