### PR TITLE
App container: fix ipcRenderer listeners not updating bug.

### DIFF
--- a/app/containers/App/App.jsx
+++ b/app/containers/App/App.jsx
@@ -1,4 +1,3 @@
-import { useState, useEffect, useCallback } from "react";
 import { IntlProvider } from "react-intl";
 import { defaultFormats } from "i18n/locales";
 import { Redirect, Route, Switch } from "react-router-dom";
@@ -9,142 +8,19 @@ import ShutdownPage from "components/views/ShutdownPage/ShutdownPage";
 import FatalErrorPage from "components/views/FatalErrorPage/FatalErrorPage";
 import Snackbar from "components/Snackbar";
 import AboutModal from "components/modals/AboutModal/AboutModal";
-import { log } from "wallet";
 import TrezorModals from "components/modals/TrezorModals/TrezorModals";
-import { ipcRenderer } from "electron";
 import { hot } from "react-hot-loader/root";
 import { CantCloseModals } from "modals";
-import { useMountEffect } from "hooks";
 import { useApp } from "../hooks";
 import styles from "./App.module.css";
 
-// minimum size to reduce the sidebar in px.
-const MINIMUM_SIZE_TO_REDUCE_SIDEBAR = 1179;
-// minimum size to sidebar goes to bottom in px.
-const MINIMUM_SIZE_BOTTOM_SIDEBAR = 768;
-
 const App = () => {
   const {
-    decreditonInit,
-    shutdownApp,
-    listenForAppReloadRequest,
-    showAboutModalMacOS,
     hideAboutModalMacOS,
-    showCantCloseModal,
-    onExpandSideBar,
-    onReduceSideBar,
-    onSidebarToBottom,
-    onSidebarLeaveBottom,
     locale,
-    window,
     aboutModalMacOSVisible,
-    modalVisible,
-    canClose,
     theme
   } = useApp();
-
-  const [isWaiting, setIsWaiting] = useState(false);
-  const [stateCanClose, setCanClose] = useState(canClose);
-  const [stateModalVisible, setModalVisible] = useState(modalVisible);
-
-  const onClick = (event) => {
-    const target = event.target;
-    if (target.localName !== "a") return;
-    const href = target.attributes.href ? target.attributes.href.value : "";
-    if (href === "") {
-      event.stopPropagation();
-      event.preventDefault();
-      return false;
-    }
-  };
-
-  // Prevent middle click from opening new electron window
-  const onAuxClick = (event) => {
-    event.stopPropagation();
-    event.preventDefault();
-    return false;
-  };
-
-  const updateWindowDimensions = () => {
-    if (isWaiting) {
-      return;
-    }
-    const updateWindow = () => {
-      setIsWaiting(false);
-      if (window.innerWidth <= MINIMUM_SIZE_BOTTOM_SIDEBAR) {
-        onSidebarToBottom();
-      } else if (window.innerWidth <= MINIMUM_SIZE_TO_REDUCE_SIDEBAR) {
-        onSidebarLeaveBottom();
-        onReduceSideBar();
-      } else {
-        onSidebarLeaveBottom();
-        onExpandSideBar();
-      }
-    };
-    setIsWaiting(true);
-    setTimeout(updateWindow, 200);
-  };
-
-  const onReloadRequested = () => {
-    log("info", "Main app received reload UI request");
-    ipcRenderer.send("app-reload-ui");
-  };
-
-  const setCanCloseCheck = useCallback(
-    (canClose) => {
-      ipcRenderer.removeAllListeners("check-can-close");
-      ipcRenderer.on("check-can-close", () => {
-        if (canClose) {
-          shutdownApp();
-        } else {
-          log("warning", "A process is still running, preventing shutdown");
-          showCantCloseModal();
-        }
-      });
-    },
-    [shutdownApp, showCantCloseModal]
-  );
-
-  const setModalVisibleCheck = useCallback(
-    (modalVisible) => {
-      ipcRenderer.removeAllListeners("show-about-modal");
-      ipcRenderer.on("show-about-modal", () => {
-        // Ignore click if a modal is already shown
-        if (modalVisible == false) {
-          showAboutModalMacOS();
-        }
-      });
-    },
-    [showAboutModalMacOS]
-  );
-
-  useMountEffect(() => {
-    window.addEventListener("click", onClick);
-    window.addEventListener("auxclick", onAuxClick);
-    window.addEventListener("resize", updateWindowDimensions);
-    updateWindowDimensions();
-    decreditonInit();
-    listenForAppReloadRequest(onReloadRequested);
-    setCanCloseCheck(stateCanClose);
-    setModalVisibleCheck(stateModalVisible);
-    log("info", "Main app container mounted");
-  });
-
-  // Updates can close check if given canClose value updated.
-  useEffect(() => {
-    if (canClose !== stateCanClose) {
-      setCanCloseCheck(canClose);
-      setCanClose(canClose);
-    }
-  }, [canClose, stateCanClose, setCanCloseCheck, setCanClose, shutdownApp]);
-
-  // Updates modal visible check if given modalVisible updated.
-  useEffect(() => {
-    if (modalVisible !== stateModalVisible) {
-      setModalVisibleCheck(modalVisible);
-      setModalVisible(modalVisible);
-    }
-  }, [modalVisible, stateModalVisible, setModalVisibleCheck, setModalVisible]);
 
   return (
     <IntlProvider

--- a/app/containers/hooks/useApp.js
+++ b/app/containers/hooks/useApp.js
@@ -1,20 +1,35 @@
+import { useState, useEffect, useCallback } from "react";
+import { ipcRenderer } from "electron";
+import { useMountEffect } from "hooks";
 import { useSelector, useDispatch } from "react-redux";
+import { log } from "wallet";
 import * as sel from "selectors";
 import * as da from "actions/DaemonActions";
 import * as cla from "actions/ClientActions";
 import * as ca from "actions/ControlActions";
 import * as sba from "actions/SidebarActions";
 
+// minimum size to reduce the sidebar in px.
+const MINIMUM_SIZE_TO_REDUCE_SIDEBAR = 1179;
+// minimum size to sidebar goes to bottom in px.
+const MINIMUM_SIZE_BOTTOM_SIDEBAR = 768;
+
 const useApp = () => {
   const dispatch = useDispatch();
 
   const decreditonInit = () => dispatch(da.decreditonInit());
-  const shutdownApp = () => dispatch(da.shutdownApp());
+  const shutdownApp = useCallback(() => dispatch(da.shutdownApp()), [dispatch]);
   const listenForAppReloadRequest = (cb) =>
     dispatch(cla.listenForAppReloadRequest(cb));
-  const showAboutModalMacOS = () => dispatch(ca.showAboutModalMacOS());
+  const showAboutModalMacOS = useCallback(
+    () => dispatch(ca.showAboutModalMacOS()),
+    [dispatch]
+  );
   const hideAboutModalMacOS = () => dispatch(ca.hideAboutModalMacOS());
-  const showCantCloseModal = () => dispatch(ca.showCantCloseModal());
+  const showCantCloseModal = useCallback(
+    () => dispatch(ca.showCantCloseModal()),
+    [dispatch]
+  );
   const onExpandSideBar = () => dispatch(sba.expandSideBar());
   const onReduceSideBar = () => dispatch(sba.reduceSideBar());
   const onSidebarToBottom = () => dispatch(sba.sidebarToBottom());
@@ -26,6 +41,109 @@ const useApp = () => {
   const modalVisible = useSelector(sel.modalVisible);
   const canClose = useSelector(sel.getCanClose);
   const theme = useSelector(sel.theme);
+
+  const [isWaiting, setIsWaiting] = useState(false);
+  const [stateCanClose, setCanClose] = useState(canClose);
+  const [stateModalVisible, setModalVisible] = useState(modalVisible);
+
+  const onClick = (event) => {
+    const target = event.target;
+    if (target.localName !== "a") return;
+    const href = target.attributes.href ? target.attributes.href.value : "";
+    if (href === "") {
+      event.stopPropagation();
+      event.preventDefault();
+      return false;
+    }
+  };
+
+  // Prevent middle click from opening new electron window
+  const onAuxClick = (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+    return false;
+  };
+
+  const updateWindowDimensions = () => {
+    if (isWaiting) {
+      return;
+    }
+    const updateWindow = () => {
+      setIsWaiting(false);
+      if (window.innerWidth <= MINIMUM_SIZE_BOTTOM_SIDEBAR) {
+        onSidebarToBottom();
+      } else if (window.innerWidth <= MINIMUM_SIZE_TO_REDUCE_SIDEBAR) {
+        onSidebarLeaveBottom();
+        onReduceSideBar();
+      } else {
+        onSidebarLeaveBottom();
+        onExpandSideBar();
+      }
+    };
+    setIsWaiting(true);
+    setTimeout(updateWindow, 200);
+  };
+
+  const onReloadRequested = () => {
+    log("info", "Main app received reload UI request");
+    ipcRenderer.send("app-reload-ui");
+  };
+
+  const setCanCloseCheck = useCallback(
+    (canClose) => {
+      ipcRenderer.removeAllListeners("check-can-close");
+      ipcRenderer.on("check-can-close", () => {
+        if (canClose) {
+          shutdownApp();
+        } else {
+          log("warning", "A process is still running, preventing shutdown");
+          showCantCloseModal();
+        }
+      });
+    },
+    [shutdownApp, showCantCloseModal]
+  );
+
+  const setModalVisibleCheck = useCallback(
+    (modalVisible) => {
+      ipcRenderer.removeAllListeners("show-about-modal");
+      ipcRenderer.on("show-about-modal", () => {
+        // Ignore click if a modal is already shown
+        if (modalVisible == false) {
+          showAboutModalMacOS();
+        }
+      });
+    },
+    [showAboutModalMacOS]
+  );
+
+  useMountEffect(() => {
+    window.addEventListener("click", onClick);
+    window.addEventListener("auxclick", onAuxClick);
+    window.addEventListener("resize", updateWindowDimensions);
+    updateWindowDimensions();
+    decreditonInit();
+    listenForAppReloadRequest(onReloadRequested);
+    setCanCloseCheck(stateCanClose);
+    setModalVisibleCheck(stateModalVisible);
+    log("info", "Main app container mounted");
+  });
+
+  // Updates can close check if given canClose value updated.
+  useEffect(() => {
+    if (canClose !== stateCanClose) {
+      setCanCloseCheck(canClose);
+      setCanClose(canClose);
+    }
+  }, [canClose, stateCanClose, setCanCloseCheck, setCanClose, shutdownApp]);
+
+  // Updates modal visible check if given modalVisible updated.
+  useEffect(() => {
+    if (modalVisible !== stateModalVisible) {
+      setModalVisibleCheck(modalVisible);
+      setModalVisible(modalVisible);
+    }
+  }, [modalVisible, stateModalVisible, setModalVisibleCheck, setModalVisible]);
 
   return {
     decreditonInit,


### PR DESCRIPTION
This fixes a bug in the App container when can close check listener didn't update when provided canClose updated.
This also re-arranges the App container (see second commit) and moves all state related logic to the `useApp` custom hook.