### PR TITLE
Re-add backup dark icon

### DIFF
--- a/app/style/themes/darkTheme.js
+++ b/app/style/themes/darkTheme.js
@@ -230,6 +230,7 @@ const darkTheme = {
   "menu-trezor-hover": "url('style/icons/trezorHoverDark.svg')",
   "menu-cancel-rescan-icon": "url('style/icons/menuCancelRescanDark.svg')",
   "politeia-loading-icon": "url('style/icons/politeia-loading-dark.gif')",
+  "backup-icon": "url('style/icons/harddriveDark.svg')",
   "loader-animation-daemon-waiting-initial":
     "url('style/icons/daemonWaitingLoaderInitialDark.gif')"
 };


### PR DESCRIPTION
It seems that recent PRs have removed @jholdstock's backup dark icon used in LN page (https://github.com/decred/decrediton/pull/2823) from master. This PR re-adds it.