### PR TITLE
Add AppImage build target for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "linux": {
       "category": "public.app-category.tools",
       "target": [
+        "AppImage",
         "deb",
         "rpm",
         "tar.gz"


### PR DESCRIPTION
This hooge PR gets `yarn package-linux` to create an AppImage file which will allow GNOME users to avoid having to launch Decrediton via CLI.
Closes https://github.com/decred/decrediton/issues/2277 and https://github.com/decred/decrediton/issues/2472.