### PR TITLE
Add icon type constants

### DIFF
--- a/app/components/layout/StandaloneHeader.js
+++ b/app/components/layout/StandaloneHeader.js
@@ -4,14 +4,14 @@ import DescriptionHeader from "./DescriptionHeader";
 const StandaloneHeader = ({
   title,
   description,
-  iconClassName,
+  iconType,
   actionButton
 }) => {
   return (
     <div className="standalone-page-header">
       <TitleHeader
         title={title}
-        iconClassName={iconClassName}
+        iconType={iconType}
         optionalButton={actionButton}
       />
       <DescriptionHeader description={description} />

--- a/app/components/layout/TitleHeader/TitleHeader.jsx
+++ b/app/components/layout/TitleHeader/TitleHeader.jsx
@@ -1,11 +1,11 @@
 import { classNames } from "pi-ui";
 import styles from "./TitleHeader.module.css";
 
-const TitleHeader = ({ title, iconClassName, optionalButton }) => (
+const TitleHeader = ({ title, iconType, optionalButton }) => (
   <div className={classNames(styles.container, "is-row")}>
     <div className="is-row">
       <div className={styles.icon}>
-        <div className={styles[iconClassName]} />
+        <div className={styles[iconType]} />
       </div>
       <div className={styles.title}>{title}</div>
     </div>

--- a/app/components/views/AccountsPage/AccountsPage.jsx
+++ b/app/components/views/AccountsPage/AccountsPage.jsx
@@ -5,6 +5,7 @@ import { PassphraseModalButton } from "buttons";
 import { AddAccountModal } from "modals";
 import { WatchOnlyWarnNotification } from "shared";
 import { useAccountsPage } from "./hooks";
+import { ACCOUNTS_ICON } from "constants";
 
 const AccountsPageHeader = React.memo(
   ({ isCreateAccountDisabled, onGetNextAccountAttempt }) => (
@@ -18,7 +19,7 @@ const AccountsPageHeader = React.memo(
           }
         />
       }
-      iconClassName={"accounts"}
+      iconType={ACCOUNTS_ICON}
       actionButton={
         <WatchOnlyWarnNotification isActive={isCreateAccountDisabled}>
           <PassphraseModalButton

--- a/app/components/views/GovernancePage/GovernancePage.jsx
+++ b/app/components/views/GovernancePage/GovernancePage.jsx
@@ -4,10 +4,11 @@ import { Switch, Redirect } from "react-router-dom";
 import ProposalsTab from "./Proposals/ProposalsTab";
 import VotingPrefsTab from "./Blockchain/Blockchain";
 import TabHeader from "./TabHeader/TabHeader";
+import { GOVERNANCE_ICON } from "constants";
 
 const PageHeader = () => (
   <TitleHeader
-    iconClassName="governance"
+    iconType={GOVERNANCE_ICON}
     title={<T id="governance.title" m="Governance" />}
   />
 );

--- a/app/components/views/LNPage/ConnectPage.js
+++ b/app/components/views/LNPage/ConnectPage.js
@@ -20,6 +20,7 @@ import {
   LNWALLET_STARTUPSTAGE_SCBRESTORE
 } from "actions/LNActions";
 import "style/ConnectPage.css";
+import { LN_ICON } from "constants";
 
 const ConnectPageHeader = () => (
   <StandaloneHeader
@@ -30,7 +31,7 @@ const ConnectPageHeader = () => (
         m={"Start, unlock and connect to the dcrlnd wallet."}
       />
     }
-    iconClassName="ln"
+    iconType={LN_ICON}
   />
 );
 
@@ -45,7 +46,7 @@ const CreateLNWalletPageHeader = () => (
         }
       />
     }
-    iconClassName="ln"
+    iconType={LN_ICON}
   />
 );
 

--- a/app/components/views/LNPage/index.js
+++ b/app/components/views/LNPage/index.js
@@ -11,10 +11,11 @@ import NetworkTabHeader from "./NetworkTab/NetworkTabHeader";
 import NetworkTab from "./NetworkTab/NetworkTab";
 import WatchtowersTab from "./WatchtowersTab/WatchtowersTab";
 import WatchtowersTabHeader from "./WatchtowersTab/WatchtowersTabHeader";
+import { LN_ICON } from "constants";
 
 const LNPageHeader = () => (
   <TitleHeader
-    iconClassName="ln"
+    iconType={LN_ICON}
     title={<T id="ln.title" m="Lightning Network" />}
   />
 );

--- a/app/components/views/ListUtxo/ListUtxo.jsx
+++ b/app/components/views/ListUtxo/ListUtxo.jsx
@@ -7,10 +7,11 @@ import { AccountsSelect } from "inputs";
 import { Balance } from "shared";
 import { useListUtxo } from "./hooks";
 import styles from "./ListUtxo.module.css";
+import { TRANSACTIONS_ICON } from "constants";
 
 const Header = () => (
   <StandaloneHeader
-    iconClassName="transactions"
+    iconType={TRANSACTIONS_ICON}
     title={<T id="listutxo.title" m="List UTXOs" />}
   />
 );

--- a/app/components/views/PrivacyPage/PrivacyPage.jsx
+++ b/app/components/views/PrivacyPage/PrivacyPage.jsx
@@ -5,6 +5,7 @@ import SecurityTab from "./SecurityPage/SecurityPage";
 import PrivacyTab from "./Privacy/Privacy";
 import { usePrivacyPage } from "./hooks";
 import style from "./Privacy/Privacy.module.css";
+import { SECURITY_ICON } from "constants";
 
 const PrivacyPageHeader = React.memo(
   ({ mixedAccountName, changeAccountName }) => {
@@ -34,7 +35,7 @@ const PrivacyPageHeader = React.memo(
       );
     return (
       <StandaloneHeader
-        iconClassName="security"
+        iconType={SECURITY_ICON}
         title={<T id="privacypage.title" m="Privacy and Security" />}
         description={description}
       />

--- a/app/components/views/ProposalDetailsPage/helpers/Header.jsx
+++ b/app/components/views/ProposalDetailsPage/helpers/Header.jsx
@@ -1,5 +1,6 @@
 import { FormattedMessage as T } from "react-intl";
 import { StandaloneHeader } from "layout";
+import { GOVERNANCE_ICON } from "constants";
 
 const Header = React.memo(function Header({ eligibleTicketCount }) {
   return (
@@ -12,7 +13,7 @@ const Header = React.memo(function Header({ eligibleTicketCount }) {
           values={{ votingPower: eligibleTicketCount }}
         />
       }
-      iconClassName="governance"
+      iconType={GOVERNANCE_ICON}
     />
   );
 });

--- a/app/components/views/SettingsPage/SettingsPage.jsx
+++ b/app/components/views/SettingsPage/SettingsPage.jsx
@@ -8,6 +8,7 @@ import { TutorialsTab } from "./TutorialsTab/TutorialsTab";
 import { SettingsTab } from "./SettingsTab/SettingsTab";
 import { useSettings } from "hooks";
 import styles from "./SettingsPage.module.css";
+import { SETTINGS_ICON } from "constants";
 
 const closeWalletModalContent = (walletName) => (
   <T
@@ -20,7 +21,7 @@ const closeWalletModalContent = (walletName) => (
 const SettingsPageHeader = ({ onCloseWallet, walletName }) => (
   <StandaloneHeader
     title={<T id="settings.title" m="Settings" />}
-    iconClassName="settings"
+    iconType={SETTINGS_ICON}
     description={
       <T
         id="settings.description"

--- a/app/components/views/TicketsPage/TicketsPage.jsx
+++ b/app/components/views/TicketsPage/TicketsPage.jsx
@@ -13,10 +13,11 @@ import { default as StatisticsTab } from "./StatisticsTab/StatisticsTab";
 import { default as MyTicketsTab } from "./MyTicketsTab/MyTicketsTab";
 import { default as VSPTicketsStatusTab } from "./VSPTicketsStatusTab/MyVSPTickets";
 import styles from "./TicketsPage.module.css";
+import { TICKET_ICON } from "constants";
 
 const PageHeader = () => (
   <TitleHeader
-    iconClassName="tickets"
+    iconType={TICKET_ICON}
     title={<T id="tickets.title" m="Staking" />}
   />
 );

--- a/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.jsx
+++ b/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.jsx
@@ -10,7 +10,15 @@ import {
   REVOCATION,
   COINBASE,
   MIXED,
-  SELFTRANSFER
+  SELFTRANSFER,
+  OUT_ICON,
+  TICKETFEE_ICON,
+  IN_ICON,
+  TICKET_ICON,
+  VOTE_ICON,
+  REVOCATION_ICON,
+  MIXED_ICON,
+  SELF_ICON
 } from "constants/Decrediton";
 import { SlateGrayButton } from "buttons";
 import { StandaloneHeader } from "layout";
@@ -27,15 +35,15 @@ const messages = defineMessages({
 });
 
 const headerIcons = {
-  [TRANSACTION_DIR_RECEIVED]: "in",
-  [TRANSACTION_DIR_SENT]: "out",
-  [TICKET_FEE]: "ticketfee",
-  [COINBASE]: "in",
-  [TICKET]: "ticket",
-  [VOTE]: "vote",
-  [REVOCATION]: "revocation",
-  [MIXED]: "mixed",
-  [SELFTRANSFER]: "self"
+  [TRANSACTION_DIR_RECEIVED]: IN_ICON,
+  [TRANSACTION_DIR_SENT]: OUT_ICON,
+  [TICKET_FEE]: TICKETFEE_ICON,
+  [COINBASE]: IN_ICON,
+  [TICKET]: TICKET_ICON,
+  [VOTE]: VOTE_ICON,
+  [REVOCATION]: REVOCATION_ICON,
+  [MIXED]: MIXED_ICON,
+  [SELFTRANSFER]: SELF_ICON
 };
 
 // If it is a regular tx we use txDirection instead
@@ -47,14 +55,14 @@ const title = ({ txType, txAmount, txDirection, ticketReward, intl }) => {
   txType !== REGULAR
     ? (titleComp = intl.formatMessage(messages[txType]))
     : (titleComp = (
-      <Balance
-        title
-        bold
-        amount={
-          txDirection !== TRANSACTION_DIR_RECEIVED ? -txAmount : txAmount
-        }
-      />
-    ));
+        <Balance
+          title
+          bold
+          amount={
+            txDirection !== TRANSACTION_DIR_RECEIVED ? -txAmount : txAmount
+          }
+        />
+      ));
   if (txType === TICKET && ticketReward) {
     titleComp = `${titleComp}, Voted`;
   }
@@ -108,10 +116,10 @@ const subtitle = ({
               </div>
             </div>
           ) : (
-              <div className={styles.subtitleDate}>
-                <T id="txDetails.unConfirmed" m="Unconfirmed" />
-              </div>
-            )}
+            <div className={styles.subtitleDate}>
+              <T id="txDetails.unConfirmed" m="Unconfirmed" />
+            </div>
+          )}
           {leaveTimestamp && (
             <div className={styles.subtitlePair}>
               <div className={styles.subtitleSentfrom}>
@@ -156,13 +164,11 @@ const subtitle = ({
               <div className={styles.subtitleSentfrom}>
                 <T id="txDetails.sentFrom" m="Sent From" />
               </div>
-              <div className={styles.subtitleAccount}>
-                {sentFromAccount}
-              </div>
+              <div className={styles.subtitleAccount}>{sentFromAccount}</div>
             </>
           ) : (
-              <div />
-            )}
+            <div />
+          )}
           <div className={styles.subtitleDate}>
             {!isPending ? (
               <T
@@ -171,8 +177,8 @@ const subtitle = ({
                 values={{ timestamp: tsDate(timestamp) }}
               />
             ) : (
-                <T id="txDetails.unConfirmed" m="Unconfirmed" />
-              )}
+              <T id="txDetails.unConfirmed" m="Unconfirmed" />
+            )}
           </div>
         </div>
       );
@@ -201,7 +207,7 @@ const TransactionHeader = ({
   return (
     <StandaloneHeader
       title={title({ txType, txAmount, txDirection, ticketReward, intl })}
-      iconClassName={icon({ txType: iconTxType, txDirection })}
+      iconType={icon({ txType: iconTxType, txDirection })}
       description={subtitle({
         txType,
         isPending,

--- a/app/components/views/TransactionsPage/TransactionsPage.jsx
+++ b/app/components/views/TransactionsPage/TransactionsPage.jsx
@@ -11,10 +11,11 @@ import {
   HistoryTabHeader
 } from "./HistoryTab/HistoryTab";
 import { default as ExportTab, ExportTabHeader } from "./ExportTab/ExportTab";
+import { TRANSACTIONS_ICON } from "constants";
 
 const PageHeader = () => (
   <TitleHeader
-    iconClassName="transactions"
+    iconType={TRANSACTIONS_ICON}
     title={<T id="transactions.title" m="Transactions" />}
   />
 );

--- a/app/components/views/TrezorPage/TrezorPage.jsx
+++ b/app/components/views/TrezorPage/TrezorPage.jsx
@@ -1,10 +1,11 @@
 import { StandalonePage, StandaloneHeader } from "layout";
 import { FormattedMessage as T } from "react-intl";
+import { TREZOR_ICON } from "constants";
 import TrezorPageContent from "./TrezorPageContent";
 
 const TrezorPageHeader = () => (
   <StandaloneHeader
-    iconClassName={"trezor"}
+    iconType={TREZOR_ICON}
     title={<T id="trezorPage.title" m="Trezor" />}
     description={
       <T id="trezorPage.description" m="Manage your Trezor device." />

--- a/app/constants/Decrediton.js
+++ b/app/constants/Decrediton.js
@@ -101,3 +101,21 @@ export const MENU_LINKS_PER_ROW = 4;
 export const VSP_FEE_PROCESS_STARTED = 0;
 export const VSP_FEE_PROCESS_PAID = 1;
 export const VSP_FEE_PROCESS_ERRORED = 2;
+
+// TitleHeader icon types
+export const ACCOUNTS_ICON = "accounts";
+export const SECURITY_ICON = "security";
+export const SETTINGS_ICON = "settings";
+export const TICKETS_ICON = "tickets";
+export const TRANSACTIONS_ICON = "transactions";
+export const GOVERNANCE_ICON = "governance";
+export const TREZOR_ICON = "trezor";
+export const LN_ICON = "ln";
+export const TICKET_ICON = "ticket";
+export const VOTE_ICON = "vote";
+export const REVOCATION_ICON = "revocation";
+export const TICKETFEE_ICON = "ticketfee";
+export const MIXED_ICON = "mixed";
+export const SELF_ICON = "self";
+export const OUT_ICON = "out";
+export const IN_ICON = "in";


### PR DESCRIPTION
This PR adds several constants to ``app/constants/Decrediton.js`` to increase verbosity and avoid explicit strings throughout our code. These constants represent CSS classes that place the right header icon depending on the page at ``app/components/layout/TitleHeader/TitleHeader.module.css``.

Closes https://github.com/decred/decrediton/issues/3295.