### PR TITLE
Bump to Electron 9.4.0

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -92,6 +92,7 @@ import { DAEMON_ADVANCED, LOCALE, DISABLE_HARDWARE_ACCEL } from "constants/confi
 
 // setPath as decrediton
 app.setPath("userData", getAppDataDirectory());
+app.allowRendererProcessReuse = false;
 
 const argv = parseArgs(process.argv.slice(1), OPTIONS);
 const debug = argv.debug || process.env.NODE_ENV === "development";

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -159,7 +159,7 @@ export const allowVSPRequests = (stakePoolHost) => {
 
 export const reloadAllowedExternalRequests = () => {
   allowedExternalRequests = {};
-  allowedURLs = [/^devtools:\/\/*/];
+  allowedURLs = [/^devtools:\/\/*/, /^file:\/\/(.*)\/app\/*/];
 
   if (process.env.NODE_ENV === "development") {
     allowedURLs.push(/^http:\/\/localhost:3000/);

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "core-decorators": "^0.20.0",
     "cross-env": "^5.2.1",
     "css-loader": "^2.1.1",
-    "electron": "8.5.2",
+    "electron": "9.4.0",
     "enzyme": "^3.11.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4851,10 +4851,10 @@ electron-to-chromium@^1.3.363:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.376.tgz#7cb7b5205564a06c8f8ecfbe832cbd47a1224bb1"
   integrity sha512-cv/PYVz5szeMz192ngilmezyPNFkUjuynuL2vNdiqIrio440nfTDdc0JJU0TS2KHLSVCs9gBbt4CFqM+HcBnjw==
 
-electron@8.5.2:
-  version "8.5.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-8.5.2.tgz#7b0246c6676a39df0e5e384b11cfe854fe5917f0"
-  integrity sha512-VU+zZnmCzxoZ5UfBg2UGVm+nyxlNlQOQkotMLfk7FCtnkIOhX+sosl618OCxUWjOvPc+Mpg5MEkEmxPU5ziW4Q==
+electron@9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-9.4.0.tgz#c3c607e3598226ddbaaff8babcdffa8bb2210936"
+  integrity sha512-hOC4q0jkb+UDYZRy8vrZ1IANnq+jznZnbkD62OEo06nU+hIbp2IrwDRBNuSLmQ3cwZMVir0WSIA1qEVK0PkzGA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
I set the `allowRendererProcessReuse` flag to `false` that reverts to the old behavior. It is functional for now, but this could be just a temporary solution until Electron 11. 