### PR TITLE
Fix flickering insufficient funds message in "Send" tab

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -536,7 +536,7 @@ export const constructTransactionAttempt = (
   confirmations,
   outputs,
   all
-) => async (dispatch, getState) => {
+) => (dispatch, getState) => {
   const request = new ConstructTransactionRequest();
   let totalAmount;
   request.setSourceAccount(parseInt(account));
@@ -576,11 +576,9 @@ export const constructTransactionAttempt = (
             dispatch({ error, type: CONSTRUCTTX_FAILED });
           };
         }
-        const newChangeAddr = await dispatch(
-          getNextAddressAttempt(unmixedAcct)
-        );
+        const newChangeAddress = sel.nextAddress(getState());
         const outputDest = new ConstructTransactionRequest.OutputDestination();
-        outputDest.setAddress(newChangeAddr.address);
+        outputDest.setAddress(newChangeAddress);
         request.setChangeDestination(outputDest);
       }
     }

--- a/app/components/shared/SendTransaction/SendTransaction.jsx
+++ b/app/components/shared/SendTransaction/SendTransaction.jsx
@@ -37,7 +37,8 @@ const SendTransaction = ({
     validateAddress,
     onClearTransaction,
     onGetNextAddressAttempt,
-    getRunningIndicator
+    getRunningIndicator,
+    constructTxRequestAttempt
   } = useSendTransaction();
 
   const {
@@ -282,12 +283,12 @@ const SendTransaction = ({
   // Executes on component updates
   useEffect(() => {
     let newOutputs;
-    if (publishTxResponse && publishTxResponse != prevPublishTxResponse) {
+    if (publishTxResponse && publishTxResponse !== prevPublishTxResponse) {
       if (isSendSelf) {
         onGetNextAddressAttempt(nextAddressAccount.value);
       }
       setIsSendAll(false);
-      onSetOutputs([baseOutput()]);
+      newOutputs = [baseOutput()];
     }
     if (
       isSendSelf &&
@@ -325,10 +326,10 @@ const SendTransaction = ({
     prevOutputs,
     onSetOutputs,
     onAttemptConstructTransaction,
-    onClearTransaction,
     onGetNextAddressAttempt,
     account,
-    prevAccount
+    prevAccount,
+    constructTxRequestAttempt
   ]);
 
   // Clear transaction info on unmount

--- a/app/components/shared/SendTransaction/hooks.js
+++ b/app/components/shared/SendTransaction/hooks.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import * as sel from "selectors";
 import * as ca from "actions/ControlActions";
 import { baseOutput } from "./helpers";
@@ -26,20 +26,21 @@ export function useSendTransaction() {
   const isTrezor = useSelector(sel.isTrezor);
   const isWatchingOnly = useSelector(sel.isWatchingOnly);
   const isConstructingTransaction = useSelector(sel.isConstructingTransaction);
+  const constructTxRequestAttempt = useSelector(sel.constructTxRequestAttempt);
 
   const dispatch = useDispatch();
 
-  const attemptConstructTransaction = (account, confirmations, outputs, all) =>
+  const attemptConstructTransaction = useCallback((account, confirmations, outputs, all) =>
     dispatch(
       ca.constructTransactionAttempt(account, confirmations, outputs, all)
-    );
+    ), [dispatch]);
 
   const validateAddress = (address) => dispatch(ca.validateAddress(address));
 
   const onClearTransaction = () => dispatch(ca.clearTransaction());
 
-  const onGetNextAddressAttempt = (account) =>
-    dispatch(ca.getNextAddressAttempt(account));
+  const onGetNextAddressAttempt = useCallback((account) =>
+    dispatch(ca.getNextAddressAttempt(account)), [dispatch]);
 
   const getRunningIndicator = useSelector(sel.getRunningIndicator);
   return {
@@ -61,7 +62,8 @@ export function useSendTransaction() {
     validateAddress,
     onClearTransaction,
     onGetNextAddressAttempt,
-    getRunningIndicator
+    getRunningIndicator,
+    constructTxRequestAttempt
   };
 }
 

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1105,7 +1105,7 @@ export const changePassphraseRequestAttempt = get([
 
 export const constructTxLowBalance = get(["control", "constructTxLowBalance"]);
 export const constructTxResponse = get(["control", "constructTxResponse"]);
-const constructTxRequestAttempt = get(["control", "constructTxRequestAttempt"]);
+export const constructTxRequestAttempt = get(["control", "constructTxRequestAttempt"]);
 const signTransactionRequestAttempt = get([
   "control",
   "signTransactionRequestAttempt"


### PR DESCRIPTION
Closes https://github.com/decred/decrediton/issues/3188 by removing ``getNextAddressAttempt`` redundant call. This issue can be reproduced by trying to send from _mixed_ to _unmixed_ accounts when having insufficient funds to do that. As ``nextAddress`` was updated, ``useEffect`` hook in ``app/components/shared/SendTransaction/SendTransaction.jsx`` tended to run indefinitely and new outputs were generated based on that new address, so the transaction was constructed generating a new address again. There's no need of calling ``getNextAddressAttempt``, for it's already called every time a new destination account is selected. It means that ``nextAddress`` is always synced with the selected destination account (``nextAddressAccount``).