### PR TITLE
Reintroduce blur effect when modals are visible.

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -804,8 +804,7 @@ export const modalVisible = () => (dispatch) =>
   dispatch({ type: MODAL_VISIBLE });
 
 export const MODAL_HIDDEN = "MODAL_HIDDEN";
-export const modalHidden = () => (dispatch) =>
-  dispatch({ type: MODAL_HIDDEN });
+export const modalHidden = () => (dispatch) => dispatch({ type: MODAL_HIDDEN });
 
 export const SHOW_ABOUT_MODAL_MACOS = "SHOW_ABOUT_MODAL_MACOS";
 export const showAboutModalMacOS = () => (dispatch) =>

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -799,6 +799,14 @@ export const publishUnminedTransactionsAttempt = () => (dispatch, getState) => {
   }
 };
 
+export const MODAL_VISIBLE = "MODAL_SHOWN";
+export const modalVisible = () => (dispatch) =>
+  dispatch({ type: MODAL_VISIBLE });
+
+export const MODAL_HIDDEN = "MODAL_HIDDEN";
+export const modalHidden = () => (dispatch) =>
+  dispatch({ type: MODAL_HIDDEN });
+
 export const SHOW_ABOUT_MODAL_MACOS = "SHOW_ABOUT_MODAL_MACOS";
 export const showAboutModalMacOS = () => (dispatch) =>
   dispatch({ type: SHOW_ABOUT_MODAL_MACOS });

--- a/app/components/modals/hooks.js
+++ b/app/components/modals/hooks.js
@@ -1,18 +1,34 @@
+import { useMountEffect } from "hooks";
 import { eventOutsideElement } from "helpers";
 import { useCallback, useRef } from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import * as sel from "selectors";
+import { modalVisible, modalHidden } from "actions/ControlActions";
 
 export function useModal(onCancelModal) {
   const expandSideBar = useSelector(sel.expandSideBar);
   const showingSidebarMenu = useSelector(sel.showingSidebarMenu);
   const modalRef = useRef(null);
 
+  const dispatch = useDispatch();
+  const onModalVisible = useCallback(() => dispatch(modalVisible()), [
+    dispatch
+  ]);
+  const onModalHidden = useCallback(() => dispatch(modalHidden()), [dispatch]);
+
+  // This switches modalVisible redux switch on when modal mount
+  // and switches it off when modal is unmounted.
+  useMountEffect(() => {
+    onModalVisible();
+
+    return () => onModalHidden();
+  });
+
   const mouseUp = useCallback(
     (event) => {
       const el = modalRef.current;
       if (eventOutsideElement(el, event.target)) {
-        onCancelModal && onCancelModal();
+        onCancelModal?.();
       }
     },
     [onCancelModal]
@@ -22,7 +38,7 @@ export function useModal(onCancelModal) {
     (event) => {
       // 27: ESC key
       if (event.keyCode === 27) {
-        onCancelModal && onCancelModal();
+        onCancelModal?.();
       }
     },
     [onCancelModal]

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -63,7 +63,7 @@ import {
   CONSTRUCTTX_SUCCESS,
   CONSTRUCTTX_FAILED_LOW_BALANCE,
   SETBALANCETOMAINTAIN,
-  MODAL_SHOWN,
+  MODAL_VISIBLE,
   MODAL_HIDDEN,
   SHOW_ABOUT_MODAL_MACOS,
   HIDE_ABOUT_MODAL_MACOS,
@@ -494,7 +494,7 @@ export default function control(state = {}, action) {
       return { ...state, exportingData: false };
     case EXPORT_ERROR:
       return { ...state, exportingData: false };
-    case MODAL_SHOWN:
+    case MODAL_VISIBLE:
       return { ...state, modalVisible: true };
     case MODAL_HIDDEN:
       return { ...state, modalVisible: false };


### PR DESCRIPTION
This adds two control redux actions, to switch `modalVisible` redux flag on & off when modals are visible
or hidden.

Closes #3338.