### PR TITLE
[Purchase ticket] fix missing mixedAccountBranch selector

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -426,16 +426,23 @@ export const startTicketBuyerV3Attempt = (
   const changeAccount = sel.getChangeAccount(getState());
   const csppServer = sel.getCsppServer(getState());
   const csppPort = sel.getCsppPort(getState());
+  const mixedAcctBranch = sel.getMixedAccountBranch(getState());
 
   if (mixedAccount && changeAccount) {
-    if (!mixedAccount || !changeAccount || !csppServer || !csppPort) {
+    if (
+      !mixedAccount ||
+      !changeAccount ||
+      !csppServer ||
+      !csppPort ||
+      typeof mixedAcctBranch === "undefined"
+    ) {
       throw "missing cspp argument";
     }
     request.setMixedAccount(mixedAccount);
     request.setMixedSplitAccount(mixedAccount);
     request.setChangeAccount(changeAccount);
-    request.setCsppServer(csppServer + ":" + csppPort);
-    request.setMixedAccountBranch(0);
+    request.setCsppServer(`${csppServer}:${csppPort}`);
+    request.setMixedAccountBranch(mixedAcctBranch);
   }
 
   request.setBalanceToMaintain(balanceToMaintain);

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -18,26 +18,24 @@ export const GETNEXTADDRESS_ATTEMPT = "GETNEXTADDRESS_ATTEMPT";
 export const GETNEXTADDRESS_FAILED = "GETNEXTADDRESS_FAILED";
 export const GETNEXTADDRESS_SUCCESS = "GETNEXTADDRESS_SUCCESS";
 
-export const getNextAddressAttempt = (accountNumber) => (
-  dispatch,
-  getState
-) => new Promise((resolve, reject) => {
-  dispatch({ type: GETNEXTADDRESS_ATTEMPT });
-  return wallet
-    .getNextAddress(sel.walletService(getState()), accountNumber)
-    .then((res) => {
-      res.accountNumber = accountNumber;
-      dispatch({
-        getNextAddressResponse: res,
-        type: GETNEXTADDRESS_SUCCESS
+export const getNextAddressAttempt = (accountNumber) => (dispatch, getState) =>
+  new Promise((resolve, reject) => {
+    dispatch({ type: GETNEXTADDRESS_ATTEMPT });
+    return wallet
+      .getNextAddress(sel.walletService(getState()), accountNumber)
+      .then((res) => {
+        res.accountNumber = accountNumber;
+        dispatch({
+          getNextAddressResponse: res,
+          type: GETNEXTADDRESS_SUCCESS
+        });
+        resolve(res);
+      })
+      .catch((error) => {
+        dispatch({ error, type: GETNEXTACCOUNT_FAILED });
+        reject(error);
       });
-      resolve(res);
-    })
-    .catch((error) => {
-      dispatch({ error, type: GETNEXTACCOUNT_FAILED });
-      reject(error);
-    });
-});
+  });
 
 export const RENAMEACCOUNT_ATTEMPT = "RENAMEACCOUNT_ATTEMPT";
 export const RENAMEACCOUNT_FAILED = "RENAMEACCOUNT_FAILED";
@@ -426,16 +424,23 @@ export const startTicketBuyerV3Attempt = (
   const changeAccount = sel.getChangeAccount(getState());
   const csppServer = sel.getCsppServer(getState());
   const csppPort = sel.getCsppPort(getState());
+  const mixedAcctBranch = sel.getMixedAccountBranch(getState());
 
   if (mixedAccount && changeAccount) {
-    if (!mixedAccount || !changeAccount || !csppServer || !csppPort) {
+    if (
+      !mixedAccount ||
+      !changeAccount ||
+      !csppServer ||
+      !csppPort ||
+      typeof mixedAcctBranch === "undefined"
+    ) {
       throw "missing cspp argument";
     }
     request.setMixedAccount(mixedAccount);
     request.setMixedSplitAccount(mixedAccount);
     request.setChangeAccount(changeAccount);
-    request.setCsppServer(csppServer + ":" + csppPort);
-    request.setMixedAccountBranch(0);
+    request.setCsppServer(`${csppServer}:${csppPort}`);
+    request.setMixedAccountBranch(mixedAcctBranch);
   }
 
   request.setBalanceToMaintain(balanceToMaintain);
@@ -539,23 +544,25 @@ export const constructTransactionAttempt = (
             dispatch({ error, type: CONSTRUCTTX_FAILED });
           };
         }
-        const newChangeAddr = await dispatch(getNextAddressAttempt(unmixedAcct));
+        const newChangeAddr = await dispatch(
+          getNextAddressAttempt(unmixedAcct)
+        );
         const outputDest = new ConstructTransactionRequest.OutputDestination();
         outputDest.setAddress(newChangeAddr.address);
         request.setChangeDestination(outputDest);
       }
     }
   } else {
-      if (outputs.length > 1) {
-        return (dispatch) => {
-          const error = "Too many outputs provided for a send all request.";
-          dispatch({ error, type: CONSTRUCTTX_FAILED });
-        };
-      }
-      if (outputs.length == 0) {
-        return (dispatch) => {
-          const error = "No destination specified for send all request.";
-          dispatch({ error, type: CONSTRUCTTX_FAILED });
+    if (outputs.length > 1) {
+      return (dispatch) => {
+        const error = "Too many outputs provided for a send all request.";
+        dispatch({ error, type: CONSTRUCTTX_FAILED });
+      };
+    }
+    if (outputs.length == 0) {
+      return (dispatch) => {
+        const error = "No destination specified for send all request.";
+        dispatch({ error, type: CONSTRUCTTX_FAILED });
       };
     }
     // set change to same destination as it is a send all tx.

--- a/app/components/views/PrivacyPage/Privacy/hooks.js
+++ b/app/components/views/PrivacyPage/Privacy/hooks.js
@@ -13,6 +13,7 @@ export function usePrivacy() {
   const changeAccount = useSelector(sel.getChangeAccount);
   const csppServer = useSelector(sel.getCsppServer);
   const csppPort = useSelector(sel.getCsppPort);
+  const mixedAccountBranch = useSelector(sel.getMixedAccountBranch);
   const accounts = useSelector(sel.sortedAccounts);
   const accountMixerError = useSelector(sel.getAccountMixerError);
   const createMixerAccountAttempt = useSelector(sel.createMixerAccountAttempt);
@@ -34,7 +35,7 @@ export function usePrivacy() {
       passphrase,
       mixedAccount,
       changeAccount,
-      mixedAccountBranch: 0,
+      mixedAccountBranch,
       csppServer: `${csppServer}:${csppPort}`
     };
     runAccountMixer(request)

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -146,6 +146,10 @@ export const getMixedAccount = get(["walletLoader", "mixedAccount"]);
 export const getChangeAccount = get(["walletLoader", "changeAccount"]);
 export const getCsppServer = get(["walletLoader", "csppServer"]);
 export const getCsppPort = get(["walletLoader", "csppPort"]);
+export const getMixedAccountBranch = get([
+  "walletLoader",
+  "mixedAccountBranch"
+]);
 
 const availableWallets = get(["daemon", "availableWallets"]);
 const availableWalletsSelect = createSelector([availableWallets], (wallets) =>


### PR DESCRIPTION
This diff fixes an issue caused by recent change which deleted the `getMixedAccountBranch` selector and used `0` as mixed account branch.  This commit re-adds the selector and uses it when calling the wallet.
