### PR TITLE
fix initial mixing account balances on the privacy page

### DIFF
--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -3,7 +3,11 @@ import Promise from "promise";
 import * as sel from "selectors";
 import * as wallet from "wallet";
 import { getWalletCfg } from "config";
-import { getAcctSpendableBalance, getAccountsAttempt } from "./ClientActions";
+import {
+  getAcctSpendableBalance,
+  getAccountsAttempt,
+  getMixerAcctsSpendableBalances
+} from "./ClientActions";
 import {
   MIN_RELAY_FEE_ATOMS,
   MIN_MIX_DENOMINATION_ATOMS,
@@ -183,6 +187,7 @@ export const createNeededAccounts = (
         changeNumber
       })
     );
+    dispatch(getMixerAcctsSpendableBalances());
   } catch (error) {
     dispatch({ type: CREATEMIXERACCOUNTS_FAILED, error });
   }


### PR DESCRIPTION
After creating default mixing accounts on the privacy page the `Unmixed Balance` and the `Mixed Balance` value is not 0.00 DCR, but the default account's value:
<img width="565" alt="DeepinScreenshot_select-area_20210223173408" src="https://user-images.githubusercontent.com/52497040/108877151-3e769080-75ff-11eb-87e7-f8886bd881e9.png">
 Closing and reopening the privacy page updates the balances to the correct value (0.00 DCR)

This diff fixes this issue.
