### PR TITLE
Delete `autobind-decorator` dep used in class components.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,7 +60,6 @@ module.exports = {
   },
   globals: {
     Uint8Array: true,
-    autobind: "readonly",
     React: "readonly",
     PropTypes: "readonly"
   }

--- a/package.json
+++ b/package.json
@@ -260,7 +260,6 @@
     "@formatjs/intl-utils": "^1.6.0",
     "@hot-loader/react-dom": "^16.13.0",
     "@xstate/react": "^0.8.1",
-    "autobind-decorator": "^2.1.0",
     "axios": "^0.21.1",
     "bs58": "^4.0.1",
     "connected-react-router": "^6.8.0",

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,10 +1,8 @@
-import autobind from "autobind-decorator";
 import React from "react";
 import PropTypes from "prop-types";
 import { configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 
-global.autobind = autobind;
 global.React = React;
 global.PropTypes = PropTypes;
 

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -66,8 +66,7 @@ export default {
 
   plugins: [ new webpack.ProvidePlugin({
     React: "react",
-    PropTypes: "prop-types",
-    autobind: [ "core-decorators", "autobind" ]
+    PropTypes: "prop-types"
   }) ],
 
   externals: Object.keys(dependencies || {}).concat(Object.keys(optionalDependencies || {}))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,11 +2862,6 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autobind-decorator@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.4.0.tgz#ea9e1c98708cf3b5b356f7cf9f10f265ff18239c"
-  integrity sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==
-
 autoprefixer@^9.7.4:
   version "9.7.4"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.7.4.tgz#f8bf3e06707d047f0641d87aee8cfb174b2a5378"


### PR DESCRIPTION
This delete `autobind-decorator` dep which was used in class components before #2438,
in order to automatically do `.bind(this)` for all class functions. 

This isn't needed with functional components anymore.