### PR TITLE
Fix declaration for pi-ui and regen yarn.lock.

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "node-abi": "^2.15.0",
     "node-addon-loader": "decred/node-addon-loader#master",
     "nouislider": "^12.0.0",
-    "pi-ui": "https://github.com/decred/pi-ui",
+    "pi-ui": "decred/pi-ui#86083b26ae7925701a73179d70bf7e88d7d67e59",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",
     "raw-loader": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9320,9 +9320,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/decred/pi-ui":
+pi-ui@decred/pi-ui#86083b26ae7925701a73179d70bf7e88d7d67e59:
   version "1.0.0"
-  resolved "https://github.com/decred/pi-ui#86083b26ae7925701a73179d70bf7e88d7d67e59"
+  resolved "https://codeload.github.com/decred/pi-ui/tar.gz/86083b26ae7925701a73179d70bf7e88d7d67e59"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"


### PR DESCRIPTION
This format matches the dependency declaration for another
Decred dependency, node-addon-loader.

Regenerating yarn.lock using this fix modifies the "resolved" line
for fetching the dependency's source, in a format that is understood
by the Nix package manager after converting the yarn.lock using
yarn2nix.  Previously, the HTML for the GitHub project was fetched
instead, which failed checksum matches and never would have been usable
in the build.

To avoid changing the version of pi-ui in the build, the package.json
references the Git sha1 of the previously resolved commit.  This can
be changed to a branch or version specification when it needs to be
updated later.