### PR TITLE
[various] Disable buttons when mixing, autobuyer or purchase tickets running

### DIFF
--- a/app/components/SideBar/Logo/Logo.module.css
+++ b/app/components/SideBar/Logo/Logo.module.css
@@ -36,7 +36,9 @@
   background-image: var(--menu-mixer-icon);
   background-size: 16px 16px;
   cursor: pointer;
-  animation: spin 1s linear infinite;
+  /* XXX Need a different animation method due to performance of this
+   animation: spin 1s linear infinite; 
+  */
 }
 
 @keyframes spin {

--- a/app/components/shared/SendTransaction/Form.jsx
+++ b/app/components/shared/SendTransaction/Form.jsx
@@ -2,7 +2,7 @@ import { FormattedMessage as T } from "react-intl";
 import { classNames } from "pi-ui";
 import { Balance, TransitionMotionWrapper } from "shared";
 import { SendTransactionButton } from "buttons";
-import { UnsignedTx } from "shared";
+import { UnsignedTx, Tooltip } from "shared";
 
 const wrapperComponent = (props) => <div {...props} />;
 
@@ -25,7 +25,8 @@ const Form = ({
   insuficientFunds,
   styles,
   hideDetails,
-  sendButtonLabel
+  sendButtonLabel,
+  getRunningIndicator
 }) => (
   <>
     <div className={classNames(styles.sendArea, styles.isRow)}>
@@ -66,6 +67,19 @@ const Form = ({
         </div>
       )}
       {((isTrezor && isWatchingOnly) || !isWatchingOnly) && (
+        getRunningIndicator ?
+        <Tooltip
+          text={
+            <T
+              id="send.indicator.running"
+              m="Privacy Mixer, Autobuyer or Purchase Ticket Attempt running, please shut them off before sending a transaction."
+            />
+          }>
+          <SendTransactionButton
+            disabled={true}
+            buttonLabel={sendButtonLabel}/>
+        </Tooltip>
+        :
         <SendTransactionButton
           disabled={!isValid()}
           showModal={showPassphraseModal}

--- a/app/components/shared/SendTransaction/SendTransaction.jsx
+++ b/app/components/shared/SendTransaction/SendTransaction.jsx
@@ -36,7 +36,8 @@ const SendTransaction = ({
     attemptConstructTransaction,
     validateAddress,
     onClearTransaction,
-    onGetNextAddressAttempt
+    onGetNextAddressAttempt,
+    getRunningIndicator
   } = useSendTransaction();
 
   const {
@@ -356,7 +357,8 @@ const SendTransaction = ({
         insuficientFunds,
         styles,
         hideDetails,
-        sendButtonLabel
+        sendButtonLabel,
+        getRunningIndicator
       }}
     />
   );

--- a/app/components/shared/SendTransaction/hooks.js
+++ b/app/components/shared/SendTransaction/hooks.js
@@ -41,6 +41,7 @@ export function useSendTransaction() {
   const onGetNextAddressAttempt = (account) =>
     dispatch(ca.getNextAddressAttempt(account));
 
+  const getRunningIndicator = useSelector(sel.getRunningIndicator);
   return {
     defaultSpendingAccount,
     unsignedTransaction,
@@ -59,7 +60,8 @@ export function useSendTransaction() {
     attemptConstructTransaction,
     validateAddress,
     onClearTransaction,
-    onGetNextAddressAttempt
+    onGetNextAddressAttempt,
+    getRunningIndicator
   };
 }
 

--- a/app/components/views/PrivacyPage/Privacy/Privacy.jsx
+++ b/app/components/views/PrivacyPage/Privacy/Privacy.jsx
@@ -21,7 +21,8 @@ const Privacy = ({ isCreateAccountDisabled, setInterval }) => {
     showInsufficientBalanceWarning,
     defaultSpendingAccountDisregardMixedAccount,
     mixedAccountSpendableBalance,
-    changeAccountSpendableBalance
+    changeAccountSpendableBalance,
+    getRunningIndicator
   } = usePrivacy();
 
   const [logs, setLogs] = useState("");
@@ -83,7 +84,8 @@ const Privacy = ({ isCreateAccountDisabled, setInterval }) => {
         defaultSpendingAccountDisregardMixedAccount,
         mixedAccountSpendableBalance,
         changeAccountSpendableBalance,
-        accounts
+        accounts,
+        getRunningIndicator
       }}
     />
   );

--- a/app/components/views/PrivacyPage/Privacy/PrivacyContent.jsx
+++ b/app/components/views/PrivacyPage/Privacy/PrivacyContent.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { FormattedMessage as T } from "react-intl";
-import { Subtitle, Log, Balance } from "shared";
+import { Subtitle, Log, Balance, Tooltip } from "shared";
 import {
   InfoDocModalButton,
   MixerPassphraseModalSwitch,
@@ -29,7 +29,8 @@ const PrivacyContent = ({
   changeAccount,
   defaultSpendingAccountDisregardMixedAccount,
   mixedAccountSpendableBalance,
-  changeAccountSpendableBalance
+  changeAccountSpendableBalance,
+  getRunningIndicator
 }) => {
   const [expandedLogs, setExpandedLogs] = useState(false);
   const onHideLog = () => setExpandedLogs(false);
@@ -92,6 +93,20 @@ const PrivacyContent = ({
                 <T id="privacy.stop.mixer" m="Stop Mixer" />
               </DangerButton>
             ) : (
+              getRunningIndicator ?
+              <Tooltip
+                text={
+                  <T
+                    id="tickets.purchase.running"
+                    m="Privacy Mixer or Autobuyer running, please shut them off before purchasing a ticket."
+                  />
+                }>
+              <MixerPassphraseModalSwitchKeyBlueButton
+                className={style.startMixerButton}
+                disabled={true}
+                buttonLabel={<T id="privacy.start.mixer" m="Start Mixer" />}/>
+              </Tooltip>
+              :
               <MixerPassphraseModalSwitch
                 modalTitle={
                   <T id="privacy.start.mixer.confirmation" m="Start Mixer" />

--- a/app/components/views/PrivacyPage/Privacy/PrivacyContent.jsx
+++ b/app/components/views/PrivacyPage/Privacy/PrivacyContent.jsx
@@ -101,10 +101,10 @@ const PrivacyContent = ({
                     m="Privacy Mixer or Autobuyer running, please shut them off before purchasing a ticket."
                   />
                 }>
-              <MixerPassphraseModalSwitchKeyBlueButton
-                className={style.startMixerButton}
-                disabled={true}
-                buttonLabel={<T id="privacy.start.mixer" m="Start Mixer" />}/>
+                <MixerPassphraseModalSwitch
+                  className={style.startMixerButton}
+                  disabled={true}
+                  buttonLabel={<T id="privacy.start.mixer" m="Start Mixer" />}/>
               </Tooltip>
               :
               <MixerPassphraseModalSwitch

--- a/app/components/views/PrivacyPage/Privacy/PrivacyContent.jsx
+++ b/app/components/views/PrivacyPage/Privacy/PrivacyContent.jsx
@@ -97,7 +97,7 @@ const PrivacyContent = ({
               <Tooltip
                 text={
                   <T
-                    id="tickets.purchase.running"
+                    id="mixer.start.running"
                     m="Privacy Mixer or Autobuyer running, please shut them off before purchasing a ticket."
                   />
                 }>

--- a/app/components/views/PrivacyPage/Privacy/hooks.js
+++ b/app/components/views/PrivacyPage/Privacy/hooks.js
@@ -76,6 +76,8 @@ export function usePrivacy() {
       .catch((err) => err);
   };
 
+  const getRunningIndicator = useSelector(sel.getRunningIndicator);
+
   return {
     stopAccountMixer,
     accountMixerRunning,
@@ -92,6 +94,7 @@ export function usePrivacy() {
     toggleAllowSendFromUnmixed,
     mixedAccountSpendableBalance,
     changeAccountSpendableBalance,
-    defaultSpendingAccountDisregardMixedAccount
+    defaultSpendingAccountDisregardMixedAccount,
+    getRunningIndicator
   };
 }

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_PurchaseTickets/Form.js
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_PurchaseTickets/Form.js
@@ -11,7 +11,8 @@ import {
   TransitionMotionWrapper,
   ShowWarning,
   ExternalLink,
-  Balance
+  Balance,
+  Tooltip
 } from "shared";
 
 import "style/StakePool.less";
@@ -40,7 +41,8 @@ const PurchaseTicketsForm = ({
   dismissBackupRedeemScript,
   onDismissBackupRedeemScript,
   isWatchingOnly,
-  notMixedAccounts
+  notMixedAccounts,
+  getRunningIndicator
 }) => (
   <>
     <div className="purchase-ticket-area-row is-row">
@@ -174,17 +176,29 @@ const PurchaseTicketsForm = ({
           {purchaseLabel()}
         </KeyBlueButton>
       ) : (
-        <PassphraseModalButton
-          modalTitle={
-            <T
-              id="tickets.purchaseConfirmation.legacy"
-              m="Ticket Purchase Confirmation"
-            />
-          }
-          disabled={getIsValid && !getIsValid()}
-          onSubmit={onPurchaseTickets}
-          buttonLabel={purchaseLabel()}
-        />
+        getRunningIndicator ?
+          <Tooltip
+            text={
+              <T
+                id="tickets.purchase-legacy.running"
+                m="Privacy Mixer or Autobuyer running, please shut them off before purchasing tickets."
+              />
+            }>
+            <PassphraseModalButton
+            disabled={true}
+            buttonLabel={purchaseLabel()}/>
+          </Tooltip> :
+          <KeyBlueButton
+            modalTitle={
+              <T
+                id="tickets.purchaseConfirmation.legacy"
+                m="Ticket Purchase Confirmation"
+              />
+            }
+            disabled={getIsValid && !getIsValid()}
+            onSubmit={onPurchaseTickets}
+            buttonLabel={purchaseLabel()}
+          />
       )}
     </div>
   </>

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_TicketAutoBuyer/Form.js
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_TicketAutoBuyer/Form.js
@@ -1,7 +1,7 @@
 import { AutoBuyerSwitch, AutoBuyerPassphraseModalSwitch } from "buttons";
 import { FormattedMessage as T } from "react-intl";
 import { DcrInput, AccountsSelect, LEGACY_StakePoolSelect } from "inputs";
-import { Balance, Subtitle } from "shared";
+import { Balance, Subtitle, Tooltip } from "shared";
 
 const TicketAutoBuyerForm = ({
   onStartAutoBuyer,
@@ -18,7 +18,8 @@ const TicketAutoBuyerForm = ({
   isFormValid,
   clicked,
   onClick,
-  notMixedAccounts
+  notMixedAccounts,
+  getRunningIndicator
 }) => (
   <>
     <Subtitle
@@ -31,6 +32,19 @@ const TicketAutoBuyerForm = ({
         {isTicketAutoBuyerEnabled ? (
           <AutoBuyerSwitch enabled onClick={onDisableTicketAutoBuyer} />
         ) : (
+          getRunningIndicator ?
+
+          <Tooltip
+            text={
+              <T
+                id="tickets.autobuyer-legacy.running"
+                m="Privacy Mixer or Purchase Ticket Attempt running, please shut them off before purchasing tickets."
+              />
+            }>
+            <AutoBuyerPassphraseModalSwitch
+              disabled={true}
+            />
+          </Tooltip> :
           <AutoBuyerPassphraseModalSwitch
             modalTitle={
               <T

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_TicketAutoBuyer/Form.js
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_TicketAutoBuyer/Form.js
@@ -33,7 +33,6 @@ const TicketAutoBuyerForm = ({
           <AutoBuyerSwitch enabled onClick={onDisableTicketAutoBuyer} />
         ) : (
           getRunningIndicator ?
-
           <Tooltip
             text={
               <T

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_Tickets.js
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_Tickets.js
@@ -36,6 +36,7 @@ const Tickets = ({
   isWatchingOnly,
   toggleIsLegacy,
   notMixedAccounts,
+  getRunningIndicator,
   ...props
 }) => {
   return (
@@ -56,7 +57,7 @@ const Tickets = ({
           }
         />
       ) : (
-        <PurchaseTickets {...{ ...props, notMixedAccounts }} />
+        <PurchaseTickets {...{ ...props, notMixedAccounts, getRunningIndicator }} />
       )}
       {isWatchingOnly ? (
         <UnsignedTickets {...{ ...props }} />
@@ -68,7 +69,7 @@ const Tickets = ({
           />
         </div>
       ) : (
-        <TicketAutoBuyer {...{ ...props, notMixedAccounts }} />
+        <TicketAutoBuyer {...{ ...props, notMixedAccounts, getRunningIndicator }} />
       )}
     </div>
   );

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/hooks.js
@@ -16,6 +16,7 @@ export function useLegacyPurchasePage(toggleShowVsp) {
   const isSavingStakePoolConfig = useSelector(sel.isSavingStakePoolConfig);
   const isImportingScript = useSelector(sel.isImportingScript);
   const notMixedAccounts = useSelector(sel.getNotMixedAccounts);
+  const getRunningIndicator = useSelector(sel.getRunningIndicator);
 
   const dispatch = useDispatch();
 
@@ -204,6 +205,7 @@ export function useLegacyPurchasePage(toggleShowVsp) {
     onEnableTicketAutoBuyer,
     onDisableTicketAutoBuyer,
     isTicketAutoBuyerEnabled,
-    notMixedAccounts
+    notMixedAccounts,
+    getRunningIndicator
   };
 }

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/index.js
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/index.js
@@ -70,7 +70,8 @@ const LEGACY_PurchasePage = ({
     onEnableTicketAutoBuyer,
     onDisableTicketAutoBuyer,
     isTicketAutoBuyerEnabled,
-    notMixedAccounts
+    notMixedAccounts,
+    getRunningIndicator
   } = useLegacyPurchasePage(toggleShowVsp);
 
   return getNoAvailableStakepools && !getStakepoolListingEnabled() ? (
@@ -119,6 +120,7 @@ const LEGACY_PurchasePage = ({
         onDisableTicketAutoBuyer,
         isTicketAutoBuyerEnabled,
         notMixedAccounts,
+        getRunningIndicator,
         ...props
       }}
     />

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/Page.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/Page.jsx
@@ -109,6 +109,7 @@ export function PurchasePage({
   notMixedAccounts,
   isVSPListingEnabled,
   onEnableVSPListing,
+  getRunningIndicator,
   ...props
 }) {
   return (
@@ -151,7 +152,8 @@ export function PurchasePage({
             isLoading,
             rememberedVspHost,
             toggleRememberVspHostCheckBox,
-            onRevokeTickets
+            onRevokeTickets,
+            getRunningIndicator
           }}
         />
       )}

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseForm.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseForm.jsx
@@ -29,7 +29,8 @@ const PurchaseTicketsForm = ({
   isLoading,
   rememberedVspHost,
   toggleRememberVspHostCheckBox,
-  notMixedAccounts
+  notMixedAccounts,
+  getRunningIndicator
 }) => (
   <>
     <div className={classNames(styles.purchaseForm, "is-row")}>
@@ -145,10 +146,20 @@ const PurchaseTicketsForm = ({
           {purchaseLabel()}
         </KeyBlueButton>
       ) : isLoading ? (
-        <KeyBlueButton disabled={true}>
-          <T id="tickets.purchase.loading" m="Loading" />
-        </KeyBlueButton>
+        <KeyBlueButton disabled={true} loading={true}/>
       ) : (
+        getRunningIndicator ?
+        <Tooltip
+          text={
+            <T
+              id="tickets.purchase.running"
+              m="Privacy Mixer or Autobuyer running, please shut them off before purchasing a ticket."
+            />
+          }>
+          <KeyBlueButton disabled={true}>
+            {purchaseLabel()}
+          </KeyBlueButton>
+        </Tooltip> :
         <PassphraseModalButton
           modalTitle={
             <T

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseForm.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseForm.jsx
@@ -1,8 +1,8 @@
 import { PassphraseModalButton, KeyBlueButton } from "buttons";
 import { AccountsSelect, NumTicketsInput, VSPSelect } from "inputs";
 import { FormattedMessage as T } from "react-intl";
-import { Balance } from "shared";
-import { classNames, Checkbox, Tooltip } from "pi-ui";
+import { Balance, Tooltip } from "shared";
+import { classNames, Checkbox } from "pi-ui";
 import styles from "../PurchaseTab.module.css";
 
 import "style/StakePool.less";
@@ -156,9 +156,9 @@ const PurchaseTicketsForm = ({
               m="Privacy Mixer or Autobuyer running, please shut them off before purchasing a ticket."
             />
           }>
-          <KeyBlueButton disabled={true}>
-            {purchaseLabel()}
-          </KeyBlueButton>
+          <PassphraseModalButton
+            disabled={true}
+            buttonLabel={purchaseLabel()}/>
         </Tooltip> :
         <PassphraseModalButton
           modalTitle={

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
@@ -24,7 +24,8 @@ const Tickets = ({ toggleIsLegacy }) => {
     onRevokeTickets,
     notMixedAccounts,
     isVSPListingEnabled,
-    onEnableVSPListing
+    onEnableVSPListing,
+    getRunningIndicator
   } = usePurchaseTab();
 
   const [account, setAccount] = useState(defaultSpendingAccount);
@@ -100,7 +101,8 @@ const Tickets = ({ toggleIsLegacy }) => {
         onRevokeTickets,
         notMixedAccounts,
         isVSPListingEnabled,
-        onEnableVSPListing
+        onEnableVSPListing,
+        getRunningIndicator
       }}
     />
   );

--- a/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/Form.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/Form.jsx
@@ -1,7 +1,7 @@
 import { AutoBuyerSwitch, AutoBuyerPassphraseModalSwitch } from "buttons";
 import { FormattedMessage as T } from "react-intl";
 import { DcrInput, AccountsSelect, VSPSelect } from "inputs";
-import { Balance, Subtitle } from "shared";
+import { Balance, Subtitle, Tooltip } from "shared";
 import styles from "../PurchaseTab.module.css";
 
 const TicketAutoBuyerForm = ({
@@ -19,7 +19,8 @@ const TicketAutoBuyerForm = ({
   isValid,
   onClick,
   clicked,
-  notMixedAccounts
+  notMixedAccounts,
+  getRunningIndicator
 }) => (
   <>
     <Subtitle
@@ -30,6 +31,18 @@ const TicketAutoBuyerForm = ({
         {isRunning ? (
           <AutoBuyerSwitch enabled onClick={onStopAutoBuyer} />
         ) : (
+          (getRunningIndicator ? (
+            <Tooltip
+              text={
+                <T
+                  id="tickets.autobuyer.running"
+                  m="Privacy Mixer or Purchase Ticket Attempt running, please shut them off before starting autobuyer."
+                />
+              }>
+              <AutoBuyerPassphraseModalSwitch
+                isValid={false}/>
+            </Tooltip>
+          ) :
           <AutoBuyerPassphraseModalSwitch
             modalTitle={
               <T
@@ -77,7 +90,7 @@ const TicketAutoBuyerForm = ({
             onClick={onClick}
             isValid={isValid}
           />
-        )}
+        ))}
         <div className="stakepool-auto-buyer-row-portion-half">
           <div className="stakepool-autobuyer-label">
             <T id="vsp.autobuyer.accountFrom" m="From" />:

--- a/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/TicketAutoBuyer.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/TicketAutoBuyer.jsx
@@ -12,7 +12,8 @@ function TicketAutoBuyer({ intl }) {
     buyerAccount,
     buyerBalanceToMantain,
     buyerVSP,
-    notMixedAccounts
+    notMixedAccounts,
+    getRunningIndicator
   } = usePurchaseTab();
   const [balanceToMaintain, setBalanceToMaintain] = useState(
     buyerBalanceToMantain
@@ -79,7 +80,8 @@ function TicketAutoBuyer({ intl }) {
         isValid,
         onClick,
         clicked,
-        notMixedAccounts
+        notMixedAccounts,
+        getRunningIndicator
       }}
     />
   );

--- a/app/components/views/TicketsPage/PurchaseTab/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/hooks.js
@@ -100,6 +100,8 @@ export const usePurchaseTab = () => {
   const mixedAccount = useSelector(sel.getMixedAccount);
   const changeAccount = useSelector(sel.getChangeAccount);
 
+  const getRunningIndicator = useSelector(sel.getRunningIndicator);
+
   return {
     spvMode,
     blocksNumberToNextTicket,
@@ -131,6 +133,7 @@ export const usePurchaseTab = () => {
     notMixedAccounts,
     isVSPListingEnabled,
     onEnableVSPListing,
-    onListUnspentOutputs
+    onListUnspentOutputs,
+    getRunningIndicator
   };
 };


### PR DESCRIPTION
To avoid issues and to help UX a bit, we should be disallowing various features to be run at the same time.

Currently when mixer, autobuyer or ticket purchases are running we disable all the other buttons as well as the send transactions.

I've also included a change to the sidebar running indicator css to remove the animation that has been shown to be really bad for performance.