### PR TITLE
Fix peer count grammar.

### DIFF
--- a/app/i18n/po/decrediton.pt.po
+++ b/app/i18n/po/decrediton.pt.po
@@ -5144,10 +5144,10 @@ msgstr "Pagamentos enviados por essa carteira LN."
 
 #. [sidebar.peersCount]
 #. defaultMessage is:
-#. Peers Count
+#. Peers
 #: app/i18n/extracted/app/components/SideBar/Logo/Logo.json
 msgctxt "sidebar.peersCount"
-msgid "Peers Count"
+msgid "Peers"
 msgstr "Número de Pares"
 
 #. [txHistory.Pending]

--- a/app/i18n/pot/decrediton.pot
+++ b/app/i18n/pot/decrediton.pot
@@ -4906,9 +4906,9 @@ msgstr ""
 #: app/i18n/extracted/app/components/SideBar/Logo/Logo.json
 #. [sidebar.peersCount]
 #. defaultMessage is:
-#. Peers Count
+#. Peers
 msgctxt "sidebar.peersCount"
-msgid "Peers Count"
+msgid "Peers"
 msgstr ""
 
 #: app/i18n/extracted/app/components/shared/TxHistory/Row.json

--- a/app/i18n/translations/original.json
+++ b/app/i18n/translations/original.json
@@ -936,7 +936,7 @@
   "sidebar.link.transactions": "Transactions",
   "sidebar.link.trezor": "Trezor Setup",
   "sidebar.mixer.running": "The mixer is running. Go to Privacy view for more information",
-  "sidebar.peersCount": "Peers Count",
+  "sidebar.peersCount": "Peers",
   "sidebar.rescanBtn.tip": "Initiate a transaction rescan.\n\nRescanning may help resolve some balance errors.\n\nNote: This scans the entire blockchain for transactions,\nbut does not re-download it.",
   "sidebar.rescanCancelBtn.tip": "Cancel rescan",
   "sidebar.spvMode": "SPV Mode",


### PR DESCRIPTION
`Peers Count: 8` is not correct - we should either go with `Peers: 8` or `Peer Count: 8`.

I have gone with `Peers: 8` because the word "count" seems redundant.