### PR TITLE
Check if peers were found

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -867,6 +867,10 @@ export const getPeerInfo = () => (dispatch, getState) => {
   return wallet
     .getPeerInfo(getState().grpc.walletService)
     .then((resp) => {
+      // if resp wrappers is null, no peers were found.
+      if (!resp.wrappers_) {
+        return dispatch({ type: GETPEERINFO_SUCCESS, peersCount: 0 })
+      }
       const peersCount = resp.wrappers_[1].length;
       dispatch({ type: GETPEERINFO_SUCCESS, peersCount });
     })

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -869,7 +869,7 @@ export const getPeerInfo = () => (dispatch, getState) => {
     .then((resp) => {
       // if resp wrappers is null, no peers were found.
       if (!resp.wrappers_) {
-        return dispatch({ type: GETPEERINFO_SUCCESS, peersCount: 0 })
+        return dispatch({ type: GETPEERINFO_SUCCESS, peersCount: 0 });
       }
       const peersCount = resp.wrappers_[1].length;
       dispatch({ type: GETPEERINFO_SUCCESS, peersCount });


### PR DESCRIPTION
This PR prevents throwing an error if no peers were found.