### PR TITLE
[startup] Filter incomplete setup wallets in wallet selection

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -250,7 +250,8 @@ export const getAvailableWallets = () => (dispatch, getState) =>
 
     get()
       .then(({ availableWallets, previousWallet }) => {
-        dispatch({ availableWallets, previousWallet, type: AVAILABLE_WALLETS });
+        const setupCompletedWallets = availableWallets.filter((w) => w.finished);
+        dispatch({ availableWallets: setupCompletedWallets, previousWallet, type: AVAILABLE_WALLETS });
         resolve({ availableWallets, previousWallet });
       })
       .catch((err) => reject(err));

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -157,7 +157,7 @@ const availableWallets = get(["daemon", "availableWallets"]);
 const availableWalletsSelect = createSelector([availableWallets], (wallets) =>
   map(
     (wallet) => ({
-      label: wallet.wallet + " (" + wallet.network + ")",
+      label: `${wallet.wallet} (${wallet.network})`,
       value: wallet,
       network: wallet.network,
       finished: wallet.finished,


### PR DESCRIPTION
This diff fixes #2920 by filtering out incomplete setup wallet in available wallets list. 