### PR TITLE
add customcertpath

### DIFF
--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -553,7 +553,7 @@ export const launchDCRWallet = (
   // add cspp cert path.
   // When in mainnet, we always include it, because if we doensn't and a user
   // sets mixing config, we would need to restart dcrwallet.
-  const certPath = path.resolve(getCertsPath(), "cspp.decred.org.pem");
+  const certPath = path.resolve(getCertsPath(argv.customcertspath), "cspp.decred.org.pem");
   !testnet && args.push("--csppserver.ca="+certPath);
   args.push(testnet ? "--csppserver=cspp.decred.org:5760" : "--csppserver=cspp.decred.org:15760");
 

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -90,9 +90,9 @@ export function getDcrdRpcCert(appDataPath) {
   return path.resolve(appDataPath ? appDataPath : getDcrdPath(), "rpc.cert");
 }
 
-export function getCertsPath(name, custombinpath) {
-  const binPath = custombinpath
-    ? custombinpath
+export function getCertsPath(customcertspath) {
+  const binPath = customcertspath
+    ? customcertspath
     : process.env.NODE_ENV === "development"
     ? path.join(__dirname, "..", "..", "certs")
     : path.join(process.resourcesPath, "certs");

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-renderer": "cross-env NODE_ENV=production node -r @babel/register ./node_modules/webpack/bin/webpack --config webpack.config.production.js --progress --profile --colors",
     "build": "npm run build-main && npm run build-renderer",
     "rebuild-natives": "cd app && ../node_modules/.bin/electron-rebuild",
-    "start": "cross-env NODE_ENV=production electron ./app/ --debug --custombinpath=./bin",
+    "start": "cross-env NODE_ENV=production electron ./app/ --debug --custombinpath=./bin --customcertspath=./certs",
     "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r @babel/register -r @babel/polyfill ./app/main.development",
     "start-hot-nosandbox": "cross-env HOT=1 NODE_ENV=development electron -r @babel/register -r @babel/polyfill ./app/main.development -r --no-sandbox",
     "postinstall": "concurrently \"electron-builder install-app-deps\" \"node node_modules/fbjs-scripts/node/check-dev-engines.js package.json\"",


### PR DESCRIPTION
Right now our `yarn start` is broken on windows. This PR adds a custom cert path when running `yarn start`, so it can properly recognize cert paths.

The build still failing with the following error, though: 

`2020-11-18 17:03:27.034 [ERR] DCTN: can't find proper module to launch dcrwallet: Error: Cannot open .\resources\918a989ac7b715fdcdcc95e243f5f821.node`