### PR TITLE
fix: 'toString' of undefined console error

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -704,9 +704,9 @@ export const getTreasuryBalance = () => (dispatch, getState) => {
   const dURL = sel.dcrdataURL(getState());
   da.getTreasuryInfo(dURL, treasuryAddress).then((treasuryInfo) => {
     // Manually convert DCR to atom amounts to avoid floating point multiplication errors (eg. 589926.57667882*1e8 => 58992657667881.99)
-    const splitedTreasuryInfo = treasuryInfo["data"]["dcr_unspent"]
-      .toString()
-      .split(".");
+    const unspentTreasury = treasuryInfo["data"]["dcr_unspent"];
+    if (!unspentTreasury) return;
+    const splitedTreasuryInfo = unspentTreasury.toString().split(".");
     const integerPart = splitedTreasuryInfo[0];
     // dcrdata can send numbers with its decimal part less than 8 decimals, so we manually add it.
     let decimalPart = splitedTreasuryInfo[1];


### PR DESCRIPTION
This diff handle rare case where treasury unspent balance info not available which caused `getTreasuryBalance` action in `ClientActions.js` to throw: `TypeError: Cannot read property 'toString' of undefined`.
As a fix I added a tiny check to make sure that the treasury info is available before trying to parse it.    

*Note*: I wasn't able to consistently reproduce the error, I had to refresh decrediton several times with `ctrl+r` in different pages/stages and jump between testnet/mainnet for it to show up.

Closes #3011 