### PR TITLE
[Tx history] fix filter

### DIFF
--- a/app/components/views/TransactionsPage/HistoryTab/HistoryTab.jsx
+++ b/app/components/views/TransactionsPage/HistoryTab/HistoryTab.jsx
@@ -92,8 +92,10 @@ const HistoryTab = () => {
         clearTimeout(isChangingFilterTimer);
       }
       const changeFilter = (newFilterOpt) => {
-        const newFilter = { ...transactionsFilter };
         const { type, direction } = newFilterOpt;
+        delete(newFilterOpt.type);
+        delete(newFilterOpt.direction);
+        const newFilter = { ...transactionsFilter, ...newFilterOpt };
         // if type is -1 it is all options, so we clean the filter.
         if (type === -1) {
           newFilter.types = [];

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -800,7 +800,11 @@ export const filteredRegularTxs = createSelector(
       .filter((v) =>
         filter.maxAmount ? Math.abs(v.txAmount) <= filter.maxAmount : true
       )
-      .filter((v) => v.mixedTx == filter.types.includes(MIXED));
+      .filter(
+        (v) =>
+          (filter.directions.length == 0 && filter.types.length == 0) || // All directions
+          v.mixedTx == filter.types.includes(MIXED)
+      );
 
     return filteredTxs;
   }


### PR DESCRIPTION
After #3194, the `Filter by address`, list direction, and the amount range tx filters not working properly. 
Also, I noticed that the `All` option doesn't list `Mixed` transactions.

This PR fixes these issues.