### PR TITLE
Fix Trezor modals cancel button

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
     "autobind-decorator": "^2.1.0",
     "axios": "^0.18.1",
     "bs58": "^4.0.1",
-    "connect": "https://github.com/JoeGruffins/npm-extended-dcr#139ffdccfccb3ab94f6f8f9098de2a868f18bf41",
+    "connect": "https://github.com/JoeGruffins/npm-extended-dcr#bed54ad6d4acecd906d79946d62718c67411ec96",
     "connected-react-router": "^6.8.0",
     "copy-webpack-plugin": "^6.0.3",
     "dom-helpers": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3952,9 +3952,9 @@ configstore@^5.0.1:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
-"connect@https://github.com/JoeGruffins/npm-extended-dcr#139ffdccfccb3ab94f6f8f9098de2a868f18bf41":
-  version "8.1.14-extended"
-  resolved "https://github.com/JoeGruffins/npm-extended-dcr#139ffdccfccb3ab94f6f8f9098de2a868f18bf41"
+"connect@https://github.com/JoeGruffins/npm-extended-dcr#bed54ad6d4acecd906d79946d62718c67411ec96":
+  version "8.1.16-extended"
+  resolved "https://github.com/JoeGruffins/npm-extended-dcr#bed54ad6d4acecd906d79946d62718c67411ec96"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@trezor/blockchain-link" "^1.0.14"


### PR DESCRIPTION
This PR updates Trezor _connect_ library to version 8.1.16, supporting ``cancel`` method in order to make Trezor model One device get back to previous screen and cancel PIN setup.

Closes https://github.com/decred/decrediton/issues/2834.