### PR TITLE
Fix broken nav bar in governance page

### DIFF
--- a/app/components/views/GovernancePage/Proposals/ProposalsTab.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsTab.module.css
@@ -28,11 +28,11 @@
   font-size: 13px;
   line-height: 19px;
   margin-top: 0;
-  width: 460px;
+  width: 560px;
 }
 
 .links {
-  margin-left: 130px;
+  margin-left: 40px;
 }
 
 .links a {


### PR DESCRIPTION
In the governance page, this PR fixes the navigation bar that has been broken due to a larger translation to German of its introductory text. 

Closes https://github.com/decred/decrediton/issues/3015.