### PR TITLE
Align decrediton's global `box-sizing` property with `pi-ui`.

### DIFF
--- a/app/components/SideBar/MenuBottom/MenuBottom.module.css
+++ b/app/components/SideBar/MenuBottom/MenuBottom.module.css
@@ -6,8 +6,8 @@
 }
 
 .shortSeparator {
-  height: 7px;
-  margin-bottom: 15px;
+  height: 15px;
+  margin-bottom: 12px;
   background-image: var(--menu-arrow-up);
   background-position: 50% 8px;
   background-repeat: no-repeat;

--- a/app/components/buttons/RescanButton/RescanButton.module.css
+++ b/app/components/buttons/RescanButton/RescanButton.module.css
@@ -1,6 +1,6 @@
 .tooltip {
   width: 20rem;
-  top: -10% !important;
+  top: -50% !important;
 }
 
 .rescan.syncing {

--- a/app/components/layout/StandaloneHeader/StandaloneHeader.module.css
+++ b/app/components/layout/StandaloneHeader/StandaloneHeader.module.css
@@ -1,11 +1,11 @@
 .header {
   background-color: var(--background-back-color);
-  padding: 43px 60px 0px 63px;
+  padding: 43px 60px 0 63px;
   position: absolute;
-  top: 0px;
-  right: 0px;
-  left: 0px;
-  height: 114px;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 157px;
 }
 
 @media screen and (max-width: 1179px) {

--- a/app/components/layout/StandalonePageBody/StandalonePageBody.module.css
+++ b/app/components/layout/StandalonePageBody/StandalonePageBody.module.css
@@ -2,10 +2,10 @@
   overflow-x: hidden;
   overflow-y: scroll;
   position: absolute;
-  right: 0px;
+  right: 0;
   top: 157px;
-  bottom: 0px;
-  left: 0px;
+  bottom: 0;
+  left: 0;
   padding: 38px 60px 30px 63px;
   background-color: var(--background-container);
 }
@@ -18,6 +18,6 @@
 
 @media screen and (max-width: 768px) {
   .body {
-    top: 113px;
+    top: 135px;
   }
 }

--- a/app/components/layout/TabbedPage/TabbedPage.module.css
+++ b/app/components/layout/TabbedPage/TabbedPage.module.css
@@ -10,12 +10,12 @@
 
 .tabbedPageHeader {
   background-color: var(--background-back-color);
-  padding: 43px 60px 0px 63px;
+  padding: 43px 60px 0 63px;
   position: absolute;
-  top: 0px;
-  right: 0px;
-  left: 0px;
-  height: 114px;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 157px;
 }
 
 .tabContent {
@@ -53,11 +53,11 @@
   }
 
   .tabbedPageHeader {
-    height: 82px;
+    height: 135px;
     padding-top: 30px;
   }
 
   .tabContent {
-    padding: 0 10px 80px 10px;
+    padding: 10px 10px 80px 10px;
   }
 }

--- a/app/components/modals/Modals.module.css
+++ b/app/components/modals/Modals.module.css
@@ -58,7 +58,7 @@
   z-index: 200;
   overflow-y: auto;
   text-align: left;
-  width: 262px;
+  width: 445px;
   background-image: var(--tickets-info-icon);
   background-attachment: local;
   background-size: 32px 32px;
@@ -190,8 +190,8 @@
   line-height: 17px;
   padding: 6px 20px;
   text-transform: none;
-  width: 40px;
-  height: 20px;
+  width: 80px;
+  height: 40px;
   align-self: flex-end;
 }
 

--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -129,41 +129,39 @@
 .direction {
   display: flex;
   align-items: center;
+  margin-left: 15px;
 }
 
 .accountName {
   background-color: var(--transaction-account-name-bg);
-  padding: 2px 4px;
+  padding: 2px;
   border-radius: 5px;
   font-size: 11px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  height: 20px;
+  max-width: 120px;
   margin-right: 10px;
-  height: 15px;
-  max-width: 210px;
-  line-height: 15px;
+  line-height: 16px;
   text-align: center;
 }
 
 .overviewRow .feeStatus {
-  margin-left: auto;
-  margin-right: 0;
-  width: 70px;
+  width: 75px;
 }
 
 .feeStatus {
   background-color: var(--transaction-account-name-bg);
-  padding: 2px 4px;
+  padding: 2px;
   border-radius: 5px;
   font-size: 11px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  height: 15px;
-  max-width: 180px;
-  margin-left: 20px;
-  line-height: 15px;
+  height: 20px;
+  max-width: 120px;
+  line-height: 16px;
   text-align: center;
 }
 
@@ -244,8 +242,8 @@
 }
 
 .overviewRow {
-  width: 368px;
-  height: 54px;
+  width: 375px;
+  height: 60px;
   background: var(--background-back-color);
   border-bottom: 1px solid var(--disabled-background-color);
   cursor: pointer;
@@ -304,7 +302,7 @@
 
 .historyRow .txInfo .txRowWrapper {
   padding: 16px 20px;
-  width: 90%;
+  width: 97%;
 }
 
 .eligibleRow {

--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -3,10 +3,6 @@
   grid-template-columns: repeat(6, minmax(0, 1fr));
 }
 
-.voteChoice > * {
-  box-sizing: border-box;
-}
-
 .yes,
 .no {
   margin: -5px 0 0 0 !important;

--- a/app/components/views/AccountsPage/Accounts/Accounts.module.css
+++ b/app/components/views/AccountsPage/Accounts/Accounts.module.css
@@ -200,15 +200,15 @@
   margin-top: 18px;
   width: 88%;
 }
-.actionsPubkey .actionsPubkeyLabel {
+.actionsPubkeyLabel {
   font-size: 13px;
   line-height: 17px;
   margin-top: 2px;
   margin-right: 14px;
 }
-.actionsPubkey .actionsPubkeyButton {
-  height: 15px;
-  width: 37px;
+.actionsPubkeyButton {
+  height: 25px;
+  width: 75px;
   color: var(--input-color-default);
   font-size: 13px;
   line-height: 17px;
@@ -219,20 +219,20 @@
   transition: all 131ms var(--ease-in-out-quart);
   cursor: auto;
 }
-.actionsPubkey .actionsPubkeyArea {
+.actionsPubkeyArea {
   color: var(--input-color);
   font-size: 13px;
   line-height: 17px;
-  font-weight: N00;
+  font-weight: 600;
   padding: 2px 20px 3px 20px;
   border-radius: 3px;
   background-color: var(--background-copy-color);
-  height: 32px;
+  height: 55px;
   width: 390px;
   word-break: break-all;
   transition: all 131ms var(--ease-in-out-quart);
 }
-.actionsPubkey .actionsPubkeyClipboard {
+.actionsPubkeyClipboard {
   margin-left: 10px;
 }
 .disabled {

--- a/app/components/views/GetStartedPage/GetStarted.module.css
+++ b/app/components/views/GetStartedPage/GetStarted.module.css
@@ -11,6 +11,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  /* XXX */
   box-sizing: border-box !important;
   width: 240px;
   clear: left;

--- a/app/components/views/GetStartedPage/GetStarted.module.css
+++ b/app/components/views/GetStartedPage/GetStarted.module.css
@@ -11,8 +11,6 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  /* XXX */
-  box-sizing: border-box !important;
   width: 240px;
   clear: left;
 }

--- a/app/components/views/GovernancePage/Blockchain/AgendaOverview/Overview.module.css
+++ b/app/components/views/GovernancePage/Blockchain/AgendaOverview/Overview.module.css
@@ -51,10 +51,6 @@
   text-transform: capitalize;
 }
 
-div.radioButtonsWrapper > * {
-  box-sizing: border-box;
-}
-
 .bottom {
   padding-top: 15px;
   display: flex;

--- a/app/components/views/GovernancePage/Blockchain/AgendaOverview/Overview.module.css
+++ b/app/components/views/GovernancePage/Blockchain/AgendaOverview/Overview.module.css
@@ -91,8 +91,8 @@ div.radioButtonsWrapper > * {
 }
 
 .agendaCard {
-  width: 180px;
-  height: 190px;
+  width: 225px;
+  height: 225px;
   margin-bottom: 20px;
   margin-right: 20px;
   padding: 20px;

--- a/app/components/views/GovernancePage/Blockchain/VotingPrefs.module.css
+++ b/app/components/views/GovernancePage/Blockchain/VotingPrefs.module.css
@@ -47,10 +47,6 @@
   margin-left: 130px;
 }
 
-.links a {
-  margin: 0 !important;
-}
-
 .infoButton {
   border-radius: 0px;
   background-image: var(--tickets-info-icon);

--- a/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsFilter/ProposalsFilter.module.css
@@ -1,5 +1,5 @@
 .tabs {
-  max-width: 738px;
+  width: 800px;
   margin-left: 85px;
   height: 40px;
 }
@@ -18,7 +18,18 @@
   padding-top: 0px;
 }
 
+@media screen and (max-width: 1179px) {
+  .tabs {
+    margin-left: 0;
+    width: 700px;
+  }
+}
+
 @media screen and (max-width: 768px) {
+  .tabs {
+    width: 100%;
+  }
+
   .allIcon {
     background-image: var(--ticket-live-icon);
   }
@@ -32,12 +43,5 @@
   }
   .tabs > div > ul {
     left: 0px;
-  }
-}
-
-@media screen and (max-width: 1179px) {
-  .tabs {
-    margin-left: 0;
-    max-width: 673px;
   }
 }

--- a/app/components/views/GovernancePage/Proposals/ProposalsListItem/ProposalsListItem.jsx
+++ b/app/components/views/GovernancePage/Proposals/ProposalsListItem/ProposalsListItem.jsx
@@ -37,7 +37,7 @@ const ProposalsListItem = ({
       onClick={viewProposalDetailsHandler}
       className={classNames(
         "is-row",
-        styles.listiTtem,
+        styles.listItem,
         styles[voteResult],
         !approved && styles.declined,
         finishedVote && styles.ended,

--- a/app/components/views/GovernancePage/Proposals/ProposalsListItem/ProposalsListItem.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsListItem/ProposalsListItem.module.css
@@ -1,22 +1,22 @@
-.listiTtem {
+.listItem {
   padding: 18px 16px 6px 20px;
   border-left: 2px solid var(--background-back-color);
   border-bottom: 2px solid var(--background-container);
   cursor: pointer;
   background-color: var(--background-back-color);
   min-height: 30px;
-  width: 700px;
+  width: 800px;
 }
 
-.listiTtem.ended.passed {
+.listItem.ended.passed {
   border-left: 2px solid var(--vote-yes-color);
 }
 
-.listiTtem.ended.declined {
+.listItem.ended.declined {
   border-left: 2px solid var(--vote-no-color);
 }
 
-.listiTtem.ended .proposalName {
+.listItem.ended .proposalName {
   color: var(--stroke-color-hovered);
 }
 
@@ -28,7 +28,7 @@
   padding-top: 6px;
 }
 
-.listiTtem:hover .name {
+.listItem:hover .name {
   color: var(--input-color);
 }
 
@@ -102,7 +102,13 @@
 }
 
 @media screen and (max-width: 1179px) {
-  .listiTtem {
-    width: 600px;
+  .listItem {
+    width: 700px;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .listItem {
+    width: 100%;
   }
 }

--- a/app/components/views/GovernancePage/Proposals/ProposalsTab.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsTab.module.css
@@ -76,10 +76,6 @@
   margin-left: 40px;
 }
 
-.links a {
-  margin: 0 !important;
-}
-
 .politeiaButton {
   font-size: 13px !important;
   line-height: 17px !important;

--- a/app/components/views/LNPage/WatchtowersTab/AddWatchtower/AddWatchtower.module.css
+++ b/app/components/views/LNPage/WatchtowersTab/AddWatchtower/AddWatchtower.module.css
@@ -7,7 +7,6 @@
   background-color: var(--background-back-color);
   padding-top: 20px;
   padding-left: 30px;
-  box-sizing: border-box;
   display: flex;
   flex-direction: column;
 }

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.module.css
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.module.css
@@ -99,10 +99,6 @@
   line-height: 0;
 }
 
-div.radioButtonsWrapper > * {
-  box-sizing: border-box;
-}
-
 .radioButtonsList {
   margin-left: -7px;
 }

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.module.css
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.module.css
@@ -55,7 +55,7 @@
   background-color: var(--transfer-details-bg);
   padding: 30px 20px;
   width: 284px;
-  height: 60px;
+  height: 130px;
 }
 
 .overviewVotingButton {
@@ -157,7 +157,7 @@
   background-color: var(--background-back-color);
   margin: 20px 0 80px;
   border-top: 1px solid var(--tabbed-page-header-bg);
-  width: 700px;
+  width: 740px;
 }
 
 .detailsText .links {
@@ -303,13 +303,13 @@
   }
 
   .detailsText {
-    width: 594px;
+    width: 635px;
   }
 }
 
 @media screen and (max-width: 768px) {
   .overview {
-    width: 355px;
+    width: 100%;
   }
 
   .overview.is-row {
@@ -332,7 +332,7 @@
 
   .detailsText {
     padding-left: 20px;
-    width: 335px;
+    width: 100%;
   }
 
   .smallWidth {

--- a/app/components/views/ProposalDetailsPage/helpers/EligibleTickets/EligibleTickets.module.css
+++ b/app/components/views/ProposalDetailsPage/helpers/EligibleTickets/EligibleTickets.module.css
@@ -1,7 +1,7 @@
 .wrapper {
   background-color: var(--background-back-color);
   padding: 20px;
-  width: 700px;
+  width: 740px;
   margin-top: 20px;
 }
 
@@ -55,12 +55,12 @@
 
 @media screen and (max-width: 1179px) {
   .wrapper {
-    width: 594px;
+    width: 635px;
   }
 }
 
 @media screen and (max-width: 768px) {
   .wrapper {
-    width: 315px;
+    width: 100%;
   }
 }

--- a/app/components/views/SettingsPage/SettingsTab/Settings.module.css
+++ b/app/components/views/SettingsPage/SettingsTab/Settings.module.css
@@ -223,10 +223,6 @@
   color: var(--error-text-color);
 }
 
-div.radioButtonsWrapper > * {
-  box-sizing: border-box;
-}
-
 .timezoneOption {
   margin: 0 0 1rem 0 !important;
 }

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_StakePools/StakePools.module.css
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_StakePools/StakePools.module.css
@@ -15,7 +15,6 @@
   background-color: var(--background-back-color);
   padding-left: 40px;
   padding-top: 20px;
-  box-sizing: border-box !important;
   position: relative;
   margin-bottom: 20px;
 }
@@ -47,7 +46,6 @@
   margin-right: 5px;
   width: 270px;
   height: 35px;
-  box-sizing: border-box !important;
   text-align: center;
 }
 
@@ -61,7 +59,6 @@
   background-color: var(--background-container);
   padding: 10px;
   word-wrap: break-word;
-  box-sizing: border-box !important;
   display: inline-block;
 }
 
@@ -74,7 +71,6 @@
   background: var(--tx-detail-raw-shadow);
   border-bottom: 1px var(--background-container) solid;
   border-left: 1px var(--background-container) solid;
-  box-sizing: border-box !important;
 }
 
 ::-webkit-scrollbar-thumb:hover {
@@ -130,7 +126,6 @@
 .addVSP {
   width: 107px;
   height: 44px;
-  box-sizing: border-box !important;
   text-align: center;
   padding: 0;
   line-height: 44px;
@@ -139,7 +134,6 @@
 .cancelVSP {
   width: 107px;
   height: 44px;
-  box-sizing: border-box !important;
 }
 
 .backupRedeemScriptModal {

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.module.css
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.module.css
@@ -107,7 +107,7 @@
 }
 .inputArea,
 .outputArea {
-  width: 180px;
+  width: 195px;
   background-color: var(--background-back-color);
   padding: 15px 20px 1px 20px;
   margin-bottom: 10px;

--- a/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.module.css
+++ b/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.module.css
@@ -5,7 +5,7 @@
 }
 .subtitlePair {
   display: flex;
-  margin-top: 3px;
+  align-items: center;
 }
 .subtitleSentfrom {
   margin-right: 5px;
@@ -28,7 +28,7 @@
   max-height: 22px;
 }
 .subtitleAccount {
-  width: 80px;
+  width: 100px;
   max-height: 22px;
 }
 .thinButton {

--- a/app/components/views/TransactionsPage/ExportTab/ExportPage/ExportPage.module.css
+++ b/app/components/views/TransactionsPage/ExportTab/ExportPage/ExportPage.module.css
@@ -13,16 +13,16 @@
   color: var(--title-text-and-button-background);
   font-size: 13px;
   line-height: 17px;
-  padding: 30px 20px 0px 28px;
-  width: 366px;
-  height: 98px;
+  padding: 30px 20px 0 28px;
+  width: 430px;
+  height: 134px;
   background-color: var(--background-back-color);
 }
 
 .exportAreaRight {
   background-color: var(--disabled-background-color-dark);
   padding: 30px 30px 10px 30px;
-  width: 266px;
+  width: 310px;
   font-size: 13px;
   line-height: 19px;
   cursor: pointer;
@@ -54,7 +54,7 @@
 }
 
 .exportInfoDescription {
-  margin-top: 0px;
+  margin-top: 0;
 }
 
 ul.exportInfoFields {

--- a/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/QRCodeModal/QRCodeModal.module.css
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/QRCodeModal/QRCodeModal.module.css
@@ -43,7 +43,6 @@
   padding-left: 20px;
   box-shadow: 0px 5px 21px var(--icons-shadow);
   margin-bottom: 20px;
-  box-sizing: border-box !important;
 }
 
 .modalAddress {

--- a/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.module.css
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.module.css
@@ -3,7 +3,6 @@
   padding-top: 20px;
   padding-left: 28px;
   width: 650px;
-  box-sizing: border-box;
   display: flex;
   flex-direction: column;
 }

--- a/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.module.css
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.module.css
@@ -2,7 +2,7 @@
   background-color: var(--background-back-color);
   padding-top: 20px;
   padding-left: 28px;
-  width: 740px;
+  width: 650px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;

--- a/app/components/views/TransactionsPage/SendTab/SendForm.module.css
+++ b/app/components/views/TransactionsPage/SendTab/SendForm.module.css
@@ -9,7 +9,7 @@
 }
 .detailsArea {
   width: 318px;
-  height: 145px;
+  height: 159px;
   background-color: var(--transfer-details-bg);
   padding: 14px 20px 0 0;
   font-size: 11px;

--- a/app/style/main.css
+++ b/app/style/main.css
@@ -22,28 +22,12 @@
 //  Global classes
 ///////////////////////////////////*/
 
-/* TODO: delete box-sizing: content-box;
-// I added this ugly `:not` workaround to be able to skip pi-ui's classes
-// which are prefixed with 'styles_'.
-// Ideally we should use `* { box-sizing: inherit; } and html { box-sizing: border-box }`(already done in pi-ui)
-// we shouldn't override it in a global level - we should take care of this while migrating this file to a css module.*/
-*:not([class^="styles_"]),
-*:not([class^="styles_"])::before,
-*:not([class^="styles_"])::after {
-  box-sizing: content-box;
-}
-
-[class^="styles_"] > * {
-  box-sizing: inherit;
-}
-
 body {
   font-family: var(--font-family-regular);
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
-  margin: 0px;
-  box-sizing: border-box;
+  margin: 0;
   font-variant-ligatures: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
This gets rid of a styling hack which was used to resolve a global styling conflict between `pi-ui` and
`decrediton`.

Before this commit:
```
/* TODO: delete box-sizing: content-box;
// I added this ugly `:not` workaround to be able to skip pi-ui's classes
// which are prefixed with 'styles_'.
// Ideally we should use `* { box-sizing: inherit; } and html { box-sizing: border-box }`(already done in pi-ui)
// we shouldn't override it in a global level - we should take care of this while migrating this file to a css module.*/
*:not([class^="styles_"]),
*:not([class^="styles_"])::before,
*:not([class^="styles_"])::after {
  box-sizing: content-box;
}

[class^="styles_"] > * {
  box-sizing: inherit;
}
```

As mentioned in the code comment above; before this diff decrediton's needed `box-sizing: content-box;` which conflicted with `pi-ui`'s which defines `* { box-sizing: inherit; } and html { box-sizing: border-box }`.

After ditching `box-sizing: content-box;` I needed to tweak width/height property of many parts of decrediton.