### PR TITLE
[privacy] Auto-detect mixed wallet 

### DIFF
--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -4,8 +4,18 @@ import * as sel from "selectors";
 import * as wallet from "wallet";
 import { getWalletCfg } from "config";
 import { getAcctSpendableBalance, getAccountsAttempt } from "./ClientActions";
+<<<<<<< HEAD
 import { MIN_RELAY_FEE_ATOMS, MIN_MIX_DENOMINATION_ATOMS } from "constants";
 import * as cfgConstants from "constants/config";
+=======
+import {
+  MIN_RELAY_FEE_ATOMS,
+  MIN_MIX_DENOMINATION_ATOMS,
+  CSPP_URL,
+  CSPP_PORT_TESTNET,
+  CSPP_PORT_MAINNET
+} from "constants";
+>>>>>>> fix mixedAccount/changeAccount index = 0 bug
 
 export const GETACCOUNTMIXERSERVICE_ATTEMPT = "GETACCOUNTMIXERSERVICE_ATTEMPT";
 export const GETACCOUNTMIXERSERVICE_SUCCESS = "GETACCOUNTMIXERSERVICE_SUCCESS";
@@ -184,12 +194,8 @@ export const setCoinjoinCfg = ({ mixedNumber, changeNumber }) => (
   const walletName = sel.getWalletName(getState());
   const cfg = getWalletCfg(isTestnet, walletName);
 
-  // TODO use constants here
-  // On this first moment we are hard coding the cspp decred's server.
-  // the idea is to allow more server on upcoming releases, but we decided
-  // to go with this approach on this first integration.
-  const csppServer = "cspp.decred.org";
-  const csppPort = isTestnet ? "15760" : "5760";
+  const csppServer = CSPP_URL;
+  const csppPort = isTestnet ? CSPP_PORT_TESTNET : CSPP_PORT_MAINNET;
 
   cfg.set(cfgConstants.CSPP_SERVER, csppServer);
   cfg.set(cfgConstants.CSPP_PORT, csppPort);

--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -222,7 +222,6 @@ export const setCoinjoinCfg = ({ mixedNumber, changeNumber }) => (
 export const getCoinjoinOutputspByAcct = () => (dispatch, getState) =>
   new Promise((resolve, reject) => {
     const { balances, walletService } = getState().grpc;
-
     wallet
       .getCoinjoinOutputspByAcct(walletService)
       .then((response) => {
@@ -230,7 +229,7 @@ export const getCoinjoinOutputspByAcct = () => (dispatch, getState) =>
           response.wrappers_ && response.wrappers_[1];
         const coinjoinSumByAcct = balances.reduce(
           (allAccts, { accountNumber }) => {
-            // if account number is equals imported account, we ignore it.
+            // if account number is equals imported account we skip it
             if (accountNumber === Math.pow(2, 31) - 1) {
               return allAccts;
             }

--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -231,7 +231,7 @@ export const getCoinjoinOutputspByAcct = () => (dispatch, getState) =>
           resolve();
         const coinjoinSumByAcct = balances.reduce(
           (allAccts, { accountNumber }) => {
-            // if account number is equals imported account we skip it
+            // if account number equals imported account we skip it
             if (accountNumber === Math.pow(2, 31) - 1) {
               return allAccts;
             }

--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -4,10 +4,7 @@ import * as sel from "selectors";
 import * as wallet from "wallet";
 import { getWalletCfg } from "config";
 import { getAcctSpendableBalance, getAccountsAttempt } from "./ClientActions";
-<<<<<<< HEAD
-import { MIN_RELAY_FEE_ATOMS, MIN_MIX_DENOMINATION_ATOMS } from "constants";
 import * as cfgConstants from "constants/config";
-=======
 import {
   MIN_RELAY_FEE_ATOMS,
   MIN_MIX_DENOMINATION_ATOMS,
@@ -15,7 +12,6 @@ import {
   CSPP_PORT_TESTNET,
   CSPP_PORT_MAINNET
 } from "constants";
->>>>>>> fix mixedAccount/changeAccount index = 0 bug
 
 export const GETACCOUNTMIXERSERVICE_ATTEMPT = "GETACCOUNTMIXERSERVICE_ATTEMPT";
 export const GETACCOUNTMIXERSERVICE_SUCCESS = "GETACCOUNTMIXERSERVICE_SUCCESS";

--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -4,13 +4,18 @@ import * as sel from "selectors";
 import * as wallet from "wallet";
 import { getWalletCfg } from "config";
 import { getAcctSpendableBalance, getAccountsAttempt } from "./ClientActions";
-import * as cfgConstants from "constants/config";
 import {
   MIN_RELAY_FEE_ATOMS,
   MIN_MIX_DENOMINATION_ATOMS,
   CSPP_URL,
   CSPP_PORT_TESTNET,
-  CSPP_PORT_MAINNET
+  CSPP_PORT_MAINNET,
+  SEND_FROM_UNMIXED,
+  CSPP_SERVER,
+  CSPP_PORT,
+  MIXED_ACCOUNT_CFG,
+  CHANGE_ACCOUNT_CFG,
+  MIXED_ACC_BRANCH
 } from "constants";
 
 export const GETACCOUNTMIXERSERVICE_ATTEMPT = "GETACCOUNTMIXERSERVICE_ATTEMPT";
@@ -45,8 +50,8 @@ export const TOGGLE_ALLOW_SEND_FROM_UNMIXED = "TOGGLE_ALLOW_SEND_FROM_UNMIXED";
 export const toggleAllowSendFromUnmixed = () => (dispatch, getState) => {
   const walletName = sel.getWalletName(getState());
   const walletCfg = getWalletCfg(sel.isTestNet(getState()), walletName);
-  const value = !walletCfg.get(cfgConstants.SEND_FROM_UNMIXED);
-  walletCfg.set(cfgConstants.SEND_FROM_UNMIXED, value);
+  const value = !walletCfg.get(SEND_FROM_UNMIXED);
+  walletCfg.set(SEND_FROM_UNMIXED, value);
   dispatch({ type: TOGGLE_ALLOW_SEND_FROM_UNMIXED, allow: value });
 };
 
@@ -193,13 +198,13 @@ export const setCoinjoinCfg = ({ mixedNumber, changeNumber }) => (
   const csppServer = CSPP_URL;
   const csppPort = isTestnet ? CSPP_PORT_TESTNET : CSPP_PORT_MAINNET;
 
-  cfg.set(cfgConstants.CSPP_SERVER, csppServer);
-  cfg.set(cfgConstants.CSPP_PORT, csppPort);
-  cfg.set(cfgConstants.MIXED_ACCOUNT_CFG, mixedNumber);
-  cfg.set(cfgConstants.CHANGE_ACCOUNT_CFG, changeNumber);
-  cfg.set(cfgConstants.MIXED_ACCBRANCH, 0);
+  cfg.set(CSPP_SERVER, csppServer);
+  cfg.set(CSPP_PORT, csppPort);
+  cfg.set(MIXED_ACCOUNT_CFG, mixedNumber);
+  cfg.set(CHANGE_ACCOUNT_CFG, changeNumber);
+  cfg.set(MIXED_ACC_BRANCH, 0);
   // by default it is only allowed to send from mixed account.
-  cfg.set(cfgConstants.SEND_FROM_UNMIXED, false);
+  cfg.set(SEND_FROM_UNMIXED, false);
 
   dispatch({
     type: CREATEMIXERACCOUNTS_SUCCESS,

--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -227,6 +227,8 @@ export const getCoinjoinOutputspByAcct = () => (dispatch, getState) =>
       .then((response) => {
         const coinjoinSumByAcctResp =
           response.wrappers_ && response.wrappers_[1];
+        if (!coinjoinSumByAcctResp)
+          resolve();
         const coinjoinSumByAcct = balances.reduce(
           (allAccts, { accountNumber }) => {
             // if account number is equals imported account we skip it

--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -3,6 +3,7 @@ import * as wallet from "wallet";
 import { onAppReloadRequested, getDcrwalletGrpcKeyCert } from "wallet";
 import * as sel from "selectors";
 import eq from "lodash/fp/eq";
+import isUndefined from "lodash/fp/isUndefined";
 import {
   getNextAddressAttempt,
   getPeerInfo,
@@ -768,12 +769,12 @@ export const getMixerAcctsSpendableBalances = () => async (
   const mixedAccount = sel.getMixedAccount(getState());
   const changeAccount = sel.getChangeAccount(getState());
   const balances = {};
-  if (mixedAccount) {
+  if (!isUndefined(mixedAccount)) {
     balances.mixedAccountSpendableBalance = await dispatch(
       getAcctSpendableBalance(mixedAccount)
     );
   }
-  if (changeAccount) {
+  if (!isUndefined(changeAccount)) {
     balances.changeAccountSpendableBalance = await dispatch(
       getAcctSpendableBalance(changeAccount)
     );

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
@@ -178,14 +178,6 @@ const CreateWalletForm = ({
                   onChange={toggleTrezor}
                 />
               </div>
-              <div className={styles.advancedOption}>
-                <Checkbox
-                  label={<T id="privacy.label" m="Privacy" />}
-                  id="privacy"
-                  checked={isPrivacy}
-                  onChange={toggleIsPrivacy}
-                />
-              </div>
             </>
           }
         />

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm.jsx
@@ -56,8 +56,6 @@ const CreateWalletForm = ({
   masterPubKeyError,
   isTrezor,
   toggleTrezor,
-  isPrivacy,
-  toggleIsPrivacy,
   onShowTrezorConfig,
   isCreateNewWallet,
   creatingWallet

--- a/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
@@ -34,7 +34,6 @@ const PreCreateWallet = ({
   const [isTrezor, setIsTrezor] = useState(false);
   const [hasFailedAttemptName, setHasFailedAttemptName] = useState(false);
   const [hasFailedAttemptPubKey, setHasFailedAttemptPubKey] = useState(false);
-  const [isPrivacy, setPrivacy] = useState(false);
 
   const hideCreateWalletForm = useCallback(() => {
     if (isTrezor) {
@@ -78,9 +77,6 @@ const PreCreateWallet = ({
     setIsWatchingOnly(false);
   }, [isTrezor, trezorEnable, trezorDisable]);
 
-  const toggleIsPrivacy = () => {
-    setPrivacy(!isPrivacy);
-  };
 
   const createWallet = useCallback(() => {
     const isNew = isCreateNewWallet;
@@ -91,7 +87,6 @@ const PreCreateWallet = ({
         isWatchingOnly,
         isTrezor,
         isNew,
-        isPrivacy,
         network: isTestNet ? "testnet" : "mainnet"
       }
     };
@@ -125,7 +120,7 @@ const PreCreateWallet = ({
     }
 
     return onCreateWallet(walletSelected)
-      .then(() => onShowCreateWallet({ isNew, isPrivacy, walletMasterPubKey }))
+      .then(() => onShowCreateWallet({ isNew, walletMasterPubKey }))
       .catch((error) => onSendError(error));
   }, [
     isCreateNewWallet,
@@ -142,8 +137,7 @@ const PreCreateWallet = ({
     trezorDevice,
     trezorGetWalletCreationMasterPubKey,
     walletMasterPubKey,
-    walletNameError,
-    isPrivacy
+    walletNameError
   ]);
 
 
@@ -187,8 +181,6 @@ const PreCreateWallet = ({
         toggleWatchOnly,
         toggleTrezor,
         onChangeCreateWalletMasterPubKey,
-        isPrivacy,
-        toggleIsPrivacy,
         intl
       }}
     />

--- a/app/components/views/GetStartedPage/SetMixedAcctPage/SetMixedAcctPage.jsx
+++ b/app/components/views/GetStartedPage/SetMixedAcctPage/SetMixedAcctPage.jsx
@@ -132,43 +132,48 @@ export default ({ onSendBack, onSendContinue }) => {
                     />
                   </div>
                 </div>
-                {acctIdx !== 0 && (<div className={classNames("is-column", styles.buttons)}>
-                  <div className={classNames("is-row", styles.checkboxRow)}>
-                    <input
-                      id={`mixed${acctIdx}`}
-                      name={acctIdx}
-                      type="checkbox"
-                      checked={mixedAcctIdx === acctIdx}
-                      onChange={() => onSetMixedAcct(acctIdx)}
-                      value={acctIdx}
-                    />
-                    <label
-                      htmlFor={`mixed${acctIdx}`}
-                      className={styles.checkboxLabel}></label>
-                    <div className={styles.label}>
-                      <T id="getstarted.setAccount.mix" m="Set Mixed Account" />
-                    </div>
-                  </div>
-                  <div className={classNames("is-row", styles.checkboxRow)}>
-                    <input
-                      id={`change${acctIdx}`}
-                      name={`a${acctIdx}`}
-                      type="checkbox"
-                      checked={changeAcctIdx === acctIdx}
-                      onChange={() => onSubmitSetChange(acctIdx)}
-                      value={acctIdx}
-                    />
-                    <label
-                      htmlFor={`change${acctIdx}`}
-                      className={styles.checkboxLabel}></label>
-                    <div className={styles.label}>
-                      <T
-                        id="getstarted.setAccount.change"
-                        m="Set Unmixed Account"
+                {acctIdx !== 0 && (
+                  <div className={classNames("is-column", styles.buttons)}>
+                    <div className={classNames("is-row", styles.checkboxRow)}>
+                      <input
+                        id={`mixed${acctIdx}`}
+                        name={acctIdx}
+                        type="checkbox"
+                        checked={mixedAcctIdx === acctIdx}
+                        onChange={() => onSetMixedAcct(acctIdx)}
+                        value={acctIdx}
                       />
+                      <label
+                        htmlFor={`mixed${acctIdx}`}
+                        className={styles.checkboxLabel}></label>
+                      <div className={styles.label}>
+                        <T
+                          id="getstarted.setAccount.mix"
+                          m="Set Mixed Account"
+                        />
+                      </div>
+                    </div>
+                    <div className={classNames("is-row", styles.checkboxRow)}>
+                      <input
+                        id={`change${acctIdx}`}
+                        name={`a${acctIdx}`}
+                        type="checkbox"
+                        checked={changeAcctIdx === acctIdx}
+                        onChange={() => onSubmitSetChange(acctIdx)}
+                        value={acctIdx}
+                      />
+                      <label
+                        htmlFor={`change${acctIdx}`}
+                        className={styles.checkboxLabel}></label>
+                      <div className={styles.label}>
+                        <T
+                          id="getstarted.setAccount.change"
+                          m="Set Unmixed Account"
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>)} 
+                )}
               </div>
             ))}
           </div>

--- a/app/components/views/GetStartedPage/SetMixedAcctPage/SetMixedAcctPage.jsx
+++ b/app/components/views/GetStartedPage/SetMixedAcctPage/SetMixedAcctPage.jsx
@@ -12,24 +12,13 @@ import { MIXED_ACCOUNT, CHANGE_ACCOUNT } from "constants";
 
 export default ({ onSendBack, onSendContinue }) => {
   const { getCoinjoinOutputspByAcct, setCoinjoinCfg } = useDaemonStartup();
-  const { onRenameAccount, mixedAccount } = useAccounts();
+  const { onRenameAccount } = useAccounts();
   const [coinjoinSumByAcct, setCjSumByAcct] = useState(null);
   const [mixedAcctIdx, setMixedAcctIdx] = useState(null);
   const [changeAcctIdx, setChangeAcctIdx] = useState(null);
   const [isValid, setIsValid] = useState(false);
   useMountEffect(() => {
-    getCoinjoinOutputspByAcct()
-      .then((r) => {
-        const hasMixedOutputs = r.reduce(
-          (foundMixed, { coinjoinSum }) => coinjoinSum > 0 || foundMixed,
-          false
-        );
-        if (!hasMixedOutputs || mixedAccount) {
-          console.log("redirect to home");
-        }
-        setCjSumByAcct(r);
-      })
-      .catch((err) => console.log(err));
+    getCoinjoinOutputspByAcct().then((r) => setCjSumByAcct(r)).catch(err => console.log(err));
   });
   const onSetMixedAcct = (acctIdx) => {
     // can't set same mixed and change acct

--- a/app/components/views/GetStartedPage/SetMixedAcctPage/SetMixedAcctPage.jsx
+++ b/app/components/views/GetStartedPage/SetMixedAcctPage/SetMixedAcctPage.jsx
@@ -12,13 +12,24 @@ import { MIXED_ACCOUNT, CHANGE_ACCOUNT } from "constants";
 
 export default ({ onSendBack, onSendContinue }) => {
   const { getCoinjoinOutputspByAcct, setCoinjoinCfg } = useDaemonStartup();
-  const { onRenameAccount } = useAccounts();
+  const { onRenameAccount, mixedAccount } = useAccounts();
   const [coinjoinSumByAcct, setCjSumByAcct] = useState(null);
   const [mixedAcctIdx, setMixedAcctIdx] = useState(null);
   const [changeAcctIdx, setChangeAcctIdx] = useState(null);
   const [isValid, setIsValid] = useState(false);
   useMountEffect(() => {
-    getCoinjoinOutputspByAcct().then((r) => setCjSumByAcct(r)).catch(err => console.log(err));
+    getCoinjoinOutputspByAcct()
+      .then((r) => {
+        const hasMixedOutputs = r.reduce(
+          (foundMixed, { coinjoinSum }) => coinjoinSum > 0 || foundMixed,
+          false
+        );
+        if (!hasMixedOutputs || mixedAccount) {
+          console.log("redirect to home");
+        }
+        setCjSumByAcct(r);
+      })
+      .catch((err) => console.log(err));
   });
   const onSetMixedAcct = (acctIdx) => {
     // can't set same mixed and change acct
@@ -41,7 +52,8 @@ export default ({ onSendBack, onSendContinue }) => {
     onSendContinue();
   };
   useEffect(() => {
-    const isValid = mixedAcctIdx !== null &&
+    const isValid =
+      mixedAcctIdx !== null &&
       changeAcctIdx !== null &&
       mixedAcctIdx !== changeAcctIdx;
     setIsValid(isValid);
@@ -51,50 +63,57 @@ export default ({ onSendBack, onSendContinue }) => {
     <div className={styles.content}>
       <div className={GetStartedStyles.goBackScreenButtonArea}>
         <Tooltip text={<GoBackMsg />}>
-          <div className={GetStartedStyles.goBackScreenButton} onClick={onSendBack} />
+          <div
+            className={GetStartedStyles.goBackScreenButton}
+            onClick={onSendBack}
+          />
         </Tooltip>
       </div>
       <Subtitle
         className={styles.subtitle}
         title={<T id="getstarted.setAccount.title" m="Set Mixed Account" />}
       />
-      {coinjoinSumByAcct &&
+      {coinjoinSumByAcct && (
         <div className={styles.description}>
-          <T id="getstarted.setAccount.description"
-            m={ `Looks like you have accounts with coinjoin outputs. Past
+          <T
+            id="getstarted.setAccount.description"
+            m={`Looks like you have accounts with coinjoin outputs. Past
                 account names cannot be restored during Recovery, so it is not
                 possible to know which account was the mixed account. You can
                 set a mixed and unmixed account now or this can be done later on
                 the privacy page.
                 
-                With this action the chosen accounts will be renamed.`
-              }
+                With this action the chosen accounts will be renamed.`}
             values={{ acctsNumber: coinjoinSumByAcct.length }}
           />
         </div>
-      }
-      {
-        mixedAcctIdx !== null &&
+      )}
+      {mixedAcctIdx !== null && (
         <div>
-          <T id="getstarted.setAcct.mixedAcct"
+          <T
+            id="getstarted.setAcct.mixedAcct"
             m="Mixed Account: {value}"
-            values = {{ value: <span>{mixedAcctIdx}</span> }} />
+            values={{ value: <span>{mixedAcctIdx}</span> }}
+          />
         </div>
-      }
-      {
-        changeAcctIdx !== null &&
+      )}
+      {changeAcctIdx !== null && (
         <div>
-          <T id="getstarted.setAcct.changAcct"
+          <T
+            id="getstarted.setAcct.changAcct"
             m="Unmixed Account: {value}"
-            values = {{ value: <span>{changeAcctIdx}</span> }} />
+            values={{ value: <span>{changeAcctIdx}</span> }}
+          />
         </div>
-      }
-      {coinjoinSumByAcct &&
+      )}
+      {coinjoinSumByAcct && (
         <>
           <div className={classNames("is-row", styles.cardsWrapper)}>
             {coinjoinSumByAcct.map(({ acctIdx, coinjoinSum }) => {
               return (
-                <div key={acctIdx} className={classNames("is-row", styles.card)}>
+                <div
+                  key={acctIdx}
+                  className={classNames("is-row", styles.card)}>
                   <div className={classNames("is-column", styles.labelWrapper)}>
                     <div className={"is-row"}>
                       <div className={styles.accountIcon} />
@@ -110,37 +129,53 @@ export default ({ onSendBack, onSendContinue }) => {
                       <T
                         id="getstarted.setAccount.sumCoinjoin"
                         m="Coinjoin Sum outputs: {coinjoinSum}"
-                        values={{ coinjoinSum: <span className={styles.coinjoinSum}>{coinjoinSum}</span> }}
+                        values={{
+                          coinjoinSum: (
+                            <span className={styles.coinjoinSum}>
+                              {coinjoinSum}
+                            </span>
+                          )
+                        }}
                       />
                     </div>
                   </div>
                   <div className={classNames("is-column", styles.buttons)}>
                     <div className={classNames("is-row", styles.checkboxRow)}>
                       <input
-                        id={"mixed"+acctIdx}
+                        id={"mixed" + acctIdx}
                         name={acctIdx}
                         type="checkbox"
                         checked={mixedAcctIdx === acctIdx}
                         onChange={() => onSetMixedAcct(acctIdx)}
                         value={acctIdx}
                       />
-                      <label htmlFor={"mixed"+acctIdx} className={styles.checkboxLabel}></label>
+                      <label
+                        htmlFor={"mixed" + acctIdx}
+                        className={styles.checkboxLabel}></label>
                       <div className={styles.label}>
-                        <T id="getstarted.setAccount.mix" m="Set Mixed Account" />
+                        <T
+                          id="getstarted.setAccount.mix"
+                          m="Set Mixed Account"
+                        />
                       </div>
                     </div>
                     <div className={classNames("is-row", styles.checkboxRow)}>
                       <input
-                        id={"change"+acctIdx}
-                        name={"a"+acctIdx}
+                        id={"change" + acctIdx}
+                        name={"a" + acctIdx}
                         type="checkbox"
                         checked={changeAcctIdx === acctIdx}
                         onChange={() => onSubmitSetChange(acctIdx)}
                         value={acctIdx}
                       />
-                      <label htmlFor={"change"+acctIdx} className={styles.checkboxLabel}></label>
+                      <label
+                        htmlFor={"change" + acctIdx}
+                        className={styles.checkboxLabel}></label>
                       <div className={styles.label}>
-                        <T id="getstarted.setAccount.change" m="Set Unmixed Account" />
+                        <T
+                          id="getstarted.setAccount.change"
+                          m="Set Unmixed Account"
+                        />
                       </div>
                     </div>
                   </div>
@@ -148,24 +183,22 @@ export default ({ onSendBack, onSendContinue }) => {
               );
             })}
           </div>
-          { !isValid &&
+          {!isValid && (
             <div className="error">
-              <T id="getstarted.setAccount.isValidMessage"
+              <T
+                id="getstarted.setAccount.isValidMessage"
                 m="You need to set a mixed and unimxed account, and they can not
                   be the same"
               />
             </div>
-          }
+          )}
           <div className={styles.buttonWrapper}>
-            <KeyBlueButton
-              onClick={onSubmitContinue}
-              disabled={!isValid}
-            >
+            <KeyBlueButton onClick={onSubmitContinue} disabled={!isValid}>
               <T id="getstarted.setAccount.continue" m="Continue" />
             </KeyBlueButton>
           </div>
         </>
-      }
+      )}
     </div>
   );
 };

--- a/app/components/views/GetStartedPage/SetMixedAcctPage/SetMixedAcctPage.jsx
+++ b/app/components/views/GetStartedPage/SetMixedAcctPage/SetMixedAcctPage.jsx
@@ -17,9 +17,7 @@ export default ({ onSendBack, onSendContinue }) => {
   const [mixedAcctIdx, setMixedAcctIdx] = useState(null);
   const [changeAcctIdx, setChangeAcctIdx] = useState(null);
   const [isValid, setIsValid] = useState(false);
-  useMountEffect(() => {
-    getCoinjoinOutputspByAcct().then((r) => setCjSumByAcct(r)).catch(err => console.log(err));
-  });
+
   const onSetMixedAcct = (acctIdx) => {
     // can't set same mixed and change acct
     if (acctIdx === changeAcctIdx) {
@@ -27,6 +25,7 @@ export default ({ onSendBack, onSendContinue }) => {
     }
     setMixedAcctIdx(acctIdx);
   };
+
   const onSubmitSetChange = (acctIdx) => {
     // can't set same mixed and change acct
     if (acctIdx === mixedAcctIdx) {
@@ -34,12 +33,20 @@ export default ({ onSendBack, onSendContinue }) => {
     }
     setChangeAcctIdx(acctIdx);
   };
+
   const onSubmitContinue = () => {
     onRenameAccount(changeAcctIdx, CHANGE_ACCOUNT);
     onRenameAccount(mixedAcctIdx, MIXED_ACCOUNT);
     setCoinjoinCfg(mixedAcctIdx, changeAcctIdx);
     onSendContinue();
   };
+
+  useMountEffect(() => {
+    getCoinjoinOutputspByAcct()
+      .then((r) => setCjSumByAcct(r))
+      .catch((err) => console.log(err));
+  });
+
   useEffect(() => {
     const isValid =
       mixedAcctIdx !== null &&
@@ -98,79 +105,72 @@ export default ({ onSendBack, onSendContinue }) => {
       {coinjoinSumByAcct && (
         <>
           <div className={classNames("is-row", styles.cardsWrapper)}>
-            {coinjoinSumByAcct.map(({ acctIdx, coinjoinSum }) => {
-              return (
-                <div
-                  key={acctIdx}
-                  className={classNames("is-row", styles.card)}>
-                  <div className={classNames("is-column", styles.labelWrapper)}>
-                    <div className={"is-row"}>
-                      <div className={styles.accountIcon} />
-                      <div className={styles.accountLabel}>
-                        <T
-                          id="getstarted.setAccount.acctIdxRow"
-                          m="Account {acctIdx}"
-                          values={{ acctIdx: <span>{acctIdx}</span> }}
-                        />
-                      </div>
-                    </div>
-                    <div className={styles.coinjoinLabel}>
+            {coinjoinSumByAcct.map(({ acctIdx, coinjoinSum }) => (
+              <div key={acctIdx} className={classNames("is-row", styles.card)}>
+                <div className={classNames("is-column", styles.labelWrapper)}>
+                  <div className="is-row">
+                    <div className={styles.accountIcon} />
+                    <div className={styles.accountLabel}>
                       <T
-                        id="getstarted.setAccount.sumCoinjoin"
-                        m="Coinjoin Sum outputs: {coinjoinSum}"
-                        values={{
-                          coinjoinSum: (
-                            <span className={styles.coinjoinSum}>
-                              {coinjoinSum}
-                            </span>
-                          )
-                        }}
+                        id="getstarted.setAccount.acctIdxRow"
+                        m="Account {acctIdx}"
+                        values={{ acctIdx: <span>{acctIdx}</span> }}
                       />
                     </div>
                   </div>
-                  <div className={classNames("is-column", styles.buttons)}>
-                    <div className={classNames("is-row", styles.checkboxRow)}>
-                      <input
-                        id={"mixed" + acctIdx}
-                        name={acctIdx}
-                        type="checkbox"
-                        checked={mixedAcctIdx === acctIdx}
-                        onChange={() => onSetMixedAcct(acctIdx)}
-                        value={acctIdx}
-                      />
-                      <label
-                        htmlFor={"mixed" + acctIdx}
-                        className={styles.checkboxLabel}></label>
-                      <div className={styles.label}>
-                        <T
-                          id="getstarted.setAccount.mix"
-                          m="Set Mixed Account"
-                        />
-                      </div>
-                    </div>
-                    <div className={classNames("is-row", styles.checkboxRow)}>
-                      <input
-                        id={"change" + acctIdx}
-                        name={"a" + acctIdx}
-                        type="checkbox"
-                        checked={changeAcctIdx === acctIdx}
-                        onChange={() => onSubmitSetChange(acctIdx)}
-                        value={acctIdx}
-                      />
-                      <label
-                        htmlFor={"change" + acctIdx}
-                        className={styles.checkboxLabel}></label>
-                      <div className={styles.label}>
-                        <T
-                          id="getstarted.setAccount.change"
-                          m="Set Unmixed Account"
-                        />
-                      </div>
-                    </div>
+                  <div className={styles.coinjoinLabel}>
+                    <T
+                      id="getstarted.setAccount.sumCoinjoin"
+                      m="Coinjoin Sum outputs: {coinjoinSum}"
+                      values={{
+                        coinjoinSum: (
+                          <span className={styles.coinjoinSum}>
+                            {coinjoinSum}
+                          </span>
+                        )
+                      }}
+                    />
                   </div>
                 </div>
-              );
-            })}
+                {acctIdx !== 0 && (<div className={classNames("is-column", styles.buttons)}>
+                  <div className={classNames("is-row", styles.checkboxRow)}>
+                    <input
+                      id={`mixed${acctIdx}`}
+                      name={acctIdx}
+                      type="checkbox"
+                      checked={mixedAcctIdx === acctIdx}
+                      onChange={() => onSetMixedAcct(acctIdx)}
+                      value={acctIdx}
+                    />
+                    <label
+                      htmlFor={`mixed${acctIdx}`}
+                      className={styles.checkboxLabel}></label>
+                    <div className={styles.label}>
+                      <T id="getstarted.setAccount.mix" m="Set Mixed Account" />
+                    </div>
+                  </div>
+                  <div className={classNames("is-row", styles.checkboxRow)}>
+                    <input
+                      id={`change${acctIdx}`}
+                      name={`a${acctIdx}`}
+                      type="checkbox"
+                      checked={changeAcctIdx === acctIdx}
+                      onChange={() => onSubmitSetChange(acctIdx)}
+                      value={acctIdx}
+                    />
+                    <label
+                      htmlFor={`change${acctIdx}`}
+                      className={styles.checkboxLabel}></label>
+                    <div className={styles.label}>
+                      <T
+                        id="getstarted.setAccount.change"
+                        m="Set Unmixed Account"
+                      />
+                    </div>
+                  </div>
+                </div>)} 
+              </div>
+            ))}
           </div>
           {!isValid && (
             <div className="error">

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -27,6 +27,7 @@ import SettingMixedAccount from "./SetMixedAcctPage/SetMixedAcctPage";
 // and styling defined in Loading.less and need to handled when loading.less
 // is migrated, and classes should be defined then in ./GetStarted.module.css
 // css animation classes
+const blockChainLoading = "blockchain-syncing";
 const daemonWaiting = "daemon-waiting";
 const discoveringAddresses = "discovering-addresses";
 const scanningBlocks = "scanning-blocks";

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -547,8 +547,11 @@ export const useGetStarted = () => {
           StateComponent: updatedComponent ? updatedComponent : component
         });
         getCoinjoinOutputspByAcct()
-          .then((r) => {
-            const hasMixedOutputs = r.reduce(
+          .then((outputsByAcctMap) => {
+            if (!outputsByAcctMap) {
+              goToHome();
+            }
+            const hasMixedOutputs = outputsByAcctMap.reduce(
               (foundMixed, { coinjoinSum }) => coinjoinSum > 0 || foundMixed,
               false
             );

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -548,10 +548,7 @@ export const useGetStarted = () => {
         });
         getCoinjoinOutputspByAcct()
           .then((outputsByAcctMap) => {
-            if (!outputsByAcctMap) {
-              goToHome();
-            }
-            const hasMixedOutputs = outputsByAcctMap.reduce(
+            const hasMixedOutputs = outputsByAcctMap && outputsByAcctMap.reduce(
               (foundMixed, { coinjoinSum }) => coinjoinSum > 0 || foundMixed,
               false
             );

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -202,7 +202,7 @@ export const useGetStarted = () => {
           });
       },
       isSyncingRPC: async (context) => {
-        const { passPhrase, isPrivacy, isSPV } = context;
+        const { passPhrase, isSPV } = context;
         if (syncAttemptRequest) {
           return;
         }
@@ -215,14 +215,7 @@ export const useGetStarted = () => {
         if (isSPV) {
           return startSPVSync(passPhrase)
             .then(() => {
-              if (isPrivacy) {
-                // if recoverying a privacy wallet, we go to settingMixedAccount
-                // state, so the user can set a mixed account based on their
-                // coinjoin outputs.
-                // This state should only be achievable if recoverying wallet.
-                send({ type: "SET_MIXED_ACCOUNT" });
-              }
-              send({ type: "GO_TO_HOME_VIEW" });
+              send({ type: "SET_MIXED_ACCOUNT" });
             })
             .catch((error) => {
               // If the error is OPENWALLET_INPUTPRIVPASS, the wallet needs the
@@ -246,15 +239,7 @@ export const useGetStarted = () => {
             throw error;
           }
 
-          if (isPrivacy) {
-            // if recoverying a privacy wallet, we go to settingMixedAccount
-            // state, so the user can set a mixed account based on their
-            // coinjoin outputs.
-            // This state should only be achievable if recoverying wallet.
-            send({ type: "SET_MIXED_ACCOUNT" });
-          }
-          // if it is not privacy we can simply go to home view.
-          send({ type: "GO_TO_HOME_VIEW" });
+          send({ type: "SET_MIXED_ACCOUNT" });
         } catch (error) {
           send({ type: "ERROR_SYNCING_WALLET", payload: { error } });
         }
@@ -355,13 +340,12 @@ export const useGetStarted = () => {
   );
 
   const onShowCreateWallet = useCallback(
-    ({ isNew, walletMasterPubKey, isTrezor, isPrivacy }) =>
+    ({ isNew, walletMasterPubKey, isTrezor }) =>
       send({
         type: "SHOW_CREATE_WALLET",
         isNew,
         walletMasterPubKey,
-        isTrezor,
-        isPrivacy
+        isTrezor
       }),
     [send]
   );

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -27,7 +27,6 @@ import SettingMixedAccount from "./SetMixedAcctPage/SetMixedAcctPage";
 // and styling defined in Loading.less and need to handled when loading.less
 // is migrated, and classes should be defined then in ./GetStarted.module.css
 // css animation classes
-const blockChainLoading = "blockchain-syncing";
 const daemonWaiting = "daemon-waiting";
 const discoveringAddresses = "discovering-addresses";
 const scanningBlocks = "scanning-blocks";

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -216,9 +216,7 @@ export const useGetStarted = () => {
         }
         if (isSPV) {
           return startSPVSync(passPhrase)
-            .then(() => {
-              send({ type: "SET_MIXED_ACCOUNT" });
-            })
+            .then(() => send({ type: "SET_MIXED_ACCOUNT" }))
             .catch((error) => {
               // If the error is OPENWALLET_INPUTPRIVPASS, the wallet needs the
               // private passphrase to discover accounts and the user typed a wrong
@@ -532,17 +530,16 @@ export const useGetStarted = () => {
         });
       }
       if (key === "settingMixedAccount") {
+        // Display a message while checking for coinjoin outputs and go to set
+        // mixed account only if coinjoin outputs found & mixed account not set yet
         animationType = establishingRpc;
-        text = <T id="loaderBar.checkingMixedAccount" m="Seaching for coinjoin transactions..." />;
+        text = (
+          <T
+            id="loaderBar.checkingMixedAccount"
+            m="Seaching for coinjoin transactions..."
+          />
+        );
         PageComponent = h(GetStartedMachinePage, {
-          submitRemoteCredentials,
-          submitAppdata,
-          error,
-          isSPV,
-          onShowReleaseNotes,
-          onShowTutorial,
-          appVersion,
-          onGetDcrdLogs,
           text: updatedText ? updatedText : text,
           animationType: updatedAnimationType
             ? updatedAnimationType

--- a/app/constants/Decrediton.js
+++ b/app/constants/Decrediton.js
@@ -89,6 +89,11 @@ export const IMPORTED_ACCOUNT = "imported";
 export const MIXED_ACCOUNT = "mixed";
 export const CHANGE_ACCOUNT = "unmixed";
 
+// CSPP CONNECTION PARAMS
+export const CSPP_URL = "cspp.decred.org";
+export const CSPP_PORT_TESTNET = "15760";
+export const CSPP_PORT_MAINNET = "5760";
+
 // MENU_LINKS_PER_ROW is the default number of menu items shown in sidebar when it's located on bottom.
 export const MENU_LINKS_PER_ROW = 4;
 

--- a/app/hooks/useAccounts.js
+++ b/app/hooks/useAccounts.js
@@ -1,15 +1,17 @@
 import { useCallback } from "react";
-import { useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import * as sel from "selectors";
 import * as ca from "actions/ControlActions";
 
 const useAccounts = () => {
   const dispatch = useDispatch();
+  const mixedAccount = useSelector(sel.getMixedAccountName);
   const onRenameAccount = useCallback(
     (acctIdx, newName) => dispatch(ca.renameAccountAttempt(acctIdx, newName)),
     [dispatch]
   );
 
-  return { onRenameAccount };
+  return { onRenameAccount, mixedAccount };
 };
 
 export default useAccounts;

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -14,8 +14,7 @@ export const getStartedMachine = Machine({
     error: null,
     isCreateNewWallet: null,
     isSPV: null,
-    isAdvancedDaemon: null,
-    isPrivacy: null
+    isAdvancedDaemon: null
   },
   states: {
     // startMachine represents the state with daemon and wallet starting operations.
@@ -28,8 +27,8 @@ export const getStartedMachine = Machine({
         SHOW_RELEASE_NOTES: "releaseNotes",
         SHOW_CREATE_WALLET: "creatingWallet",
         SET_MIXED_ACCOUNT: {
-          target: "settingMixedAccount",
-          cond: (context) => !!context.isPrivacy
+          target: "settingMixedAccount"
+          //cond: (context) => !!context.isPrivacy
         },
         GO_TO_HOME_VIEW: "goToHomeView"
       },
@@ -293,10 +292,7 @@ export const getStartedMachine = Machine({
                 console.log(e);
               }
               return spawnedMachine;
-            },
-            // set isPrivacy in case recoverying a privacy wallet. With that
-            // it is possible to set mixed account when recoverying wallets.
-            isPrivacy: (ctx, e) => e.isPrivacy
+            }
           })
         }
       },

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -28,7 +28,6 @@ export const getStartedMachine = Machine({
         SHOW_CREATE_WALLET: "creatingWallet",
         SET_MIXED_ACCOUNT: {
           target: "settingMixedAccount"
-          //cond: (context) => !!context.isPrivacy
         },
         GO_TO_HOME_VIEW: "goToHomeView"
       },


### PR DESCRIPTION
This diff deletes current `Privacy` toggle from wallet restore page and auto detects mixed wallet by 
checking for coinjoin outputs on startup.

---

Based on #3029 
Closes #2907