### PR TITLE
[governance] Fix light theme refresh proposals icon.

### DIFF
--- a/app/style/themes/lightTheme.js
+++ b/app/style/themes/lightTheme.js
@@ -249,7 +249,7 @@ const lightTheme = {
   "decentralized-loop-animation":
     "url('style/icons/decentralizedLoopAnimation.gif')",
   "self-transaction-icon": "url('style/icons/sentToSelfTx.svg')",
-  "proposals-refresh-icon": "url('style/icons/MixerDark.svg')"
+  "proposals-refresh-icon": "url('style/icons/menuMixer.svg')"
 };
 
 export default lightTheme;


### PR DESCRIPTION
Wrong `.svg` icon name was used for proposals refresh icon in light theme.

After:
![image](https://user-images.githubusercontent.com/10324528/107992147-bd0c7600-6fe0-11eb-9ce1-913e7d3f7d3d.png)


Fixes #3217.