### PR TITLE
Assorted minor fixes

### DIFF
--- a/app/components/SideBar/MenuBottom/MenuBottom.module.css
+++ b/app/components/SideBar/MenuBottom/MenuBottom.module.css
@@ -87,11 +87,16 @@
   text-decoration: none;
 }
 
-.peersCount {
+.bottomBar {
   display: flex;
   align-items: center;
   padding: 0 16px 8px;
   background-color: var(--info-modal-button-text);
+}
+
+.peersCount {
+  display: flex;
+  align-items: center;
 }
 
 .peersIcon {
@@ -130,12 +135,14 @@
   animation: spin 1s linear infinite;
 }
 
+.spvIconContainer {
+  margin-left: auto;
+}
+
 .spvIcon {
   background-image: var(--enable-spv);
-  height: 1.6rem;
-  width: 1.6rem;
-  align-items: center;
-  left: 16rem;
+  height: 2.0rem;
+  width: 2.0rem; 
 }
 
 .spvLabel {

--- a/app/components/SideBar/MenuBottom/MenuBottomExpanded.jsx
+++ b/app/components/SideBar/MenuBottom/MenuBottomExpanded.jsx
@@ -1,10 +1,10 @@
 import { FormattedMessage as T } from "react-intl";
-import { Balance } from "shared";
+import { Balance, Tooltip } from "shared";
 import { RescanButton } from "buttons";
 import { RescanProgress } from "indicators";
 import LastBlockTime from "./LastBlockTime/LastBlockTime";
 import styles from "./MenuBottom.module.css";
-import { classNames, Tooltip } from "pi-ui";
+import { classNames } from "pi-ui";
 
 const MenuBarExpanded = ({
   isShowingAccounts,
@@ -56,16 +56,20 @@ const MenuBarExpanded = ({
         </>
       )}
     </div>
-    <div className={styles.peersCount}>
-      <div className={styles.peersIcon}></div>
-      <span className={styles.peersCountLabel}>
-        <T id="sidebar.peersCount" m="Peers" />
-      </span>
-      <span className={styles.peersCountValue}>&nbsp;{peersCount}</span>
+    <div className={styles.bottomBar}>
+      <div className={styles.peersCount}>
+        <div className={styles.peersIcon}></div>
+        <span className={styles.peersCountLabel}>
+          <T id="sidebar.peersCount" m="Peers" />
+        </span>
+        <span className={styles.peersCountValue}>&nbsp;{peersCount}</span>
+      </div>
       {isSPV && (
-        <Tooltip className={styles.spvIcon} content={<T id="sidebar.spvMode" m="SPV Mode" />}>
-          <div  />
-        </Tooltip>
+        <div className={styles.spvIconContainer}>
+          <Tooltip text={<T id="sidebar.spvMode" m="SPV Mode" />}>
+            <div className={styles.spvIcon} />
+          </Tooltip>
+        </div>
       )}
     </div>
   </div>

--- a/app/components/views/GovernancePage/Proposals/PoliteiaDisabled.jsx
+++ b/app/components/views/GovernancePage/Proposals/PoliteiaDisabled.jsx
@@ -5,10 +5,10 @@ import styles from "./ProposalsTab.module.css";
 
 export default ({ getTokenAndInitialBatch }) => (
   <div className={styles.politeiaDisabled}>
-    <p>
+    <p className={styles.politeiaDisabledMsg}>
       <T
         id="proposals.enablePoliteia.description"
-        m="Politeia integration is currently disabled in your privacy settings. Please enable it if you want to be able to access the proposal system."
+        m="Politeia integration is disabled by privacy settings. It must be enabled to access the proposal system."
       />
     </p>
     <EnableExternalRequestButton

--- a/app/components/views/GovernancePage/Proposals/ProposalsTab.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsTab.module.css
@@ -60,6 +60,10 @@
   padding: 38px 60px 30px 63px;
 }
 
+.politeiaDisabledMsg {
+  padding-bottom: 24px;
+}
+
 .proposalsLink {
   color: var(--button-text) !important;
 }

--- a/app/i18n/po/decrediton.de.po
+++ b/app/i18n/po/decrediton.de.po
@@ -4325,13 +4325,13 @@ msgstr "Politeia"
 
 #. [proposals.enablePoliteia.description]
 #. defaultMessage is:
-#. Politeia integration is currently disabled in your privacy settings. Please
-#. enable it if you want to be able to access the proposal system.
+#. Politeia integration is disabled by privacy settings.
+#. It must be enabled to access the proposal system.
 #: app/i18n/extracted/app/components/views/GovernancePage/Proposals/PoliteiaDisabled.json
 msgctxt "proposals.enablePoliteia.description"
 msgid ""
-"Politeia integration is currently disabled in your privacy settings. Please "
-"enable it if you want to be able to access the proposal system."
+"Politeia integration is disabled by privacy settings. "
+"It must be enabled to access the proposal system."
 msgstr ""
 "Die Politeia-Integration ist derzeit in Ihren Datenschutzeinstellungen "
 "deaktiviert. Bitte aktivieren Sie sie, wenn Sie auf das Proposal-System "
@@ -5834,7 +5834,7 @@ msgstr "Stake-Prämien"
 
 #. [stake.enableStakePoolListing.description]
 #. defaultMessage is:
-#. StakePool listing from external API endpoint is currently disabled. Please
+#. StakePool listing from external API endpoint is currently disabled
 #. enable the access to this third party service or manually configure the
 #. stakepool.
 #: app/i18n/extracted/app/components/views/TicketsPage/PurchaseTab/StakePools/index.json

--- a/app/i18n/po/decrediton.es.po
+++ b/app/i18n/po/decrediton.es.po
@@ -4336,13 +4336,13 @@ msgstr "Politeia"
 
 #. [proposals.enablePoliteia.description]
 #. defaultMessage is:
-#. Politeia integration is currently disabled in your privacy settings. Please
-#. enable it if you want to be able to access the proposal system.
+#. Politeia integration is disabled by privacy settings.
+#. It must be enabled to access the proposal system.
 #: app/i18n/extracted/app/components/views/GovernancePage/Proposals/PoliteiaDisabled.json
 msgctxt "proposals.enablePoliteia.description"
 msgid ""
-"Politeia integration is currently disabled in your privacy settings. Please "
-"enable it if you want to be able to access the proposal system."
+"Politeia integration is disabled by privacy settings. "
+"It must be enabled to access the proposal system."
 msgstr ""
 "La integración de Politeia está deshabilitada en sus ajustes de privacidad. "
 "Habilítela si quiere acceder al sistema de propuestas."
@@ -5842,7 +5842,7 @@ msgstr "Recompensas de participación"
 
 #. [stake.enableStakePoolListing.description]
 #. defaultMessage is:
-#. StakePool listing from external API endpoint is currently disabled. Please
+#. StakePool listing from external API endpoint is currently disabled
 #. enable the access to this third party service or manually configure the
 #. stakepool.
 #: app/i18n/extracted/app/components/views/TicketsPage/PurchaseTab/StakePools/index.json

--- a/app/i18n/po/decrediton.fr.po
+++ b/app/i18n/po/decrediton.fr.po
@@ -4336,13 +4336,13 @@ msgstr "Politeia"
 
 #. [proposals.enablePoliteia.description]
 #. defaultMessage is:
-#. Politeia integration is currently disabled in your privacy settings. Please
-#. enable it if you want to be able to access the proposal system.
+#. Politeia integration is disabled by privacy settings.
+#. It must be enabled to access the proposal system.
 #: app/i18n/extracted/app/components/views/GovernancePage/Proposals/PoliteiaDisabled.json
 msgctxt "proposals.enablePoliteia.description"
 msgid ""
-"Politeia integration is currently disabled in your privacy settings. Please "
-"enable it if you want to be able to access the proposal system."
+"Politeia integration is disabled by privacy settings. "
+"It must be enabled to access the proposal system."
 msgstr ""
 "L'intégration de Politeia est actuellement désactivée dans vos paramètres de"
 " confidentialité. Veuillez l'activer si vous souhaitez accéder au système de"
@@ -5847,7 +5847,7 @@ msgstr "Récompenses d'enjeu"
 
 #. [stake.enableStakePoolListing.description]
 #. defaultMessage is:
-#. StakePool listing from external API endpoint is currently disabled. Please
+#. StakePool listing from external API endpoint is currently disabled
 #. enable the access to this third party service or manually configure the
 #. stakepool.
 #: app/i18n/extracted/app/components/views/TicketsPage/PurchaseTab/StakePools/index.json

--- a/app/i18n/po/decrediton.ja.po
+++ b/app/i18n/po/decrediton.ja.po
@@ -4257,13 +4257,13 @@ msgstr "Politeia"
 
 #. [proposals.enablePoliteia.description]
 #. defaultMessage is:
-#. Politeia integration is currently disabled in your privacy settings. Please
-#. enable it if you want to be able to access the proposal system.
+#. Politeia integration is disabled by privacy settings.
+#. It must be enabled to access the proposal system.
 #: app/i18n/extracted/app/components/views/GovernancePage/Proposals/PoliteiaDisabled.json
 msgctxt "proposals.enablePoliteia.description"
 msgid ""
-"Politeia integration is currently disabled in your privacy settings. Please "
-"enable it if you want to be able to access the proposal system."
+"Politeia integration is disabled by privacy settings. "
+"It must be enabled to access the proposal system."
 msgstr "Politeiaの統合は、現在プライバシー設定で無効になっています。プロポーザルシステムにアクセスするには、これを有効にしてください。"
 
 #. [purchaseTickets.advanced.poolAddress]
@@ -5752,7 +5752,7 @@ msgstr "ステーク報酬"
 
 #. [stake.enableStakePoolListing.description]
 #. defaultMessage is:
-#. StakePool listing from external API endpoint is currently disabled. Please
+#. StakePool listing from external API endpoint is currently disabled
 #. enable the access to this third party service or manually configure the
 #. stakepool.
 #: app/i18n/extracted/app/components/views/TicketsPage/PurchaseTab/StakePools/index.json

--- a/app/i18n/po/decrediton.pt.po
+++ b/app/i18n/po/decrediton.pt.po
@@ -5299,13 +5299,13 @@ msgstr "Politeia"
 
 #. [proposals.enablePoliteia.description]
 #. defaultMessage is:
-#. Politeia integration is currently disabled in your privacy settings. Please
-#. enable it if you want to be able to access the proposal system.
+#. Politeia integration is disabled by privacy settings.
+#. It must be enabled to access the proposal system.
 #: app/i18n/extracted/app/components/views/GovernancePage/Proposals/PoliteiaDisabled.json
 msgctxt "proposals.enablePoliteia.description"
 msgid ""
-"Politeia integration is currently disabled in your privacy settings. Please "
-"enable it if you want to be able to access the proposal system."
+"Politeia integration is disabled by privacy settings. "
+"It must be enabled to access the proposal system."
 msgstr ""
 "Integração da Politeia está desabilitada nas suas preferências de "
 "privacidade. Por favor habilite-a se você quer ser capaz de acessar o "

--- a/app/i18n/po/decrediton.zh.po
+++ b/app/i18n/po/decrediton.zh.po
@@ -4254,13 +4254,13 @@ msgstr "Politeia"
 
 #. [proposals.enablePoliteia.description]
 #. defaultMessage is:
-#. Politeia integration is currently disabled in your privacy settings. Please
-#. enable it if you want to be able to access the proposal system.
+#. Politeia integration is disabled by privacy settings.
+#. It must be enabled to access the proposal system.
 #: app/i18n/extracted/app/components/views/GovernancePage/Proposals/PoliteiaDisabled.json
 msgctxt "proposals.enablePoliteia.description"
 msgid ""
-"Politeia integration is currently disabled in your privacy settings. Please "
-"enable it if you want to be able to access the proposal system."
+"Politeia integration is disabled by privacy settings. "
+"It must be enabled to access the proposal system."
 msgstr "Politeia集成在您的私人设置中当前是被禁用的，如果您想登录投票系统，请授权允许。"
 
 #. [purchaseTickets.advanced.poolAddress]
@@ -5748,7 +5748,7 @@ msgstr "投票奖励"
 
 #. [stake.enableStakePoolListing.description]
 #. defaultMessage is:
-#. StakePool listing from external API endpoint is currently disabled. Please
+#. StakePool listing from external API endpoint is currently disabled
 #. enable the access to this third party service or manually configure the
 #. stakepool.
 #: app/i18n/extracted/app/components/views/TicketsPage/PurchaseTab/StakePools/index.json

--- a/app/i18n/pot/decrediton.pot
+++ b/app/i18n/pot/decrediton.pot
@@ -5051,9 +5051,9 @@ msgstr ""
 #: app/i18n/extracted/app/components/views/GovernancePage/Proposals/PoliteiaDisabled.json
 #. [proposals.enablePoliteia.description]
 #. defaultMessage is:
-#. Politeia integration is currently disabled in your privacy settings. Please enable it if you want to be able to access the proposal system.
+#. Politeia integration is disabled by privacy settings. It must be enabled to access the proposal system.
 msgctxt "proposals.enablePoliteia.description"
-msgid "Politeia integration is currently disabled in your privacy settings. Please enable it if you want to be able to access the proposal system."
+msgid "Politeia integration is disabled by privacy settings. It must be enabled to access the proposal system."
 msgstr ""
 
 #: app/i18n/extracted/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_PurchaseTickets/PurchaseTicketsAdvanced.json

--- a/app/i18n/translations/original.json
+++ b/app/i18n/translations/original.json
@@ -718,7 +718,7 @@
   "proposals.detail.wallet.eligible.headers.status": "Ticket Status",
   "proposals.detail.wallet.eligible.headers.transaction": "Transaction",
   "proposals.enablePoliteia.button": "Enable Politeia Integration",
-  "proposals.enablePoliteia.description": "Politeia integration is currently disabled in your privacy settings. Please enable it if you want to be able to access the proposal system.",
+  "proposals.enablePoliteia.description": "Politeia integration is disabled by privacy settings. It must be enabled to access the proposal system.",
   "proposals.quorumNotMet": "Quorum not met",
   "proposals.statusLinks.abandoned": "Abandoned",
   "proposals.statusLinks.preVote": "In Discussion",

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -245,8 +245,8 @@
   background-size: 20px;
   background-repeat: no-repeat;
   box-shadow: none;
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
   background-color: transparent;
   border: 0;
   line-height: inherit;


### PR DESCRIPTION
## Dont crop "?" icon

Was previously being displayed as a square because the icon was cropped. Making the height and width match the background-size ensures the full icon is displayed

#### Before

![Screenshot from 2020-11-12 15-26-16](https://user-images.githubusercontent.com/6762864/98959722-78fa6880-24fb-11eb-9873-d067344a312b.png)

#### After

![Screenshot from 2020-11-12 15-26-35](https://user-images.githubusercontent.com/6762864/98959709-75ff7800-24fb-11eb-80ef-22081f0d0224.png)


---

## Tweak SPV mode tooltip

- Remove hardcoded "left" from the SPV icon. Use "margin-left: auto" instead.
- Revert from pi-ui tooltip to Decrediton tooltip. pi-ui tooltip is distinctly different to other tooltips, and forces the "SPV Mode" string to appear on two lines due to a bug.
There is already another issue open which should include migrating this to pi-ui with the correct styling #2512
---

## Add spacing under pi integration msg, tweak text.

#### Before

![Screenshot from 2020-11-12 15-24-15](https://user-images.githubusercontent.com/6762864/98959402-2620b100-24fb-11eb-8c55-0916cf3cc062.png)

#### After 

![Screenshot from 2020-11-12 15-24-10](https://user-images.githubusercontent.com/6762864/98959393-2456ed80-24fb-11eb-9594-442235e1f9dd.png)


