### PR TITLE
[Settings] Cleanup politeia's network specific csrf on network switch

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -3,11 +3,12 @@ import {
   setSelectedWallet,
   openWalletAttempt
 } from "./WalletLoaderActions";
-import { getVersionServiceAttempt } from "./VersionActions";
+import { getVersionServiceAttempt, semverCompatible } from "./VersionActions";
 import { stopNotifcations } from "./NotificationActions";
 import { saveSettings, updateStateSettingsChanged } from "./SettingsActions";
 import { rescanCancel } from "./ControlActions";
-import { semverCompatible } from "./VersionActions";
+import { enableTrezor } from "./TrezorActions";
+import { TOGGLE_ISLEGACY, SET_REMEMBERED_VSP_HOST } from "./VSPActions";
 import * as wallet from "wallet";
 import { push as pushHistory, goBack } from "connected-react-router";
 import { ipcRenderer } from "electron";
@@ -16,9 +17,6 @@ import { isTestNet } from "selectors";
 import axios from "axios";
 import { STANDARD_EXTERNAL_REQUESTS } from "main_dev/externalRequests";
 import { DIFF_CONNECTION_ERROR, LOCALE, TESTNET } from "constants";
-import { enableTrezor } from "./TrezorActions";
-import { TOGGLE_ISLEGACY } from "actions/VSPActions";
-import { SET_REMEMBERED_VSP_HOST } from "actions/VSPActions";
 
 export const DECREDITON_VERSION = "DECREDITON_VERSION";
 export const SELECT_LANGUAGE = "SELECT_LANGUAGE";
@@ -335,7 +333,10 @@ export const closeDaemonRequest = () => async (dispatch, getState) => {
   }
 };
 
-export const startWallet = (selectedWallet, hasPassPhrase) => (dispatch, getState) =>
+export const startWallet = (selectedWallet, hasPassPhrase) => (
+  dispatch,
+  getState
+) =>
   new Promise((resolve, reject) => {
     const start = async () => {
       const { currentSettings } = getState().settings;
@@ -593,11 +594,13 @@ export const getDcrdLogs = () => {
     });
 };
 
-export const getDcrdLastLineLogs = () => () => new Promise((resolve, reject) =>
-  wallet.getDcrdLastLogLine()
-    .then((log) => resolve(log))
-    .catch(err => reject(err))
-);
+export const getDcrdLastLineLogs = () => () =>
+  new Promise((resolve, reject) =>
+    wallet
+      .getDcrdLastLogLine()
+      .then((log) => resolve(log))
+      .catch((err) => reject(err))
+  );
 
 export const getDcrwalletLogs = () => () =>
   new Promise((resolve, reject) =>
@@ -607,11 +610,13 @@ export const getDcrwalletLogs = () => () =>
       .catch((err) => reject(err))
   );
 
-export const getPrivacyLogs = () => () => new Promise((resolve, reject) =>
-  wallet.getPrivacyLogs()
-    .then((logs) => resolve(logs))
-    .catch(err => reject(err))
-);
+export const getPrivacyLogs = () => () =>
+  new Promise((resolve, reject) =>
+    wallet
+      .getPrivacyLogs()
+      .then((logs) => resolve(logs))
+      .catch((err) => reject(err))
+  );
 
 export const getDecreditonLogs = () => {
   wallet

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -148,9 +148,7 @@ export const GETTOKEN_INVENTORY_ATTEMPT = "GETTOKEN_INVENTORY_ATTEMPT";
 export const GETTOKEN_INVENTORY_SUCCESS = "GETTOKEN_INVENTORY_SUCCESS";
 export const GETTOKEN_INVENTORY_FAILED = "GETTOKEN_INVENTORY_FAILED";
 
-export const cleanupPoliteiaCSRF = () => () => {
-  pi.cleanupCSRF();
-};
+export const cleanupPoliteiaCSRF = () => () => pi.cleanupCSRF();
 
 const getTokenInventory = () => async (dispatch, getState) => {
   dispatch({ type: GETTOKEN_INVENTORY_ATTEMPT });

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -148,6 +148,10 @@ export const GETTOKEN_INVENTORY_ATTEMPT = "GETTOKEN_INVENTORY_ATTEMPT";
 export const GETTOKEN_INVENTORY_SUCCESS = "GETTOKEN_INVENTORY_SUCCESS";
 export const GETTOKEN_INVENTORY_FAILED = "GETTOKEN_INVENTORY_FAILED";
 
+export const cleanupPoliteiaCSRF = () => () => {
+  pi.cleanupCSRF();
+};
+
 const getTokenInventory = () => async (dispatch, getState) => {
   dispatch({ type: GETTOKEN_INVENTORY_ATTEMPT });
   const piURL = sel.politeiaURL(getState());
@@ -429,7 +433,7 @@ export const getProposalsAndUpdateVoteStatus = (tokensBatch) => async (
       prop.proposalStatus = prop.status;
 
       fillVoteSummary(prop, proposalSummary, blockTimestampFromNow);
-      prop.currentVoteChoice = getVoteOption(
+      prop.currentVoteChoice = walletName && getVoteOption(
         token,
         prop,
         null,

--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -91,7 +91,6 @@ export const saveSettings = (settings) => async (dispatch, getState) => {
     // we need to cleanup politeia's csrf as this info is network specific.
     dispatch(cleanupPoliteiaCSRF());
     dispatch(closeWalletRequest());
-    dispatch(cleanupPoliteiaCSRF());
     await dispatch(closeDaemonRequest());
     dispatch(backToCredentials());
   }
@@ -163,7 +162,6 @@ export function updateStateSettingsChanged(settings, norestart) {
       false
     );
 
-    console.log(3333333);
     if (newDiffersFromTemp) {
       const newDiffersFromCurrent = settingsFields.reduce(
         (d, f) => d || newSettings[f] !== currentSettings[f],

--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -17,6 +17,7 @@ import {
   getTokenAndInitialBatch,
   resetInventoryAndProposals
 } from "actions/GovernanceActions";
+import { cleanupPoliteiaCSRF } from "./GovernanceActions";
 import * as configConstants from "constants/config";
 
 export const SETTINGS_SAVE = "SETTINGS_SAVE";
@@ -59,16 +60,6 @@ export const saveSettings = (settings) => async (dispatch, getState) => {
     const walletConfig = getWalletCfg(isTestNet(getState()), walletName);
     walletConfig.set("currency_display", settings.currencyDisplay);
     walletConfig.set("gaplimit", settings.gapLimit);
-
-    // We can not enable politeia without wallet name as we need it to check for cached votes.
-    const newPoliteiaEnabled =
-      settings.allowedExternalRequests.indexOf(EXTERNALREQUEST_POLITEIA) > -1;
-    if (newPoliteiaEnabled === true) {
-      dispatch(getTokenAndInitialBatch());
-    }
-    if (newPoliteiaEnabled === false) {
-      dispatch(resetInventoryAndProposals());
-    }
   }
 
   if (
@@ -97,9 +88,23 @@ export const saveSettings = (settings) => async (dispatch, getState) => {
   }
 
   if (needNetworkReset) {
+    // we need to cleanup politeia's csrf and cached inventory tokens here,
+    // as this info is network specific.
+    dispatch(cleanupPoliteiaCSRF());
     dispatch(closeWalletRequest());
+    dispatch(cleanupPoliteiaCSRF());
     await dispatch(closeDaemonRequest());
     dispatch(backToCredentials());
+  }
+
+  // This should happen after dispatching `SETTINGS_SAVE` action
+  const newPoliteiaEnabled =
+    settings.allowedExternalRequests.indexOf(EXTERNALREQUEST_POLITEIA) > -1;
+  if (newPoliteiaEnabled === true) {
+    dispatch(getTokenAndInitialBatch());
+  }
+  if (newPoliteiaEnabled === false) {
+    dispatch(resetInventoryAndProposals());
   }
 };
 
@@ -159,6 +164,7 @@ export function updateStateSettingsChanged(settings, norestart) {
       false
     );
 
+    console.log(3333333);
     if (newDiffersFromTemp) {
       const newDiffersFromCurrent = settingsFields.reduce(
         (d, f) => d || newSettings[f] !== currentSettings[f],

--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -88,8 +88,7 @@ export const saveSettings = (settings) => async (dispatch, getState) => {
   }
 
   if (needNetworkReset) {
-    // we need to cleanup politeia's csrf and cached inventory tokens here,
-    // as this info is network specific.
+    // we need to cleanup politeia's csrf as this info is network specific.
     dispatch(cleanupPoliteiaCSRF());
     dispatch(closeWalletRequest());
     dispatch(cleanupPoliteiaCSRF());

--- a/app/middleware/politeiaapi.js
+++ b/app/middleware/politeiaapi.js
@@ -38,6 +38,8 @@ function POST(piURL, path, payload) {
   });
 }
 
+export const cleanupCSRF = () => CSRFPromise = null;
+
 export const getProposal = ({ piURL, token }, cb) =>
   GET(piURL, "/v1/proposals/" + token).then(function (response) {
     cb(response);

--- a/app/wallet/politeia.js
+++ b/app/wallet/politeia.js
@@ -12,6 +12,8 @@ const promisifyReqLogNoData = (fnName, Req) => {
   );
 };
 
+export const cleanupCSRF = () => api.cleanupCSRF();
+
 export const getProposal = promisifyReqLogNoData(
   "getProposal",
   api.getProposal


### PR DESCRIPTION
This diff fixes #2914 by cleaning up csrf token on network switch, and changing actions order in order to 
ensure that we save new politeiaURL before fetching token inventory from politeia.
