### PR TITLE
[tickets] Add sanity check for legacy purchase tickets

### DIFF
--- a/app/wallet/control.js
+++ b/app/wallet/control.js
@@ -127,7 +127,8 @@ export const purchaseTickets = (
   signTx
 ) =>
   new Promise((ok, fail) => {
-    if (stakepool.PoolAddress == "" || stakepool.PoolFees == 0) {
+    if ((!stakepool.PoolAddress && stakepool.PoolAddress == "") ||
+    (!stakepool.PoolFees && stakepool.PoolFees == 0)) {
       return fail("Purchase ticket failed: Pool Address or Pool Fees can't be empty");
     }
     const request = new api.PurchaseTicketsRequest();

--- a/app/wallet/control.js
+++ b/app/wallet/control.js
@@ -127,6 +127,10 @@ export const purchaseTickets = (
   signTx
 ) =>
   new Promise((ok, fail) => {
+    if (stakepool.PoolAddress == "" || stakepool.PoolFees == 0) {
+      fail("Purchase ticket failed: Pool Address or Pool Fees can't be empty");
+      return;
+    }
     const request = new api.PurchaseTicketsRequest();
     signTx && request.setPassphrase(new Uint8Array(Buffer.from(passphrase)));
     request.setAccount(accountNum);

--- a/app/wallet/control.js
+++ b/app/wallet/control.js
@@ -128,8 +128,7 @@ export const purchaseTickets = (
 ) =>
   new Promise((ok, fail) => {
     if (stakepool.PoolAddress == "" || stakepool.PoolFees == 0) {
-      fail("Purchase ticket failed: Pool Address or Pool Fees can't be empty");
-      return;
+      return fail("Purchase ticket failed: Pool Address or Pool Fees can't be empty");
     }
     const request = new api.PurchaseTicketsRequest();
     signTx && request.setPassphrase(new Uint8Array(Buffer.from(passphrase)));


### PR DESCRIPTION
We've had various reports of legacy ticket purchases not having Pool Address and Pool Fees populated which resulted in malformed legacy VSP tickets.  This is a final sanity check that should catch any that are attempted.  While this won't fix what's causing the core problem, it will stop them from happening until it's identified.