### PR TITLE
Redraw optimization

### DIFF
--- a/app/components/shared/SendTransaction/hooks.js
+++ b/app/components/shared/SendTransaction/hooks.js
@@ -2,21 +2,27 @@ import { useState } from "react";
 import * as sel from "selectors";
 import * as ca from "actions/ControlActions";
 import { baseOutput } from "./helpers";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector, useDispatch, shallowEqual } from "react-redux";
 import { usePrevious } from "hooks";
 
 export function useSendTransaction() {
-  const defaultSpendingAccount = useSelector(sel.defaultSpendingAccount);
+  const defaultSpendingAccount = useSelector(
+    sel.defaultSpendingAccount,
+    shallowEqual
+  );
   const unsignedTransaction = useSelector(sel.unsignedTransaction);
   const unsignedRawTx = useSelector(sel.unsignedRawTx);
   const estimatedFee = useSelector(sel.estimatedFee);
   const estimatedSignedSize = useSelector(sel.estimatedSignedSize);
   const totalSpent = useSelector(sel.totalSpent);
   const nextAddress = useSelector(sel.nextAddress);
-  const nextAddressAccount = useSelector(sel.nextAddressAccount);
+  const nextAddressAccount = useSelector(sel.nextAddressAccount, shallowEqual);
   const constructTxLowBalance = useSelector(sel.constructTxLowBalance);
   const publishTxResponse = useSelector(sel.publishTxResponse);
-  const notMixedAccounts = useSelector(sel.getNotMixedAcctIfAllowed);
+  const notMixedAccounts = useSelector(
+    sel.getNotMixedAcctIfAllowed,
+    shallowEqual
+  );
   const isTrezor = useSelector(sel.isTrezor);
   const isWatchingOnly = useSelector(sel.isWatchingOnly);
   const isConstructingTransaction = useSelector(sel.isConstructingTransaction);

--- a/app/components/views/PrivacyPage/Privacy/hooks.js
+++ b/app/components/views/PrivacyPage/Privacy/hooks.js
@@ -1,5 +1,5 @@
 import { useEffect, useCallback } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector, shallowEqual } from "react-redux";
 import * as act from "actions/AccountMixerActions";
 import * as ca from "actions/ClientActions";
 import { getPrivacyLogs } from "actions/DaemonActions";
@@ -40,7 +40,8 @@ export function usePrivacy() {
     [dispatch]
   );
   const defaultSpendingAccountDisregardMixedAccount = useSelector(
-    sel.defaultSpendingAccountDisregardMixedAccount
+    sel.defaultSpendingAccountDisregardMixedAccount,
+    shallowEqual
   );
   useMountEffect(() => {
     getMixerAcctsSpendableBalances();

--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -29,8 +29,9 @@ const pageAnimation = {
 
 @autobind
 class Wallet extends React.Component {
-  componentDidMount() {
-    const { compareInventory, politeiaEnabled, getPeerInfo } = this.props;
+  constructor(props) {
+    super(props);
+    const { compareInventory, politeiaEnabled, getPeerInfo } = props;
     // Compare politeias inventory and update proposal list if they are different
     // every 1 minute.
     this.fetchPoliteiaInventory = this.props.setInterval(() => {
@@ -40,17 +41,11 @@ class Wallet extends React.Component {
     }, 60000);
     // Get peer info every 10 seconds, so we can no if there are no available
     // peers.
-    this.peerInfoIntervalRef = this.props.setInterval(() => {
-      getPeerInfo();
+    this.props.setInterval(() => {
+      if (politeiaEnabled) {
+        getPeerInfo();
+      }
     }, 10000);
-  }
-  componentWillUnmount() {
-    if (this.fetchPoliteiaInventory !== null) {
-      this.props.clearInterval(this.fetchPoliteiaInventory);
-    }
-    if (this.peerInfoIntervalRef !== null) {
-      this.props.clearInterval(this.peerInfoIntervalRef);
-    }
   }
 
   render() {

--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -29,9 +29,8 @@ const pageAnimation = {
 
 @autobind
 class Wallet extends React.Component {
-  constructor(props) {
-    super(props);
-    const { compareInventory, politeiaEnabled, getPeerInfo } = props;
+  componentDidMount() {
+    const { compareInventory, politeiaEnabled, getPeerInfo } = this.props;
     // Compare politeias inventory and update proposal list if they are different
     // every 1 minute.
     this.fetchPoliteiaInventory = this.props.setInterval(() => {
@@ -41,11 +40,17 @@ class Wallet extends React.Component {
     }, 60000);
     // Get peer info every 10 seconds, so we can no if there are no available
     // peers.
-    this.props.setInterval(() => {
-      if (politeiaEnabled) {
-        getPeerInfo();
-      }
+    this.peerInfoIntervalRef = this.props.setInterval(() => {
+      getPeerInfo();
     }, 10000);
+  }
+  componentWillUnmount() {
+    if (this.fetchPoliteiaInventory !== null) {
+      this.props.clearInterval(this.fetchPoliteiaInventory);
+    }
+    if (this.peerInfoIntervalRef !== null) {
+      this.props.clearInterval(this.peerInfoIntervalRef);
+    }
   }
 
   render() {


### PR DESCRIPTION
After some profiling, I found these issues:
- leaving the app for some time - or refresh it by F5 or close wallet and reopen it - the `GETPEERINFO_ATTEMPT/GETPEERINFO_SUCCESS` requests pile up (**update**: #2901 resolves this part of the issue)
- the `Privacy` and the `SendTransaction` components are redrawn after every `GETPEERINFO_ATTEMPT/GETPEERINFO_SUCCESS` request despite the redux state did not change at all.
- these two factors can increase CPU usage quite high after some time.

This PR fixes this.