### PR TITLE
Add `cursor: not-allowed` to `plus` button in send funds

### DIFF
--- a/app/components/views/TransactionsPage/SendTab/SendOutputRow/SendOutputRow.module.css
+++ b/app/components/views/TransactionsPage/SendTab/SendOutputRow/SendOutputRow.module.css
@@ -34,7 +34,7 @@
 .sendIconWrapper.add.disabled {
   background-image: var(--add-icon);
   background-color: var(--disabled-background-color-lighter);
-  cursor: auto;
+  cursor: not-allowed;
 }
 
 .sendIconWrapper.delete {


### PR DESCRIPTION
This commit adds a tiny css nit which was missed in #2908 - showing `not-allowed` cursor to give a better ux for
a disabled button.

Screenshot:

![image](https://user-images.githubusercontent.com/10324528/98861482-068f7700-246e-11eb-8d83-b8725ee27cee.png)
