### PR TITLE
[TxHistory] Use `monospace` font for dates & improve alignment

### DIFF
--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -92,12 +92,13 @@
 
 .info {
   display: grid;
-  grid-template-columns: 0.5fr 3fr 10fr 3fr;
+  grid-template-columns: 0.5fr 3fr 10fr;
   width: 100%;
 }
 
 .overviewInfo {
   display: grid;
+  font-family: var(--font-family-monospace);
 }
 
 .overviewInfo .txDirection {
@@ -109,7 +110,6 @@
   font-size: 11px;
   padding-bottom: 3px;
   color: var(--overview-balance-label) !important;
-  font-family: var(--font-family-monospace);
 }
 
 .overviewInfo .txDirection .accountName {


### PR DESCRIPTION
Closes #3085 

After:

![image](https://user-images.githubusercontent.com/10324528/102266556-4a6c1500-3f21-11eb-98bc-d852cf35341d.png)
