### PR TITLE
Improve UI performance

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -3,7 +3,6 @@ import { defaultFormats } from "i18n/locales";
 // XXX useTheming already exists in app/hooks
 import { app, theming } from "connectors";
 import { Redirect, Route, Switch } from "react-router-dom";
-import { AnimatedSwitch } from "react-router-transition";
 import { StaticSwitch } from "shared";
 import GetStartedContainer from "./GetStarted";
 import WalletContainer from "./Wallet";
@@ -17,12 +16,6 @@ import "style/Layout.less";
 import { ipcRenderer } from "electron";
 import { hot } from "react-hot-loader/root";
 import { CantCloseModals } from "modals";
-
-const topLevelAnimation = {
-  atEnter: { opacity: 0 },
-  atLeave: { opacity: 0 },
-  atActive: { opacity: 1 }
-};
 
 // minimum size to reduce the sidebar in px.
 const MINIMUM_SIZE_TO_REDUCE_SIDEBAR = 1179;
@@ -126,7 +119,6 @@ class App extends React.Component {
       aboutModalMacOSVisible,
       hideAboutModalMacOS
     } = this.props;
-    const MainSwitch = this.props.uiAnimations ? AnimatedSwitch : StaticSwitch;
 
     return (
       <IntlProvider
@@ -140,12 +132,12 @@ class App extends React.Component {
             <Redirect from="/" exact to="/getstarted" />
           </Switch>
           <Snackbar />
-          <MainSwitch {...topLevelAnimation} className="top-level-container">
+          <StaticSwitch className="top-level-container">
             <Route path="/getstarted" component={GetStartedContainer} />
             <Route path="/shutdown" component={ShutdownPage} />
             <Route path="/error" component={FatalErrorPage} />
             <Route path="/" component={WalletContainer} />
-          </MainSwitch>
+          </StaticSwitch>
 
           <div id="modal-portal" />
           <div id="modal-portal-macos">

--- a/app/containers/Wallet.jsx
+++ b/app/containers/Wallet.jsx
@@ -1,6 +1,5 @@
 import ReactTimeout from "react-timeout";
 import { Route } from "react-router-dom";
-import { AnimatedSwitch } from "react-router-transition";
 import { StaticSwitch } from "shared";
 import HomePage from "components/views/HomePage/HomePage";
 import SettingsPage from "components/views/SettingsPage/SettingsPage";
@@ -21,18 +20,10 @@ import SideBar from "components/SideBar/SideBar";
 import ListUtxo from "components/views/ListUtxo/ListUtxo";
 import { BlurableContainer } from "layout";
 import { useWallet } from "./hooks";
-import { useTheming, useMountEffect } from "hooks";
-
-const pageAnimation = {
-  atEnter: { opacity: 0 },
-  atLeave: { opacity: 0 },
-  atActive: { opacity: 1 }
-};
+import { useMountEffect } from "hooks";
 
 const Wallet = ({ setInterval }) => {
   const { getPeerInfo, expandSideBar } = useWallet();
-
-  const { uiAnimations } = useTheming();
 
   // Notice that we return a cleanup logic function in useEffect/useMountEffect
   // which will run on unmount.
@@ -47,14 +38,12 @@ const Wallet = ({ setInterval }) => {
     };
   });
 
-  const MainSwitch = uiAnimations ? AnimatedSwitch : StaticSwitch;
-
   return (
     <div className={"page-body"}>
       <SideBar />
       <BlurableContainer
         className={expandSideBar ? "page-view" : "page-view-reduced-bar"}>
-        <MainSwitch {...pageAnimation}>
+        <StaticSwitch>
           <Route path="/home" component={HomePage} />
           <Route path="/accounts" component={AccountsPage} />
           <Route path="/settings" component={SettingsPage} />
@@ -69,7 +58,7 @@ const Wallet = ({ setInterval }) => {
           <Route path="/trezor" component={TrezorPage} />
           <Route path="/ln" component={LNPage} />
           <Route path="/listUtxo" component={ListUtxo} />
-        </MainSwitch>
+        </StaticSwitch>
         <Route
           path="/transaction/history/:txHash"
           component={TransactionPage}

--- a/package.json
+++ b/package.json
@@ -303,7 +303,6 @@
     "react-motion": "^0.5.2",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.2",
-    "react-router-transition": "^2.0.0",
     "react-select": "1.0.0",
     "react-timeout": "^1.2.0",
     "react-visibility-sensor": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10143,14 +10143,6 @@ react-router-dom@^5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router-transition@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-router-transition/-/react-router-transition-2.0.0.tgz#c00a4240f0aad5f44152cf1de49c682bf00e43ac"
-  integrity sha512-jcEU/MblHx3KUj6TrYEUk1X3iv4cCZ8tLpoyytpaDjqP45K6vD7nfI2IW8ax1eHolvvz+6GCYc9uXZi+pAxL2A==
-  dependencies:
-    prop-types "^15.7.2"
-    react-motion "^0.5.2"
-
 react-router@5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.1.2.tgz#6ea51d789cb36a6be1ba5f7c0d48dd9e817d3418"


### PR DESCRIPTION
As discussed in Decrediton room in Matrix, according to @alexlyp:

> (...) wondering if you guys could take a look at a performance issue i've noticed recently. was running tip decrediton and noticed a bit of CPU churn after starting the mixer (on the privacy page). I'm thinking it could be the gifs on that page, though i still see the CPU bump when toggling to a different page (transactions or tickets, etc)

and @vctt94:

> I noticed my CPU struggling more on latest master, as well

It seems that our recent changes mainly in the privacy page resonated in some lack of performance. After investigating, we realized high CPU usage due to ``react-router-transition`` expensive transitions and ``menuMixer.svg`` CSS animation.

Below, the performance of three use cases, all of them following the script: 10s on privacy page, 10s on accounts page, and 10s on privacy page again, disabling ``react-router-transition`` and while the mixer is started. Data was acquired using Dev Tools.

![image](https://user-images.githubusercontent.com/39631429/103832200-7b40f500-505c-11eb-8fa9-f187a562b232.png)

Now, using ``react-router-transition``.

![image](https://user-images.githubusercontent.com/39631429/103832500-2ce02600-505d-11eb-8f68-17b16feaa8ee.png)

- 1 (no gif nor svg);
- 2 (only gif in provacy page);
- 3 (mix svg and gif in privacy page).

In order to diminish CPU usage, the following resolutions have been taken in this PR:

- Remove ``react-router-transition``;
- Replace ``menuMixer.svg`` with a new GIF ``menuMixer.gif`` that renders in 5 frames per second, rather than 60 FPS;

![menuMixer](https://user-images.githubusercontent.com/39631429/103832669-9829f800-505d-11eb-90f1-6816b07703f4.gif)

- Optimize ``mixerArrows.gif`` and ``decentralizedLoopAnimation.gif`` to use 1/4 of their frames.

After that, CPU usage was measured again, comparing now mixer started (# 1) and stopped (# 2).

![Captura de tela de 2021-01-06 19-59-49](https://user-images.githubusercontent.com/39631429/103832870-3027e180-505e-11eb-9519-b2a050276918.png)

The GIF's replacement and optimization can be discussed with @linnutee as well, as some quality has been lost in exchange for performance. Also, we still can achieve more performance using static images.