### PR TITLE
GetStarted: Hide top nav menu links in nested pages

### DIFF
--- a/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
+++ b/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
@@ -11,7 +11,7 @@ import { useService } from "@xstate/react";
 import { sendParent } from "xstate";
 import { useCreateWallet } from "./hooks";
 
-const CreateWalletPage = ({ createWalletRef }) => {
+const CreateWalletPage = ({ createWalletRef, onSendBack }) => {
   // XXX: move redux logic to custom hook
   const {
     decodeSeed,
@@ -39,14 +39,14 @@ const CreateWalletPage = ({ createWalletRef }) => {
     send({ type: "CONTINUE" });
   }, [send]);
 
-  const sendBack = useCallback(() => {
+  const previousStep = useCallback(() => {
     send({ type: "BACK", isTestNet });
   }, [send, isTestNet]);
 
   const cancelWalletCreation = useCallback(async () => {
     await cancelCreateWallet();
-    send({ type: "BACK" });
-  }, [send, cancelCreateWallet]);
+    onSendBack();
+  }, [onSendBack, cancelCreateWallet]);
 
   const setError = useCallback(
     (error) => {
@@ -127,7 +127,7 @@ const CreateWalletPage = ({ createWalletRef }) => {
         if (!mnemonic) return;
         component = h(ConfirmSeed, {
           mnemonic,
-          sendBack,
+          sendBack: previousStep,
           setPassPhrase,
           onCreateWallet,
           isValid,
@@ -164,13 +164,13 @@ const CreateWalletPage = ({ createWalletRef }) => {
 
     return setStateComponent(component);
   }, [
+    previousStep,
     cancelWalletCreation,
     current.context,
     current.value,
     decodeSeed,
     isValid,
     onCreateWallet,
-    sendBack,
     sendContinue,
     setError,
     setPassPhrase,

--- a/app/components/views/GetStartedPage/GetStarted.jsx
+++ b/app/components/views/GetStartedPage/GetStarted.jsx
@@ -18,7 +18,8 @@ const GetStarted = ({
   getCurrentBlockCount,
   getNeededBlocks,
   getEstimatedTimeLeft,
-  isTestNet
+  isTestNet,
+  showNavLinks
 }) => (
   <div
     className={classNames(
@@ -31,15 +32,17 @@ const GetStarted = ({
         {updateAvailable && (
           <UpdateAvailableLink updateAvailable={updateAvailable} />
         )}
-        <>
-          <AboutModalButton {...{ appVersion, updateAvailable }} />
-          <InvisibleButton onClick={onShowSettings}>
-            <SettingsLinkMsg />
-          </InvisibleButton>
-          <InvisibleButton onClick={onShowLogs}>
-            <LogsLinkMsg />
-          </InvisibleButton>
-        </>
+        <AboutModalButton {...{ appVersion, updateAvailable }} />
+        {showNavLinks && (
+          <>
+            <InvisibleButton onClick={onShowSettings}>
+              <SettingsLinkMsg />
+            </InvisibleButton>
+            <InvisibleButton onClick={onShowLogs}>
+              <LogsLinkMsg />
+            </InvisibleButton>
+          </>
+        )}
       </div>
       {PageComponent &&
         (React.isValidElement(PageComponent) ? (

--- a/app/components/views/GetStartedPage/GetStartedMachinePage.jsx
+++ b/app/components/views/GetStartedPage/GetStartedMachinePage.jsx
@@ -3,8 +3,6 @@ import { SlateGrayButton } from "buttons";
 import { LearnBasicsMsg, WhatsNewLink, LoaderTitleMsg } from "./messages";
 import { classNames } from "pi-ui";
 import styles from "./GetStarted.module.css";
-import { useSelector } from "react-redux";
-import * as sel from "selectors";
 
 export default ({
   StateComponent,
@@ -21,59 +19,52 @@ export default ({
   onShowReleaseNotes,
   onShowTutorial,
   appVersion,
+  daemonWarning,
   ...props
-}) => {
-  const daemonWarning = useSelector(sel.daemonWarning);
+}) => (
+  <>
+    <div className={styles.contentTitle}>
+      <LoaderTitleMsg />
+    </div>
+    <div className={styles.loaderButtons}>
+      <SlateGrayButton
+        onClick={onShowTutorial}
+        className={styles.tutorialButton}>
+        <LearnBasicsMsg />
+      </SlateGrayButton>
+      <WhatsNewLink {...{ onShowReleaseNotes, appVersion }} />
+    </div>
+    <div className={styles.loaderBar}>
+      <AnimatedLinearProgressFull
+        {...{
+          getDaemonStarted,
+          getDaemonSynced,
+          isSPV,
+          text,
+          getCurrentBlockCount,
+          animationType,
+          min: 0,
+          max: getNeededBlocks,
+          getEstimatedTimeLeft,
+          lastDcrwalletLogLine,
+          disabled: false
+        }}
+      />
+    </div>
+    {error && (
+      <div className={classNames(styles.error, styles.launchError)}>
+        {error}
+      </div>
+    )}
+    {daemonWarning && (
+      <div className={classNames(styles.daemonWarning)}>{daemonWarning}</div>
+    )}
 
-  return (
-    <>
-      <div className={styles.contentTitle}>
-        <LoaderTitleMsg />
-      </div>
-      <div className={styles.loaderButtons}>
-        <SlateGrayButton
-          onClick={onShowTutorial}
-          className={styles.tutorialButton}>
-          <LearnBasicsMsg />
-        </SlateGrayButton>
-        <WhatsNewLink {...{ onShowReleaseNotes, appVersion }} />
-      </div>
-      <div className={styles.loaderBar}>
-        <AnimatedLinearProgressFull
-          {...{
-            getDaemonStarted,
-            getDaemonSynced,
-            isSPV,
-            text,
-            getCurrentBlockCount,
-            animationType,
-            min: 0,
-            max: getNeededBlocks,
-            getEstimatedTimeLeft,
-            lastDcrwalletLogLine,
-            disabled: false
-          }}
-        />
-      </div>
-      {error && (
-        <div className={classNames(styles.error, styles.launchError)}>
-          {error}
-        </div>
-      )}
-      {
-        daemonWarning && (
-          <div className={classNames(styles.daemonWarning)}>
-            {daemonWarning}
-          </div>
-        )
-      }
-
-      {StateComponent &&
-        (React.isValidElement(StateComponent) ? (
-          StateComponent
-        ) : (
-            <StateComponent {...{ ...props }} />
-          ))}
-    </>
-  );
-};
+    {StateComponent &&
+      (React.isValidElement(StateComponent) ? (
+        StateComponent
+      ) : (
+        <StateComponent {...{ ...props }} />
+      ))}
+  </>
+);

--- a/app/components/views/GetStartedPage/GetStartedPage.jsx
+++ b/app/components/views/GetStartedPage/GetStartedPage.jsx
@@ -8,13 +8,20 @@ const GetStarted = () => {
     onShowSettings,
     updateAvailable,
     isTestNet,
-    PageComponent
+    PageComponent,
+    showNavLinks
   } = useGetStarted();
 
   return (
     <GetStartedWrapper
       PageComponent={PageComponent}
-      {...{ onShowLogs, onShowSettings, updateAvailable, isTestNet }}
+      {...{
+        onShowLogs,
+        onShowSettings,
+        showNavLinks,
+        updateAvailable,
+        isTestNet
+      }}
     />
   );
 };

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -63,9 +63,11 @@ export const useGetStarted = () => {
     onShowTutorial,
     appVersion,
     syncAttemptRequest,
-    onGetDcrdLogs
+    onGetDcrdLogs,
+    daemonWarning
   } = useDaemonStartup();
   const [PageComponent, setPageComponent] = useState(null);
+  const [showNavLinks, setShowNavLinks] = useState(true);
   const [state, send] = useMachine(getStartedMachine, {
     actions: {
       isAtPreStart: () => {
@@ -321,9 +323,16 @@ export const useGetStarted = () => {
     });
   }, [send, getDaemonSynced, getSelectedWallet, isAdvancedDaemon, isSPV]);
 
-  const onSendContinue = useCallback(() => send({ type: "CONTINUE" }), [send]);
+  const onSendContinue = useCallback(() => {
+    send({ type: "CONTINUE" });
+    setShowNavLinks(false);
+  }, [send]);
 
-  const onSendBack = useCallback(() => send({ type: "BACK" }), [send]);
+  const onSendBack = useCallback(() => {
+    send({ type: "BACK" });
+    console.log(111111);
+    setShowNavLinks(true);
+  }, [send]);
 
   const onSendError = useCallback((error) => send({ type: "ERROR", error }), [
     send
@@ -507,6 +516,7 @@ export const useGetStarted = () => {
           onShowTutorial,
           appVersion,
           onGetDcrdLogs,
+          daemonWarning,
           // if updated* is set, we use it, as it means it is called by the componentDidUpdate.
           text: updatedText ? updatedText : text,
           animationType: updatedAnimationType
@@ -528,7 +538,11 @@ export const useGetStarted = () => {
         PageComponent = h(ReleaseNotes, { onSendBack });
       }
       if (key === "creatingWallet") {
-        PageComponent = h(CreateWalletMachine, { createWalletRef, isTestNet });
+        PageComponent = h(CreateWalletMachine, {
+          createWalletRef,
+          isTestNet,
+          onSendBack
+        });
       }
       if (key === "settingMixedAccount") {
         PageComponent = h(SettingMixedAccount, { onSendBack, onSendContinue });
@@ -555,7 +569,8 @@ export const useGetStarted = () => {
       onGetDcrdLogs,
       onSendDiscoverAccountsPassInput,
       onSendSetPassphrase,
-      error
+      error,
+      daemonWarning
     ]
   );
 
@@ -626,6 +641,7 @@ export const useGetStarted = () => {
     onShowSettings,
     updateAvailable,
     isTestNet,
-    PageComponent
+    PageComponent,
+    showNavLinks
   };
 };

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -39,6 +39,7 @@ const useDaemonStartup = () => {
   const trezorDevice = useSelector(sel.trezorDevice);
   const isTrezor = useSelector(sel.isTrezor);
   const syncAttemptRequest = useSelector(sel.getSyncAttemptRequest);
+  const daemonWarning = useSelector(sel.daemonWarning);
   // end of daemon selectors
 
   // sync dcrwallet spv or rpc selectors
@@ -278,7 +279,8 @@ const useDaemonStartup = () => {
     goToHome,
     setCoinjoinCfg,
     onGetDcrdLogs,
-    syncAttemptRequest
+    syncAttemptRequest,
+    daemonWarning
   };
 };
 


### PR DESCRIPTION
This diff hides the top nav menu links `Settings` & `Logs` when navigating to a nested page in the
wallet creation or wallet restore flows.

Closes #3079 