### PR TITLE
Add account validation and warning tooltip in AccountsSelect

### DIFF
--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -3,11 +3,15 @@ import Promise from "promise";
 import * as sel from "selectors";
 import * as wallet from "wallet";
 import { getWalletCfg } from "config";
+<<<<<<< HEAD
 import {
   getAccountsAttempt,updateAccount,
   getAcctSpendableBalance,
   getMixerAcctsSpendableBalances
 } from "./ClientActions";
+=======
+import { getAcctSpendableBalance, getAccountsAttempt, showAccount } from "./ClientActions";
+>>>>>>> 3b6059ee (Replace updateAccount with showAccount action call)
 import {
   MIN_RELAY_FEE_ATOMS,
   MIN_MIX_DENOMINATION_ATOMS,
@@ -63,7 +67,7 @@ export const toggleAllowSendFromUnmixed = () => (dispatch, getState) => {
       const { accountName, accountNumber, hidden } = account;
       const changeAccountToVisible = hidden && (accountName === MIXED_ACCOUNT || accountName === CHANGE_ACCOUNT);
       if (changeAccountToVisible)
-        dispatch(updateAccount({ accountNumber, hidden: false }));
+        dispatch(showAccount(accountNumber));
     });
   }
   walletCfg.set(SEND_FROM_UNMIXED, value);

--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -3,15 +3,12 @@ import Promise from "promise";
 import * as sel from "selectors";
 import * as wallet from "wallet";
 import { getWalletCfg } from "config";
-<<<<<<< HEAD
 import {
-  getAccountsAttempt,updateAccount,
+  getAccountsAttempt,
+  getMixerAcctsSpendableBalances,
   getAcctSpendableBalance,
-  getMixerAcctsSpendableBalances
+  showAccount
 } from "./ClientActions";
-=======
-import { getAcctSpendableBalance, getAccountsAttempt, showAccount } from "./ClientActions";
->>>>>>> 3b6059ee (Replace updateAccount with showAccount action call)
 import {
   MIN_RELAY_FEE_ATOMS,
   MIN_MIX_DENOMINATION_ATOMS,

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -438,7 +438,7 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
         csppPort,
         mixedAccountBranch
       });
-      // selectedWallet.value.isTrezor && dispatch(enableTrezor());
+      selectedWallet.value.isTrezor && dispatch(enableTrezor());
       await dispatch(getVersionServiceAttempt());
       await dispatch(openWalletAttempt("", false));
       return discoverAccountsComplete;

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -438,7 +438,7 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
         csppPort,
         mixedAccountBranch
       });
-      selectedWallet.value.isTrezor && dispatch(enableTrezor());
+      // selectedWallet.value.isTrezor && dispatch(enableTrezor());
       await dispatch(getVersionServiceAttempt());
       await dispatch(openWalletAttempt("", false));
       return discoverAccountsComplete;

--- a/app/components/inputs/AccountsSelect.js
+++ b/app/components/inputs/AccountsSelect.js
@@ -1,7 +1,8 @@
 import Select from "react-select";
 import { accountsSelect } from "connectors";
-import { injectIntl, defineMessages } from "react-intl";
+import { injectIntl, defineMessages, FormattedMessage as T } from "react-intl";
 import { Balance, LinkToAccounts } from "shared";
+import { Tooltip } from "pi-ui";
 
 const messages = defineMessages({
   placeholder: {
@@ -76,10 +77,22 @@ class AccountsSelect extends React.Component {
     return filteredAccounts;
   }
 
+  showNoAccountsTooltip(component) {
+    return !this.state.accounts?.length ?
+      (<Tooltip content={
+        <T
+          id="accountsSelect.noAccountsTooltip"
+          m="Make sure you have at least one visible account"
+        />
+      }>
+        {component}
+      </Tooltip>) : component;
+  }
+
   render() {
     const { formatMessage } = this.props.intl;
     const { className, showAccountsButton, disabled } = this.props;
-    return (
+    return this.showNoAccountsTooltip(
       <div className={"is-row " + className}>
         <Select
           disabled={disabled}

--- a/app/components/inputs/AccountsSelect.js
+++ b/app/components/inputs/AccountsSelect.js
@@ -82,7 +82,7 @@ class AccountsSelect extends React.Component {
       (<Tooltip content={
         <T
           id="accountsSelect.noAccountsTooltip"
-          m="Make sure you have at least one visible account"
+          m="Make sure your mixed account is visible"
         />
       }>
         {component}

--- a/app/components/inputs/ReceiveAccountsSelect.jsx
+++ b/app/components/inputs/ReceiveAccountsSelect.jsx
@@ -19,6 +19,7 @@ function ReceiveAccountsSelect({
     (value) => dispatch(ca.getNextAddressAttempt(value)),
     [dispatch]
   );
+
   const onChangeAccount = useCallback(
     (account) => {
       onChange && onChange(account);
@@ -27,11 +28,12 @@ function ReceiveAccountsSelect({
     [getNextAddressAttempt, onChange]
   );
 
+  const nextAddressAccountValue =
+    account && account !== nextAddressAccount?.value;
+
   useEffect(() => {
-    if (account && account != nextAddressAccount.value) {
-      getNextAddressAttempt(account);
-    }
-  }, [account, getNextAddressAttempt, nextAddressAccount.value]);
+    if (nextAddressAccountValue) getNextAddressAttempt(account);
+  }, [account, getNextAddressAttempt, nextAddressAccountValue]);
 
   return (
     <AccountsSelect
@@ -45,10 +47,7 @@ function ReceiveAccountsSelect({
         // needs to be called with it, which updates nextAddressAccount
         // eventually. Until it happens, it's better to show no account
         // than a previously chosen one.
-        account:
-          account && account != nextAddressAccount.value
-            ? null
-            : nextAddressAccount,
+        account: nextAddressAccountValue ? null : nextAddressAccount,
         disabled
       }}
     />

--- a/app/components/shared/SendTransaction/SendTransaction.jsx
+++ b/app/components/shared/SendTransaction/SendTransaction.jsx
@@ -248,13 +248,18 @@ const SendTransaction = ({
     }));
   };
 
+  const accountSpendableAmount = account?.spendable;
+  const accountValue = account?.value;
+
   const onAttemptConstructTransaction = useCallback(() => {
+    if (accountSpendableAmount === undefined || accountValue === undefined)
+      return;
     const confirmations = 0;
-    setSendAllAmount(account.spendable);
+    setSendAllAmount(accountSpendableAmount);
     if (hasError()) return;
     if (!isSendAll) {
       return attemptConstructTransaction(
-        account.value,
+        accountValue,
         confirmations,
         outputs.map(({ data }) => ({
           amount: data.amount,
@@ -263,7 +268,7 @@ const SendTransaction = ({
       );
     } else {
       return attemptConstructTransaction(
-        account.value,
+        accountValue,
         confirmations,
         outputs,
         true
@@ -274,8 +279,8 @@ const SendTransaction = ({
     hasError,
     isSendAll,
     attemptConstructTransaction,
-    account.spendable,
-    account.value,
+    accountSpendableAmount,
+    accountValue,
     outputs
   ]);
 

--- a/app/components/shared/SendTransaction/SendTransaction.jsx
+++ b/app/components/shared/SendTransaction/SendTransaction.jsx
@@ -185,15 +185,16 @@ const SendTransaction = ({
     return outputs.some(outputHasError);
   }, [outputs]);
 
-  console.log(receiveAccount, visibleAccounts);
+  const isReceiveAccountVisible =
+    receiveAccount === undefined ||
+    visibleAccounts.find(
+      (visibleAccount) => visibleAccount.value === receiveAccount
+    );
 
   const isValid = () =>
     !!(
       receiveAccount !== null &&
-      (receiveAccount === undefined ||
-        visibleAccounts.find(
-          (visibleAccount) => visibleAccount.value === receiveAccount
-        )) &&
+      isReceiveAccountVisible &&
       !hasError() &&
       unsignedTransaction &&
       !isConstructingTransaction &&

--- a/app/components/shared/SendTransaction/hooks.js
+++ b/app/components/shared/SendTransaction/hooks.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import * as sel from "selectors";
 import * as ca from "actions/ControlActions";
 import { baseOutput } from "./helpers";
@@ -26,20 +26,21 @@ export function useSendTransaction() {
   const isTrezor = useSelector(sel.isTrezor);
   const isWatchingOnly = useSelector(sel.isWatchingOnly);
   const isConstructingTransaction = useSelector(sel.isConstructingTransaction);
+  const visibleAccounts = useSelector(sel.visibleAccounts);
 
   const dispatch = useDispatch();
 
-  const attemptConstructTransaction = (account, confirmations, outputs, all) =>
+  const attemptConstructTransaction = useCallback((account, confirmations, outputs, all) =>
     dispatch(
       ca.constructTransactionAttempt(account, confirmations, outputs, all)
-    );
+    ), [dispatch]);
 
   const validateAddress = (address) => dispatch(ca.validateAddress(address));
 
-  const onClearTransaction = () => dispatch(ca.clearTransaction());
+  const onClearTransaction = useCallback(() => dispatch(ca.clearTransaction()), [dispatch]);
 
-  const onGetNextAddressAttempt = (account) =>
-    dispatch(ca.getNextAddressAttempt(account));
+  const onGetNextAddressAttempt = useCallback((account) =>
+    dispatch(ca.getNextAddressAttempt(account)), [dispatch]);
 
   const getRunningIndicator = useSelector(sel.getRunningIndicator);
   return {
@@ -57,6 +58,7 @@ export function useSendTransaction() {
     isTrezor,
     isWatchingOnly,
     isConstructingTransaction,
+    visibleAccounts,
     attemptConstructTransaction,
     validateAddress,
     onClearTransaction,

--- a/app/components/views/AccountsPage/Accounts/AccountRow/AccountDetails.jsx
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/AccountDetails.jsx
@@ -3,12 +3,26 @@ import { Tooltip, classNames } from "pi-ui";
 import { Balance, CopyToClipboard } from "shared";
 import { SlateGrayButton } from "buttons";
 import style from "../Accounts.module.css";
-import { IMPORTED_ACCOUNT, DEFAULT_ACCOUNT } from "constants";
+import { classNames } from "pi-ui";
+import {
+  IMPORTED_ACCOUNT,
+  DEFAULT_ACCOUNT,
+  MIXED_ACCOUNT,
+  CHANGE_ACCOUNT
+} from "constants";
 
-const isHidable = (account) =>
-  account.accountName !== IMPORTED_ACCOUNT &&
-  account.accountName !== DEFAULT_ACCOUNT &&
-  !account.total;
+function isHidable(account, allowSendFromUnmixed) {
+  return (
+    account.accountName !== IMPORTED_ACCOUNT &&
+    account.accountName !== DEFAULT_ACCOUNT &&
+    !account.total &&
+    !(
+      !allowSendFromUnmixed &&
+      (account.accountName === MIXED_ACCOUNT ||
+        account.accountName === CHANGE_ACCOUNT)
+    )
+  );
+}
 
 const DataLine = ({ children }) => (
   <div className={style.detailsBottomSpec}>
@@ -25,7 +39,8 @@ const AccountsDetails = ({
   showAccount,
   showPubKey,
   onTogglePubkey,
-  accountExtendedKey
+  accountExtendedKey,
+  allowSendFromUnmixed
 }) => (
   <div key={`details${account.accountNumber}`}>
     <div className={style.detailsBottomColumns}>
@@ -137,8 +152,8 @@ const AccountsDetails = ({
             />
           </Tooltip>
         )}
-        {isHidable(account) && !hidden && (
-          <Tooltip content={<T id="accounts.hide.tip" m="Hide" />}>
+        {isHidable(account, allowSendFromUnmixed) && !hidden && (
+          <Tooltip text={<T id="accounts.hide.tip" m="Hide" />}>
             <div className={style.hideButton} onClick={hideAccount} />
           </Tooltip>
         )}

--- a/app/components/views/AccountsPage/Accounts/AccountRow/AccountDetails.jsx
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/AccountDetails.jsx
@@ -3,7 +3,6 @@ import { Tooltip, classNames } from "pi-ui";
 import { Balance, CopyToClipboard } from "shared";
 import { SlateGrayButton } from "buttons";
 import style from "../Accounts.module.css";
-import { classNames } from "pi-ui";
 import {
   IMPORTED_ACCOUNT,
   DEFAULT_ACCOUNT,

--- a/app/components/views/AccountsPage/Accounts/AccountRow/AccountRow.jsx
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/AccountRow.jsx
@@ -13,7 +13,8 @@ const AccountRow = ({
   hideAccount,
   onGetAccountExtendedKey,
   accountExtendedKey,
-  hasTickets
+  hasTickets,
+  allowSendFromUnmixed
 }) => {
   const {
     isShowingRenameAccount,
@@ -64,7 +65,8 @@ const AccountRow = ({
         showAccount: showAccountCallback,
         onTogglePubkey,
         showPubKey,
-        accountExtendedKey
+        accountExtendedKey,
+        allowSendFromUnmixed
       }}
     />
   );

--- a/app/components/views/AccountsPage/Accounts/Accounts.jsx
+++ b/app/components/views/AccountsPage/Accounts/Accounts.jsx
@@ -22,21 +22,23 @@ const Accounts = () => {
   return !walletService ? (
     <ErrorScreen />
   ) : (
-      <AccountsList
-        {...{
-          onGetAccountExtendedKey,
-          onHideAccount,
-          onShowAccount,
-          onRenameAccount,
-          accounts,
-          isLoading,
-          accountExtendedKey,
-          walletName,
-          hasTickets,
-          allowSendFromUnmixed
-        }}
-      />
-    );
+    <AccountsList
+      {...{
+        onGetAccountExtendedKey,
+        onHideAccount,
+        onShowAccount,
+        onRenameAccount,
+        accounts,
+        mixedAccount,
+        changeAccount,
+        isLoading,
+        accountExtendedKey,
+        walletName,
+        hasTickets,
+        allowSendFromUnmixed
+      }}
+    />
+  );
 };
 
 export default Accounts;

--- a/app/components/views/AccountsPage/Accounts/Accounts.jsx
+++ b/app/components/views/AccountsPage/Accounts/Accounts.jsx
@@ -12,6 +12,7 @@ const Accounts = () => {
     accountExtendedKey,
     walletName,
     hasTickets,
+    allowSendFromUnmixed,
     onRenameAccount,
     onHideAccount,
     onShowAccount,
@@ -21,22 +22,21 @@ const Accounts = () => {
   return !walletService ? (
     <ErrorScreen />
   ) : (
-    <AccountsList
-      {...{
-        onGetAccountExtendedKey,
-        onHideAccount,
-        onShowAccount,
-        onRenameAccount,
-        accounts,
-        mixedAccount,
-        changeAccount,
-        isLoading,
-        accountExtendedKey,
-        walletName,
-        hasTickets
-      }}
-    />
-  );
+      <AccountsList
+        {...{
+          onGetAccountExtendedKey,
+          onHideAccount,
+          onShowAccount,
+          onRenameAccount,
+          accounts,
+          isLoading,
+          accountExtendedKey,
+          walletName,
+          hasTickets,
+          allowSendFromUnmixed
+        }}
+      />
+    );
 };
 
 export default Accounts;

--- a/app/components/views/AccountsPage/Accounts/AccountsList.jsx
+++ b/app/components/views/AccountsPage/Accounts/AccountsList.jsx
@@ -38,7 +38,8 @@ const AccountsList = ({
   onRenameAccount,
   accountNumDetailsShown,
   walletName,
-  hasTickets
+  hasTickets,
+  allowSendFromUnmixed
 }) => (
   <>
     {isLoading ? (
@@ -67,6 +68,7 @@ const AccountsList = ({
               renameAccount={onRenameAccount}
               hideAccount={onHideAccount}
               showAccount={onShowAccount}
+              allowSendFromUnmixed={allowSendFromUnmixed}
             />
           ))}
         </div>

--- a/app/components/views/AccountsPage/Accounts/hooks.js
+++ b/app/components/views/AccountsPage/Accounts/hooks.js
@@ -19,6 +19,7 @@ export function useAccounts() {
   const accountExtendedKey = useSelector(sel.accountExtendedKey);
   const walletName = useSelector(sel.getWalletName);
   const hasTickets = useSelector(sel.hasTickets);
+  const allowSendFromUnmixed = useSelector(sel.getAllowSendFromUnmixed);
 
   const dispatch = useDispatch();
 
@@ -49,6 +50,7 @@ export function useAccounts() {
     accountExtendedKey,
     walletName,
     hasTickets,
+    allowSendFromUnmixed,
     onRenameAccount,
     onHideAccount,
     onShowAccount,

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseForm.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseForm.jsx
@@ -95,7 +95,7 @@ const PurchaseTicketsForm = ({
         </div>
         <NumTicketsInput
           required
-          invalid={account.spendable < numTickets * ticketPrice}
+          invalid={!account || account.spendable < numTickets * ticketPrice}
           invalidMessage={
             <T
               id="purchaseTickets.errors.insufficientBalance"
@@ -109,7 +109,7 @@ const PurchaseTicketsForm = ({
           onKeyDown={handleOnKeyDown}
           showErrors={true}
         />
-        {account.spendable >= numTickets * ticketPrice && (
+        {account && account.spendable >= numTickets * ticketPrice && (
           <div className="input-purchase-ticket-valid-message-area">
             <T
               id="purchaseTickets.validMsg"

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
@@ -53,8 +53,7 @@ const Tickets = ({ toggleIsLegacy }) => {
   };
 
   useEffect(() => {
-    const { spendable } = account;
-    const canAfford = numTickets * ticketPrice <= spendable;
+    const canAfford = account && account.spendable >= numTickets * ticketPrice;
     const hasTickets = numTickets > 0;
     setIsValid(canAfford && hasTickets && !!vsp);
   }, [ticketPrice, numTickets, account, vsp]);

--- a/app/components/views/TicketsPage/VSPTicketsStatusTab/Page.jsx
+++ b/app/components/views/TicketsPage/VSPTicketsStatusTab/Page.jsx
@@ -73,7 +73,7 @@ const TicketListPage = ({
           onChangeSortType
         })}
       />
-      {hasVSPTicketsError && (
+      {hasVSPTicketsError && account !== null && (
         <PassphraseModalButton
           {...{
             onSubmit: onSyncVspTicketsRequest,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1083,19 +1083,19 @@ export const getNextAddressRequestAttempt = get([
 ]);
 export const nextAddressAccount = createSelector(
   [visibleAccounts, nextAddressAccountNumber],
-  (accounts, number) => accounts.find(compose(eq(number), get("value")))
+  (accounts, number) => accounts.find(compose(eq(number), get("value"))) || null
 );
 export const nextAddress = compose(get("address"), getNextAddressResponse);
 
 export const defaultSpendingAccount = createSelector(
   [visibleAccounts, getMixedAccount],
   (accounts, mixedAccount) =>
-    accounts.find(compose(eq(mixedAccount || 0), get("value")))
+    accounts.find(compose(eq(mixedAccount || 0), get("value"))) || null
 );
 
 export const defaultSpendingAccountDisregardMixedAccount = createSelector(
   [visibleAccounts],
-  (accounts) => accounts.find(compose(eq(0), get("value")))
+  (accounts) => accounts.find(compose(eq(0), get("value"))) || null
 );
 
 export const changePassphraseRequestAttempt = get([

--- a/app/style/ReactSelectGlobal.css
+++ b/app/style/ReactSelectGlobal.css
@@ -455,7 +455,7 @@
 }
 
 .accounts-select {
-  width: 300px;
+  width: 260px;
 }
 
 .accounts-select-value {


### PR DESCRIPTION
Closes https://github.com/decred/decrediton/issues/3177.

Currently, it's possible to hide _mixed_ and _change (unmixed)_ accounts even when "Allow send from unmixed accounts" isn't checked (balance should be zero DCR, of course). This PR prevents users from hiding these accounts in this case. Also, if one checks "Allow send from unmixed accounts" and hide one of these accounts, then they will be unhidden automatically just after  "Allow send from unmixed accounts" has been unchecked.

This PR also checks for the ``account`` object definition before trying to access some attribute of it. Furthermore, a tooltip was added in ``AccountsSelect`` component to warn users when there's no available visible account to be selected. This is especially important when trying to buy tickets with privacy enabled, since that, in this case, it's impossible to buy a ticket using an account other than _mixed_, even if "Allow send from unmixed accounts" is checked.

![image](https://user-images.githubusercontent.com/39631429/105882586-97451000-5fe4-11eb-8159-823954d06567.png)

