### PR TITLE
Improve balance overview tooltip's alignment & width.

### DIFF
--- a/app/components/views/HomePage/HomePage.module.css
+++ b/app/components/views/HomePage/HomePage.module.css
@@ -139,6 +139,10 @@
   .overviewContentWrapper {
     padding-left: 20px;
   }
+
+  .balanceTooltip {
+    left: 110% !important;
+  }
 }
 
 @media screen and (max-width: 768px) {

--- a/app/components/views/HomePage/HomePage.module.css
+++ b/app/components/views/HomePage/HomePage.module.css
@@ -115,6 +115,12 @@
   height: 250px;
 }
 
+.balanceTooltip {
+  width: 31rem;
+  max-width: 31rem !important;
+  left: 90% !important;
+}
+
 .lockedBalanceTooltipGrid {
   display: grid;
   grid-template-columns: repeat(2, max-content);

--- a/app/components/views/HomePage/Tabs/BalanceTab/BalanceTab.jsx
+++ b/app/components/views/HomePage/Tabs/BalanceTab/BalanceTab.jsx
@@ -32,6 +32,7 @@ const BalanceTab = () => {
           </div>
         </div>
         <Tooltip
+          contentClassName={styles.balanceTooltip}
           content={
             <div className={styles.lockedBalanceTooltipGrid}>
               <T id="home.immatureRewardBalanceLabel" m="Immature Rewards" />:


### PR DESCRIPTION
Before:
![Screenshot 2021-03-28 at 20 07 35](https://user-images.githubusercontent.com/10324528/112760903-50ce5a80-9001-11eb-8cc0-69907c729034.png)

After:
![Screenshot 2021-03-28 at 20 07 09](https://user-images.githubusercontent.com/10324528/112760892-44e29880-9001-11eb-93ea-b65720832c6a.png)
