### PR TITLE
multi: Allow trezor ticket purchasing on testnet.

### DIFF
--- a/app/components/buttons/SendTransactionButton/hooks.js
+++ b/app/components/buttons/SendTransactionButton/hooks.js
@@ -14,7 +14,11 @@ export function useSendTransactionButton() {
     dispatch(ca.signTransactionAttempt(passphrase, rawTx, acct));
   };
   const onAttemptSignTransactionTrezor = (rawUnsigTx, constructTxResponse) =>
-    dispatch(tza.signTransactionAttemptTrezor(rawUnsigTx, constructTxResponse));
+    dispatch(
+      tza.signTransactionAttemptTrezor(rawUnsigTx, [
+        constructTxResponse.changeIndex
+      ])
+    );
 
   return {
     unsignedTransaction,

--- a/app/components/shared/PurchaseTicketsForm/PurchaseTicketsForm.jsx
+++ b/app/components/shared/PurchaseTicketsForm/PurchaseTicketsForm.jsx
@@ -58,7 +58,8 @@ const PurchaseTicketsForm = ({
   getAdvancedComponent,
   willEnter,
   willLeave,
-  toggleShowVsp
+  toggleShowVsp,
+  isPurchasingTicketsTrezor
 }) => {
   const intl = useIntl();
   return (
@@ -240,7 +241,10 @@ const PurchaseTicketsForm = ({
       )}
       <div className={styles.buttonsArea}>
         {isWatchingOnly ? (
-          <PiUiButton disabled={!isValid} onClick={onPurchaseTickets}>
+          <PiUiButton
+            disabled={!isValid}
+            loading={isPurchasingTicketsTrezor}
+            onClick={onPurchaseTickets}>
             {purchaseLabel()}
           </PiUiButton>
         ) : isLoading ? (

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/Page.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/Page.jsx
@@ -73,6 +73,7 @@ export function PurchasePage({
   isVSPListingEnabled,
   onEnableVSPListing,
   getRunningIndicator,
+  isPurchasingTicketsTrezor,
   ...props
 }) {
   return (
@@ -115,7 +116,9 @@ export function PurchasePage({
             toggleRememberVspHostCheckBox,
             getRunningIndicator,
             toggleIsLegacy,
-            isLegacy: false
+            isLegacy: false,
+            isPurchasingTicketsTrezor,
+            isWatchingOnly
           }}
         />
       )}

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
@@ -26,7 +26,8 @@ const Tickets = ({ toggleIsLegacy }) => {
     isVSPListingEnabled,
     onEnableVSPListing,
     getRunningIndicator,
-    visibleAccounts
+    visibleAccounts,
+    isPurchasingTicketsTrezor
   } = usePurchaseTab();
 
   const [account, setAccount] = useState(defaultSpendingAccount);
@@ -140,7 +141,8 @@ const Tickets = ({ toggleIsLegacy }) => {
         notMixedAccounts,
         isVSPListingEnabled,
         onEnableVSPListing,
-        getRunningIndicator
+        getRunningIndicator,
+        isPurchasingTicketsTrezor
       }}
     />
   );

--- a/app/components/views/TicketsPage/PurchaseTab/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/hooks.js
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { useSettings } from "hooks";
 import { EXTERNALREQUEST_STAKEPOOL_LISTING } from "constants";
 
+import { purchaseTicketsV3 as trezorPurchseTicketsV3 } from "actions/TrezorActions.js";
 import * as vspa from "actions/VSPActions";
 import * as ca from "actions/ControlActions.js";
 import { listUnspentOutputs } from "actions/TransactionActions";
@@ -23,6 +24,8 @@ export const usePurchaseTab = () => {
   const isLegacy = useSelector(sel.getIsLegacy);
   const isLoading = useSelector(sel.purchaseTicketsRequestAttempt);
   const notMixedAccounts = useSelector(sel.getNotMixedAccounts);
+  const isTrezor = useSelector(sel.isTrezor);
+  const isPurchasingTicketsTrezor = useSelector(sel.isPurchasingTicketsTrezor);
 
   const rememberedVspHost = useSelector(sel.getRememberedVspHost);
   const visibleAccounts = useSelector(sel.visibleAccounts);
@@ -41,11 +44,16 @@ export const usePurchaseTab = () => {
     [dispatch]
   );
   const onPurchaseTicketV3 = useCallback(
-    (passphrase, account, numTickets, vsp) =>
-      dispatch(
-        ca.newPurchaseTicketsAttempt(passphrase, account, numTickets, vsp)
-      ),
-    [dispatch]
+    (passphrase, account, numTickets, vsp) => {
+      if (isTrezor) {
+        dispatch(trezorPurchseTicketsV3(account, numTickets, vsp));
+      } else {
+        dispatch(
+          ca.newPurchaseTicketsAttempt(passphrase, account, numTickets, vsp)
+        );
+      }
+    },
+    [dispatch, isTrezor]
   );
   const onEnableTicketAutoBuyer = useCallback(
     (passphrase, account, balanceToMaintain, vsp) =>
@@ -120,6 +128,7 @@ export const usePurchaseTab = () => {
     onEnableVSPListing,
     onListUnspentOutputs,
     getRunningIndicator,
-    visibleAccounts
+    visibleAccounts,
+    isPurchasingTicketsTrezor
   };
 };

--- a/app/helpers/msgTx.js
+++ b/app/helpers/msgTx.js
@@ -268,6 +268,7 @@ export function decodeRawTransaction(rawTx) {
     position += 4;
     tx.expiry = rawTx.readUInt32LE(position);
     position += 4;
+    tx.prefixOffset = position;
   }
 
   if (tx.serType !== SERTYPE_NOWITNESS) {

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -121,6 +121,10 @@ export const installSessionHandlers = (mainLogger) => {
         `connect-src ${connectSrc}; `;
     }
 
+    const requestURL = new URL(details.url);
+    const maybeVSPReqType = `stakepool_${requestURL.protocol}//${requestURL.host}`;
+    const isVSPRequest = allowedExternalRequests[maybeVSPReqType];
+
     if (isDev && /^http[s]?:\/\//.test(details.url)) {
       // In development (when accessing via the HMR server) we need to overwrite
       // the origin, otherwise electron fails to contact external servers due
@@ -142,6 +146,12 @@ export const installSessionHandlers = (mainLogger) => {
       if (isPoliteia && details.method === "OPTIONS") {
         statusLine = "OK";
         newHeaders["Access-Control-Allow-Headers"] = "Content-Type";
+      }
+
+      if (isVSPRequest && details.method === "OPTIONS") {
+        statusLine = "OK";
+        newHeaders["Access-Control-Allow-Headers"] =
+          "Content-Type,vsp-client-signature";
       }
 
       const globalCfg = getGlobalCfg();
@@ -207,6 +217,7 @@ export const LEGACY_allowStakepoolRequests = (stakePoolHost) => {
   addAllowedURL(stakePoolHost + "/api/v2/voting");
   addAllowedURL(stakePoolHost + "/api/v1/getpurchaseinfo");
   addAllowedURL(stakePoolHost + "/api/v1/stats");
+  allowedExternalRequests[reqType] = true;
 };
 
 // allowVSPRequests allows external vsp request into decrediton.
@@ -216,6 +227,10 @@ export const allowVSPRequests = (stakePoolHost) => {
 
   addAllowedURL(stakePoolHost + "/api/v3/vspinfo");
   addAllowedURL(stakePoolHost + "/api/v3/ticketstatus");
+  addAllowedURL(stakePoolHost + "/api/v3/feeaddress");
+  addAllowedURL(stakePoolHost + "/api/v3/payfee");
+  addAllowedURL(stakePoolHost + "/api/ticketstatus");
+  allowedExternalRequests[reqType] = true;
 };
 
 export const reloadAllowedExternalRequests = () => {

--- a/app/middleware/vspapi.js
+++ b/app/middleware/vspapi.js
@@ -181,3 +181,25 @@ export function getVSPTicketStatus({ host, sig, json }, cb) {
     .then((resp) => cb(resp, null, host))
     .catch((error) => cb(null, error, host));
 }
+
+// getFeeAddress gets a ticket`s fee address.
+export function getFeeAddress({ host, sig, req }, cb) {
+  console.log(req);
+  POST(host + "/api/v3/feeaddress", sig, req)
+    .then((resp) => cb(resp, null, host))
+    .catch((error) => cb(null, error, host));
+}
+
+// payFee infomrs of a ticket`s fee payment.
+export function payFee({ host, sig, req }, cb) {
+  console.log(req);
+  POST(host + "/api/v3/payfee", sig, req)
+    .then((resp) => cb(resp, null, host))
+    .catch((error) => cb(null, error, host));
+}
+
+export function getTicketStatus({ host, vspClientSig, request }, cb) {
+  POST(host + "/api/ticketstatus", vspClientSig, request)
+    .then((resp) => cb(resp, null, host))
+    .catch((error) => cb(null, error, host));
+}

--- a/app/reducers/trezor.js
+++ b/app/reducers/trezor.js
@@ -19,6 +19,9 @@ import {
   TRZ_PASSPHRASE_REQUESTED,
   TRZ_PASSPHRASE_ENTERED,
   TRZ_PASSPHRASE_CANCELED,
+  TRZ_PURCHASETICKET_ATTEMPT,
+  TRZ_PURCHASETICKET_FAILED,
+  TRZ_PURCHASETICKET_SUCCESS,
   TRZ_WORD_REQUESTED,
   TRZ_WORD_ENTERED,
   TRZ_WORD_CANCELED,
@@ -235,6 +238,12 @@ export default function trezor(state = {}, action) {
         performingOperation: false,
         deviceLabel: action.deviceLabel
       };
+    case TRZ_PURCHASETICKET_ATTEMPT:
+      return {
+        ...state,
+        performingOperation: true,
+        purchasingTickets: true
+      };
     case SIGNTX_FAILED:
     case SIGNTX_SUCCESS:
     case TRZ_TOGGLEPINPROTECTION_FAILED:
@@ -264,6 +273,13 @@ export default function trezor(state = {}, action) {
         ...state,
         performingOperation: false,
         performingUpdate: false
+      };
+    case TRZ_PURCHASETICKET_FAILED:
+    case TRZ_PURCHASETICKET_SUCCESS:
+      return {
+        ...state,
+        performingOperation: false,
+        purchasingTickets: false
       };
     case CLOSEWALLET_SUCCESS:
       return { ...state, enabled: false };

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1569,6 +1569,7 @@ export const confirmationDialogModalVisible = bool(
 
 export const isTrezor = get(["trezor", "enabled"]);
 export const isPerformingTrezorUpdate = get(["trezor", "performingUpdate"]);
+export const isPurchasingTicketsTrezor = get(["trezor", "purchasingTickets"]);
 
 export const isSignMessageDisabled = and(isWatchingOnly, not(isTrezor));
 export const isChangePassPhraseDisabled = isWatchingOnly;

--- a/app/wallet/control.js
+++ b/app/wallet/control.js
@@ -280,6 +280,8 @@ export const purchaseTicketsV3 = (
       resObj.ticketHashes = response
         .getTicketHashesList()
         .map((v) => rawHashToHex(v));
+      resObj.splitTx = Buffer.from(response.getSplitTx());
+      resObj.ticketsList = response.getTicketsList().map((v) => Buffer.from(v));
       resolve(resObj);
     });
   });

--- a/app/wallet/vsp.js
+++ b/app/wallet/vsp.js
@@ -49,6 +49,11 @@ export const getStakePoolInfo = promisifyReqLogNoData(
   api.stakePoolInfo
 );
 export const getVSPInfo = promisifyReqLogNoData("getVSPInfo", api.getVSPInfo);
+export const getVSPFeeAddress = promisifyReqLogNoData(
+  "getFeeAddress",
+  api.getFeeAddress
+);
+export const payVSPFee = promisifyReqLogNoData("getFeeAddress", api.payFee);
 export const getVSPTicketStatus = promisifyReqLogNoData(
   "getVSPTicketStatus",
   api.getVSPTicketStatus

--- a/test/data/decodedTransactions.js
+++ b/test/data/decodedTransactions.js
@@ -1,5 +1,6 @@
 export const decodedPurchasedTicketTx = {
   "version": 1,
+  "prefixOffset": 172,
   "serType": 0,
   "numInputs": 1,
   "inputs": [
@@ -56,6 +57,7 @@ export const decodedPurchasedTicketTx = {
 // multiTxPrefix is a tx prefix in the format of how our decodeTxs are. We get
 // this format from wallet.decodeRawTransaction().
 export const multiTxPrefix = {
+  prefixOffset: 211,
   serType: 1, // TxSerializeNoWitness,
   version: 1,
   numInputs: 1,
@@ -113,6 +115,7 @@ export const multiTxPrefix = {
 
 export const decodedVoteTx = {
   "version": 1,
+  "prefixOffset": 201,
   "serType": 0,
   "numInputs": 2,
   "inputs": [

--- a/test/unit/components/buttons/SendTransactionButton.spec.js
+++ b/test/unit/components/buttons/SendTransactionButton.spec.js
@@ -79,10 +79,11 @@ test("render SendTransactionButton when trezor is enabled", async () => {
   const button = screen.getByRole("button");
   user.click(button);
   expect(mockSignTransactionAttempt).not.toHaveBeenCalled();
-  expect(mockSignTransactionAttemptTrezor).toHaveBeenCalledWith(
-    testUnsignedTransaction,
-    testConstructTxResponse
-  );
+  expect(
+    mockSignTransactionAttemptTrezor
+  ).toHaveBeenCalledWith(testUnsignedTransaction, [
+    testConstructTxResponse.changeIndex
+  ]);
   await wait(() => expect(mockOnSubmit).toHaveBeenCalled());
 });
 


### PR DESCRIPTION
Fix updating firmware with model T by sending binary rather than hex.

In signTransactionAttemptTrezor give spending from stake scripts
inputs specific script types "SPENDSSRTX" and "SPENDSSGEN" rather than
"SPENDADDRESS" as trezor needs this information to process the scripts.

Add purchaseTicketsV3 which purchases tickets using a watching only
trezor wallet from a vsp with api v3. Errors if not on testnet.

Add separate payVSPFee function that will pay a tickets fee if not
already paid, and throws if already paid.

Correct purchase ticket button for watching only wallets. It no longer
asks for a password. Connect purchasing through trezor when isTrezor is
true.

Add vsp v3 endpoints "feeaddress" and "payfee" to allowed external
requests.

Change wallet/control.js to not require an unlocked wallet when signTx
is false.