### PR TITLE
[Tx History] Improve tx history layout on smaller screens

### DIFF
--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -92,7 +92,7 @@
 
 .info {
   display: grid;
-  grid-template-columns: 0.5fr 3fr 10fr 2fr;
+  grid-template-columns: 0.5fr 3.5fr 10fr 2.2fr;
   width: 100%;
 }
 
@@ -139,7 +139,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  margin-right: 20px;
+  margin-right: 10px;
   height: 15px;
   max-width: 210px;
   line-height: 15px;
@@ -160,7 +160,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  height: 15px; 
+  height: 15px;
   max-width: 180px;
   margin-left: 20px;
   line-height: 15px;
@@ -337,6 +337,15 @@
 }
 
 @media screen and (max-width: 1179px) {
+  .info {
+    grid-template-columns: 0.5fr 3.5fr 10fr 2.5fr;
+  }
+  .info.overviewInfo {
+    grid-template-columns: 0.5fr 3fr 10fr;
+  }
+  .accountName {
+    max-width: 150px;
+  }
   .overviewRow {
     width: 315px;
   }
@@ -367,9 +376,10 @@
     font-family: var(--font-family-monospace);
   }
   .txRowWrapper {
-    padding: 5px 20px 27px 20px !important;
+    padding: 8px 20px 27px 10px !important;
   }
   .info {
+    grid-template-columns: 0.5fr 4fr 2fr;
     padding-bottom: 1rem;
   }
   .myTickets {

--- a/app/components/views/TransactionsPage/HistoryTab/HistoryPage/HistoryPage.module.css
+++ b/app/components/views/TransactionsPage/HistoryTab/HistoryPage/HistoryPage.module.css
@@ -29,7 +29,7 @@
   }
 
   .historyContainer {
-    margin-left: 0;
+    margin: 15px 0 0 0;
   }
 
   .historyContentTitle {
@@ -42,6 +42,6 @@
   }
 
   .historySearchTx {
-    width: 250px;
+    width: 255px;
   }
 }


### PR DESCRIPTION
Before: 
<img width="285" alt="DeepinScreenshot_select-area_20210202184120" src="https://user-images.githubusercontent.com/52497040/106640606-8c5f2200-6586-11eb-98ab-cc8f5b8a076d.png">
<img width="591" alt="DeepinScreenshot_select-area_20210202184103" src="https://user-images.githubusercontent.com/52497040/106640587-879a6e00-6586-11eb-9b60-f2ddd866275d.png">

After:
<img width="283" alt="DeepinScreenshot_select-area_20210202183921" src="https://user-images.githubusercontent.com/52497040/106640653-97b24d80-6586-11eb-97f5-0220b226dc96.png">
<img width="515" alt="DeepinScreenshot_select-area_20210202183900" src="https://user-images.githubusercontent.com/52497040/106640659-9aad3e00-6586-11eb-87f3-68326b2e7778.png">


