### PR TITLE
[Tickets] Show "sync" button on fee error automatically

### DIFF
--- a/app/components/views/TicketsPage/VSPTicketsStatusTab/Page.jsx
+++ b/app/components/views/TicketsPage/VSPTicketsStatusTab/Page.jsx
@@ -8,7 +8,6 @@ import {
 import { TxHistory, Subtitle, Tooltip } from "shared";
 import { EyeFilterMenu, PassphraseModalButton } from "buttons";
 import style from "./MyTicketsTab.module.css";
-import { VSP_FEE_PROCESS_ERRORED } from "constants";
 import { SyncVSPFailedTickets } from "modals";
 
 const subtitleMenu = ({
@@ -70,7 +69,7 @@ const TicketListPage = ({
         })}
       />
       {
-        selectedTicketTypeKey == VSP_FEE_PROCESS_ERRORED && (
+        hasVSPTicketsError && (
           <PassphraseModalButton
             {...{
               onSubmit: onSyncVspTicketsRequest,


### PR DESCRIPTION
Closes #2858 
Now, if a ticket is errored the sync button is visible independently of the ticket filter.