### PR TITLE
[CSS] fix security page misalignments

### DIFF
--- a/app/components/shared/Subtitle/Subtitle.module.css
+++ b/app/components/shared/Subtitle/Subtitle.module.css
@@ -5,6 +5,7 @@
   margin-bottom: 17px;
   margin-left: 0;
   width: 740px;
+  clear: both;
 }
 
 .tabbedPageSubtitle.export {

--- a/app/components/views/PrivacyPage/SecurityPage/SecurityPage.module.css
+++ b/app/components/views/PrivacyPage/SecurityPage/SecurityPage.module.css
@@ -117,14 +117,15 @@
 
 @media screen and (max-width: 768px) {
   .securityPageTab {
+    margin-top: 30px;
     width: 355px;
   }
-  
+
   .securityPageFormRowField,
   .securityPageFormRowFieldMessage {
     width: 224px;
   }
-   
+
   .securityPage {
     margin-left: 37px;
   }

--- a/app/components/views/PrivacyPage/SecurityPage/ValidateAddress/ValidateAddressForm.module.css
+++ b/app/components/views/PrivacyPage/SecurityPage/ValidateAddress/ValidateAddressForm.module.css
@@ -13,7 +13,7 @@
   font-size: 19px;
   line-height: 15px;
 }
-  
+
 .validateAddressFormInput {
   float: left;
   width: 300px;
@@ -50,9 +50,9 @@
 .validateAddressOwnedForm {
   padding: 10px 0 26px 58px;
   background-color: var(--background-back-color);
-  float:left;
-  width: 682px; 
-  
+  float: left;
+  width: 682px;
+  clear: both;
 }
 
 .validateAddressOwnedData {
@@ -71,16 +71,15 @@
   }
 }
 
-
 @media screen and (max-width: 768px) {
   .validateAddressForm {
     width: 355px;
   }
-  
+
   .validateAddressFormInput {
     width: 224px;
   }
-   
+
   .validateAddressFormResponse {
     margin-right: 95px;
     margin-top: 7px;


### PR DESCRIPTION
Closes #3147 and fix two more misalignments on smaller screens:
<img width="178" alt="DeepinScreenshot_select-area_20210119124641" src="https://user-images.githubusercontent.com/52497040/105031122-1ec6d800-5a55-11eb-9c7c-80fae8d6b455.png">
<img width="497" alt="DeepinScreenshot_select-area_20210119124710" src="https://user-images.githubusercontent.com/52497040/105031124-1f5f6e80-5a55-11eb-86d0-4d440120bb80.png">
