### PR TITLE
TabsHeader: Fix wrong aligned tabs in finished propsoals list.

### DIFF
--- a/app/components/shared/TabsHeader/TabsHeader.jsx
+++ b/app/components/shared/TabsHeader/TabsHeader.jsx
@@ -1,36 +1,33 @@
 import styles from "./TabsHeader.module.css";
 import { Tabs, Tab, classNames } from "pi-ui";
 
-const TabsHeader = ({ tabs, setActiveTabIndex, activeTabIndex, tabsWrapperClassName, contentClassName }) => {
+const TabsHeader = ({
+  tabs,
+  setActiveTabIndex,
+  activeTabIndex,
+  className,
+  contentClassName
+}) => {
   return (
     <div className={styles.tabsContainer}>
-      <div
-        className={classNames(
-          styles.tabsWrapper,
-          tabsWrapperClassName && tabsWrapperClassName
-        )}>
+      <div className={styles.tabsWrapper}>
         <Tabs
           activeTabIndex={activeTabIndex}
           onSelectTab={setActiveTabIndex}
-          contentClassName={classNames(
-            styles.tabsContent,
-            contentClassName && contentClassName
-          )}
-          className={styles.tabs}>
-          {tabs.map((tab, index) => {
-            return (
-              <Tab
-                label={tab.label}
-                key={index}
-                className={classNames(
-                  styles.tab,
-                  tab.icon,
-                  activeTabIndex === index ? styles.active : styles.inactive
-                )}>
-                {tab.component}
-              </Tab>
-            );
-          })}
+          contentClassName={classNames(styles.tabsContent, contentClassName)}
+          className={classNames(styles.tabs, className)}>
+          {tabs.map((tab, index) => (
+            <Tab
+              label={tab.label}
+              key={index}
+              className={classNames(
+                styles.tab,
+                tab.icon,
+                activeTabIndex === index ? styles.active : styles.inactive
+              )}>
+              {tab.component}
+            </Tab>
+          ))}
         </Tabs>
       </div>
     </div>

--- a/app/components/shared/TabsHeader/TabsHeader.module.css
+++ b/app/components/shared/TabsHeader/TabsHeader.module.css
@@ -2,16 +2,15 @@
   background-color: var(--background-back-color);
   width: 100%;
 }
+
 .tabsWrapper {
-  padding-top: 20px;
-  width: 883px;
   position: relative;
 }
 
 .tabs {
   position: absolute;
-  right: 43px;
-  top: -40px;
+  right: 0;
+  top: 10px;
   overflow: hidden !important;
 }
 .active {
@@ -29,19 +28,7 @@
   border-color: transparent !important;
 }
 
-@media screen and (max-width: 1179px) {
-  .tabsWrapper {
-    width: 735px;
-  }
-}
 @media screen and (max-width: 768px) {
-  .tabsWrapper {
-    width: 375px;
-  }
-  .tabs {
-    right: -10px;
-    top: -40px;
-  }
   .tabs > li > span {
     color: transparent;
   }

--- a/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.module.css
@@ -1,8 +1,7 @@
 .tabs {
-  text-align: right;
   max-width: 738px;
   margin-left: 85px;
-  margin-top: 15px;
+  height: 40px;
 }
 
 .tabs > div > ul {

--- a/app/components/views/HomePage/HomePage.jsx
+++ b/app/components/views/HomePage/HomePage.jsx
@@ -76,7 +76,7 @@ export default () => {
           setActiveTabIndex,
           activeTabIndex,
           contentClassName: styles.tabsContent,
-          tabsWrapperClassName: styles.tabsWrapper
+          className: styles.tabs
         }}
       />
       <div

--- a/app/components/views/HomePage/HomePage.module.css
+++ b/app/components/views/HomePage/HomePage.module.css
@@ -104,8 +104,10 @@
 .tabsContent {
   width: 100%;
 }
-.tabsWrapper {
-  height: 250px;
+
+.tabs {
+  top: -55px;
+  right: 50px;
 }
 
 @media screen and (max-width: 1179px) {


### PR DESCRIPTION
This improves the alignment of TabHeader component which used is in the finished proposals list.

It Replaces `TabsHeader`'s `tabsWrapperClassName` prop with a new `className` prop which is used to override
the default absolute position css attributes.
With that I was able to position the tabs in `HomePage` and  `ProposalsFilter` components differently.