### PR TITLE
Fix Privacy tab on a brand new wallet

### DIFF
--- a/app/components/views/PrivacyPage/Privacy/hooks.js
+++ b/app/components/views/PrivacyPage/Privacy/hooks.js
@@ -34,8 +34,6 @@ export function usePrivacy() {
   const changeAccountSpendableBalance = useSelector(
     sel.getChangeAccountSpendableBalance
   );
-  const mixedAccountObject = accounts[mixedAccount];
-  const changeAccountObject = accounts[changeAccount];
   const getMixerAcctsSpendableBalances = useCallback(
     () => dispatch(ca.getMixerAcctsSpendableBalances()),
     [dispatch]
@@ -43,13 +41,7 @@ export function usePrivacy() {
 
   useEffect(() => {
     getMixerAcctsSpendableBalances();
-  }, [
-    getMixerAcctsSpendableBalances,
-    mixedAccount,
-    changeAccount,
-    mixedAccountObject.spendable,
-    changeAccountObject.spendable
-  ]);
+  }, [getMixerAcctsSpendableBalances, mixedAccount, changeAccount, accounts]);
 
   const createNeededAccounts = (
     passphrase,


### PR DESCRIPTION
@jholdstock found this issue: "I cant seem to open the Privacy tab on a brand new wallet. I think its only working on wallets which already have privacy enabled"

```
hooks.js:50 Uncaught TypeError: Cannot read property 'spendable' of undefined
    at usePrivacy (hooks.js:50)
    at Privacy (Privacy.jsx:25)
    at renderWithHooks (react-dom.development.js:14826)
    at mountIndeterminateComponent (react-dom.development.js:17506)
    at beginWork (react-dom.development.js:18630)
    at HTMLUnknownElement.callCallback (react-dom.development.js:189)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:238)
    at invokeGuardedCallback (react-dom.development.js:293)
    at beginWork$1 (react-dom.development.js:23235)
    at performUnitOfWork (react-dom.development.js:22189)
```

This PR fixes it.