### PR TITLE
move wallet config initial values to constants

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -8,7 +8,6 @@ import {
   dcrwalletConf,
   getDcrdRpcCert
 } from "./main_dev/paths";
-import { DCR } from "constants";
 import * as cfgConstants from "constants/config";
 
 export function getGlobalCfg() {
@@ -21,64 +20,15 @@ export function getWalletCfg(testnet, walletPath) {
   return config;
 }
 
-// TODO: move this constants to constants directory file.
 export function initWalletCfg(testnet, walletPath) {
   const config = new Store({ cwd: getWalletPath(testnet, walletPath) });
-  if (!config.has(cfgConstants.ENABLE_TICKET_BUYER)) {
-    config.set(cfgConstants.ENABLE_TICKET_BUYER, "0");
-  }
-  if (!config.has(cfgConstants.BALANCE_TO_MAINTAIN)) {
-    config.set(cfgConstants.BALANCE_TO_MAINTAIN, "0");
-  }
-  if (!config.has(cfgConstants.CURRENCY_DISPLAY)) {
-    config.set(cfgConstants.CURRENCY_DISPLAY, DCR);
-  }
-  if (!config.has(cfgConstants.HIDDEN_ACCOUNTS)) {
-    const hiddenAccounts = Array();
-    config.set(cfgConstants.HIDDEN_ACCOUNTS, hiddenAccounts);
-  }
-  if (!config.has(cfgConstants.DISCOVER_ACCOUNTS)) {
-    config.set(cfgConstants.DISCOVER_ACCOUNTS, true);
-  }
-  if (!config.has(cfgConstants.GAP_LIMIT)) {
-    config.set(cfgConstants.GAP_LIMIT, "20");
-  }
-  if (!config.has(cfgConstants.IS_WATCH_ONLY)) {
-    config.set(cfgConstants.IS_WATCH_ONLY, false);
-  }
-  if (!config.has(cfgConstants.POLITEIA_LAST_ACCESS_TIME)) {
-    config.set(cfgConstants.POLITEIA_LAST_ACCESS_TIME, 0);
-  }
-  if (!config.has(cfgConstants.POLITEIA_LAST_ACCESS_BLOCK)) {
-    config.set(cfgConstants.POLITEIA_LAST_ACCESS_BLOCK, 0);
-  }
-  if (!config.has(cfgConstants.TREZOR)) {
-    config.set(cfgConstants.TREZOR, false);
-  }
-  if (!config.has(cfgConstants.VSP_IS_LEGACY)) {
-    config.set(cfgConstants.VSP_IS_LEGACY, false);
-  }
-  if (!config.has(cfgConstants.ENABLE_PRIVACY)) {
-    config.set(cfgConstants.ENABLE_PRIVACY, true);
-  }
-  if (!config.has(cfgConstants.LN_ADDRESS)) {
-    config.set(cfgConstants.LN_ADDRESS, "");
-  }
-  if (!config.has(cfgConstants.LN_PORT)) {
-    config.set(cfgConstants.LN_PORT, 10009);
-  }
-  if (!config.has(cfgConstants.LN_CERTPATH)) {
-    config.set(cfgConstants.LN_CERTPATH, "");
-  }
-  if (!config.has(cfgConstants.LN_MACAROONPATH)) {
-    config.set(cfgConstants.LN_MACAROONPATH, "");
-  }
-  // if privacy if configured, set send_from_unmixed if not set.
-  if (!config.has(cfgConstants.SEND_FROM_UNMIXED) && config.has(cfgConstants.MIXED_ACCOUNT_CFG)) {
-    config.set(cfgConstants.SEND_FROM_UNMIXED, false);
-  }
+  Object.keys(cfgConstants.WALLET_INITIAL_VALUE).map((key) => {
+    if (!config.has(key)) {
+      config.set(key, cfgConstants.WALLET_INITIAL_VALUE[key]);
+    }
+  });
 
-  stakePoolInfo(function (foundStakePoolConfigs) {
+  stakePoolInfo((foundStakePoolConfigs) => {
     if (foundStakePoolConfigs !== null) {
       updateStakePoolConfig(config, foundStakePoolConfigs);
     }
@@ -87,37 +37,14 @@ export function initWalletCfg(testnet, walletPath) {
   return config;
 }
 
+// remove unecessary config keys if exists
 function cleanWalletCfg(config) {
-  let key;
-  const walletCfgFields = [
-    cfgConstants.ENABLE_TICKET_BUYER,
-    cfgConstants.BALANCE_TO_MAINTAIN,
-    cfgConstants.CURRENCY_DISPLAY,
-    cfgConstants.LN_WALLET_EXISTS,
-    cfgConstants.LN_ACCOUNT,
-    cfgConstants.ENABLE_PRIVACY,
-    cfgConstants.SEND_FROM_UNMIXED,
-    cfgConstants.MIXED_ACCOUNT_CFG,
-    cfgConstants.MIXED_ACC_BRANCH,
-    cfgConstants.CHANGE_ACCOUNT_CFG,
-    cfgConstants.HIDDEN_ACCOUNTS,
-    cfgConstants.DISCOVER_ACCOUNTS,
-    cfgConstants.GAP_LIMIT,
-    cfgConstants.IS_WATCH_ONLY,
-    cfgConstants.STAKEPOOLS,
-    cfgConstants.LAST_ACCESS,
-    cfgConstants.POLITEIA_LAST_ACCESS_TIME,
-    cfgConstants.POLITEIA_LAST_ACCESS_BLOCK,
-    cfgConstants.CSPP_SERVER,
-    cfgConstants.CSPP_PORT,
-    cfgConstants.DISMISS_BACKUP_MSG_REDEEM_SCRIPT,
-    cfgConstants.VSP_IS_LEGACY,
-    cfgConstants.REMEMBERED_VSP_HOST
-  ];
-  for (key in config.store) {
+  const walletCfgFields = Object.keys(cfgConstants.WALLET_INITIAL_VALUE);
+
+  for (const key in config.store) {
     let found = false;
     for (let i = 0; i < walletCfgFields.length; i++) {
-      if (key == walletCfgFields[i]) {
+      if (key === walletCfgFields[i]) {
         found = true;
         break;
       }

--- a/app/constants/config.js
+++ b/app/constants/config.js
@@ -1,4 +1,4 @@
-import { MAINNET } from "./Decrediton";
+import { MAINNET, DCR } from "./Decrediton";
 
 // Global config constants
 export const DAEMON_ADVANCED = "daemon_start_advanced";
@@ -23,6 +23,28 @@ export const DISABLE_HARDWARE_ACCEL = "disable_hardware_accel";
 export const LN_ENABLED = "ln_enabled";
 export const TREZOR_DEBUG = "trezor_debug";
 export const UPGD_ELECTRON8 = "is_electron8";
+
+// advanced daemon configs
+export const RPCUSER = "rpc_user";
+export const RPCPASS = "rpc_pass";
+export const RPCCERT = "rpc_cert";
+export const RPCHOST = "rpc_host";
+export const RPCPORT = "rpc_port";
+
+// aux function for setting remote daemon credentials
+export const setDaemonRemoteCredentials = (
+  rpcuser,
+  rpcpass,
+  rpccert,
+  rpchost,
+  rpcport
+) => ({
+    [RPCUSER]: rpcuser,
+    [RPCPASS]: rpcpass,
+    [RPCCERT]: rpccert,
+    [RPCHOST]: rpchost,
+    [RPCPORT]: rpcport
+  });
 
 // Wallet config constants
 export const ENABLE_TICKET_BUYER = "enableticketbuyer";
@@ -53,27 +75,42 @@ export const REMEMBERED_VSP_HOST = "remembered_vsp_host";
 export const LAST_ACCESS = "lastaccess";
 export const STAKEPOOLS = "stakepools";
 export const LN_WALLET_EXISTS = "ln_wallet_exists";
+export const USED_VSPS = "used_vsps";
 
-export const RPCUSER = "rpc_user";
-export const RPCPASS = "rpc_pass";
-export const RPCCERT = "rpc_cert";
-export const RPCHOST = "rpc_host";
-export const RPCPORT = "rpc_port";
-
-export const setDaemonRemoteCredentials = (
-  rpcuser,
-  rpcpass,
-  rpccert,
-  rpchost,
-  rpcport
-) => {
-  return {
-    [RPCUSER]: rpcuser,
-    [RPCPASS]: rpcpass,
-    [RPCCERT]: rpccert,
-    [RPCHOST]: rpchost,
-    [RPCPORT]: rpcport
-  };
+export const WALLET_INITIAL_VALUE = {
+  [ENABLE_TICKET_BUYER]: false,
+  [BALANCE_TO_MAINTAIN]: "0",
+  [CURRENCY_DISPLAY]: DCR,
+  [HIDDEN_ACCOUNTS]: [],
+  [DISCOVER_ACCOUNTS]: true,
+  [GAP_LIMIT]: 20,
+  [IS_WATCH_ONLY]: false,
+  [POLITEIA_LAST_ACCESS_TIME]: 0,
+  [POLITEIA_LAST_ACCESS_BLOCK]: 0,
+  [TREZOR]: false,
+  [VSP_IS_LEGACY]: false,
+  // enable_privacy only shows the privacy menu on the wallet
+  [ENABLE_PRIVACY]: true,
+  [LN_ACCOUNT]: null,
+  [LN_ADDRESS]: "",
+  [LN_PORT]: 10009,
+  [LN_CERTPATH]: "",
+  [LN_MACAROONPATH]: "",
+  [SEND_FROM_UNMIXED]: false,
+  [MIXED_ACCOUNT_CFG]: null,
+  [DISMISS_BACKUP_MSG_REDEEM_SCRIPT]: false,
+  // change_account used when mixing
+  [CHANGE_ACCOUNT_CFG]: null,
+  [CSPP_SERVER]: "",
+  [CSPP_PORT]: "",
+  [MIXED_ACC_BRANCH]: null,
+  [REMEMBERED_VSP_HOST]: null,
+  [LAST_ACCESS]: 0,
+  [USED_VSPS]: [],
+  [LN_WALLET_EXISTS]: false,
+  // STAKEPOOLS is a legacy code which can be deleted after stopping giving
+  // support for old vsp versions.
+  [STAKEPOOLS]: []
 };
 
 export const INITIAL_VALUES = {


### PR DESCRIPTION
This PR moves how we start our wallet initial config, based on how we start our global config, for keeping consistency and simplicity.

It moves the constants initial value to our constant file and initialize them. 