### PR TITLE
fix: TxHistory broken layout in Transactions History Page

### DIFF
--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -92,12 +92,13 @@
 
 .info {
   display: grid;
-  grid-template-columns: 0.5fr 3fr 10fr;
+  grid-template-columns: 0.5fr 3fr 10fr 2fr;
   width: 100%;
 }
 
 .overviewInfo {
   display: grid;
+  grid-template-columns: 0.5fr 3fr 10fr;
   font-family: var(--font-family-monospace);
 }
 


### PR DESCRIPTION
This diff fixes a display bug which was introduced by #3090 - see screenshots below:

Before:
![image](https://user-images.githubusercontent.com/10324528/102830143-56f4df80-43f1-11eb-86f0-74a14c472fee.png)


After:
![image](https://user-images.githubusercontent.com/10324528/102830171-62480b00-43f1-11eb-9c3d-8b29e253f5b8.png)

