### PR TITLE
Reverse txhash to avoid missing Transaction errors

### DIFF
--- a/app/actions/TransactionActions.js
+++ b/app/actions/TransactionActions.js
@@ -10,7 +10,7 @@ import {
 import { getVSPTicketsByFeeStatus } from "./VSPActions";
 import { TransactionDetails } from "middleware/walletrpc/api_pb";
 import { getStartupStats } from "./StatisticsActions";
-import { hexToBytes, strHashToRaw } from "helpers";
+import { hexToBytes, strHashToRaw, rawHashToHex } from "helpers";
 import {
   RECENT_TX_COUNT,
   BATCH_TX_COUNT,
@@ -692,7 +692,7 @@ const getMissingStakeTxData = async (
     const spenderHash = ticket.spender.getHash();
     if (spenderHash) {
       try {
-        const spender = await wallet.getTransaction(walletService, spenderHash);
+        const spender = await wallet.getTransaction(walletService, rawHashToHex(spenderHash));
         spenderTx = spender.tx;
       } catch (error) {
         if (String(error).indexOf("NOT_FOUND") === -1) {


### PR DESCRIPTION
There were pretty constant `wallet.TransactionSummary(XXXX): item does not exist` errors being logged, but no noticeable problems in the UI.  Apparently the ticket spender hash that was being requested here was reversed so the tx was thought to be missing. 