### PR TITLE
[governance] "Finished Vote" tab filters

### DIFF
--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -33,7 +33,9 @@ const defaultInventory = {
   activeVote: [],
   abandonedVote: [],
   finishedVote: [],
-  preVote: []
+  preVote: [],
+  approvedVote: [],
+  rejectedVote: []
 };
 
 // getDefaultInventory gets the inventory default's state.
@@ -136,6 +138,8 @@ const updateInventoryFromApiData = (data) => {
   inventory.activeVote = data.active;
   inventory.finishedVote = [...data.approved, ...data.rejected];
   inventory.abandonedVote = data.abandoned;
+  inventory.approvedVote = data.approved;
+  inventory.rejectedVote = data.rejected;
 
   return inventory;
 };
@@ -211,7 +215,9 @@ export const compareInventory = () => async (dispatch, getState) => {
       oInventoryCopy.activeVote,
       oInventoryCopy.abandonedVote,
       oInventoryCopy.finishedVote,
-      oInventoryCopy.preVote
+      oInventoryCopy.preVote,
+      oInventoryCopy.approvedVote,
+      oInventoryCopy.rejectedVote
     ].reduce((acc, v) => {
       v.forEach((p) => {
         return (acc[p] = p);
@@ -222,7 +228,9 @@ export const compareInventory = () => async (dispatch, getState) => {
       inventory.activeVote,
       inventory.abandonedVote,
       inventory.finishedVote,
-      inventory.preVote
+      inventory.preVote,
+      inventory.approvedVote,
+      inventory.rejectedVote
     ].reduce((acc, v) => {
       v.forEach((p) => (acc[p] = p));
       return acc;
@@ -415,7 +423,7 @@ export const getProposalsAndUpdateVoteStatus = (tokensBatch) => async (
     const { bestBlock } = summaries;
     tokensBatch.forEach((token) => {
       const proposalSummary = summaries[token];
-      const { status } = proposalSummary;
+      const { status, approved } = proposalSummary;
       const prop = findProposal(proposals, token);
       prop.token = token;
       prop.proposalStatus = prop.status;
@@ -447,6 +455,11 @@ export const getProposalsAndUpdateVoteStatus = (tokensBatch) => async (
             break;
           case VOTESTATUS_FINISHEDVOTE:
             proposalsUpdated.finishedVote.push(prop);
+            if (approved) {
+              proposalsUpdated.approvedVote.push(prop);
+            } else {
+              proposalsUpdated.rejectedVote.push(prop);
+            }
             break;
           default:
             proposalsUpdated.preVote.push(prop);

--- a/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.jsx
+++ b/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.jsx
@@ -1,0 +1,59 @@
+import { Tooltip } from "shared";
+import { useState } from "react";
+import { FormattedMessage as T } from "react-intl";
+import { TabsHeader } from "shared";
+import styles from "./ProposalsFilter.module.css";
+
+const tabs = [
+  {
+    label: (
+      <Tooltip text={<T id="proposals.statusLinks.allFinishedVote" m="All" />}>
+        <T id="proposals.statusLinks.allFinishedVote" m="All" />
+      </Tooltip>
+    ),
+    value: "finishedVote",
+    icon: styles.allIcon
+  },
+  {
+    label: (
+      <Tooltip
+        text={<T id="proposals.statusLinks.approvedVote" m="Approved" />}>
+        <T id="proposals.statusLinks.approvedVote" m="Approved" />
+      </Tooltip>
+    ),
+    value: "approvedVote",
+    icon: styles.approvedIcon
+  },
+  {
+    label: (
+      <Tooltip
+        text={<T id="proposals.statusLinks.rejectedVote" m="Rejected" />}>
+        <T id="proposals.statusLinks.rejectedVote" m="Rejected" />
+      </Tooltip>
+    ),
+    value: "rejectedVote",
+    icon: styles.rejectedIcon
+  }
+];
+
+const ProposalsFilter = ({ setFilterTab }) => {
+  const [filterTabIndex, setFilterTabIndex] = useState(0);
+
+  const onSelectFilterTab = (index) => {
+    const newTab = tabs[index].value;
+    setFilterTabIndex(index);
+    setFilterTab(newTab);
+  };
+
+  return (
+    <div className={styles.tabs}>
+      <TabsHeader
+        tabs={tabs}
+        setActiveTabIndex={onSelectFilterTab}
+        activeTabIndex={filterTabIndex}
+      />
+    </div>
+  );
+};
+
+export default ProposalsFilter;

--- a/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.module.css
@@ -2,7 +2,7 @@
   text-align: right;
   max-width: 738px;
   margin-left: 85px;
-  margin-top: 30px;
+  margin-top: 15px;
 }
 
 .tabs > div > ul {
@@ -19,18 +19,17 @@
   padding-top: 0px;
 }
 
-
 @media screen and (max-width: 768px) {
   .allIcon {
-    background-image: var(--ticket-live-icon); 
+    background-image: var(--ticket-live-icon);
   }
-  
+
   .approvedIcon {
     background-image: var(--ticket-voted-icon);
   }
-  
+
   .rejectedIcon {
-    background-image: var(--ticket-revoked-icon); 
+    background-image: var(--ticket-revoked-icon);
   }
   .tabs > div > ul {
     left: 0px;
@@ -42,5 +41,4 @@
     margin-left: 0;
     max-width: 673px;
   }
-  
 }

--- a/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.module.css
@@ -1,0 +1,46 @@
+.tabs {
+  text-align: right;
+  max-width: 738px;
+  margin-left: 85px;
+  margin-top: 30px;
+}
+
+.tabs > div > ul {
+  justify-content: right;
+  position: relative;
+  right: -20px;
+  width: fit-content;
+  margin-left: auto;
+  top: 0;
+}
+
+.tabs > div {
+  background-color: transparent;
+  padding-top: 0px;
+}
+
+
+@media screen and (max-width: 768px) {
+  .allIcon {
+    background-image: var(--ticket-live-icon); 
+  }
+  
+  .approvedIcon {
+    background-image: var(--ticket-voted-icon);
+  }
+  
+  .rejectedIcon {
+    background-image: var(--ticket-revoked-icon); 
+  }
+  .tabs > div > ul {
+    left: 0px;
+  }
+}
+
+@media screen and (max-width: 1179px) {
+  .tabs {
+    margin-left: 0;
+    max-width: 673px;
+  }
+  
+}

--- a/app/components/views/GovernancePage/Proposals/ProposalsList/ProposalsList.jsx
+++ b/app/components/views/GovernancePage/Proposals/ProposalsList/ProposalsList.jsx
@@ -5,17 +5,23 @@ import { useProposalsList } from "../hooks";
 import { LoadingError } from "shared";
 import styles from "./ProposalsList.module.css";
 import { useCallback, useLayoutEffect, useState, useEffect } from "react";
+import ProposalsFilter from "../ProposalsFilter/ProposalsFilter";
 
 const ProposalsList = ({ finishedVote, tab }) => {
+  const [filterTab, setFilterTab] = useState(tab);
   const {
-    noMoreProposals,
-    state,
-    proposals,
-    loadMore,
     getProposalError,
     inventoryError,
+    loadMore,
+    noMoreProposals,
+    proposals,
+    state,
     send
-  } = useProposalsList(tab);
+  } = useProposalsList(filterTab);
+
+  const handleSetFilterTab = (tab) => {
+    setFilterTab(tab);
+  };
 
   // This part of the code is meant to solve the situation when the window
   // is too tall, and the user can not trigger `loadMore` with scrolling.
@@ -48,13 +54,18 @@ const ProposalsList = ({ finishedVote, tab }) => {
         </div>
       );
     case "success":
-      return proposals && proposals[tab] && proposals[tab].length ? (
+      return proposals &&
+        proposals[filterTab] &&
+        proposals[filterTab].length ? (
         <div
           ref={ref}
           style={{
             height: "100%",
             overflow: "auto"
           }}>
+          {tab === "finishedVote" && (
+            <ProposalsFilter setFilterTab={handleSetFilterTab} />
+          )}
           <InfiniteScroll
             hasMore={!noMoreProposals}
             loadMore={loadMore}
@@ -62,7 +73,7 @@ const ProposalsList = ({ finishedVote, tab }) => {
             useWindow={false}
             threshold={300}>
             <div className={styles.proposalList}>
-              {proposals[tab].map((v) => (
+              {proposals[filterTab].map((v) => (
                 <ProposalsListItem
                   key={v.token}
                   {...v}

--- a/app/components/views/GovernancePage/Proposals/ProposalsList/ProposalsList.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsList/ProposalsList.module.css
@@ -12,7 +12,7 @@
 }
 
 .proposalList {
-  margin-top: 30px;
+  margin-top: 15px;
   margin-left: 85px;
   padding-bottom: 50px;
   display: block;

--- a/app/components/views/GovernancePage/Proposals/ProposalsList/ProposalsList.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsList/ProposalsList.module.css
@@ -15,8 +15,22 @@
   margin-top: 30px;
   margin-left: 85px;
   padding-bottom: 50px;
+  display: block;
 }
 
+.proposalListWrapper {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 50px;
+  overflow-y: auto;
+  height: calc(100% - 50px);
+}
+
+@media screen and (max-width: 768px) {
+  .proposalList {
+    padding-bottom: 100px;
+  }
+}
 @media screen and (max-width: 1179px) {
   .proposalList {
     margin-left: 35px;

--- a/app/components/views/GovernancePage/Proposals/ProposalsTab.jsx
+++ b/app/components/views/GovernancePage/Proposals/ProposalsTab.jsx
@@ -58,6 +58,7 @@ const ProposalsTab = () => {
     tab,
     getTokenAndInitialBatch
   } = useProposalsTab();
+
   if (!politeiaEnabled) {
     return <PoliteiaDisabled {...{ getTokenAndInitialBatch }} />;
   }


### PR DESCRIPTION
This diff adds the possibility to filter finished voting proposals by its approved or rejected status.

I think we cannot filter proposals by timestamp, since timestamp filtering is not implemented on politeia, but we can add some filters into the **Finished Vote** tab, so we could filter props by **Approved** and **Rejected** status.

Closes #2786