### PR TITLE
WalletLoaderActions: Clear trezor values on close.

### DIFF
--- a/app/actions/TrezorActions.js
+++ b/app/actions/TrezorActions.js
@@ -37,6 +37,7 @@ const BOOTLOADER_MODE = "bootloader";
 
 let setListeners = false;
 
+export const TRZ_WALLET_CLOSED = "TRZ_WALLET_CLOSED";
 export const TRZ_TREZOR_ENABLED = "TRZ_TREZOR_ENABLED";
 
 // enableTrezor attepts to start a connection with connect if none exist and

--- a/app/actions/TrezorActions.js
+++ b/app/actions/TrezorActions.js
@@ -65,6 +65,7 @@ export const initTransport = async (session, debug) => {
     env: "web",
     lazyLoad: false,
     popup: false,
+    transportReconnect: false,
     manifest: {
       email: "joegruffins@gmail.com",
       appUrl: "https://github.com/decred/decrediton"

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -18,7 +18,7 @@ import {
 import { WALLETREMOVED_FAILED } from "./DaemonActions";
 import { getWalletCfg, getDcrdCert } from "config";
 import { getWalletPath } from "main_dev/paths";
-import { isTestNet } from "selectors";
+import { isTestNet, trezorDevice } from "selectors";
 import {
   SpvSyncRequest,
   SyncNotificationType,
@@ -32,6 +32,7 @@ import * as cfgConstants from "constants/config";
 import { ipcRenderer } from "electron";
 import { RESCAN_PROGRESS } from "./ControlActions";
 import { stopAccountMixer } from "./AccountMixerActions";
+import { TRZ_WALLET_CLOSED } from "actions/TrezorActions";
 
 const MAX_RPC_RETRIES = 5;
 const RPC_RETRY_DELAY = 5000;
@@ -259,6 +260,7 @@ export const closeWalletRequest = () => async (dispatch, getState) => {
     }
     await wallet.stopWallet();
     dispatch({ type: CLOSEWALLET_SUCCESS });
+    if (trezorDevice(getState())) dispatch({ type: TRZ_WALLET_CLOSED });
     dispatch(pushHistory("/getstarted/initial"));
   } catch (error) {
     dispatch({ error, type: CLOSEWALLET_FAILED });

--- a/app/helpers/trezor.js
+++ b/app/helpers/trezor.js
@@ -74,15 +74,14 @@ export const walletTxToBtcjsTx = async (
   });
 
   const outputs = tx.outputs.map(async (outp, i) => {
-    if (!outp.decodedScript.address) {
+    const addr = outp.decodedScript.address;
+    if (!addr) {
       // TODO: this will be true on OP_RETURNs. Support those.
       throw new Error("Output has different number of addresses than expected");
     }
-    let addr = outp.decodedScript.address;
     const addrValidResp = await wallet.validateAddress(walletService, addr);
     if (!addrValidResp.getIsValid()) throw "Not a valid address: " + addr;
     let address_n = null;
-
     if (i === changeIndex && addrValidResp.getIsMine()) {
       const addrIndex = addrValidResp.getIndex();
       const addrBranch = addrValidResp.getIsInternal() ? 1 : 0;
@@ -92,7 +91,6 @@ export const walletTxToBtcjsTx = async (
         WALLET_ACCOUNT,
         chainParams.HDCoinType
       );
-      addr = null;
     }
     const out = {
       amount: outp.value.toString(),

--- a/app/reducers/trezor.js
+++ b/app/reducers/trezor.js
@@ -1,4 +1,5 @@
 import {
+  TRZ_WALLET_CLOSED,
   TRZ_TREZOR_ENABLED,
   TRZ_TREZOR_DISABLED,
   TRZ_CONNECT_ATTEMPT,
@@ -99,6 +100,14 @@ export default function trezor(state = {}, action) {
         ...state,
         device: null,
         deviceLabel: null
+      };
+    case TRZ_WALLET_CLOSED:
+      return {
+        ...state,
+        device: null,
+        deviceLabel: null,
+        performingOperation: false,
+        connected: false
       };
     case TRZ_SELECTEDDEVICE_CHANGED:
     case TRZ_LOADDEVICE:

--- a/app/reducers/trezor.js
+++ b/app/reducers/trezor.js
@@ -99,7 +99,8 @@ export default function trezor(state = {}, action) {
       return {
         ...state,
         device: null,
-        deviceLabel: null
+        deviceLabel: null,
+        connected: false
       };
     case TRZ_WALLET_CLOSED:
       return {

--- a/app/reducers/trezor.js
+++ b/app/reducers/trezor.js
@@ -96,6 +96,7 @@ export default function trezor(state = {}, action) {
         connected: false
       };
     case TRZ_NOCONNECTEDDEVICE:
+      // Losing the device also means that it is no longer connected.
       return {
         ...state,
         device: null,


### PR DESCRIPTION
This ensures that session.connect is called when changing wallets, which
clears the password data stored on the Trezor, allowing switching trezor
wallets with password enabled.