### PR TITLE
sidebar: Improve peers count

### DIFF
--- a/app/components/SideBar/Logo/Logo.jsx
+++ b/app/components/SideBar/Logo/Logo.jsx
@@ -10,12 +10,9 @@ const Logo = React.memo(
     onReduceSideBar,
     onExpandSideBar,
     isWatchingOnly,
-    getRunningIndicator,
-    peersCount
+    getRunningIndicator
   }) => (
-    <div
-      className={expandSideBar ? style.logo : style.reducedLogo}
-    >
+    <div className={expandSideBar ? style.logo : style.reducedLogo}>
       {isWatchingOnly && (
         <Tooltip
           text={
@@ -34,15 +31,6 @@ const Logo = React.memo(
           !expandSideBar ? style.hamburger : isTestNet ? TESTNET : MAINNET
         }
       />
-      <Tooltip
-        text={
-          <T
-            id="sidebar.peersCount"
-            m="Peers Count"
-          />
-        }>
-        <div className={style.peersCount}>{peersCount}</div>
-      </Tooltip>
       {getRunningIndicator && (
         <Tooltip
           text={

--- a/app/components/SideBar/Logo/Logo.module.css
+++ b/app/components/SideBar/Logo/Logo.module.css
@@ -42,21 +42,6 @@
   opacity: 0.7;
 }
 
-.peersCount {
-  border-radius: 50%;
-  width: 15px;
-  height: 15px;
-  margin-top: 4px;
-
-  background: #fff;
-  border: 1px solid var(--white-border);
-  color: var(--sidebar-menu-link);;
-  text-align: center;
-  padding-bottom: 4px;
-
-  font-size: 13pt;
-}
-
 @media screen and (max-width: 768px) {
   .logo {
     flex-direction: row-reverse;

--- a/app/components/SideBar/MenuBottom/MenuBottom.module.css
+++ b/app/components/SideBar/MenuBottom/MenuBottom.module.css
@@ -87,6 +87,23 @@
   text-decoration: none;
 }
 
+.peersCount {
+  display: flex;
+  align-items: center;
+  padding-left: 47px;
+  padding-bottom: 16px;
+  background-color: var(--info-modal-button-text);
+}
+
+.peersCountLabel {
+  color: var(--disabled-color);
+}
+
+.peersCountValue {
+  font-family: var(--font-family-monospace);
+  color: var(--sidebar-bottom-light-text-color);
+}
+
 .rescanButtonArea {
   padding-top: 2px;
   padding-right: 5px;

--- a/app/components/SideBar/MenuBottom/MenuBottomExpanded.jsx
+++ b/app/components/SideBar/MenuBottom/MenuBottomExpanded.jsx
@@ -3,7 +3,7 @@ import { Balance } from "shared";
 import { RescanButton } from "buttons";
 import { RescanProgress } from "indicators";
 import LastBlockTime from "./LastBlockTime/LastBlockTime";
-import style from "./MenuBottom.module.css";
+import styles from "./MenuBottom.module.css";
 import { classNames, Tooltip } from "pi-ui";
 
 const MenuBarExpanded = ({
@@ -15,49 +15,56 @@ const MenuBarExpanded = ({
   lastBlockTimestamp,
   onShowAccounts,
   onHideAccounts,
-  isSPV
+  isSPV,
+  peersCount
 }) => (
-  <div className={style.bottom}>
+  <div className={styles.bottom}>
     <div
-      className={style.short}
+      className={styles.short}
       onMouseEnter={rescanRequest ? null : onShowAccounts}
       onMouseLeave={rescanRequest ? null : onHideAccounts}>
       <div
         className={classNames(
-          style.shortSeparator,
-          isShowingAccounts && style.showAccounts
+          styles.shortSeparator,
+          isShowingAccounts && styles.showAccounts
         )}></div>
-      <div className={style.shortName}>
+      <div className={styles.shortName}>
         <T id="sidebar.totalBalance" m="Total Balance" />:
       </div>
-      <div className={style.shortValue}>
+      <div className={styles.shortValue}>
         <Balance amount={totalBalance} />
       </div>
     </div>
-    <div className={style.latestBlock}>
+    <div className={styles.latestBlock}>
       {rescanRequest ? <RescanProgress /> : null}
       {currentBlockHeight && !rescanRequest && (
         <>
-          <div className={style.rescanButtonArea}>
+          <div className={styles.rescanButtonArea}>
             <RescanButton {...{ rescanRequest, rescanAttempt }} />
           </div>
-          <a className={style.latestBlockName}>
+          <a className={styles.latestBlockName}>
             <T id="sidebar.latestBlock" m="Latest Block" />
-            <span className={style.latestBlockNumber}>
+            <span className={styles.latestBlockNumber}>
               {" "}
               {currentBlockHeight}
             </span>
           </a>
           {isSPV && (
             <Tooltip content={<T id="sidebar.spvMode" m="SPV Mode" />}>
-              <div className={style.spvIcon} />
+              <div className={styles.spvIcon} />
             </Tooltip>
           )}
-          <div className={style.latestBlockTime}>
+          <div className={styles.latestBlockTime}>
             <LastBlockTime lastBlockTimestamp={lastBlockTimestamp} />
           </div>
         </>
       )}
+    </div>
+    <div className={styles.peersCount}>
+      <span className={styles.peersCountLabel}>
+        <T id="sidebar.peersCount" m="Peers" />
+      </span>
+      <span className={styles.peersCountValue}>&nbsp;{peersCount}</span>
     </div>
   </div>
 );

--- a/app/components/SideBar/SideBar.jsx
+++ b/app/components/SideBar/SideBar.jsx
@@ -45,8 +45,7 @@ const SideBar = () => {
           onReduceSideBar,
           onExpandSideBar,
           isWatchingOnly,
-          getRunningIndicator,
-          peersCount
+          getRunningIndicator
         }}
       />
       <div
@@ -75,7 +74,8 @@ const SideBar = () => {
             lastBlockTimestamp,
             onShowAccounts,
             onHideAccounts,
-            isSPV
+            isSPV,
+            peersCount
           }}
         />
       ) : (


### PR DESCRIPTION
This diff improves the peers count a bit by moving it to the bottom of the sidebar, 
and showing it next to the latest block.

After:
![image](https://user-images.githubusercontent.com/10324528/97879427-a17aa980-1d28-11eb-924f-eb6981e135f3.png)

![image](https://user-images.githubusercontent.com/10324528/97879467-afc8c580-1d28-11eb-943a-80305498bb9d.png)


---

Closes #2801 