### PR TITLE
[LN] Disable rest service

### DIFF
--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -690,6 +690,7 @@ export const launchDCRLnd = (
 
     const args = [
       "--nolisten",
+      "--norest",
       "--logdir=" + path.join(dcrlndRoot, "logs"),
       "--datadir=" + path.join(dcrlndRoot, "data"),
       "--tlscertpath=" + tlsCertPath,


### PR DESCRIPTION
It's not needed for dcrlnd and runs on a very commonly used port, which might
interfere with existing services.

Close #2797 