### PR TITLE
[CSS] Purchase Tickets misalignment

### DIFF
--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTab.module.css
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTab.module.css
@@ -107,6 +107,7 @@
   }
   .purchaseForm {
     padding-bottom: 0;
+    flex-direction: column !important;
   }
 
   .purchaseForm.isRow {


### PR DESCRIPTION
I noticed a CSS misalignment on the Purchase Tickets form in small width. This diff fixes it.

<img width="579" alt="Screenshot 2020-12-14 at 20 14 55" src="https://user-images.githubusercontent.com/52497040/102125732-69e43e80-3e4a-11eb-9033-f6601065058c.png">
