### PR TITLE
Allow runtime translation of Electron menus

### DIFF
--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -68,10 +68,6 @@ export const saveSettings = (settings) => async (dispatch, getState) => {
     wallet.reloadAllowedExternalRequests();
   }
 
-  if (oldTheme != settings.theme) {
-    dispatch({ theme: settings.theme, type: SETTINGS_TOGGLE_THEME });
-  }
-
   if (locale != settings.locale) {
     ipcRenderer.sendSync("change-menu-locale", settings.locale);
   }

--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -19,6 +19,7 @@ import {
 } from "actions/GovernanceActions";
 import { cleanupPoliteiaCSRF } from "./GovernanceActions";
 import * as configConstants from "constants/config";
+import { ipcRenderer } from "electron";
 
 export const SETTINGS_SAVE = "SETTINGS_SAVE";
 export const SETTINGS_CHANGED = "SETTINGS_CHANGED";
@@ -26,7 +27,7 @@ export const SETTINGS_UNCHANGED = "SETTINGS_UNCHANGED";
 
 export const saveSettings = (settings) => async (dispatch, getState) => {
   const {
-    settings: { needNetworkReset }
+    settings: { needNetworkReset, currentSettings: { locale } }
   } = getState();
   const {
     daemon: { walletName }
@@ -65,6 +66,14 @@ export const saveSettings = (settings) => async (dispatch, getState) => {
     !equalElements(oldAllowedExternalRequests, settings.allowedExternalRequests)
   ) {
     wallet.reloadAllowedExternalRequests();
+  }
+
+  if (oldTheme != settings.theme) {
+    dispatch({ theme: settings.theme, type: SETTINGS_TOGGLE_THEME });
+  }
+
+  if (locale != settings.locale) {
+    ipcRenderer.sendSync("change-menu-locale", settings.locale);
   }
 
   const newDcrdataEnabled =

--- a/app/main_dev/templates.js
+++ b/app/main_dev/templates.js
@@ -181,17 +181,17 @@ export const getGrpcVersions = () => grpcVersions;
 
 export const setGrpcVersions = (versions) => (grpcVersions = versions);
 
-const inputMenuRoles = [
-  { role: "cut" },
-  { role: "copy" },
-  { role: "paste" },
+const inputMenuRoles = (locale) => [
+  { label: locale.messages["appMenu.cut"], role: "cut" },
+  { label: locale.messages["appMenu.copy"], role: "copy" },
+  { label: locale.messages["appMenu.paste"], role: "paste" },
   { type: "separator" },
-  { role: "selectall" }
+  { label: locale.messages["appMenu.selectAll"], role: "selectall" }
 ];
-const selectionMenuRoles = [
-  { role: "copy" },
+const selectionMenuRoles = (locale) => [
+  { label: locale.messages["appMenu.copy"], role: "copy" },
   { type: "separator" },
-  { role: "selectall" }
+  { label: locale.messages["appMenu.selectAll"], role: "selectall" }
 ];
 
 const inspectElement = (mainWindow, x, y) => {
@@ -201,12 +201,12 @@ const inspectElement = (mainWindow, x, y) => {
   };
 };
 
-export const inputMenu = (isDevelopment, mainWindow, x, y) =>
+export const inputMenu = (isDevelopment, mainWindow, x, y, locale) =>
   isDevelopment
-    ? [...inputMenuRoles, inspectElement(mainWindow, x, y)]
-    : inputMenuRoles;
+    ? [...inputMenuRoles(locale), inspectElement(mainWindow, x, y)]
+    : inputMenuRoles(locale);
 
-export const selectionMenu = (isDevelopment, mainWindow, x, y) =>
+export const selectionMenu = (isDevelopment, mainWindow, x, y, locale) =>
   isDevelopment
-    ? [...selectionMenuRoles, inspectElement(mainWindow, x, y)]
-    : selectionMenuRoles;
+    ? [...selectionMenuRoles(locale), inspectElement(mainWindow, x, y)]
+    : selectionMenuRoles(locale);


### PR DESCRIPTION
This PR allows runtime translation of Electron menus - top menu bar and context menu - when setting a different locale on the Settings page.

![image](https://user-images.githubusercontent.com/39631429/104107396-96994380-529a-11eb-8917-11f8cf6d01d3.png)

Closes https://github.com/decred/decrediton/issues/3132.