### PR TITLE
Call processManageTickets on every startup if having live tickets

### DIFF
--- a/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
+++ b/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
@@ -3,7 +3,7 @@ import { GoBackMsg } from "../messages";
 import { FormattedMessage as T } from "react-intl";
 import GetStartedStyles from "../GetStarted.module.css";
 import { useState } from "react";
-import { PassphraseModalButton } from "buttons";
+import { PassphraseModalButton, InvisibleButton } from "buttons";
 import styles from "./ProcessUnmanagedTickets.module.css";
 import { useEffect } from "react";
 import { VSPSelect } from "inputs";
@@ -61,6 +61,12 @@ export default ({ cancel, send, onSendContinue, onProcessTickets, title, descrip
           disabled={!isValid}>
 
         </PassphraseModalButton>
+        <InvisibleButton className={styles.skipButton} onClick={cancel}>
+          <T
+            id="process.mangedTickets.button.skip"
+            m="Skip"
+          />
+        </InvisibleButton>
       </div>
     </div>
   );

--- a/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
+++ b/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
@@ -14,7 +14,7 @@ export default ({ cancel, send, onSendContinue, onProcessTickets, title, descrip
   const onSubmitContinue = async (passphrase) => {
     // send a continue so we can go to the loading state
     onSendContinue();
-    await onProcessTickets(passphrase).then(() => send({ type: "FINISH" }));
+    await onProcessTickets(passphrase).then(() => send({ type: "CONTINUE" }));
     return;
   };
 

--- a/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessUnmanagedTickets.module.css
+++ b/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessUnmanagedTickets.module.css
@@ -18,3 +18,7 @@
 .buttonWrapper {
   margin-top: 10px;
 }
+
+.skipButton {
+  margin-left: 10px;
+}

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -315,6 +315,12 @@ export const useGetStarted = () => {
             tx.status === LIVE ||
             tx.status === UNMINED
           ) {
+            // On old vsp the fee is an input. So if the tx has more than one
+            // input, it means it is an old vsp ticket and have no feeStatus.
+            // So we can skip it.
+            if (tx.txInputs.length !== 1) {
+              return false;
+            }
             return true;
           }
         });

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -690,9 +690,10 @@ export const useGetStarted = () => {
           noVspSelection: true,
           description: <T
           id="getstarted.processManagedTickets.description"
-          m={`Looks like you have vsp ticket with unprocessed fee. If they are picked
-              to vote and they are not linked with a vsp, they may miss, if you are not
-              properly dealing with solo vote.`}
+          m={ `Your wallet appears to have live tickets. Processing managed
+            tickets confirms with the VSPs that all of your submitted tickets
+            are currently known and paid for by the VSPs.`
+          }
         />
         });
       }

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -71,7 +71,6 @@ export const useGetStarted = () => {
     getCoinjoinOutputspByAcct,
     onProcessUnmanagedTickets,
     onProcessManagedTickets,
-    hasTicketFeeError,
     stakeTransactions
   } = useDaemonStartup();
   const { mixedAccount } = useAccounts();
@@ -275,6 +274,8 @@ export const useGetStarted = () => {
           // goToHome();
         }
       },
+      // processingUnmanagedTickets process solo tickets and must be called
+      // after processingManagedTickets.
       isAtProcessingUnmanagedTickets: () => {
         console.log("is at processingUnmanagedTickets");
         let hasSoloTickets = false;
@@ -303,11 +304,23 @@ export const useGetStarted = () => {
           send({ type: "BACK" });
         }
       },
+      // processingManagedTickets process vsp tickets updating its status.
       isAtProcessingManagedTickets: () => {
         console.log("is at isAtProcessingManagedTickets");
-        // if no tickets with error, we can continue
-        if (!hasTicketFeeError) {
-          send({ type: "GO_TO_HOME_VIEW" });
+        const hasLive = Object.keys(stakeTransactions).some((hash) => {
+          const tx = stakeTransactions[hash];
+          // check if the wallet has at least one vsp live ticket.
+          if (
+            tx.status === IMMATURE ||
+            tx.status === LIVE ||
+            tx.status === UNMINED
+          ) {
+            return true;
+          }
+        });
+        // if no live tickets, we can skip it.
+        if (!hasLive) {
+          onSendBack();
         }
       },
       isAtFinishMachine: () => goToHome()
@@ -665,6 +678,7 @@ export const useGetStarted = () => {
         PageComponent = h(ProcessManagedTickets, {
           onSendContinue,
           send,
+          cancel: onSendBack,
           onProcessTickets: onProcessManagedTickets,
           title: <T id="getstarted.processManagedTickets.title" m="Process Managed Tickets" />,
           noVspSelection: true,

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -45,10 +45,7 @@ const useDaemonStartup = () => {
 
   // vsp selectors
   const rememberedVspHost = useSelector(sel.getRememberedVspHost);
-  const hasTicketFeeError = useSelector(sel.getHasTicketFeeError);
-  // needed for checking if still have solo tickets.
   const stakeTransactions = useSelector(sel.stakeTransactions);
-
   // end of vsp selectors
 
   // sync dcrwallet spv or rpc selectors
@@ -304,7 +301,6 @@ const useDaemonStartup = () => {
     daemonWarning,
     onProcessUnmanagedTickets,
     onProcessManagedTickets,
-    hasTicketFeeError,
     stakeTransactions,
     rememberedVspHost
   };

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -333,18 +333,7 @@ export const getStartedMachine = Machine({
       },
       on: {
         FINISH: "goToHomeView",
-        CONTINUE: "processingUnmanagedTickets"
-      }
-    },
-    processingUnmanagedTickets: {
-      onEntry: "isAtProcessingUnmanagedTickets",
-      initial: "processingUnmanagedTickets",
-      states: {
-        processingUnmanagedTickets: {}
-      },
-      on: {
-        BACK: "goToHomeView",
-        CONTINUE: "isLoadingConfig"
+        CONTINUE: "processingManagedTickets"
       }
     },
     processingManagedTickets: {
@@ -354,8 +343,19 @@ export const getStartedMachine = Machine({
         processingManagedTickets: {}
       },
       on: {
+        BACK: "processingUnmanagedTickets",
+        CONTINUE: "isLoadingConfig"
+      }
+    },
+    processingUnmanagedTickets: {
+      onEntry: "isAtProcessingUnmanagedTickets",
+      initial: "processingUnmanagedTickets",
+      states: {
+        processingUnmanagedTickets: {}
+      },
+      on: {
         CONTINUE: "isLoadingConfig",
-        GO_TO_HOME_VIEW: "goToHomeView"
+        BACK: "goToHomeView"
       }
     },
     isLoadingConfig: {
@@ -366,7 +366,7 @@ export const getStartedMachine = Machine({
       },
       on: {
         FINISH: "goToHomeView",
-        CONTINUE: "processingManagedTickets"
+        CONTINUE: "processingUnmanagedTickets"
       }
     },
     releaseNotes: {

--- a/app/wallet/control.js
+++ b/app/wallet/control.js
@@ -333,36 +333,17 @@ export const getPeerInfo = (walletService) => new Promise((ok, fail) => {
   );
 });
 
-export const processManagedTickets = (walletService, passphrase, vspHost, vspPubkey, feeAccount, changeAccount) =>
+export const processManagedTickets = (walletService, vspHost, vspPubkey, feeAccount, changeAccount) =>
   new Promise((resolve, reject) => {
-    const unlockReq = new api.UnlockWalletRequest();
-    unlockReq.setPassphrase(new Uint8Array(Buffer.from(passphrase)));
-    // Unlock wallet so we can call the request.
-    walletService.unlockWallet(unlockReq, (error) => {
-      if (error) {
-        reject(error);
-      }
+    const request = new api.ProcessManagedTicketsRequest();
+    request.setVspHost("https://" + vspHost);
+    request.setVspPubkey(vspPubkey);
+    request.setFeeAccount(feeAccount);
+    request.setChangeAccount(changeAccount);
 
-      const request = new api.ProcessManagedTicketsRequest();
-      request.setVspHost("https://" + vspHost);
-      request.setVspPubkey(vspPubkey);
-      request.setFeeAccount(feeAccount);
-      request.setChangeAccount(changeAccount);
-
-      walletService.processManagedTickets(request, (err, response) => {
-        // err ? fail(err) : ok(res);
-
-        const lockReq = new api.LockWalletRequest();
-
-        // Lock wallet and return response from the request.
-        walletService.lockWallet(lockReq, (error) => {
-          if (error) {
-            reject(error);
-          }
-          resolve(response);
-        });
-      });
-    });
+    walletService.processManagedTickets(request, (err, res) =>
+      err ? reject(err) : resolve(res)
+    );
   });
 
 // processUnmanagedTicketsStartup
@@ -408,5 +389,28 @@ new Promise((resolve, reject) => {
         resolve(response);
       });
     });
+  });
+});
+
+export const unlockWallet = (walletService, passphrase) => new Promise((resolve, reject) => {
+  const unlockReq = new api.UnlockWalletRequest();
+  unlockReq.setPassphrase(new Uint8Array(Buffer.from(passphrase)));
+  // Unlock wallet so we can call the request.
+  walletService.unlockWallet(unlockReq, (error) => {
+    if (error) {
+      reject(error);
+    }
+    resolve(true);
+  });
+});
+
+export const lockWallet = (walletService) => new Promise((resolve, reject) => {
+  const lockReq = new api.LockWalletRequest();
+
+  walletService.lockWallet(lockReq, (error) => {
+    if (error) {
+      reject(error);
+    }
+    resolve(true);
   });
 });


### PR DESCRIPTION
This PR changes how we call processManaged tickets, to be called before processUnmanagedTickets and also to be called on every startup if the wallet have live tickets