### PR TITLE
[launcher] Show error and retry on bad passphrase for ProcessManaged/ProcessUnmanagedTickets

### DIFF
--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -584,10 +584,9 @@ export const processManagedTickets = (passphrase) => (dispatch, getState) =>
         if (error.indexOf(
           "wallet.Unlock: invalid passphrase:: secretkey.DeriveKey"
         )) {
-          reject("Invalid private passphrase, please try again.");
-        } else {
-          reject(error);
+          return reject("Invalid private passphrase, please try again.");
         }
+        return reject(error);
       }
     };
 

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -584,9 +584,11 @@ export const processManagedTickets = (passphrase) => (dispatch, getState) =>
         if (error.indexOf(
           "wallet.Unlock: invalid passphrase:: secretkey.DeriveKey"
         )) {
-          return reject("Invalid private passphrase, please try again.");
+           reject("Invalid private passphrase, please try again.");
+           return;
         }
-        return reject(error);
+        reject(error);
+        return;
       }
     };
 

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -602,7 +602,7 @@ export const PROCESSUNMANAGEDTICKETS_FAILED = "PROCESSUNMANAGEDTICKETS_FAILED";
 // It is called on wallet restore.
 export const processUnmanagedTickets = (passphrase, vspHost, vspPubkey) => (dispatch, getState) =>
   new Promise((resolve, reject) => {
-    const process = async () => {
+    const asyncProcess = async () => {
       dispatch({ type: PROCESSUNMANAGEDTICKETS_ATTEMPT });
       try {
         const walletService = sel.walletService(getState());
@@ -633,7 +633,5 @@ export const processUnmanagedTickets = (passphrase, vspHost, vspPubkey) => (disp
         return error;
       }
     };
-  process()
-    .then(() => resolve())
-    .catch((err) => reject(err));
+    asyncProcess().then(r => resolve(r)).catch(error => reject(error));
   });

--- a/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
+++ b/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
@@ -25,16 +25,6 @@ export default ({
     onProcessTickets(passphrase)
       .then(() => send({ type: "CONTINUE" }))
       .catch(error => {
-        if (error.isTimeout) {
-          const { vspHost } = error;
-          error = <T
-            id="process.mangedTickets.error"
-            m="A timeout happened when verifying the following vsp: {vsp}"
-            values={{
-              vsp: vspHost
-            }}
-          />;
-        }
         send({ type: "ERROR", error });
       });
     return;

--- a/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
+++ b/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
@@ -11,18 +11,17 @@ import { VSPSelect } from "inputs";
 export default ({
   cancel,
   send,
-  onSendContinue,
   onProcessTickets,
   title,
   description,
   noVspSelection,
-  error
+  error,
+  isProcessingManaged
 }) => {
   const [isValid, setIsValid] = useState(false);
   const [vsp, setVSP] = useState(null);
   const onSubmitContinue = (passphrase) => {
     // send a continue so we can go to the loading state
-    onSendContinue();
     onProcessTickets(passphrase)
       .then(() => send({ type: "CONTINUE" }))
       .catch(error => {
@@ -40,7 +39,6 @@ export default ({
       });
     return;
   };
-
   useEffect(() => {
     if (noVspSelection) {
       setIsValid(true);
@@ -84,7 +82,8 @@ export default ({
           modalClassName={styles.passphraseModal}
           onSubmit={onSubmitContinue}
           buttonLabel={<T id="process.mangedTickets.button" m="Continue" />}
-          disabled={!isValid}>
+          disabled={!isValid || isProcessingManaged}
+          loading={isProcessingManaged}>
 
         </PassphraseModalButton>
         <InvisibleButton className={styles.skipButton} onClick={cancel}>

--- a/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
+++ b/app/components/views/GetStartedPage/ProcessManagedTickets/ProcessManagedTickets.jsx
@@ -48,16 +48,17 @@ export default ({
       setIsValid(true);
     }
   }, [vsp, noVspSelection]);
-
   return (
     <div className={styles.content}>
       <div className={GetStartedStyles.goBackScreenButtonArea}>
-        <Tooltip text={<GoBackMsg />}>
-          <div
-            className={GetStartedStyles.goBackScreenButton}
-            onClick={cancel}
-          />
-        </Tooltip>
+        { !isProcessingManaged &&
+          <Tooltip text={<GoBackMsg />}>
+            <div
+              className={GetStartedStyles.goBackScreenButton}
+              onClick={cancel}
+            />
+          </Tooltip>
+        }
       </div>
       <Subtitle
         className={styles.subtitle}
@@ -83,15 +84,15 @@ export default ({
           onSubmit={onSubmitContinue}
           buttonLabel={<T id="process.mangedTickets.button" m="Continue" />}
           disabled={!isValid || isProcessingManaged}
-          loading={isProcessingManaged}>
-
-        </PassphraseModalButton>
-        <InvisibleButton className={styles.skipButton} onClick={cancel}>
-          <T
-            id="process.mangedTickets.button.skip"
-            m="Skip"
-          />
-        </InvisibleButton>
+          loading={isProcessingManaged}/>
+        { !isProcessingManaged &&
+          <InvisibleButton className={styles.skipButton} onClick={cancel}>
+            <T
+              id="process.mangedTickets.button.skip"
+              m="Skip"
+            />
+          </InvisibleButton>
+        }
       </div>
     </div>
   );

--- a/app/components/views/GetStartedPage/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
+++ b/app/components/views/GetStartedPage/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
@@ -8,19 +8,15 @@ import styles from "./ProcessUnmanagedTickets.module.css";
 import { useEffect } from "react";
 import { VSPSelect } from "inputs";
 
-export default ({ cancel, onSendContinue, onSendError, send, onProcessTickets, title, description, noVspSelection, isProcessingUnmanaged }) => {
+export default ({ cancel, send, onProcessTickets, title, description, noVspSelection, isProcessingUnmanaged, error }) => {
   const [isValid, setIsValid] = useState(false);
   const [vsp, setVSP] = useState(null);
   const onSubmitContinue = async (passphrase) => {
     await onProcessTickets(passphrase, vsp.host, vsp.pubkey)
-      .then(() => {
-        onSendContinue();
-        send({ type: "CONTINUE" });
-      })
-      .catch((error) => {
-        onSendError(error);
-        send({ type: "ERROR", error });
-      });
+    .then(() => send({ type: "CONTINUE" }))
+    .catch(error => {
+      send({ type: "ERROR", error });
+    });
     return;
   };
 
@@ -57,6 +53,9 @@ export default ({ cancel, onSendContinue, onSendError, send, onProcessTickets, t
           className={styles.vspSelect}
           {...{ onChange: setVSP }}
         />
+      }
+      {
+        error && <div className="error">{error}</div>
       }
       <div className={styles.buttonWrapper}>
         <PassphraseModalButton

--- a/app/components/views/GetStartedPage/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
+++ b/app/components/views/GetStartedPage/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
@@ -3,7 +3,7 @@ import { GoBackMsg } from "../messages";
 import { FormattedMessage as T } from "react-intl";
 import GetStartedStyles from "../GetStarted.module.css";
 import { useState } from "react";
-import { PassphraseModalButton } from "buttons";
+import { PassphraseModalButton, InvisibleButton } from "buttons";
 import styles from "./ProcessUnmanagedTickets.module.css";
 import { useEffect } from "react";
 import { VSPSelect } from "inputs";
@@ -11,8 +11,8 @@ import { VSPSelect } from "inputs";
 export default ({ cancel, send, onProcessTickets, title, description, noVspSelection, isProcessingUnmanaged, error }) => {
   const [isValid, setIsValid] = useState(false);
   const [vsp, setVSP] = useState(null);
-  const onSubmitContinue = (passphrase) => {
-    return onProcessTickets(passphrase, vsp.host, vsp.pubkey)
+  const onSubmitContinue = async (passphrase) => {
+    await onProcessTickets(passphrase, vsp.host, vsp.pubkey)
     .then(() => send({ type: "CONTINUE" }))
     .catch(error => {
       send({ type: "ERROR", error });

--- a/app/components/views/GetStartedPage/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
+++ b/app/components/views/GetStartedPage/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
@@ -11,13 +11,12 @@ import { VSPSelect } from "inputs";
 export default ({ cancel, send, onProcessTickets, title, description, noVspSelection, isProcessingUnmanaged, error }) => {
   const [isValid, setIsValid] = useState(false);
   const [vsp, setVSP] = useState(null);
-  const onSubmitContinue = async (passphrase) => {
-    await onProcessTickets(passphrase, vsp.host, vsp.pubkey)
+  const onSubmitContinue = (passphrase) => {
+    return onProcessTickets(passphrase, vsp.host, vsp.pubkey)
     .then(() => send({ type: "CONTINUE" }))
     .catch(error => {
       send({ type: "ERROR", error });
     });
-    return;
   };
 
   useEffect(() => {

--- a/app/components/views/GetStartedPage/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
+++ b/app/components/views/GetStartedPage/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
@@ -11,8 +11,8 @@ import { VSPSelect } from "inputs";
 export default ({ cancel, send, onProcessTickets, title, description, noVspSelection, isProcessingUnmanaged, error }) => {
   const [isValid, setIsValid] = useState(false);
   const [vsp, setVSP] = useState(null);
-  const onSubmitContinue = async (passphrase) => {
-    await onProcessTickets(passphrase, vsp.host, vsp.pubkey)
+  const onSubmitContinue = (passphrase) => {
+    onProcessTickets(passphrase, vsp.host, vsp.pubkey)
     .then(() => send({ type: "CONTINUE" }))
     .catch(error => {
       send({ type: "ERROR", error });

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -61,7 +61,8 @@ export const useGetStarted = () => {
     onProcessUnmanagedTickets,
     onProcessManagedTickets,
     stakeTransactions,
-    isProcessingManaged
+    isProcessingManaged,
+    isProcessingUnmanaged
   } = useDaemonStartup();
   const { mixedAccount } = useAccounts();
   const [PageComponent, setPageComponent] = useState(null);
@@ -662,8 +663,11 @@ export const useGetStarted = () => {
       }
       if (key === "processingUnmanagedTickets") {
         PageComponent = h(ProcessUnmanagedTickets, {
+          send,
           onSendContinue,
+          onSendError,
           onProcessTickets: onProcessUnmanagedTickets,
+          isProcessingUnmanaged: isProcessingUnmanaged,
           cancel: onSendBack,
           title: (
             <T
@@ -754,7 +758,8 @@ export const useGetStarted = () => {
       onProcessUnmanagedTickets,
       onProcessManagedTickets,
       send,
-      isProcessingManaged
+      isProcessingManaged,
+      isProcessingUnmanaged
     ]
   );
 

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -663,6 +663,7 @@ export const useGetStarted = () => {
       }
       if (key === "processingUnmanagedTickets") {
         PageComponent = h(ProcessUnmanagedTickets, {
+          error,
           send,
           onSendContinue,
           onSendError,
@@ -706,7 +707,8 @@ export const useGetStarted = () => {
               id="getstarted.processManagedTickets.description"
               m={`Your wallet appears to have live tickets. Processing managed
             tickets confirms with the VSPs that all of your submitted tickets
-            are currently known and paid for by the VSPs.`}
+            are currently known and paid for by the VSPs. If you've already 
+            confirmed your tickets then you may skip this step.`}
             />
           )
         });

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -60,7 +60,8 @@ export const useGetStarted = () => {
     getCoinjoinOutputspByAcct,
     onProcessUnmanagedTickets,
     onProcessManagedTickets,
-    stakeTransactions
+    stakeTransactions,
+    isProcessingManaged
   } = useDaemonStartup();
   const { mixedAccount } = useAccounts();
   const [PageComponent, setPageComponent] = useState(null);
@@ -684,6 +685,7 @@ export const useGetStarted = () => {
         PageComponent = h(ProcessManagedTickets, {
           error,
           onSendContinue,
+          onSendError,
           send,
           cancel: onSendBack,
           onProcessTickets: onProcessManagedTickets,
@@ -693,6 +695,7 @@ export const useGetStarted = () => {
               m="Process Managed Tickets"
             />
           ),
+          isProcessingManaged: isProcessingManaged,
           noVspSelection: true,
           description: (
             <T
@@ -750,7 +753,8 @@ export const useGetStarted = () => {
       daemonWarning,
       onProcessUnmanagedTickets,
       onProcessManagedTickets,
-      send
+      send,
+      isProcessingManaged
     ]
   );
 

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -46,6 +46,7 @@ const useDaemonStartup = () => {
   // vsp selectors
   const rememberedVspHost = useSelector(sel.getRememberedVspHost);
   const stakeTransactions = useSelector(sel.stakeTransactions);
+  const isProcessingManaged = useSelector(sel.isProcessingManaged);
   // end of vsp selectors
 
   // sync dcrwallet spv or rpc selectors
@@ -224,7 +225,7 @@ const useDaemonStartup = () => {
   );
 
   const onProcessManagedTickets = useCallback(
-    async (passphrase) => await dispatch(processManagedTickets(passphrase)),
+    async (passphrase) => dispatch(processManagedTickets(passphrase)),
     [dispatch]
   );
 
@@ -302,7 +303,8 @@ const useDaemonStartup = () => {
     onProcessUnmanagedTickets,
     onProcessManagedTickets,
     stakeTransactions,
-    rememberedVspHost
+    rememberedVspHost,
+    isProcessingManaged
   };
 };
 

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -48,7 +48,7 @@ const useDaemonStartup = () => {
   const stakeTransactions = useSelector(sel.stakeTransactions);
   const isProcessingManaged = useSelector(sel.isProcessingManaged);
   // end of vsp selectors
-
+  console.log("daemon startup", isProcessingManaged);
   // sync dcrwallet spv or rpc selectors
   const peerCount = useSelector(sel.peerCount);
   const synced = useSelector(sel.synced);
@@ -225,7 +225,7 @@ const useDaemonStartup = () => {
   );
 
   const onProcessManagedTickets = useCallback(
-    async (passphrase) => dispatch(processManagedTickets(passphrase)),
+    (passphrase) => dispatch(processManagedTickets(passphrase)),
     [dispatch]
   );
 

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -47,8 +47,9 @@ const useDaemonStartup = () => {
   const rememberedVspHost = useSelector(sel.getRememberedVspHost);
   const stakeTransactions = useSelector(sel.stakeTransactions);
   const isProcessingManaged = useSelector(sel.isProcessingManaged);
+  const isProcessingUnmanaged = useSelector(sel.isProcessingUnmanaged);
   // end of vsp selectors
-  console.log("daemon startup", isProcessingManaged);
+
   // sync dcrwallet spv or rpc selectors
   const peerCount = useSelector(sel.peerCount);
   const synced = useSelector(sel.synced);
@@ -218,7 +219,7 @@ const useDaemonStartup = () => {
   );
 
   const onProcessUnmanagedTickets = useCallback(
-    async (passphrase, vspHost, vspPubkey) => await dispatch(
+    (passphrase, vspHost, vspPubkey) => dispatch(
       processUnmanagedTickets(passphrase, vspHost, vspPubkey)
     ),
     [dispatch]
@@ -304,7 +305,8 @@ const useDaemonStartup = () => {
     onProcessManagedTickets,
     stakeTransactions,
     rememberedVspHost,
-    isProcessingManaged
+    isProcessingManaged,
+    isProcessingUnmanaged
   };
 };
 

--- a/app/index.js
+++ b/app/index.js
@@ -85,7 +85,11 @@ const initialState = {
     availableVSPsError: null,
     ticketAutoBuyerRunning: null,
     isLegacy: null,
-    rememberedVspHost: null
+    rememberedVspHost: null,
+    processUnmanagedTicketsAttempt: false,
+    processUnmanagedTicketsError: null,
+    processManagedTicketsAttempt: false,
+    processManagedTicketsError: null
   },
   daemon: {
     networkMatch: false,

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -37,7 +37,8 @@ import {
   ADDCUSTOMSTAKEPOOL_FAILED,
   REFRESHSTAKEPOOLPURCHASEINFORMATION_FAILED,
   SYNCVSPTICKETS_SUCCESS,
-  SYNCVSPTICKETS_FAILED
+  SYNCVSPTICKETS_FAILED,
+  PROCESSMANAGEDTICKETS_FAILED
 } from "../actions/VSPActions";
 import {
   ABANDONTRANSACTION_SUCCESS,
@@ -533,6 +534,10 @@ const messages = defineMessages({
   SYNCVSPTICKETS_FAILED: {
     id: "sync.vsp.failed",
     defaultMessage: "{originalError}"
+  },
+  PROCESSMANAGEDTICKETS_FAILED: {
+    id: "processmanaged.failed",
+    defaultMessage: "{originalError}"
   }
 });
 
@@ -727,6 +732,7 @@ export default function snackbar(state = {}, action) {
     case LNWALLET_LISTWATCHTOWERS_FAILED:
     case RUNACCOUNTMIXER_FAILED:
     case SYNCVSPTICKETS_FAILED:
+    case PROCESSMANAGEDTICKETS_FAILED:
       type = "Error";
       if (
         action.error &&

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -9,8 +9,11 @@ import {
   SYNCVSPTICKETS_FAILED,
   SYNCVSPTICKETS_SUCCESS,
   PROCESSMANAGEDTICKETS_ATTEMPT,
-  PROCESSMANAGEDTICKETS_SUCCES,
-  PROCESSMANAGEDTICKETS_FAILED
+  PROCESSMANAGEDTICKETS_SUCCESS,
+  PROCESSMANAGEDTICKETS_FAILED,
+  PROCESSUNMANAGEDTICKETS_ATTEMPT,
+  PROCESSUNMANAGEDTICKETS_SUCCESS,
+  PROCESSUNMANAGEDTICKETS_FAILED
 } from "actions/VSPActions";
 import {
   STARTTICKETBUYERV3_ATTEMPT,
@@ -91,7 +94,7 @@ export default function vsp(state = {}, action) {
         processManagedTicketsAttempt: true,
         processManagedTicketsError: null
       };
-    case PROCESSMANAGEDTICKETS_SUCCES:
+    case PROCESSMANAGEDTICKETS_SUCCESS:
     return { ...state,
       processManagedTicketsAttempt: false,
       processManagedTicketsError: null
@@ -101,6 +104,21 @@ export default function vsp(state = {}, action) {
       processManagedTicketsAttempt: false,
       processManagedTicketsError: action.error
     };
+    case PROCESSUNMANAGEDTICKETS_ATTEMPT:
+      return { ...state,
+        processUnmanagedTicketsAttempt: true,
+        processUnmanagedTicketsError: null
+      };
+    case PROCESSUNMANAGEDTICKETS_SUCCESS:
+      return { ...state,
+        processUnmanagedTicketsAttempt: false,
+        processUnmanagedTicketsError: null
+      };
+    case PROCESSUNMANAGEDTICKETS_FAILED:
+      return { ...state,
+        processUnmanagedTicketsAttempt: false,
+        processUnmanagedTicketsError: action.error
+      };
     default:
       return state;
   }

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -7,7 +7,10 @@ import {
   SET_REMEMBERED_VSP_HOST,
   SYNCVSPTICKETS_ATTEMPT,
   SYNCVSPTICKETS_FAILED,
-  SYNCVSPTICKETS_SUCCESS
+  SYNCVSPTICKETS_SUCCESS,
+  PROCESSMANAGEDTICKETS_ATTEMPT,
+  PROCESSMANAGEDTICKETS_SUCCES,
+  PROCESSMANAGEDTICKETS_FAILED
 } from "actions/VSPActions";
 import {
   STARTTICKETBUYERV3_ATTEMPT,
@@ -83,6 +86,21 @@ export default function vsp(state = {}, action) {
         syncVSPRequestAttempt: false,
         syncVSPRequestError: null
       };
+    case PROCESSMANAGEDTICKETS_ATTEMPT:
+      return { ...state,
+        processManagedTicketsAttempt: true,
+        processManagedTicketsError: null
+      };
+    case PROCESSMANAGEDTICKETS_SUCCES:
+    return { ...state,
+      processManagedTicketsAttempt: false,
+      processManagedTicketsError: null
+    };
+    case PROCESSMANAGEDTICKETS_FAILED:
+    return { ...state,
+      processManagedTicketsAttempt: false,
+      processManagedTicketsError: action.error
+    };
     default:
       return state;
   }

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -913,6 +913,7 @@ export const getVSPTickets = createSelector(
   }
 );
 
+export const isProcessingManaged = get(["vsp", "processManagedTicketsAttempt"]);
 // ****************** end of vsp selectors ******************
 
 export const dailyBalancesStats = get(["statistics", "dailyBalances"]);

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -914,6 +914,7 @@ export const getVSPTickets = createSelector(
 );
 
 export const isProcessingManaged = get(["vsp", "processManagedTicketsAttempt"]);
+export const isProcessingUnmanaged = get(["vsp", "processUnmanagedTicketsAttempt"]);
 // ****************** end of vsp selectors ******************
 
 export const dailyBalancesStats = get(["statistics", "dailyBalances"]);

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -361,7 +361,13 @@ export const getStartedMachine = Machine({
       },
       on: {
         CONTINUE: "isLoadingConfig",
-        BACK: "goToHomeView"
+        BACK: "goToHomeView",
+        ERROR: {
+          target: "processingUnmanagedTickets",
+          actions: assign({
+            error: (context, event) => event.error && event.error
+          })
+        }
       }
     },
     isLoadingConfig: {

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -344,7 +344,7 @@ export const getStartedMachine = Machine({
       },
       on: {
         BACK: "processingUnmanagedTickets",
-        CONTINUE: "isLoadingConfig",
+        CONTINUE: "processingUnmanagedTickets",
         ERROR: {
           target: "processingManagedTickets",
           actions: assign({
@@ -360,7 +360,7 @@ export const getStartedMachine = Machine({
         processingUnmanagedTickets: {}
       },
       on: {
-        CONTINUE: "isLoadingConfig",
+        CONTINUE: "goToHomeView",
         BACK: "goToHomeView",
         ERROR: {
           target: "processingUnmanagedTickets",

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -344,7 +344,13 @@ export const getStartedMachine = Machine({
       },
       on: {
         BACK: "processingUnmanagedTickets",
-        CONTINUE: "isLoadingConfig"
+        CONTINUE: "isLoadingConfig",
+        ERROR: {
+          target: "processingManagedTickets",
+          actions: assign({
+            error: (context, event) => event.error && event.error
+          })
+        }
       }
     },
     processingUnmanagedTickets: {


### PR DESCRIPTION
A user reported that no error was shown after a bad passphrase was entered for the process managed tickets modal.  This should fix this.