### PR TITLE
Remove border-radius from tickets details

### DIFF
--- a/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfo.module.css
+++ b/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfo.module.css
@@ -1,7 +1,6 @@
 .area {
   background-color: var(--background-back-color);
   padding: 16px 19px 16px 19px;
-  border-radius: 5px;
   position: relative;
   display: grid;
   grid-template-areas: "purchaseTicketsTitle purchaseTicketsTitle purchaseTicketsTitle purchaseTicketsTitle";


### PR DESCRIPTION
According to our [design specs](https://xd.adobe.com/spec/0b2049ed-80d2-4978-703a-72ad6ceea744-7d11/screen/374a754d-5ee4-4de1-b7e8-f3d1467ca3eb/specs/), the div showing tickets details in "Purchase Tickets" tab shouldn't have the property ``border-radius`` set. Currently, it's set to 5px, which causes some misalignments when expanding the div below. This PR fixes that.

![image](https://user-images.githubusercontent.com/39631429/107967990-93296400-6f8c-11eb-86ab-16a8709e8cda.png)
