### PR TITLE
Disable autobuy when changing VSP modes

### DIFF
--- a/app/components/views/TicketsPage/PurchaseTab/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/hooks.js
@@ -18,6 +18,7 @@ export const usePurchaseTab = () => {
   const ticketPrice = useSelector(sel.ticketPrice);
   const availableVSPs = useSelector(sel.getAvailableVSPs);
   const availableVSPsError = useSelector(sel.getDiscoverAvailableVSPError);
+  const autoBuyerRunning = useSelector(sel.isTicketAutoBuyerEnabled);
   const ticketAutoBuyerRunning = useSelector(sel.getTicketAutoBuyerRunning);
   const isLegacy = useSelector(sel.getIsLegacy);
   const isLoading = useSelector(sel.purchaseTicketsRequestAttempt);
@@ -75,6 +76,14 @@ export const usePurchaseTab = () => {
   };
 
   const toggleIsLegacy = (isLegacy) => {
+    if (autoBuyerRunning) {
+      // stop runnig legacy autobuyer
+      dispatch(ca.ticketBuyerV2Cancel());
+    }
+    if (ticketAutoBuyerRunning) {
+      // stop running new autobuyer
+      dispatch(ca.ticketBuyerCancel());
+    }
     dispatch(vspa.toggleIsLegacy(isLegacy));
   };
 
@@ -84,7 +93,8 @@ export const usePurchaseTab = () => {
   const setRememberedVspHost = (vsp) =>
     dispatch(vspa.setRememberedVspHost(vsp));
 
-  const onListUnspentOutputs = (accountNum) => dispatch(listUnspentOutputs(accountNum));
+  const onListUnspentOutputs = (accountNum) =>
+    dispatch(listUnspentOutputs(accountNum));
 
   // purchase cspp ticket
   const mixedAccount = useSelector(sel.getMixedAccount);

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -8,8 +8,10 @@ import {
   PURCHASETICKETS_SUCCESS,
   PURCHASETICKETS_FAILED,
   STARTTICKETBUYERV2_SUCCESS,
+  STARTTICKETBUYERV3_SUCCESS,
   STARTTICKETBUYERV2_FAILED,
   STOPTICKETBUYERV2_SUCCESS,
+  STOPTICKETBUYER_SUCCESS,
   REVOKETICKETS_SUCCESS,
   REVOKETICKETS_FAILED,
   IMPORTSCRIPT_MANUAL_SUCCESS,
@@ -305,6 +307,10 @@ const messages = defineMessages({
     id: "runTicketBuyer.Success",
     defaultMessage: "Ticket Buyer successfully started."
   },
+  STARTTICKETBUYERV3_SUCCESS: {
+    id: "runTicketBuyerNew.Success",
+    defaultMessage: "Ticket Buyer successfully started."
+  },
   STARTTICKETBUYERV2_FAILED: {
     id: "runTicketBuyer.Failed",
     defaultMessage: "Invalid private password. Please try again."
@@ -313,10 +319,13 @@ const messages = defineMessages({
     id: "stopTicketBuyer.Success",
     defaultMessage: "Ticket Buyer successfully stopped."
   },
+  STOPTICKETBUYER_SUCCESS: {
+    id: "stopTicketBuyerNew.Success",
+    defaultMessage: "Ticket Buyer successfully stopped."
+  },
   WRONG_PASSPHRASE_MSG: {
     id: "errors.wrongPassphrase",
-    defaultMessage:
-      "Wrong private passphrase entered."
+    defaultMessage: "Wrong private passphrase entered."
   },
   TRZ_TOGGLEPINPROTECTION_SUCCESS_ENABLED: {
     id: "trezor.pinProtectionSuccess.enabled",
@@ -568,7 +577,9 @@ export default function snackbar(state = {}, action) {
     case REVOKETICKETS_SUCCESS:
     case IMPORTSCRIPT_MANUAL_SUCCESS:
     case STARTTICKETBUYERV2_SUCCESS:
+    case STARTTICKETBUYERV3_SUCCESS:
     case STOPTICKETBUYERV2_SUCCESS:
+    case STOPTICKETBUYER_SUCCESS:
     case UPDATESTAKEPOOLCONFIG_SUCCESS:
     case REMOVESTAKEPOOLCONFIG:
     case SEEDCOPIEDTOCLIPBOARD:


### PR DESCRIPTION
Closes  #3181
Also, I've added snackbar notifications for the new auto buyer's start and stop events similar to the legacy auto buyer's events. Thus it is a little bit easier to follow what is happening in the background.