### PR TITLE
Fix GUI reloading through menu bar and F5 shortcut

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -113,7 +113,7 @@ class App extends React.Component {
     return false;
   }
 
-  onReloadRequested(event) {
+  onReloadRequested() {
     log("info", "Main app received reload UI request");
     this.refreshing = true;
     ipcRenderer.send("app-reload-ui");

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -116,7 +116,7 @@ class App extends React.Component {
   onReloadRequested(event) {
     log("info", "Main app received reload UI request");
     this.refreshing = true;
-    event.sender.send("app-reload-ui");
+    ipcRenderer.send("app-reload-ui");
   }
 
   render() {

--- a/app/main_dev/templates.js
+++ b/app/main_dev/templates.js
@@ -149,7 +149,7 @@ const regularTemplate = (mainWindow, locale) => [
         label: locale.messages["appMenu.reloadUI"],
         accelerator: "F5",
         click() {
-          mainWindow.webContents.send("app-reload-requested", mainWindow);
+          mainWindow.webContents.send("app-reload-requested");
         }
       },
       {


### PR DESCRIPTION
Closes https://github.com/decred/decrediton/issues/3228.

According to [Electron docs](https://github.com/electron/electron/blob/v9.4.0/docs/api/web-contents.md#contentssendchannel-args), since version 9, ``webContents`` can serialize only a [strict set of types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) that no more includes specific Electron ones. Thus, it's possible to bypass this limitation by using ``ipcRenderer.send`` method to send a message from the renderer process to the main process, instead of injecting the event emitter of the last through a callback function argument.