### PR TITLE
Add scroll to browse sidebar accounts

### DIFF
--- a/app/components/SideBar/AccountsList/AccountsList.jsx
+++ b/app/components/SideBar/AccountsList/AccountsList.jsx
@@ -5,14 +5,14 @@ import { classNames } from "pi-ui";
 
 const isImported = (accountNumber) => accountNumber === Math.pow(2, 31) - 1;
 
-const AccountsList = ({ isShowingAccounts, balances }) => (
+const AccountsList = ({ isShowingAccounts, balances, accountsListRef }) => (
   <div
     data-testid="account-list"
     className={classNames(
       style.extended,
       isShowingAccounts && style.showingAccounts
     )}>
-    <div className={style.extendedBottom}>
+    <div className={style.extendedBottom} ref={accountsListRef}>
       {balances.map(
         ({ hidden, total, accountName, accountNumber }) =>
           !hidden && (
@@ -22,8 +22,7 @@ const AccountsList = ({ isShowingAccounts, balances }) => (
                 isImported(accountNumber) && style.imported
               )}
               key={accountName}>
-              <div
-                className={style.extendedBottomAccountName}>
+              <div className={style.extendedBottomAccountName}>
                 {accountName === "default" ? (
                   <T id="sidebar.accounts.name.default" m="Primary Account" />
                 ) : (

--- a/app/components/SideBar/AccountsList/AccountsList.module.css
+++ b/app/components/SideBar/AccountsList/AccountsList.module.css
@@ -17,6 +17,7 @@
 
 .extendedBottom {
   padding-right: 18px;
+  overflow-y: auto;
 }
 
 .extendedBottomAccount {

--- a/app/components/SideBar/MenuBottom/MenuBottomExpanded.jsx
+++ b/app/components/SideBar/MenuBottom/MenuBottomExpanded.jsx
@@ -16,13 +16,15 @@ const MenuBarExpanded = ({
   onShowAccounts,
   onHideAccounts,
   isSPV,
-  peersCount
+  peersCount,
+  onAccountsListWheel
 }) => (
   <div className={styles.bottom}>
     <div
       className={styles.short}
       onMouseEnter={rescanRequest ? null : onShowAccounts}
-      onMouseLeave={rescanRequest ? null : onHideAccounts}>
+      onMouseLeave={rescanRequest ? null : onHideAccounts}
+      onWheel={onAccountsListWheel}>
       <div
         className={classNames(
           styles.shortSeparator,
@@ -44,8 +46,7 @@ const MenuBarExpanded = ({
           </div>
           <a className={styles.latestBlockName}>
             <T id="sidebar.latestBlock" m="Latest Block" />
-            <span className={styles.latestBlockNumber}>
-              {" "}
+            <span className={style.latestBlockNumber}>
               {currentBlockHeight}
             </span>
           </a>

--- a/app/components/SideBar/MenuBottom/MenuBottomExpanded.jsx
+++ b/app/components/SideBar/MenuBottom/MenuBottomExpanded.jsx
@@ -46,7 +46,7 @@ const MenuBarExpanded = ({
           </div>
           <a className={styles.latestBlockName}>
             <T id="sidebar.latestBlock" m="Latest Block" />
-            <span className={style.latestBlockNumber}>
+            <span className={styles.latestBlockNumber}>
               {currentBlockHeight}
             </span>
           </a>

--- a/app/components/SideBar/SideBar.jsx
+++ b/app/components/SideBar/SideBar.jsx
@@ -26,7 +26,9 @@ const SideBar = () => {
     onExpandSideBar,
     onReduceSideBar,
     isSPV,
-    peersCount
+    peersCount,
+    accountsListRef,
+    onAccountsListWheel
   } = useSideBar();
   const { rescanAttempt, rescanCancel } = useRescan();
 
@@ -59,7 +61,8 @@ const SideBar = () => {
         <AccountsList
           {...{
             isShowingAccounts,
-            balances
+            balances,
+            accountsListRef
           }}
         />
       </div>
@@ -75,7 +78,8 @@ const SideBar = () => {
             onShowAccounts,
             onHideAccounts,
             isSPV,
-            peersCount
+            peersCount,
+            onAccountsListWheel
           }}
         />
       ) : (

--- a/app/components/SideBar/hooks.js
+++ b/app/components/SideBar/hooks.js
@@ -1,10 +1,19 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import * as sel from "selectors";
 import * as sba from "../../actions/SidebarActions";
 
 export function useSideBar() {
   const [isShowingAccounts, setIsShowingAccounts] = useState(false);
+
+  const accountsListRef = useRef(null);
+
+  const onAccountsListWheel = useCallback((e) =>
+    accountsListRef.current.scrollBy({
+      top: e.deltaY * 2,
+      behavior: "smooth"
+    })
+    , []);
 
   const isTestNet = useSelector(sel.isTestNet);
   const balances = useSelector(sel.balances);
@@ -45,6 +54,8 @@ export function useSideBar() {
     onExpandSideBar,
     onReduceSideBar,
     isSPV,
-    peersCount
+    peersCount,
+    accountsListRef,
+    onAccountsListWheel
   };
 }


### PR DESCRIPTION
This PR adds the possibility of scrolling through the accounts listed in the sidebar by rolling the scroll wheel when the list is visible.

Closes https://github.com/decred/decrediton/issues/2870.