### PR TITLE
[transaction] Use native `Intl.DateTimeFormat` to format tx timestamp

### DIFF
--- a/app/components/shared/TxHistory/TxHistory.jsx
+++ b/app/components/shared/TxHistory/TxHistory.jsx
@@ -3,8 +3,8 @@ import StakeTxRow from "./StakeTxRow";
 import EligibleRow from "./EligibleRow";
 import LiveStakeTxRow from "./LiveStakeTxRow";
 import * as txTypes from "constants/Decrediton";
-import { defineMessages, injectIntl } from "react-intl";
 import { withRouter } from "react-router-dom";
+import { dateFormatter, shortDatetimeFormatter } from "helpers";
 
 const TxRowByType = {
   // LiveStakeTxRow is used for tickets which can still be voted.
@@ -27,17 +27,6 @@ const TxRowByType = {
   [txTypes.ELIGIBLE]: EligibleRow
 };
 
-const timeMessageDefine = defineMessages({
-  dayMonthHourDisplay: {
-    id: "txHistory.dayMonthHourDisplay",
-    defaultMessage: "{value, date, short-month-24hour}"
-  },
-  dayMonthDisplay: {
-    id: "txHistory.dayMonthDisplay",
-    defaultMessage: "{value, date}"
-  }
-});
-
 // TxHistory is responsible for calling the right component row according to
 // the Tx row type.
 const TxHistory = ({
@@ -46,7 +35,6 @@ const TxHistory = ({
   overview,
   mode,
   tsDate,
-  intl,
   history
 }) => {
   const isEligibleTicket = mode === "eligible";
@@ -74,6 +62,7 @@ const TxHistory = ({
             .filter((o) => !o.isChange)
             .map((o) => o.address)
             .join(" ");
+
         return (
           <Component
             key={key}
@@ -81,21 +70,15 @@ const TxHistory = ({
               ...tx,
               txOutputAddresses,
               className: rowType,
-              intl,
               txTs: txTimestamp && tsDate(txTimestamp),
               txLeaveTs: tx.leaveTimestamp && tsDate(tx.leaveTimestamp),
               overview,
               pending: tx.isPending,
               onClick: () => history.push(`/transaction/history/${tx.txHash}`),
               timeMessage: (txTimestamp) =>
-                intl.formatMessage(
-                  isEligibleTicket
-                    ? timeMessageDefine.dayMonthDisplay
-                    : timeMessageDefine.dayMonthHourDisplay,
-                  {
-                    value: txTimestamp
-                  }
-                )
+                isEligibleTicket
+                  ? dateFormatter.format(txTimestamp)
+                  : shortDatetimeFormatter.format(txTimestamp)
             }}
           />
         );
@@ -104,4 +87,4 @@ const TxHistory = ({
   );
 };
 
-export default withRouter(injectIntl(TxHistory));
+export default withRouter(TxHistory);

--- a/app/helpers/dateFormat.js
+++ b/app/helpers/dateFormat.js
@@ -1,5 +1,27 @@
 import { format } from "util";
 
+const shortDateTimeOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  hourCycle: "h23"
+};
+
+export const shortDatetimeFormatter = new Intl.DateTimeFormat(
+  "default",
+  shortDateTimeOptions
+);
+
+const dateOptions = {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric"
+};
+
+export const dateFormatter = new Intl.DateTimeFormat("default", dateOptions);
+
 // dateToLocal converts the specified unix timestamp (possibly a block or
 // transaction timestamp) from seconds to a JS Date object.
 export function dateToLocal(timestamp) {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -30,8 +30,7 @@ import {
   DCRDATA_URL_TESTNET,
   DCRDATA_URL_MAINNET
 } from "./middleware/dcrdataapi";
-import { dateToLocal, dateToUTC } from "./helpers/dateFormat";
-import { isMixTx } from "./helpers/transactions";
+import { isMixTx, dateToLocal, dateToUTC } from "./helpers";
 import {
   MIN_RELAY_FEE,
   DCR,


### PR DESCRIPTION
This diff uses `Intl.DateTimeFormat` to achieve custom date format (`23hour` date time - `00:29` instead on `24:29`) which isn't possible with latest `react-intl` versions.

See https://github.com/decred/decrediton/issues/2968#issuecomment-734437460 which explains the suggestion to work with `Intl.DateTimeFormat` as a solution.  

---

Closes #2968 