### PR TITLE
[Wallet restore] Unhandled rejected promise

### DIFF
--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -256,7 +256,9 @@ export const useGetStarted = () => {
           return;
         }
         if (isCreateNewWallet === false) {
-          await onProcessManagedTickets(passPhrase);
+          await onProcessManagedTickets(passPhrase).catch((error) => {
+            console.log("onProcessManagedTickets failed:", error);
+          });
           onSendContinue();
         } else {
           onSendContinue();


### PR DESCRIPTION
During wallet restore if syncing vsp tickets time out, the rejected promise is unhandled and the wallet restoring process stop. This diff fixes this.

<img width="356" alt="DeepinScreenshot_select-area_20210217154450" src="https://user-images.githubusercontent.com/52497040/108222794-65cde900-7139-11eb-99f6-4525df8b77b8.png">
