### PR TITLE
[css modules] Ditch AccountRow & AccountsPage .less files.

### DIFF
--- a/app/components/shared/VericalAccordion/VerticalAccordion.jsx
+++ b/app/components/shared/VericalAccordion/VerticalAccordion.jsx
@@ -12,7 +12,8 @@ const VerticalAccordion = ({
   className,
   header,
   headerClassName,
-  arrowClassName
+  arrowClassName,
+  activeArrowClassName
 }) => {
   const [childHeight, setChildHeight] = useState(0);
   const childRef = useCallback(
@@ -99,6 +100,7 @@ const VerticalAccordion = ({
         <div
           className={classNames(
             disabled && "disabled",
+            show && activeArrowClassName,
             styles.arrow,
             arrowClassName
           )}

--- a/app/components/views/AccountsPage/Accounts/AccountRow/AccountRowContent.jsx
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/AccountRowContent.jsx
@@ -1,7 +1,6 @@
 import { FormattedMessage as T } from "react-intl";
 import { Balance, VerticalAccordion } from "shared";
-import "style/AccountRow.less";
-import style from "../Accounts.module.css";
+import styles from "../Accounts.module.css";
 import { classNames } from "pi-ui";
 import { DEFAULT_ACCOUNT } from "constants";
 
@@ -18,14 +17,14 @@ const Header = React.memo(
     return (
       <div
         className={classNames(
-          style.detailsTop,
-          hidden && style.hidden,
-          isImported(account) && style.imported,
-          isImported(account) && !hasTickets && style.disabled,
-          isMixed && style.mixed,
-          isChange && style.unmixed
+          styles.detailsTop,
+          hidden && styles.hidden,
+          isImported(account) && styles.imported,
+          isImported(account) && !hasTickets && styles.disabled,
+          isMixed && styles.mixed,
+          isChange && styles.unmixed
         )}>
-        <div className={style.topName}>
+        <div className={styles.topName}>
           {account.accountName === DEFAULT_ACCOUNT ? (
             <T id="accounts.name.default" m="Primary Account" />
           ) : (
@@ -33,18 +32,18 @@ const Header = React.memo(
           )}
           {hidden ? <span>(hidden)</span> : null}
         </div>
-        <div className={style.topFunds}>
-          <div className={style.topTotalValue}>
+        <div className={styles.topFunds}>
+          <div className={styles.topTotalValue}>
             {isImported(account) ? (
               <Balance amount={account.votingAuthority} />
             ) : (
               <Balance amount={account.total} />
             )}
           </div>
-          <div className={classNames(style.topSpendable, style.isRow)}>
+          <div className={classNames(styles.topSpendable, styles.isRow)}>
             <T id="accounts.row.spendable" m="Spendable:" />
             <Balance
-              classNameWrapper={style.topSpendableValue}
+              classNameWrapper={styles.topSpendableValue}
               flat
               amount={account.spendable}
             />
@@ -76,9 +75,9 @@ const Row = ({
     disabled={isImported(account) && !hasTickets}
     onToggleAccordion={onToggleShowDetails}
     show={isShowingDetails}
-    //TODO: encapsulate end provide .active CSS class in shared/VerticalAccordion.jsx
-    arrowClassName="vertical-accordion-arrow"
-    className={classNames(style.detailsBottom, "account-row-details-bottom")}>
+    arrowClassName={styles.accordionArrow}
+    activeArrowClassName={styles.activeAccordionArrow}
+    className={styles.detailsBottom}>
     {isShowingDetails ? (
       isShowingRenameAccount ? (
         getRenameAccountStyles()

--- a/app/components/views/AccountsPage/Accounts/AccountRow/RenameAccount.jsx
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/RenameAccount.jsx
@@ -19,7 +19,7 @@ const RenameAccount = ({
   intl,
   hasFailedAttempt
 }) => (
-  <div className={style.renameBottom} key={"details" + account.accountNumber}>
+  <div className={style.renameBottom} key={`details${account.accountNumber}`}>
     <div className={style.renameBottomTitle}>
       <T id="accounts.rename" m="Rename Account" />
     </div>
@@ -30,8 +30,8 @@ const RenameAccount = ({
       <div className={style.renameBottomValue}>
         <TextInput
           required
-          autoFocus={true}
-          key={"rename" + account.accountNumber}
+          autoFocus
+          key={`rename${account.accountNumber}`}
           placeholder={intl.formatMessage(messages.newNamePlaceholder)}
           maxLength="50"
           value={renameAccountName}

--- a/app/components/views/AccountsPage/Accounts/AccountRow/index.js
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AccountRow";

--- a/app/components/views/AccountsPage/Accounts/Accounts.module.css
+++ b/app/components/views/AccountsPage/Accounts/Accounts.module.css
@@ -1,3 +1,14 @@
+.accordionArrow {
+  right: 0;
+  left: 65px;
+  top: 44%;
+  transform: rotate(0deg);  
+}
+
+.activeAccordionArrow {
+  background-color: var(--sidebar-color);
+}
+
 .infoFields strong {
   color: var(--input-color);
 }

--- a/app/components/views/AccountsPage/Accounts/AccountsList.jsx
+++ b/app/components/views/AccountsPage/Accounts/AccountsList.jsx
@@ -1,10 +1,7 @@
 import { FormattedMessage as T } from "react-intl";
-import AccountRow from "./AccountRow/AccountRow";
+import AccountRow from "./AccountRow";
 import { DecredLoading } from "indicators";
 import { InfoDocModalButton } from "buttons";
-import { classNames } from "pi-ui";
-// XXX this should go away!
-import "style/AccountsPage.less";
 import { Subtitle } from "shared";
 import style from "./Accounts.module.css";
 
@@ -50,8 +47,7 @@ const AccountsList = ({
           className={style.isRow}
           children={<SubtitleInfoIcon />}
         />
-        {/* TODO: encapsulate end provide .vertical-accordion-arrow CSS class in shared/VerticalAccordion.jsx */}
-        <div className={classNames(style.contentNest, "account-content-nest")}>
+        <div className={style.contentNest}>
           {accounts.map((account) => (
             <AccountRow
               {...{

--- a/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfo.module.css
+++ b/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfo.module.css
@@ -1,3 +1,13 @@
+.accordion {
+  margin-bottom: 40px;
+}
+
+.accordionArrow {
+  top: 15px;
+  right: 20px;
+  height: 13px;
+}
+
 .area {
   background-color: var(--background-back-color);
   padding: 16px 19px 16px 19px;
@@ -137,6 +147,10 @@
 }
 
 @media screen and (max-width: 768px) {
+  .accordion {
+    margin-bottom: 30px;
+  }
+
   .area {
     grid-template-areas:
       "purchaseTicketsTitle purchaseTicketsTitle"

--- a/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfoDisplay.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfoDisplay.jsx
@@ -52,123 +52,120 @@ const StakeInfoDisplay = ({
   lastVotedTicket,
   currencyDisplay,
   tsDate
-}) => {
-  return (
-    <>
-      <Subtitle
-        title={<T id="stake.stackingOverview" m="Staking Overview" />}
-      />
-      <VerticalAccordion
-        header={
-          <div className={styles.area}>
-            {isSPV ? (
-              <StakeInfoDisplayItem
-                label={<T id="stake.unspentTickets" m="Unspent Tickets" />}
-                value={
-                  <StakeInfoDisplayTicketCount value={unspentTicketsCount} />
-                }
-              />
-            ) : (
-              <StakeInfoDisplayItem
-                label={<T id="stake.liveTickets" m="Live" />}
-                value={<StakeInfoDisplayTicketCount value={liveTicketsCount} />}
-                foot={
-                  <T
-                    id="stake.liveTicketsFoot"
-                    m="Own Mempool: {ownMempoolTickets}       Immature: {immatureTickets }"
-                    values={{
-                      ownMempoolTickets: (
-                        <FormattedNumber value={ownMempoolTicketsCount} />
-                      ),
-                      immatureTickets: (
-                        <FormattedNumber value={immatureTicketsCount} />
-                      )
-                    }}
-                  />
-                }
-              />
-            )}
+}) => (
+  <>
+    <Subtitle title={<T id="stake.stackingOverview" m="Staking Overview" />} />
+    <VerticalAccordion
+      header={
+        <div className={styles.area}>
+          {isSPV ? (
             <StakeInfoDisplayItem
-              label={<T id="stakeSPV.totalVotedTickets" m="Total Voted" />}
-              value={<StakeInfoDisplayTicketCount value={votedTicketsCount} />}
-            />
-            <StakeInfoDisplayItem
-              label={<T id="stake.lastVotedTicket" m="Last Ticket Voted" />}
+              label={<T id="stake.unspentTickets" m="Unspent Tickets" />}
               value={
-                lastVotedTicket ? (
-                  <FormattedRelative
-                    value={tsDate(lastVotedTicket.leaveTimestamp)}
-                  />
-                ) : (
-                  <T id="stake.lastVotedTicket.none" m="None" />
-                )
+                <StakeInfoDisplayTicketCount value={unspentTicketsCount} />
               }
+            />
+          ) : (
+            <StakeInfoDisplayItem
+              label={<T id="stake.liveTickets" m="Live" />}
+              value={<StakeInfoDisplayTicketCount value={liveTicketsCount} />}
               foot={
-                lastVotedTicket && (
-                  <Link
-                    to={`/transaction/history/${lastVotedTicket.txHash}`}
-                    className={styles.foot}>
-                    <span className={styles.purchaseTicketFoot}>
-                      <T
-                        id="stake.lastTicketLink"
-                        m="{shortHash}... View &rarr;"
-                        values={{
-                          shortHash: lastVotedTicket.txHash.substr(0, 6)
-                        }}
-                      />
-                    </span>
-                  </Link>
-                )
-              }
-            />
-            <StakeInfoDisplayItem
-              label={<T id="stake.totalRewards" m="Total Rewards Earned" />}
-              value={
                 <T
-                  id="stake.totalRewardsValue"
-                  m="{value} {currency}"
+                  id="stake.liveTicketsFoot"
+                  m="Own Mempool: {ownMempoolTickets}       Immature: {immatureTickets }"
                   values={{
-                    value: (
-                      <Balance
-                        hideCurrency
-                        noSmallAmount
-                        classNameWrapper={styles.balance}
-                        amount={totalSubsidy}
-                      />
+                    ownMempoolTickets: (
+                      <FormattedNumber value={ownMempoolTicketsCount} />
                     ),
-                    currency: (
-                      <span className={styles.purchaseTicketLabel}>
-                        {currencyDisplay}
-                      </span>
+                    immatureTickets: (
+                      <FormattedNumber value={immatureTicketsCount} />
                     )
                   }}
                 />
               }
             />
-          </div>
-        }
-        show={isShowingDetails}
-        onToggleAccordion={onToggleStakeinfo}
-        className="detailsAccordion"
-        arrowClassName="vertical-accordion-arrow">
-        <StakeInfoDetails
-          {...{
-            ticketPoolSize,
-            votedTicketsCount,
-            allMempoolTicketsCount,
-            missedTicketsCount,
-            revokedTicketsCount,
-            expiredTicketsCount,
-            immatureTicketsCount,
-            ownMempoolTicketsCount,
-            liveTicketsCount,
-            totalSubsidy,
-            isSPV
-          }}
-        />
-      </VerticalAccordion>
-    </>
-  );
-};
+          )}
+          <StakeInfoDisplayItem
+            label={<T id="stakeSPV.totalVotedTickets" m="Total Voted" />}
+            value={<StakeInfoDisplayTicketCount value={votedTicketsCount} />}
+          />
+          <StakeInfoDisplayItem
+            label={<T id="stake.lastVotedTicket" m="Last Ticket Voted" />}
+            value={
+              lastVotedTicket ? (
+                <FormattedRelative
+                  value={tsDate(lastVotedTicket.leaveTimestamp)}
+                />
+              ) : (
+                <T id="stake.lastVotedTicket.none" m="None" />
+              )
+            }
+            foot={
+              lastVotedTicket && (
+                <Link
+                  to={`/transaction/history/${lastVotedTicket.txHash}`}
+                  className={styles.foot}>
+                  <span className={styles.purchaseTicketFoot}>
+                    <T
+                      id="stake.lastTicketLink"
+                      m="{shortHash}... View &rarr;"
+                      values={{
+                        shortHash: lastVotedTicket.txHash.substr(0, 6)
+                      }}
+                    />
+                  </span>
+                </Link>
+              )
+            }
+          />
+          <StakeInfoDisplayItem
+            label={<T id="stake.totalRewards" m="Total Rewards Earned" />}
+            value={
+              <T
+                id="stake.totalRewardsValue"
+                m="{value} {currency}"
+                values={{
+                  value: (
+                    <Balance
+                      hideCurrency
+                      noSmallAmount
+                      classNameWrapper={styles.balance}
+                      amount={totalSubsidy}
+                    />
+                  ),
+                  currency: (
+                    <span className={styles.purchaseTicketLabel}>
+                      {currencyDisplay}
+                    </span>
+                  )
+                }}
+              />
+            }
+          />
+        </div>
+      }
+      show={isShowingDetails}
+      onToggleAccordion={onToggleStakeinfo}
+      className={styles.accordion}
+      arrowClassName={styles.accordionArrow}
+      >
+      <StakeInfoDetails
+        {...{
+          ticketPoolSize,
+          votedTicketsCount,
+          allMempoolTicketsCount,
+          missedTicketsCount,
+          revokedTicketsCount,
+          expiredTicketsCount,
+          immatureTicketsCount,
+          ownMempoolTicketsCount,
+          liveTicketsCount,
+          totalSubsidy,
+          isSPV
+        }}
+      />
+    </VerticalAccordion>
+  </>
+);
 
 export default StakeInfoDisplay;

--- a/app/style/AccountRow.less
+++ b/app/style/AccountRow.less
@@ -1,3 +1,0 @@
-.account-row-details-bottom.active {
-  background-color: var(--sidebar-color);
-}

--- a/app/style/AccountsPage.less
+++ b/app/style/AccountsPage.less
@@ -1,6 +1,0 @@
-.account-content-nest .vertical-accordion-arrow {
-  right: 0px;
-  left: 65px;
-  top: 44%;
-  transform: rotate(0deg);
-}

--- a/app/style/PurchaseTickets.less
+++ b/app/style/PurchaseTickets.less
@@ -342,16 +342,6 @@
   }
 }
 
-.detailsAccordion .vertical-accordion-arrow {
-  top: 15px !important;
-  right: 20px !important;
-  height: 13px !important;
-}
-
-.detailsAccordion {
-  margin-bottom: 40px;
-}
-
 .input-purchase-ticket-valid-message-area {
   width: 200px;
   position: relative;
@@ -398,10 +388,6 @@
 }
 
 @media screen and (max-width: 768px) {
-  .detailsAccordion {
-    margin-bottom: 30px;
-  }
-
   .purchase-ticket-advanced-info-grid {
     grid-template-columns: repeat(2, max-content);
 


### PR DESCRIPTION
This gets rid of two more `.less` files: `AccountRow.less`, `AccountsPage.less`.
Also, it adds new `activeArrowClassName` prop to `VerticalAccordion` to make it possible for consumers
to custom style active arrows.

Part of #2439 - and another good example why local encapsulate css modules makes our app much more readable, 
predictable, debuggable & flexible.