### PR TITLE
[tx] avoid race condition in tx send view

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -572,13 +572,13 @@ export const constructTransactionAttempt = (
     request.setChangeDestination(outputDest);
   }
 
-  let { constructTxCall } = getState().control;
-  if (constructTxCall) {
-    constructTxCall.cancel();
+  let { constructTxRequestAttempt } = getState().control;
+  if (constructTxRequestAttempt) {
+    constructTxRequestAttempt.cancel();
   }
   const chainParams = sel.chainParams(getState());
   const { walletService } = getState().grpc;
-  constructTxCall = walletService.constructTransaction(request, function (
+  constructTxRequestAttempt = walletService.constructTransaction(request, function (
     error,
     constructTxResponse
   ) {
@@ -631,7 +631,7 @@ export const constructTransactionAttempt = (
       type: CONSTRUCTTX_SUCCESS
     });
   });
-  dispatch({ type: CONSTRUCTTX_ATTEMPT, constructTxCall });
+  dispatch({ type: CONSTRUCTTX_ATTEMPT, constructTxRequestAttempt });
 };
 
 export const VALIDATEADDRESS_CLEANSTORE = "VALIDATEADDRESS_CLEANSTORE";

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -572,10 +572,13 @@ export const constructTransactionAttempt = (
     request.setChangeDestination(outputDest);
   }
 
-  dispatch({ type: CONSTRUCTTX_ATTEMPT });
+  let { constructTxCall } = getState().control;
+  if (constructTxCall) {
+    constructTxCall.cancel();
+  }
   const chainParams = sel.chainParams(getState());
   const { walletService } = getState().grpc;
-  walletService.constructTransaction(request, function (
+  constructTxCall = walletService.constructTransaction(request, function (
     error,
     constructTxResponse
   ) {
@@ -596,7 +599,7 @@ export const constructTransactionAttempt = (
           1
         );
         dispatch({ error, type: CONSTRUCTTX_FAILED });
-      } else {
+      } else if (String(error).indexOf("Cancelled") == 0) {
         dispatch({ error, type: CONSTRUCTTX_FAILED });
       }
       return;
@@ -628,6 +631,7 @@ export const constructTransactionAttempt = (
       type: CONSTRUCTTX_SUCCESS
     });
   });
+  dispatch({ type: CONSTRUCTTX_ATTEMPT, constructTxCall });
 };
 
 export const VALIDATEADDRESS_CLEANSTORE = "VALIDATEADDRESS_CLEANSTORE";

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -462,27 +462,31 @@ export default function control(state = {}, action) {
       return {
         ...state,
         constructTxRequestAttempt: true,
-        constructTxLowBalance: false
+        constructTxLowBalance: false,
+        constructTxCall: action.constructTxCall
       };
     case CONSTRUCTTX_FAILED:
       return {
         ...state,
         constructTxRequestAttempt: false,
-        constructTxResponse: null
+        constructTxResponse: null,
+        constructTxCall: null
       };
     case CONSTRUCTTX_FAILED_LOW_BALANCE:
       return {
         ...state,
         constructTxRequestAttempt: false,
         constructTxResponse: null,
-        constructTxLowBalance: true
+        constructTxLowBalance: true,
+        constructTxCall: null
       };
     case CONSTRUCTTX_SUCCESS:
       return {
         ...state,
         changeScriptByAccount: action.changeScriptByAccount,
         constructTxRequestAttempt: false,
-        constructTxResponse: action.constructTxResponse
+        constructTxResponse: action.constructTxResponse,
+        constructTxCall: null
       };
     case WALLET_AUTOBUYER_SETTINGS:
       return { ...state, balanceToMaintain: action.balanceToMaintain };

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -461,32 +461,28 @@ export default function control(state = {}, action) {
     case CONSTRUCTTX_ATTEMPT:
       return {
         ...state,
-        constructTxRequestAttempt: true,
-        constructTxLowBalance: false,
-        constructTxCall: action.constructTxCall
+        constructTxRequestAttempt: action.constructTxRequestAttempt,
+        constructTxLowBalance: false
       };
     case CONSTRUCTTX_FAILED:
       return {
         ...state,
         constructTxRequestAttempt: false,
-        constructTxResponse: null,
-        constructTxCall: null
+        constructTxResponse: null
       };
     case CONSTRUCTTX_FAILED_LOW_BALANCE:
       return {
         ...state,
         constructTxRequestAttempt: false,
         constructTxResponse: null,
-        constructTxLowBalance: true,
-        constructTxCall: null
+        constructTxLowBalance: true
       };
     case CONSTRUCTTX_SUCCESS:
       return {
         ...state,
         changeScriptByAccount: action.changeScriptByAccount,
         constructTxRequestAttempt: false,
-        constructTxResponse: action.constructTxResponse,
-        constructTxCall: null
+        constructTxResponse: action.constructTxResponse
       };
     case WALLET_AUTOBUYER_SETTINGS:
       return { ...state, balanceToMaintain: action.balanceToMaintain };


### PR DESCRIPTION
Closes #2950 
I could reproduce issue #2950 in win10 in VirtualBox. I found that sometimes responses for `constructTransaction` requests don't arrive in the same order as they requested.
My solution is to save the last request and cancel it before the next one if it is necessary.