### PR TITLE
Improve error handling on wallet create and restore views

### DIFF
--- a/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
+++ b/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
@@ -70,12 +70,13 @@ const CreateWalletPage = ({ createWalletRef, onSendBack }) => {
   );
 
   const checkIsValid = useCallback(() => {
-    const { seed, passPhrase } = current.context;
+    const { seed, passPhrase, error } = current.context;
     // We validate our seed and passphrase at their specific components
     // So if they are set at the machine it means they have passed validation.
     if (!seed || !passPhrase) return setIsValid(false);
     if (seed.length === 0) return setIsValid(false);
     if (passPhrase.length === 0) return setIsValid(false);
+    if (error !== "") return setIsValid(false);
 
     return setIsValid(true);
   }, [setIsValid, current.context]);

--- a/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
+++ b/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
@@ -76,7 +76,7 @@ const CreateWalletPage = ({ createWalletRef, onSendBack }) => {
     if (!seed || !passPhrase) return setIsValid(false);
     if (seed.length === 0) return setIsValid(false);
     if (passPhrase.length === 0) return setIsValid(false);
-    if (error !== "") return setIsValid(false);
+    if (error) return setIsValid(false);
 
     return setIsValid(true);
   }, [setIsValid, current.context]);

--- a/app/components/views/GetStartedPage/CreateWalletPage/ExistingSeed/ExistingSeed.jsx
+++ b/app/components/views/GetStartedPage/CreateWalletPage/ExistingSeed/ExistingSeed.jsx
@@ -151,7 +151,10 @@ const ExistingSeed = ({
     } else if (prevHexSeed === hexSeed) {
       return;
     }
-    validateSeed(seedWords).catch((err) => onError(err));
+    validateSeed(seedWords).catch((err) => {
+      setSeed([]);
+      return onError(err);
+    });
   }, [
     seedWords,
     seedType,

--- a/app/stateMachines/CreateWalletStateMachine.js
+++ b/app/stateMachines/CreateWalletStateMachine.js
@@ -78,19 +78,10 @@ export const CreateWalletMachine = Machine({
           actions: [
             assign({
               passPhrase: (context, event) =>
-                event.passPhrase
-                  ? event.passPhrase
-                  : context.passPhrase
-                  ? context.passPhrase
-                  : "",
+                event.passPhrase ?? context.passPhrase ?? "",
               seed: (context, event) =>
                 event.seed ? event.seed : context.seed ? context.seed : [],
-              error: (context, event) =>
-                event.error !== undefined
-                  ? event.error
-                  : context.error
-                  ? context.error
-                  : ""
+              error: (context, event) => event.error ?? context.error ?? ""
             })
           ]
         }
@@ -119,19 +110,10 @@ export const CreateWalletMachine = Machine({
           actions: [
             assign({
               passPhrase: (context, event) =>
-                event.passPhrase
-                  ? event.passPhrase
-                  : context.passPhrase
-                  ? context.passPhrase
-                  : "",
+                event.passPhrase ?? context.passPhrase ?? "",
               seed: (context, event) =>
                 event.seed ? event.seed : context.seed ? context.seed : [],
-              error: (context, event) =>
-                event.error !== undefined
-                  ? event.error
-                  : context.error
-                  ? context.error
-                  : ""
+              error: (context, event) => event.error ?? context.error ?? ""
             })
           ]
         }


### PR DESCRIPTION
closes #3235

Now the `Create Wallet` button reacts to invalid inputs properly. 
After the button was enabled, it is toggled to disabled state when:
- passphrases cleared or,
- passphrases do not match or,
- seeds are not valid or,
- one or more seeds are deleted

Automated tests were expanded to cover this new behavior.