### PR TITLE
[get-started] style: improve messaging on restore wallet form

### DIFF
--- a/app/components/shared/Collapse.jsx
+++ b/app/components/shared/Collapse.jsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import styles from "./shared.module.css";
+import { classNames } from "pi-ui";
+import PropTypes from "prop-types";
+
+const Collapse = ({ isInfo, header, content }) => {
+  const [show, setShow] = useState(false);
+  return (
+    <div className={classNames(styles.collapse, isInfo && styles.info)}>
+      <div onClick={() => setShow(!show)}>{header}</div>
+      <div
+        className={classNames(styles.readMoreIcon, show && styles.active)}
+        onClick={() => setShow(!show)}
+      />
+      {show && <div className={styles.content}>{content}</div>}
+    </div>
+  );
+};
+
+Collapse.propTypes = {
+  header: PropTypes.node.isRequired,
+  content: PropTypes.node.isRequired,
+  isInfo: PropTypes.bool
+};
+
+export default Collapse;

--- a/app/components/shared/index.js
+++ b/app/components/shared/index.js
@@ -24,4 +24,5 @@ export { default as TabsHeader } from "./TabsHeader/TabsHeader";
 export { default as PrivacyForm } from "./PrivacyForm/PrivacyForm";
 export { default as Log } from "./Log/Log";
 export { default as SendTransaction } from "./SendTransaction/SendTransaction";
+export { default as Collapse } from "./Collapse";
 export * from "./RoutedTabsHeader";

--- a/app/components/shared/shared.module.css
+++ b/app/components/shared/shared.module.css
@@ -29,3 +29,42 @@
   font-size: 13px;
   color: var(--modal-text);
 }
+
+.collapse {
+  background-color: var(--info-message-background);
+  display: grid;
+  grid-template-columns: 30fr 1fr;
+  grid-row-gap: 10px;
+  padding: 10px 10px 10px 20px;
+  cursor: pointer;
+}
+
+.collapse.info {
+  background-image: var(--tickets-info-icon);
+  background-position-x: 10px;
+  background-position-y: 10px;
+  background-repeat: no-repeat;
+  background-size: 20px;
+  padding-left: 40px;
+}
+
+.collapse > .content {
+  width: 100%;
+  cursor: default;
+}
+
+.collapse > .readMoreIcon {
+  background-image: var(--arrow-down-mid-blue-icon);
+  background-position-x: right;
+  background-position-y: 8px;
+  background-repeat: no-repeat;
+  background-size: 12px;
+  height: 15px;
+  width: 12px;
+  margin-left: auto;
+}
+
+.collapse > .readMoreIcon.active {
+  transform: rotate(180deg);
+  background-position-y: 0px;
+}

--- a/app/components/views/GetStartedPage/GetStarted.module.css
+++ b/app/components/views/GetStartedPage/GetStarted.module.css
@@ -815,6 +815,10 @@
   padding: 10px;
 }
 
+.advancedOptionsLabel {
+  margin-left: 22px;
+}
+
 @media screen and (max-width: 1919px) {
   .settings .goBackScreenButtonArea {
     left: 1230px;

--- a/app/components/views/GetStartedPage/GetStarted.module.css
+++ b/app/components/views/GetStartedPage/GetStarted.module.css
@@ -103,16 +103,20 @@
 
 .daemonLongInput {
   padding-left: 20px;
-  float: left;
   width: 450px;
 }
 
 .advancedOption {
-  margin-left: 62px;
+  margin: 10px;
 }
 
-.advancedOptionsLabel {
-  margin-left: 22px;
+.advancedOption > .extra {
+  margin: 10px;
+}
+
+.advancedOptions {
+  height: 100%;
+  margin-bottom: 20px;
 }
 
 .pageBody.getstarted {

--- a/app/components/views/GetStartedPage/GetStarted.module.css
+++ b/app/components/views/GetStartedPage/GetStarted.module.css
@@ -103,7 +103,7 @@
 
 .daemonLongInput {
   padding-left: 20px;
-  width: 450px;
+  width: 350px;
 }
 
 .advancedOption {
@@ -111,12 +111,16 @@
 }
 
 .advancedOption > .extra {
-  margin: 10px;
+  margin: 15px 23px 30px;
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
 }
 
 .advancedOptions {
   height: 100%;
   margin-bottom: 20px;
+  max-width: 600px;
 }
 
 .pageBody.getstarted {
@@ -815,6 +819,10 @@
 
 .trezorConfigSections {
   margin-top: 14em;
+}
+
+.trezorDocs {
+  color: var(--link-color);
 }
 
 .launchError {

--- a/app/components/views/GetStartedPage/GetStarted.module.css
+++ b/app/components/views/GetStartedPage/GetStarted.module.css
@@ -107,6 +107,14 @@
   width: 450px;
 }
 
+.advancedOption {
+  margin-left: 62px;
+}
+
+.advancedOptionsLabel {
+  margin-left: 22px;
+}
+
 .pageBody.getstarted {
   padding: 40px;
   display: block;
@@ -813,10 +821,6 @@
 
 .daemonWarning {
   padding: 10px;
-}
-
-.advancedOptionsLabel {
-  margin-left: 22px;
 }
 
 @media screen and (max-width: 1919px) {

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
@@ -1,7 +1,7 @@
 import { FormattedMessage as T, defineMessages } from "react-intl";
 import { TextInput } from "inputs";
-import { KeyBlueButton, InvisibleButton, ToggleSwitch } from "buttons";
-import { Tooltip } from "shared";
+import { KeyBlueButton, InvisibleButton } from "buttons";
+import { Tooltip, Collapse } from "shared";
 import { NewSeedTabMsg, RestoreTabMsg } from "../messages";
 import { classNames, Checkbox } from "pi-ui";
 import styles from "../GetStarted.module.css";
@@ -104,76 +104,86 @@ const CreateWalletForm = ({
       </div>
     </div>
     {!isCreateNewWallet && (
-      <>
-        <div className={styles.daemonRow}>
-          <div className={styles.advancedOptionsLabel}>
-            <T id="createwallet.advancedOptions.label" m="Advanced Options" />:
-          </div>
-        </div>
-        <div className={styles.daemonRow}>
-          <div className={styles.advancedOption}>
-            <Checkbox
-              label={<T id="createwallet.walletOnly.label" m="Watch only" />}
-              id="watchonly"
-              description={intl.formatMessage(
-                messages.messageWalletWatchOnlyDescription
-              )}
-              checked={isWatchingOnly}
-              onChange={toggleWatchOnly}
-            />
-          </div>
-        </div>
-        <div className={styles.daemonRow}>
-          <div className={styles.advancedOption}>
-            <Checkbox
-              label={<T id="createwallet.isTrezor.label" m="Trezor" />}
-              id="trezor"
-              description={intl.formatMessage(
-                messages.messageWalletTrezorDescription
-              )}
-              checked={isTrezor}
-              onChange={toggleTrezor}
-            />
-          </div>
-        </div>
-        <div className={styles.daemonRow}>
-          <div className={styles.advancedOption}>
-            <Checkbox
-              label={<T id="privacy.label" m="Privacy" />}
-              id="privacy"
-              checked={isPrivacy}
-              onChange={toggleIsPrivacy}
-            />
-          </div>
-        </div>
-        {isWatchingOnly && (
-          <div className={styles.daemonRow}>
-            <div className={styles.daemonLabel}>
-              <T
-                id="createwallet.walletmasterpubkey.label"
-                m="Master Pub Key"
-              />
-            </div>
-            <div className={styles.daemonLongInput}>
-              <TextInput
-                required
-                value={walletMasterPubKey}
-                onChange={(e) =>
-                  onChangeCreateWalletMasterPubKey(e.target.value)
-                }
-                placeholder={intl.formatMessage(
-                  messages.messageWalletMasterPubKey
+      <div className={classNames(styles.daemonRow, styles.advancedOptions)}>
+        <Collapse
+          header={
+            <T id="createwallet.advancedOptions.label" m="Advanced Options" />
+          }
+          content={
+            <>
+              <div className={styles.advancedOption}>
+                <Checkbox
+                  label={
+                    <T id="createwallet.walletOnly.label" m="Watch only" />
+                  }
+                  id="watchonly"
+                  description={intl.formatMessage(
+                    messages.messageWalletWatchOnlyDescription
+                  )}
+                  checked={isWatchingOnly}
+                  onChange={toggleWatchOnly}
+                />
+                {isWatchingOnly && (
+                  <div className={styles.extra}>
+                    <T
+                      id="createwallet.walletmasterpubkey.label"
+                      m="Master Pub Key"
+                    />
+                    <div className={styles.daemonLongInput}>
+                      <TextInput
+                        required
+                        value={walletMasterPubKey}
+                        onChange={(e) =>
+                          onChangeCreateWalletMasterPubKey(e.target.value)
+                        }
+                        placeholder={intl.formatMessage(
+                          messages.messageWalletMasterPubKey
+                        )}
+                        showErrors={hasFailedAttemptPubKey || masterPubKeyError}
+                        invalid={masterPubKeyError}
+                        invalidMessage={intl.formatMessage(
+                          messages.messageWalletMasterPubkeyError
+                        )}
+                      />
+                    </div>
+                  </div>
                 )}
-                showErrors={hasFailedAttemptPubKey || masterPubKeyError}
-                invalid={masterPubKeyError}
-                invalidMessage={intl.formatMessage(
-                  messages.messageWalletMasterPubkeyError
-                )}
-              />
-            </div>
-          </div>
-        )}
-      </>
+              </div>
+              <div className={styles.advancedOption}>
+                <Checkbox
+                  label={
+                    <>
+                      <T id="createwallet.isTrezor.label" m="Trezor" />
+                      <span
+                        className={styles.whatsnew}
+                        onClick={onShowTrezorConfig}>
+                        <T
+                          id="createWallet.isTrezor.setupLink"
+                          m="(setup device)"
+                        />
+                      </span>
+                    </>
+                  }
+                  id="trezor"
+                  description={intl.formatMessage(
+                    messages.messageWalletTrezorDescription
+                  )}
+                  checked={isTrezor}
+                  onChange={toggleTrezor}
+                />
+              </div>
+              <div className={styles.advancedOption}>
+                <Checkbox
+                  label={<T id="privacy.label" m="Privacy" />}
+                  id="privacy"
+                  checked={isPrivacy}
+                  onChange={toggleIsPrivacy}
+                />
+              </div>
+            </>
+          }
+        />
+      </div>
     )}
     <div className={styles.daemonRow}>
       <KeyBlueButton onClick={createWallet}>

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
@@ -1,7 +1,7 @@
 import { FormattedMessage as T, defineMessages } from "react-intl";
 import { TextInput } from "inputs";
 import { KeyBlueButton, InvisibleButton } from "buttons";
-import { Tooltip, Collapse } from "shared";
+import { Tooltip, Collapse, ExternalLink } from "shared";
 import { NewSeedTabMsg, RestoreTabMsg } from "../messages";
 import { classNames, Checkbox } from "pi-ui";
 import styles from "../GetStarted.module.css";
@@ -17,13 +17,14 @@ const messages = defineMessages({
       "The name is used to identify your wallet. Restoring a wallet does not require the name to match the previous wallet name."
   },
   messageWalletWatchOnlyDescription: {
-    id: "createwallet.watchonly.tooltip",
+    id: "createwallet.watchonly.description",
     defaultMessage:
-      "You’ll not be able to spend any DCR associated with that wallet. It is used only to view the balance and monitor the wallet's transaction activity"
+      "A watch-only wallet has limited functionality. It can only be used to view the balance and monitor transaction history. You won't be able to spend any DCR associated with this wallet."
   },
   messageWalletTrezorDescription: {
-    id: "createwallet.trezor.tooltip",
-    defaultMessage: "Trezor is a hardware wallet."
+    id: "createwallet.trezor.description",
+    defaultMessage:
+      "Trezor is a hardware wallet. For more information, visit {link}"
   },
   messageWalletMasterPubKey: {
     id: "createwallet.walletpubkey.placeholder",
@@ -113,9 +114,7 @@ const CreateWalletForm = ({
             <>
               <div className={styles.advancedOption}>
                 <Checkbox
-                  label={
-                    <T id="createwallet.walletOnly.label" m="Watch only" />
-                  }
+                  label={<T id="createwallet.watchOnly.label" m="Watch only" />}
                   id="watchonly"
                   description={intl.formatMessage(
                     messages.messageWalletWatchOnlyDescription
@@ -166,7 +165,16 @@ const CreateWalletForm = ({
                   }
                   id="trezor"
                   description={intl.formatMessage(
-                    messages.messageWalletTrezorDescription
+                    messages.messageWalletTrezorDescription,
+                    {
+                      link: (
+                        <ExternalLink
+                          className={styles.trezorDocs}
+                          href="https://docs.decred.org/wallets/decrediton/trezor/">
+                          docs.decred.org
+                        </ExternalLink>
+                      )
+                    }
                   )}
                   checked={isTrezor}
                   onChange={toggleTrezor}

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
@@ -3,7 +3,7 @@ import { TextInput } from "inputs";
 import { KeyBlueButton, InvisibleButton, ToggleSwitch } from "buttons";
 import { Tooltip } from "shared";
 import { NewSeedTabMsg, RestoreTabMsg } from "../messages";
-import { classNames } from "pi-ui";
+import { classNames, Checkbox } from "pi-ui";
 import styles from "../GetStarted.module.css";
 
 const messages = defineMessages({
@@ -16,12 +16,12 @@ const messages = defineMessages({
     defaultMessage:
       "The name is used to identify your wallet. Restoring a wallet does not require the name to match the previous wallet name."
   },
-  messageWalletWatchOnlyTooltip: {
+  messageWalletWatchOnlyDescription: {
     id: "createwallet.watchonly.tooltip",
     defaultMessage:
       "You’ll not be able to spend any DCR associated with that wallet. It is used only to view the balance and monitor the wallet's transaction activity"
   },
-  messageWalletTrezorTooltip: {
+  messageWalletTrezorDescription: {
     id: "createwallet.trezor.tooltip",
     defaultMessage: "Trezor is a hardware wallet."
   },
@@ -111,61 +111,39 @@ const CreateWalletForm = ({
           </div>
         </div>
         <div className={styles.daemonRow}>
-          <div className={styles.daemonLabel}>
-            <Tooltip
-              text={intl.formatMessage(messages.messageWalletWatchOnlyTooltip)}>
-              <T id="createwallet.walletOnly.label" m="Watch only" />
-            </Tooltip>
-          </div>
-          <div className={styles.daemonInput}>
-            <div className={styles.walletSwitch}>
-              <ToggleSwitch
-                enabled={isWatchingOnly}
-                onClick={toggleWatchOnly}
-                enabledText={<T id="watchOnly.enabled" m="Watch Only" />}
-                notEnabledText={<T id="watchOnly.disabled" m="Normal" />}
-              />
-            </div>
+          <div className={styles.advancedOption}>
+            <Checkbox
+              label={<T id="createwallet.walletOnly.label" m="Watch only" />}
+              id="watchonly"
+              description={intl.formatMessage(
+                messages.messageWalletWatchOnlyDescription
+              )}
+              checked={isWatchingOnly}
+              onChange={toggleWatchOnly}
+            />
           </div>
         </div>
         <div className={styles.daemonRow}>
-          <div className={styles.daemonLabel}>
-            <Tooltip
-              text={intl.formatMessage(messages.messageWalletTrezorTooltip)}>
-              <T id="createwallet.isTrezor.label" m="Trezor" />
-            </Tooltip>
-          </div>
-          <div className={styles.daemonInput}>
-            <div className={styles.walletSwitch}>
-              <ToggleSwitch
-                enabled={isTrezor}
-                onClick={toggleTrezor}
-                enabledText={
-                  <T id="createWallet.restore.trezor.enabled" m="Enabled" />
-                }
-                notEnabledText={
-                  <T id="createWallet.restore.trezor.disabled" m="Disabled" />
-                }
-              />
-              <span onClick={onShowTrezorConfig}>
-                <T id="createWallet.isTrezor.setupLink" m="(setup device)" />
-              </span>
-            </div>
+          <div className={styles.advancedOption}>
+            <Checkbox
+              label={<T id="createwallet.isTrezor.label" m="Trezor" />}
+              id="trezor"
+              description={intl.formatMessage(
+                messages.messageWalletTrezorDescription
+              )}
+              checked={isTrezor}
+              onChange={toggleTrezor}
+            />
           </div>
         </div>
         <div className={styles.daemonRow}>
-          <div className={styles.daemonLabel}>
-            <T id="privacy.label" m="Privacy" />
-          </div>
-          <div className={styles.daemonInput}>
-            <div className={styles.walletSwitch}>
-              <ToggleSwitch
-                enabled={isPrivacy}
-                onClick={toggleIsPrivacy}
-                enabledText={<T id="privacy.label" m="Privacy" />}
-                notEnabledText={<T id="watchOnly.disabled" m="Normal" />}
-              />
-            </div>
+          <div className={styles.advancedOption}>
+            <Checkbox
+              label={<T id="privacy.label" m="Privacy" />}
+              id="privacy"
+              checked={isPrivacy}
+              onChange={toggleIsPrivacy}
+            />
           </div>
         </div>
         {isWatchingOnly && (

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
@@ -1,10 +1,7 @@
 import { FormattedMessage as T, defineMessages } from "react-intl";
 import { TextInput } from "inputs";
-import {
-  KeyBlueButton,
-  InvisibleButton,
-  ToggleSwitch
-} from "buttons";
+import { KeyBlueButton, InvisibleButton, ToggleSwitch } from "buttons";
+import { Tooltip } from "shared";
 import { NewSeedTabMsg, RestoreTabMsg } from "../messages";
 import { classNames } from "pi-ui";
 import styles from "../GetStarted.module.css";
@@ -13,6 +10,20 @@ const messages = defineMessages({
   messageWalletNamePlaceholder: {
     id: "createwallet.walletname.placehlder",
     defaultMessage: "Choose a Name"
+  },
+  messageWalletNameTooltip: {
+    id: "createwallet.walletname.tooltip",
+    defaultMessage:
+      "The name is used to identify your wallet. Restoring a wallet does not require the name to match the previous wallet name."
+  },
+  messageWalletWatchOnlyTooltip: {
+    id: "createwallet.watchonly.tooltip",
+    defaultMessage:
+      "You’ll not be able to spend any DCR associated with that wallet. It is used only to view the balance and monitor the wallet's transaction activity"
+  },
+  messageWalletTrezorTooltip: {
+    id: "createwallet.trezor.tooltip",
+    defaultMessage: "Trezor is a hardware wallet."
   },
   messageWalletMasterPubKey: {
     id: "createwallet.walletpubkey.placeholder",
@@ -59,16 +70,22 @@ const CreateWalletForm = ({
         </div>
       </div>
     ) : (
-        <div className={styles.newWalletTitleArea}>
-          <div className={classNames(styles.walletIconSmall, styles.restore)} />
-          <div className={styles.newWalletTitle}>
-            <RestoreTabMsg />
-          </div>
+      <div className={styles.newWalletTitleArea}>
+        <div className={classNames(styles.walletIconSmall, styles.restore)} />
+        <div className={styles.newWalletTitle}>
+          <RestoreTabMsg />
         </div>
-      )}
+      </div>
+    )}
     <div className={styles.daemonRow}>
       <div className={styles.daemonLabel}>
-        <T id="createwallet.walletname.label" m="Wallet Name" />
+        {!isCreateNewWallet ? (
+          <Tooltip text={intl.formatMessage(messages.messageWalletNameTooltip)}>
+            <T id="createwallet.walletname.label" m="Wallet Name" />
+          </Tooltip>
+        ) : (
+          <T id="createwallet.walletname.label" m="Wallet Name" />
+        )}
       </div>
       <div className={styles.daemonInput}>
         <TextInput
@@ -89,8 +106,16 @@ const CreateWalletForm = ({
     {!isCreateNewWallet && (
       <>
         <div className={styles.daemonRow}>
+          <div className={styles.advancedOptionsLabel}>
+            <T id="createwallet.advancedOptions.label" m="Advanced Options" />:
+          </div>
+        </div>
+        <div className={styles.daemonRow}>
           <div className={styles.daemonLabel}>
-            <T id="createwallet.walletOnly.label" m="Watch only" />
+            <Tooltip
+              text={intl.formatMessage(messages.messageWalletWatchOnlyTooltip)}>
+              <T id="createwallet.walletOnly.label" m="Watch only" />
+            </Tooltip>
           </div>
           <div className={styles.daemonInput}>
             <div className={styles.walletSwitch}>
@@ -105,20 +130,27 @@ const CreateWalletForm = ({
         </div>
         <div className={styles.daemonRow}>
           <div className={styles.daemonLabel}>
-            <T id="createwallet.isTrezor.label" m="Trezor" />
+            <Tooltip
+              text={intl.formatMessage(messages.messageWalletTrezorTooltip)}>
+              <T id="createwallet.isTrezor.label" m="Trezor" />
+            </Tooltip>
           </div>
           <div className={styles.daemonInput}>
             <div className={styles.walletSwitch}>
               <ToggleSwitch
                 enabled={isTrezor}
                 onClick={toggleTrezor}
-                enabledText={<T id="createWallet.restore.trezor.enabled" m="Enabled" />}
-                notEnabledText={<T id="createWallet.restore.trezor.disabled" m="Disabled" />}
+                enabledText={
+                  <T id="createWallet.restore.trezor.enabled" m="Enabled" />
+                }
+                notEnabledText={
+                  <T id="createWallet.restore.trezor.disabled" m="Disabled" />
+                }
               />
+              <span onClick={onShowTrezorConfig}>
+                <T id="createWallet.isTrezor.setupLink" m="(setup device)" />
+              </span>
             </div>
-            <span onClick={onShowTrezorConfig} className={styles.whatsnew}>
-              <T id="createWallet.isTrezor.setupLink" m="(setup device)" />
-            </span>
           </div>
         </div>
         <div className={styles.daemonRow}>


### PR DESCRIPTION
This diff adds tooltips for Watch Only and Trezor, since Privacy will be removed by #3020, and adds an "Advanced Options" label.

Closes #3020 

<img width="1670" alt="Screen Shot 2020-12-01 at 6 52 14 PM" src="https://user-images.githubusercontent.com/22639213/100802536-6abbb000-3408-11eb-81b2-f860fd7d68f9.png">
<img width="1671" alt="Screen Shot 2020-12-01 at 6 52 04 PM" src="https://user-images.githubusercontent.com/22639213/100802557-70b19100-3408-11eb-8a84-fc0aa74f7834.png">
