### PR TITLE
[privacy] Update mixer balances when new transaction recieved

### DIFF
--- a/app/actions/TransactionActions.js
+++ b/app/actions/TransactionActions.js
@@ -2,7 +2,11 @@ import * as wallet from "wallet";
 import * as sel from "selectors";
 import eq from "lodash/fp/eq";
 import { checkUnmixedAccountBalance } from "./AccountMixerActions";
-import { getStakeInfoAttempt, getBalanceUpdateAttempt, getMixerAcctsSpendableBalances } from "./ClientActions";
+import {
+  getStakeInfoAttempt,
+  getBalanceUpdateAttempt,
+  getMixerAcctsSpendableBalances
+} from "./ClientActions";
 import { TransactionDetails } from "middleware/walletrpc/api_pb";
 import { getStartupStats } from "./StatisticsActions";
 import { hexToBytes, strHashToRaw } from "helpers";
@@ -127,7 +131,7 @@ export const newTransactionsReceived = (
   accountsToUpdate = Array.from(new Set(accountsToUpdate));
   accountsToUpdate.forEach((v) => dispatch(getBalanceUpdateAttempt(v, 0)));
 
-  // Update mixer change account balance
+  // Update mixer accounts balances
   const changeAccount = sel.getChangeAccount(getState());
   dispatch(checkUnmixedAccountBalance(changeAccount));
   dispatch(getMixerAcctsSpendableBalances());

--- a/app/actions/TransactionActions.js
+++ b/app/actions/TransactionActions.js
@@ -2,7 +2,7 @@ import * as wallet from "wallet";
 import * as sel from "selectors";
 import eq from "lodash/fp/eq";
 import { checkUnmixedAccountBalance } from "./AccountMixerActions";
-import { getStakeInfoAttempt, getBalanceUpdateAttempt } from "./ClientActions";
+import { getStakeInfoAttempt, getBalanceUpdateAttempt, getMixerAcctsSpendableBalances } from "./ClientActions";
 import { TransactionDetails } from "middleware/walletrpc/api_pb";
 import { getStartupStats } from "./StatisticsActions";
 import { hexToBytes, strHashToRaw } from "helpers";
@@ -130,6 +130,7 @@ export const newTransactionsReceived = (
   // Update mixer change account balance
   const changeAccount = sel.getChangeAccount(getState());
   dispatch(checkUnmixedAccountBalance(changeAccount));
+  dispatch(getMixerAcctsSpendableBalances());
 
   const hasStakeTxs =
     checkForStakeTransactions(newlyUnminedTransactions) ||

--- a/app/actions/TransactionActions.js
+++ b/app/actions/TransactionActions.js
@@ -1,6 +1,7 @@
 import * as wallet from "wallet";
 import * as sel from "selectors";
 import eq from "lodash/fp/eq";
+import { checkUnmixedAccountBalance } from "./AccountMixerActions";
 import { getStakeInfoAttempt, getBalanceUpdateAttempt } from "./ClientActions";
 import { TransactionDetails } from "middleware/walletrpc/api_pb";
 import { getStartupStats } from "./StatisticsActions";
@@ -99,12 +100,16 @@ export const newTransactionsReceived = (
   const newlyMinedMap = newlyMinedTransactions.reduce((m, v) => {
     m[v.txHash] = v;
     // update our txs selector value.
-    v.isStake ? stakeTransactions[v.txHash] = v : regularTransactions[v.txHash] = v;
+    v.isStake
+      ? (stakeTransactions[v.txHash] = v)
+      : (regularTransactions[v.txHash] = v);
     return m;
   }, {});
   const newlyUnminedMap = newlyUnminedTransactions.reduce((m, v) => {
     // update our txs selector value.
-    v.isStake ? stakeTransactions[v.txHash] = v : regularTransactions[v.txHash] = v;
+    v.isStake
+      ? (stakeTransactions[v.txHash] = v)
+      : (regularTransactions[v.txHash] = v);
     m[v.txHash] = v;
     return m;
   }, {});
@@ -121,6 +126,10 @@ export const newTransactionsReceived = (
   );
   accountsToUpdate = Array.from(new Set(accountsToUpdate));
   accountsToUpdate.forEach((v) => dispatch(getBalanceUpdateAttempt(v, 0)));
+
+  // Update mixer change account balance
+  const changeAccount = sel.getChangeAccount(getState());
+  dispatch(checkUnmixedAccountBalance(changeAccount));
 
   const hasStakeTxs =
     checkForStakeTransactions(newlyUnminedTransactions) ||
@@ -752,20 +761,17 @@ export const getTxFromInputs = (unsignedTx) => (dispatch, getState) => {
 
   // Create a map with all the unique tx hashes we need to fetch.
   const txsMap = {};
-  unsignedTx.inputs.forEach(inp => txsMap[inp.prevTxId] = true);
+  unsignedTx.inputs.forEach((inp) => (txsMap[inp.prevTxId] = true));
 
   // Start fetching all txs concurrently.
-  const txPromises = Object.keys(txsMap).map(async prevTxId => {
+  const txPromises = Object.keys(txsMap).map(async (prevTxId) => {
     const oldTx = await wallet.getTransaction(walletService, prevTxId);
     if (!oldTx) {
       throw new Error(`Transaction ${prevTxId} not found`);
     }
 
     const rawTxBuffer = Buffer.from(hexToBytes(oldTx.rawTx));
-    const tx = wallet.decodeRawTransaction(
-      rawTxBuffer,
-      chainParams
-    );
+    const tx = wallet.decodeRawTransaction(rawTxBuffer, chainParams);
 
     // Fill in the hash to avoid having to recalculate it.
     tx.hash = prevTxId;


### PR DESCRIPTION
This diff dispatches `checkUnmixedAccountBalance` action, to update the mixer accounts balances and error
state in privacy page.

Also, it dispatches `getMixerAcctsSpendableBalances` to update the balances in the privacy/mixer page when new transaction received.

Closes #2992