### PR TITLE
[Purchase Tickets] fix ticket number input increment button

### DIFF
--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
@@ -42,7 +42,7 @@ const Tickets = ({ toggleIsLegacy }) => {
   // onChangeNumTickets deals with ticket increment or decrement.
   const onChangeNumTickets = (increment) => {
     if (numTickets === 0 && !increment) return;
-    increment ? setNumTickets(numTickets + 1) : setNumTickets(numTickets - 1);
+    increment ? setNumTickets(parseInt(numTickets) + 1) : setNumTickets(parseInt(numTickets) - 1);
   };
 
   const onV3PurchaseTicket = (passphrase) => {


### PR DESCRIPTION
After typing manually a value into ticket number input on the purchase tickets page, the increment button or the up cursor key adds "1" char to the tail of the value instead of incrementing it. 
This diff fixes it by converting the ticket number to Integer before incrementing.


![Screen Recording 2021-01-20 at 21 42 56](https://user-images.githubusercontent.com/52497040/105233095-a7cf3380-5b69-11eb-9357-d08d286affb5.gif)
