### PR TITLE
Add running indicator on cant close selector

### DIFF
--- a/app/components/modals/CantCloseModals/AccountMixerRunningModal.jsx
+++ b/app/components/modals/CantCloseModals/AccountMixerRunningModal.jsx
@@ -1,0 +1,46 @@
+import Modal from "../Modal";
+import { FormattedMessage as T } from "react-intl";
+import { InvisibleButton, KeyBlueButton } from "buttons";
+import style from "../Modals.module.css";
+
+const AutobuyerRunningModal = ({ show, onCancelModal, onSubmit }) => (
+  <Modal className={style.confirm} {...{ show, onCancelModal }}>
+    <div className={style.confirmHeader}>
+      <div className={style.confirmHeaderTitle}>
+        <T
+          id="account.mixer.running.title"
+          m="Account mixer is running"
+        />
+      </div>
+    </div>
+    {
+      <div className={style.confirmContent}>
+        <T
+          id="account.mixer.running.message"
+          m="Account mixer is running. If closed no more dcr will be mixed.
+          Should decrediton close?"
+        />
+      </div>
+
+    }
+    <div className={style.confirmToolbar}>
+      <KeyBlueButton
+        className={style.confirmConfirmButton}
+        onClick={onSubmit}>
+        {
+          <T
+            id="account.mixer.running.btnConfirm"
+            m="Confirm"
+          />
+        }
+      </KeyBlueButton>
+      <InvisibleButton
+        className={style.confirmCloseButton}
+        onClick={onCancelModal}>
+        <T id="account.mixer.running.btnCancel" m="Cancel" />
+      </InvisibleButton>
+    </div>
+  </Modal>
+);
+
+export default AutobuyerRunningModal;

--- a/app/components/modals/CantCloseModals/AccountMixerRunningModal.jsx
+++ b/app/components/modals/CantCloseModals/AccountMixerRunningModal.jsx
@@ -17,8 +17,9 @@ const AutobuyerRunningModal = ({ show, onCancelModal, onSubmit }) => (
       <div className={style.confirmContent}>
         <T
           id="account.mixer.running.message"
-          m="Account mixer is running. If closed no more dcr will be mixed.
-          Should decrediton close?"
+          m="Account mixer is currently running. Ongoing mixes will be
+            cancelled and no more Decred will be mixed if Decrediton is
+            closed now."
         />
       </div>
 
@@ -30,7 +31,7 @@ const AutobuyerRunningModal = ({ show, onCancelModal, onSubmit }) => (
         {
           <T
             id="account.mixer.running.btnConfirm"
-            m="Confirm"
+            m="Close Decrediton"
           />
         }
       </KeyBlueButton>

--- a/app/components/modals/CantCloseModals/CantCloseModals.jsx
+++ b/app/components/modals/CantCloseModals/CantCloseModals.jsx
@@ -1,3 +1,5 @@
+import PurchasingTicketsModal from "./PurchasingTicketsModal";
+import AccountMixerRunningModal from "./AccountMixerRunningModal";
 import AutobuyerRunning from "./AutobuyerRunningModal";
 import HasTicketFeeErro from "./HasTicketFeeError";
 import { useCantCloseModal } from "./hooks";
@@ -9,18 +11,21 @@ const CantCloseModals = () => {
     autobuyerRunningModalVisible,
     onHideCantCloseModal,
     shutdownApp,
-    runningIndicator
+    accountMixerRunning,
+    purchasingTickets
   } = useCantCloseModal();
   let Component = () => <></>;
-
   if (autBuyerRunning) {
     Component = AutobuyerRunning;
   }
   if (hasUnpaidFee) {
     Component = HasTicketFeeErro;
   }
-  if (runningIndicator) {
-    Component = AutobuyerRunning;
+  if (accountMixerRunning) {
+    Component = AccountMixerRunningModal;
+  }
+  if (purchasingTickets) {
+    Component = PurchasingTicketsModal;
   }
 
   return <Component

--- a/app/components/modals/CantCloseModals/CantCloseModals.jsx
+++ b/app/components/modals/CantCloseModals/CantCloseModals.jsx
@@ -8,7 +8,8 @@ const CantCloseModals = () => {
     hasUnpaidFee,
     autobuyerRunningModalVisible,
     onHideCantCloseModal,
-    shutdownApp
+    shutdownApp,
+    runningIndicator
   } = useCantCloseModal();
   let Component = () => <></>;
 
@@ -17,6 +18,9 @@ const CantCloseModals = () => {
   }
   if (hasUnpaidFee) {
     Component = HasTicketFeeErro;
+  }
+  if (runningIndicator) {
+    Component = AutobuyerRunning;
   }
 
   return <Component

--- a/app/components/modals/CantCloseModals/PurchasingTicketsModal.jsx
+++ b/app/components/modals/CantCloseModals/PurchasingTicketsModal.jsx
@@ -17,7 +17,9 @@ const AutobuyerRunningModal = ({ show, onCancelModal, onSubmit }) => (
       <div className={style.confirmContent}>
         <T
           id="tickets.purchasing.message"
-          m="Decrediton is finishing the purchasing ticket process and should wait."
+          m="Decrediton is still finalizing ticket purchases. Tickets may not
+            be registered with the VSP if Decrediton is closed now, which can
+            result in missed votes."
         />
       </div>
 
@@ -29,7 +31,7 @@ const AutobuyerRunningModal = ({ show, onCancelModal, onSubmit }) => (
         {
           <T
             id="tickets.purchasing.confirmModal.btnConfirm"
-            m="Confirm"
+            m="Close Decrediton"
           />
         }
       </KeyBlueButton>

--- a/app/components/modals/CantCloseModals/PurchasingTicketsModal.jsx
+++ b/app/components/modals/CantCloseModals/PurchasingTicketsModal.jsx
@@ -1,0 +1,45 @@
+import Modal from "../Modal";
+import { FormattedMessage as T } from "react-intl";
+import { InvisibleButton, KeyBlueButton } from "buttons";
+import style from "../Modals.module.css";
+
+const AutobuyerRunningModal = ({ show, onCancelModal, onSubmit }) => (
+  <Modal className={style.confirm} {...{ show, onCancelModal }}>
+    <div className={style.confirmHeader}>
+      <div className={style.confirmHeaderTitle}>
+        <T
+          id="tickets.purchasing.title"
+          m="Purchasing Tickets"
+        />
+      </div>
+    </div>
+    {
+      <div className={style.confirmContent}>
+        <T
+          id="tickets.purchasing.message"
+          m="Decrediton is finishing the purchasing ticket process and should wait."
+        />
+      </div>
+
+    }
+    <div className={style.confirmToolbar}>
+      <KeyBlueButton
+        className={style.confirmConfirmButton}
+        onClick={onSubmit}>
+        {
+          <T
+            id="tickets.purchasing.confirmModal.btnConfirm"
+            m="Confirm"
+          />
+        }
+      </KeyBlueButton>
+      <InvisibleButton
+        className={style.confirmCloseButton}
+        onClick={onCancelModal}>
+        <T id="tickets.purchasing.confirmModal.btnCancel" m="Cancel" />
+      </InvisibleButton>
+    </div>
+  </Modal>
+);
+
+export default AutobuyerRunningModal;

--- a/app/components/modals/CantCloseModals/hooks.js
+++ b/app/components/modals/CantCloseModals/hooks.js
@@ -9,6 +9,9 @@ export function useCantCloseModal() {
   const hasUnpaidFee = useSelector(sel.getHasUnpaidFee);
   const autobuyerRunningModalVisible = useSelector(sel.autobuyerRunningModalVisible);
   const runningIndicator = useSelector(sel.getRunningIndicator);
+  const accountMixerRunning = useSelector(sel.getAccountMixerRunning);
+  const purchasingTickets = useSelector(sel.purchaseTicketsRequestAttempt);
+
   const dispatch = useDispatch();
   const onHideCantCloseModal = () => dispatch(hideCantCloseModal());
   const shutdownApp = () => dispatch(da.shutdownApp());
@@ -24,6 +27,8 @@ export function useCantCloseModal() {
     onHideCantCloseModal,
     shutdownApp,
     onGoToTicketsStatus,
-    runningIndicator
+    runningIndicator,
+    accountMixerRunning,
+    purchasingTickets
   };
 }

--- a/app/components/modals/CantCloseModals/hooks.js
+++ b/app/components/modals/CantCloseModals/hooks.js
@@ -8,6 +8,7 @@ export function useCantCloseModal() {
   const autBuyerRunning = useSelector(sel.isTicketAutoBuyerEnabled);
   const hasUnpaidFee = useSelector(sel.getHasUnpaidFee);
   const autobuyerRunningModalVisible = useSelector(sel.autobuyerRunningModalVisible);
+  const runningIndicator = useSelector(sel.getRunningIndicator);
   const dispatch = useDispatch();
   const onHideCantCloseModal = () => dispatch(hideCantCloseModal());
   const shutdownApp = () => dispatch(da.shutdownApp());
@@ -22,6 +23,7 @@ export function useCantCloseModal() {
     autobuyerRunningModalVisible,
     onHideCantCloseModal,
     shutdownApp,
-    onGoToTicketsStatus
+    onGoToTicketsStatus,
+    runningIndicator
   };
 }

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1272,19 +1272,6 @@ export const startAutoBuyerSuccess = get(["control", "startAutoBuyerSuccess"]);
 export const stopAutoBuyerError = get(["control", "stopAutoBuyerError"]);
 export const stopAutoBuyerSuccess = get(["control", "stopAutoBuyerSuccess"]);
 
-// selectors for checking if decrediton can be closed.
-
-export const isTicketAutoBuyerEnabled = bool(startAutoBuyerResponse);
-export const getHasUnpaidFee = createSelector([getVSPTickets], (vspTickets) => {
-  if (!vspTickets) return;
-  return vspTickets[VSP_FEE_PROCESS_ERRORED]
-    ? vspTickets[VSP_FEE_PROCESS_ERRORED].length > 0
-    : false;
-});
-export const getCanClose = not(or(isTicketAutoBuyerEnabled, getHasUnpaidFee));
-
-// end of selectors for closing decrediton.
-
 const purchaseTicketsResponse = get(["control", "purchaseTicketsResponse"]);
 
 export const splitTx = createSelector(
@@ -1364,14 +1351,6 @@ export const purchaseTicketsRequestAttempt = get([
   "control",
   "purchaseTicketsRequestAttempt"
 ]);
-
-// getRunningIndicator is a indicator for indicate something is runnning on
-// decrediton, like the ticket auto buyer or the mixer.
-export const getRunningIndicator = or(
-  getAccountMixerRunning,
-  getTicketAutoBuyerRunning,
-  purchaseTicketsRequestAttempt
-);
 
 const importScriptRequestAttempt = get([
   "control",
@@ -1682,6 +1661,29 @@ export const trezorWalletCreationMasterPubkeyAttempt = get([
   "walletCreationMasterPubkeyAttempt"
 ]);
 
+// getRunningIndicator is a indicator for indicate something is runnning on
+// decrediton, like the ticket auto buyer or the mixer.
+export const getRunningIndicator = or(
+  getAccountMixerRunning,
+  getTicketAutoBuyerRunning,
+  purchaseTicketsRequestAttempt
+);
+
+// selectors for checking if decrediton can be closed.
+
+export const isTicketAutoBuyerEnabled = bool(startAutoBuyerResponse);
+export const getHasUnpaidFee = createSelector([getVSPTickets], (vspTickets) => {
+  if (!vspTickets) return;
+  return vspTickets[VSP_FEE_PROCESS_ERRORED]
+    ? vspTickets[VSP_FEE_PROCESS_ERRORED].length > 0
+    : false;
+});
+export const getCanClose = not(or(getRunningIndicator, isTicketAutoBuyerEnabled, getHasUnpaidFee));
+
+// end of selectors for closing decrediton.
+
+// ln selectors
+
 export const lnEnabled = bool(and(not(isWatchingOnly), not(isTrezor)));
 export const lnActive = bool(get(["ln", "active"]));
 export const lnStartupStage = get(["ln", "startupStage"]);
@@ -1706,3 +1708,5 @@ export const lnAddInvoiceAttempt = get(["ln", "addInvoiceAttempt"]);
 export const lnSCBPath = get(["ln", "scbPath"]);
 export const lnSCBUpdatedTime = get(["ln", "scbUpdatedTime"]);
 export const lnTowersList = get(["ln", "towersList"]);
+
+// end of ln selectors

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1237,7 +1237,6 @@ export const totalSubsidy = compose(
 
 export const ticketBuyerService = get(["grpc", "ticketBuyerService"]);
 export const ticketBuyerConfig = get(["control", "ticketBuyerConfig"]);
-const startAutoBuyerResponse = get(["control", "startAutoBuyerResponse"]);
 
 export const balanceToMaintain = get(["control", "balanceToMaintain"]);
 
@@ -1661,24 +1660,28 @@ export const trezorWalletCreationMasterPubkeyAttempt = get([
   "walletCreationMasterPubkeyAttempt"
 ]);
 
+// selectors for checking if decrediton can be closed.
+
+// TODO remove duplicated auto buyer running selector
+const startAutoBuyerResponse = get(["control", "startAutoBuyerResponse"]);
+export const isTicketAutoBuyerEnabled = bool(startAutoBuyerResponse);
+
 // getRunningIndicator is a indicator for indicate something is runnning on
 // decrediton, like the ticket auto buyer or the mixer.
 export const getRunningIndicator = or(
   getAccountMixerRunning,
   getTicketAutoBuyerRunning,
-  purchaseTicketsRequestAttempt
+  purchaseTicketsRequestAttempt,
+  isTicketAutoBuyerEnabled
 );
 
-// selectors for checking if decrediton can be closed.
-
-export const isTicketAutoBuyerEnabled = bool(startAutoBuyerResponse);
 export const getHasUnpaidFee = createSelector([getVSPTickets], (vspTickets) => {
   if (!vspTickets) return;
   return vspTickets[VSP_FEE_PROCESS_ERRORED]
     ? vspTickets[VSP_FEE_PROCESS_ERRORED].length > 0
     : false;
 });
-export const getCanClose = not(or(getRunningIndicator, isTicketAutoBuyerEnabled, getHasUnpaidFee));
+export const getCanClose = not(or(getRunningIndicator, getHasUnpaidFee));
 
 // end of selectors for closing decrediton.
 


### PR DESCRIPTION
This PR adds the running indicator selector into the can't close selector.

This way decrediton will not allowed to be closed if it is perfoming any action represented by the running indicator: Ticket auto buyer, running mixer or purchasing tickets