### PR TITLE
[Tx History] filter txs by multiple type at once

### DIFF
--- a/app/components/buttons/EyeFilterMenu/EyeFilterMenu.jsx
+++ b/app/components/buttons/EyeFilterMenu/EyeFilterMenu.jsx
@@ -42,7 +42,9 @@ const EyeFilterMenu = ({
             key={i}
             className={classNames(
               styles.contextMenuItem,
-              selected === option.key && styles.selected
+              (Array.isArray(selected)
+                ? selected.includes(option.key)
+                : selected === option.key) && styles.selected
             )}
             onClick={(e) =>
               onMenuChanged(e, { value: option.value, key: option.key })

--- a/app/components/views/TransactionsPage/HistoryTab/HistoryPage/HistoryPage.jsx
+++ b/app/components/views/TransactionsPage/HistoryTab/HistoryPage/HistoryPage.jsx
@@ -22,7 +22,7 @@ const subtitleMenu = ({
   sortTypes,
   txTypes,
   selectedSortOrderKey,
-  selectedTxTypeKey,
+  selectedTxTypeKeys,
   searchText,
   intl,
   onChangeSelectedType,
@@ -63,7 +63,7 @@ const subtitleMenu = ({
       text={<T id="transactions.txtypes.tooltip" m="Transaction Type" />}>
       <EyeFilterMenu
         options={txTypes}
-        selected={selectedTxTypeKey}
+        selected={selectedTxTypeKeys}
         onChange={onChangeSelectedType}
       />
     </Tooltip>
@@ -77,7 +77,7 @@ const Page = ({
   transactionsFilter,
   noMoreTransactions,
   selectedSortOrderKey,
-  selectedTxTypeKey,
+  selectedTxTypeKeys,
   searchText,
   currencyDisplay,
   unitDivisor,
@@ -98,7 +98,7 @@ const Page = ({
         sortTypes,
         txTypes,
         selectedSortOrderKey,
-        selectedTxTypeKey,
+        selectedTxTypeKeys,
         searchText,
         intl,
         onChangeSelectedType,

--- a/app/components/views/TransactionsPage/HistoryTab/helpers.js
+++ b/app/components/views/TransactionsPage/HistoryTab/helpers.js
@@ -6,19 +6,21 @@ import {
   MIXED
 } from "constants";
 
-export const selectedTxTypeFromFilter = (filter) => {
-  const types = getTxTypes();
-  let key;
-  types.forEach((type) => {
-    if (filter.direction === type.value.direction) {
-      key = type.key;
-      return;
-    }
-  });
-  return key;
+export const selectedTxTypesFromFilter = (filter) => {
+  const txTypes = getTxTypes();
+  const keys = txTypes
+    .filter(
+      (txType) =>
+        filter.directions.includes(txType.value.direction) ||
+        filter.types.includes(txType.value.type)
+    )
+    .map((type) => type.key);
+
+  // return 'all' key if there is no direction or type was set
+  return keys.length == 0 ? [txTypes[0].key] : keys;
 };
 
-export const getSortTypes = () => ([
+export const getSortTypes = () => [
   {
     value: "desc",
     key: "desc",
@@ -29,31 +31,28 @@ export const getSortTypes = () => ([
     key: "asc",
     label: <T id="transaction.sortby.oldest" m="Oldest" />
   }
-]);
+];
 
-export const getTxTypes = () => ([
+// -1 cleans the filter types
+export const getTxTypes = () => [
   {
     key: "all",
     value: { direction: null, type: -1 },
     label: <T id="txFilter.type.all" m="All" />
   },
-  // -1 cleans the filter types, and right now we are cleaning transaction
-  // types if a direction is set, instead of acumullating them, because we
-  // need to apply changes on EyeFilterMenu Component, for having multiple
-  // options marked.
   {
     key: "sent",
-    value: { direction: TRANSACTION_DIR_SENT, type: -1 },
+    value: { direction: TRANSACTION_DIR_SENT },
     label: <T id="txFilter.type.sent" m="Sent" />
   },
   {
     key: "receiv",
-    value: { direction: TRANSACTION_DIR_RECEIVED, type: -1 },
+    value: { direction: TRANSACTION_DIR_RECEIVED },
     label: <T id="txFilter.type.received" m="Received" />
   },
   {
     key: "ticketf",
-    value: { direction: TICKET_FEE, type: -1 },
+    value: { direction: TICKET_FEE },
     label: <T id="txFilter.type.ticketfee" m="Ticket fee" />
   },
   {
@@ -61,4 +60,4 @@ export const getTxTypes = () => ([
     value: { type: MIXED },
     label: <T id="txFilter.type.mixed" m="Mixed" />
   }
-]);
+];

--- a/app/index.js
+++ b/app/index.js
@@ -52,12 +52,15 @@ const currentSettings = {
   daemonStartAdvanced:
     hasCliOption("daemonStartAdvanced") || getDaemonIsAdvanced(),
   daemonStartAdvancedFromCli: !!hasCliOption("daemonStartAdvanced"),
-  allowedExternalRequests: globalCfg.get(cfgConstants.ALLOWED_EXTERNAL_REQUESTS),
+  allowedExternalRequests: globalCfg.get(
+    cfgConstants.ALLOWED_EXTERNAL_REQUESTS
+  ),
   proxyType: globalCfg.get(cfgConstants.PROXY_TYPE),
   proxyLocation: globalCfg.get(cfgConstants.PROXY_LOCATION),
   spvMode: hasCliOption("spvMode") || getIsSpv(),
   spvModeFromCli: !!hasCliOption("spvMode"),
-  spvConnect: hasCliOption("spvConnect") || globalCfg.get(cfgConstants.SPV_CONNECT),
+  spvConnect:
+    hasCliOption("spvConnect") || globalCfg.get(cfgConstants.SPV_CONNECT),
   spvConnectFromCli: !!hasCliOption("spvConnect"),
   timezone: globalCfg.get(cfgConstants.TIMEZONE),
   currencyDisplay: DCR,
@@ -203,8 +206,8 @@ const initialState = {
     transactionsFilter: {
       search: null, // The freeform text in the Search box
       listDirection: "desc", // asc = oldest -> newest, desc => newest -> oldest
-      types: [], // desired transaction types (code). All if blank.
-      direction: null, // direction of desired transactions (sent/received/transfer)
+      types: [], // desired transaction types (code). All if blank. (mixed)
+      directions: [], // directions of desired transactions (sent/received/transfer/ticketfee)
       maxAmount: null,
       minAmount: null
     },

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -649,7 +649,7 @@ export default function grpc(state = {}, action) {
           search: null,
           listDirection: "desc",
           types: [],
-          direction: null
+          directions: []
         },
         recentRegularTransactions: [],
         recentStakeTransactions: [],

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -242,8 +242,8 @@ export const getMixedAccountName = createSelector(
     !mixedAcc
       ? null
       : balances
-        .filter(({ accountNumber }) => accountNumber === mixedAcc)
-        .map(({ accountName }) => accountName)[0]
+          .filter(({ accountNumber }) => accountNumber === mixedAcc)
+          .map(({ accountName }) => accountName)[0]
 );
 
 export const getChangeAccountName = createSelector(
@@ -252,8 +252,8 @@ export const getChangeAccountName = createSelector(
     !changeAcc
       ? null
       : balances
-        .filter(({ accountNumber }) => accountNumber === changeAcc)
-        .map(({ accountName }) => accountName)[0]
+          .filter(({ accountNumber }) => accountNumber === changeAcc)
+          .map(({ accountName }) => accountName)[0]
 );
 
 // getNotMixedAccounts Is an array of all accountNumbers which is not the mixedaccount.
@@ -265,8 +265,8 @@ export const getNotMixedAccounts = createSelector(
     !mixedAcc
       ? []
       : balances
-        .filter(({ accountNumber }) => accountNumber !== mixedAcc)
-        .map(({ accountNumber }) => accountNumber)
+          .filter(({ accountNumber }) => accountNumber !== mixedAcc)
+          .map(({ accountNumber }) => accountNumber)
 );
 
 // getNotMixedAcctIfAllowed checks if it is allowed to send from unmixed
@@ -346,21 +346,24 @@ export const locale = createSelector(
 );
 
 export const txURLBuilder = createSelector([network], (network) => (txHash) =>
-  `https://${network !== TESTNET ? "dcrdata" : "testnet"
+  `https://${
+    network !== TESTNET ? "dcrdata" : "testnet"
   }.decred.org/tx/${txHash}`
 );
 
 export const blockURLBuilder = createSelector(
   [network],
   (network) => (txHash) =>
-    `https://${network !== TESTNET ? "dcrdata" : "testnet"
+    `https://${
+      network !== TESTNET ? "dcrdata" : "testnet"
     }.decred.org/block/${txHash}`
 );
 
 export const txOutURLBuilder = createSelector(
   [network],
   (network) => (txHash, outputIdx) =>
-    `https://${network !== "testnet" ? "explorer" : network
+    `https://${
+      network !== "testnet" ? "explorer" : network
     }.dcrdata.org/tx/${txHash}/out/${outputIdx}`
 );
 
@@ -662,18 +665,18 @@ export const transactionNormalizer = createSelector(
       const txDetails =
         totalFundsReceived + totalChange + fee < totalDebit
           ? {
-            txAmount: totalDebit - fee - totalChange - totalFundsReceived,
-            txDirection: TRANSACTION_DIR_SENT,
-            txAccountName: debitedAccountName
-          }
+              txAmount: totalDebit - fee - totalChange - totalFundsReceived,
+              txDirection: TRANSACTION_DIR_SENT,
+              txAccountName: debitedAccountName
+            }
           : totalFundsReceived + totalChange + fee === totalDebit
-            ? {
+          ? {
               txAmount: fee,
               txDirection: TICKET_FEE,
               txAccountNameCredited: creditedAccountName,
               txAccountNameDebited: debitedAccountName
             }
-            : {
+          : {
               txAmount: totalFundsReceived,
               txDirection: TRANSACTION_DIR_RECEIVED,
               txAccountName: creditedAccountName
@@ -766,8 +769,9 @@ export const getStakeTransactionsCancel = get([
 //
 // Currently supported filters in the filter object:
 // - type (array): Array of types a transaction must belong to, to be accepted.
-// - direction (string): A string of one of the allowed directions for regular
-//   transactions (sent/received/transferred)
+//   Currently, just the MIXED type is supported
+// - directions (array): Array of allowed directions for regular
+//   transactions (sent/received/transferred/ticketfee)
 //
 // If empty, all transactions are accepted.
 export const filteredRegularTxs = createSelector(
@@ -775,17 +779,19 @@ export const filteredRegularTxs = createSelector(
   (transactions, filter) => {
     const filteredTxs = Object.keys(transactions)
       .map((hash) => transactions[hash])
-      .filter((v) =>
-        filter.direction ? filter.direction === v.txDirection : true
+      .filter(
+        (v) =>
+          filter.directions.length == 0 || // All directions
+          filter.directions.includes(v.txDirection)
       )
       .filter((v) =>
         filter.search
           ? v.creditAddresses.find(
-            (address) =>
-              address.length > 1 &&
-              address.toLowerCase().indexOf(filter.search.toLowerCase()) !==
-              -1
-          ) != undefined
+              (address) =>
+                address.length > 1 &&
+                address.toLowerCase().indexOf(filter.search.toLowerCase()) !==
+                  -1
+            ) != undefined
           : true
       )
       .filter((v) =>
@@ -794,18 +800,7 @@ export const filteredRegularTxs = createSelector(
       .filter((v) =>
         filter.maxAmount ? Math.abs(v.txAmount) <= filter.maxAmount : true
       )
-      .filter((v) => {
-        let isSameType = true;
-        if (filter.types.length > 0) {
-          isSameType = false;
-          filter.types.forEach((type) =>
-            type === v.txType || (type === MIXED && v.mixedTx)
-              ? (isSameType = true)
-              : null
-          );
-        }
-        return isSameType;
-      });
+      .filter((v) => v.mixedTx == filter.types.includes(MIXED));
 
     return filteredTxs;
   }
@@ -1009,19 +1004,21 @@ export const visibleAccounts = createSelector(
         accountName === "imported" || hidden
           ? accounts
           : [
-            ...accounts,
-            {
-              value: accountNumber,
-              label: `${accountName}: ${spendable / unitDivisor
+              ...accounts,
+              {
+                value: accountNumber,
+                label: `${accountName}: ${
+                  spendable / unitDivisor
                 } ${currencyDisplay}`,
-              name: accountName,
-              spendableAndUnit: `${spendable / unitDivisor
+                name: accountName,
+                spendableAndUnit: `${
+                  spendable / unitDivisor
                 } ${currencyDisplay}`,
-              spendable,
-              hidden,
-              ...data
-            }
-          ],
+                spendable,
+                hidden,
+                ...data
+              }
+            ],
       [],
       balances
     )
@@ -1035,18 +1032,20 @@ export const spendingAccounts = createSelector(
         accountNumber !== 0 && (accountName === "imported" || spendable <= 0)
           ? accounts
           : [
-            ...accounts,
-            {
-              value: accountNumber,
-              label: `${accountName}: ${spendable / unitDivisor
+              ...accounts,
+              {
+                value: accountNumber,
+                label: `${accountName}: ${
+                  spendable / unitDivisor
                 } ${currencyDisplay}`,
-              name: accountName,
-              spendableAndUnit: `${spendable / unitDivisor
+                name: accountName,
+                spendableAndUnit: `${
+                  spendable / unitDivisor
                 } ${currencyDisplay}`,
-              spendable,
-              ...data
-            }
-          ],
+                spendable,
+                ...data
+              }
+            ],
       [],
       balances
     )
@@ -1147,7 +1146,11 @@ export const isConstructingTransaction = bool(constructTxRequestAttempt);
 
 export const tempSettings = get(["settings", "tempSettings"]);
 export const settingsChanged = get(["settings", "settingsChanged"]);
-export const uiAnimations = get(["settings", "currentSettings", "uiAnimations"]);
+export const uiAnimations = get([
+  "settings",
+  "currentSettings",
+  "uiAnimations"
+]);
 export const changePassphraseError = get(["control", "changePassphraseError"]);
 export const changePassphraseSuccess = get([
   "control",
@@ -1435,7 +1438,7 @@ export const blockTimestampFromNow = createSelector(
     return (block) => {
       return Math.trunc(
         currentTimestamp +
-        (block - currentHeight) * chainParams.TargetTimePerBlock
+          (block - currentHeight) * chainParams.TargetTimePerBlock
       );
     };
   }
@@ -1676,12 +1679,15 @@ export const getRunningIndicator = or(
   isTicketAutoBuyerEnabled
 );
 
-export const getHasTicketFeeError = createSelector([getVSPTickets], (vspTickets) => {
-  if (!vspTickets) return;
-  return vspTickets[VSP_FEE_PROCESS_ERRORED]
-    ? vspTickets[VSP_FEE_PROCESS_ERRORED].length > 0
-    : false;
-});
+export const getHasTicketFeeError = createSelector(
+  [getVSPTickets],
+  (vspTickets) => {
+    if (!vspTickets) return;
+    return vspTickets[VSP_FEE_PROCESS_ERRORED]
+      ? vspTickets[VSP_FEE_PROCESS_ERRORED].length > 0
+      : false;
+  }
+);
 export const getCanClose = not(or(getRunningIndicator, getHasTicketFeeError));
 
 // end of selectors for closing decrediton.


### PR DESCRIPTION
In this diff, I've added support for filtering transactions by multiple types at the same time. For example, when the user selects `sent` and `received`, it lists all the sent and received transactions: 
<img width="144" alt="DeepinScreenshot_select-area_20210202173341" src="https://user-images.githubusercontent.com/52497040/106631238-d6dba100-657c-11eb-93ee-6c835b0b3a5d.png">

This feature closes #3180 because if just the `sent`, `received`, and `ticket fee` options are selected, it lists all "normal" transactions but mixed:
<img width="147" alt="DeepinScreenshot_select-area_20210202173453" src="https://user-images.githubusercontent.com/52497040/106631342-f83c8d00-657c-11eb-8303-5ee02179489f.png">

