### PR TITLE
[Logs] missing dcrlnd logs

### DIFF
--- a/app/components/views/SettingsPage/LogsTab/Page.jsx
+++ b/app/components/views/SettingsPage/LogsTab/Page.jsx
@@ -50,8 +50,7 @@ const Logs = ({
       onShowLog={onShowDecreditonLogs}
       onHideLog={onHideDecreditonLogs}
     />
-    {lnActive ||
-      (lnStartAttempt && (
+    {(lnActive || lnStartAttempt) && (
         <Log
           title={<T id="help.logs.dcrlnd" m="dcrlnd" />}
           expanded={showDcrlndLogs}
@@ -59,7 +58,7 @@ const Logs = ({
           onHideLog={onHideDcrlndLogs}
           log={dcrlndLogs}
         />
-      ))}
+      )}
   </>
 );
 


### PR DESCRIPTION
I noticed that LN logs in the Logs tab are only visible during the LN start process. After that, they disappear. This diff fixes it.