### PR TITLE
Improve disabled `plus` button bg color in send funds

### DIFF
--- a/app/components/views/TransactionsPage/SendTab/SendOutputRow/SendOutputRow.module.css
+++ b/app/components/views/TransactionsPage/SendTab/SendOutputRow/SendOutputRow.module.css
@@ -33,7 +33,7 @@
 
 .sendIconWrapper.add.disabled {
   background-image: var(--add-icon);
-  background-color: #E7EAED;
+  background-color: var(--disabled-background-color-lighter);
   cursor: auto;
 }
 


### PR DESCRIPTION
After:

![image](https://user-images.githubusercontent.com/10324528/98829777-47719680-2442-11eb-9fe9-1eb0af82dc64.png)


Closes #2883 