### PR TITLE
[privacy] fix: fetch spendable account balances only once

### DIFF
--- a/app/components/views/PrivacyPage/Privacy/hooks.js
+++ b/app/components/views/PrivacyPage/Privacy/hooks.js
@@ -4,6 +4,7 @@ import * as act from "actions/AccountMixerActions";
 import * as ca from "actions/ClientActions";
 import { getPrivacyLogs } from "actions/DaemonActions";
 import * as sel from "selectors";
+import { useMountEffect } from "hooks";
 
 export function usePrivacy() {
   const dispatch = useDispatch();
@@ -41,9 +42,9 @@ export function usePrivacy() {
   const defaultSpendingAccountDisregardMixedAccount = useSelector(
     sel.defaultSpendingAccountDisregardMixedAccount
   );
-  useEffect(() => {
+  useMountEffect(() => {
     getMixerAcctsSpendableBalances();
-  }, [getMixerAcctsSpendableBalances, mixedAccount, changeAccount, accounts]);
+  });
 
   const createNeededAccounts = (
     passphrase,


### PR DESCRIPTION
This diff fixes too many getbalance requests being sent when visiting privacy page by using
`useMountEffect` hook to call the `getMixerAcctsSpendableBalances` action only once - on mount.