### PR TITLE
Fix webpack css modules & pure css configs.

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -41,8 +41,7 @@ export default merge(baseConfig, {
               sourceMap: true,
               importLoaders: 1,
               modules: {
-                // Adds original className as prefix to the hashed css module
-                // class names.
+                // Prepend the original class name in dev mode to ease debugging.
                 localIdentName: "[local]__[hash:base64:5]"
               }
             }

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -29,9 +29,9 @@ export default merge(baseConfig, {
   },
 
   module: {
+    // CSS files injected directly in the DOM.
     rules: [
       {
-        // CSS files injected directly in the DOM.
         test: /\.css$/,
         use: [
           "style-loader",
@@ -47,7 +47,24 @@ export default merge(baseConfig, {
               }
             }
           }
-        ]
+        ],
+        include: /\.module\.css$/
+      },
+      {
+        test: [/\.css$/],
+        use: [
+          {
+            loader: "style-loader"
+          },
+          {
+            loader: "css-loader",
+            options: {
+              sourceMap: true,
+              importLoaders: 1
+            }
+          }
+        ],
+        exclude: /\.module\.css$/
       }
     ]
   },

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -30,8 +30,39 @@ export default merge(baseConfig, {
 
   module: {
     rules: [
-      // CSS and Less files, injected directly in the DOM.
-      { test: /\.css$/, use: [ "style-loader", "css-loader" ] },
+      {
+        test: /\.css$/,
+        use: [
+          "style-loader",
+          {
+            loader: "css-loader",
+            options: {
+              sourceMap: true,
+              importLoaders: 1,
+              modules: {
+                localIdentName: "[local]__[hash:base64:5]"
+              }
+            }
+          }
+        ],
+        include: /\.module\.css$/
+      },
+      {
+        test: [/\.css$/],
+        use: [
+          {
+            loader: "style-loader"
+          },
+          {
+            loader: "css-loader",
+            options: {
+              sourceMap: true,
+              importLoaders: 1
+            }
+          }
+        ],
+        exclude: /\.module\.css$/
+      }
     ]
   },
   resolve: {

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -31,6 +31,7 @@ export default merge(baseConfig, {
   module: {
     rules: [
       {
+        // CSS files injected directly in the DOM.
         test: /\.css$/,
         use: [
           "style-loader",
@@ -40,28 +41,13 @@ export default merge(baseConfig, {
               sourceMap: true,
               importLoaders: 1,
               modules: {
+                // Adds original className as prefix to the hashed css module
+                // class names.
                 localIdentName: "[local]__[hash:base64:5]"
               }
             }
           }
-        ],
-        include: /\.module\.css$/
-      },
-      {
-        test: [/\.css$/],
-        use: [
-          {
-            loader: "style-loader"
-          },
-          {
-            loader: "css-loader",
-            options: {
-              sourceMap: true,
-              importLoaders: 1
-            }
-          }
-        ],
-        exclude: /\.module\.css$/
+        ]
       }
     ]
   },

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -24,41 +24,8 @@ const config = merge(baseConfig, {
   },
 
   module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: [
-          {
-            loader: MiniCssExtractPlugin.loader
-          },
-          {
-            loader: "css-loader",
-            options: {
-              importLoaders: 1,
-              modules: {
-                localIdentName: "[hash:base64]"
-              }
-            }
-          }
-        ],
-        include: /\.module\.css$/
-      },
-      {
-        test: [/\.css$/],
-        use: [
-          {
-            loader: MiniCssExtractPlugin.loader
-          },
-          {
-            loader: "css-loader",
-            options: {
-              importLoaders: 1
-            }
-          }
-        ],
-        exclude: /\.module\.css$/
-      }
-    ]
+    // CSS injected directly in the DOM.
+    rules: [{ test: /\.css$/, use: ["style-loader", "css-loader"] }]
   },
 
   plugins: [

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -16,10 +16,7 @@ const config = merge(baseConfig, {
 
   devtool: "cheap-module-source-map",
 
-  entry: [
-    "@babel/polyfill",
-    "./app/index"
-  ],
+  entry: ["@babel/polyfill", "./app/index"],
 
   output: {
     path: path.join(__dirname, "app/dist"),
@@ -28,8 +25,39 @@ const config = merge(baseConfig, {
 
   module: {
     rules: [
-      // CSS and Less files, bundled into a single css file.
-      { test: /\.css$/, use: [ { loader: MiniCssExtractPlugin.loader }, "css-loader" ] },
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader
+          },
+          {
+            loader: "css-loader",
+            options: {
+              importLoaders: 1,
+              modules: {
+                localIdentName: "[hash:base64]"
+              }
+            }
+          }
+        ],
+        include: /\.module\.css$/
+      },
+      {
+        test: [/\.css$/],
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader
+          },
+          {
+            loader: "css-loader",
+            options: {
+              importLoaders: 1
+            }
+          }
+        ],
+        exclude: /\.module\.css$/
+      }
     ]
   },
 

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -25,7 +25,12 @@ const config = merge(baseConfig, {
 
   module: {
     // CSS injected directly in the DOM.
-    rules: [{ test: /\.css$/, use: ["style-loader", "css-loader"] }]
+    rules: [
+      {
+        test: /\.css$/,
+        use: [{ loader: MiniCssExtractPlugin.loader }, "css-loader"]
+      }
+    ]
   },
 
   plugins: [


### PR DESCRIPTION
Our webpack 4.* config didn't work as is becuase of `css-loader` moving `localIdentName` option to be under `modules` instead of directly under options - see https://stackoverflow.com/a/57903310/8148239:

webpack 4:
```
 {
            loader: "css-loader",
            options: {
              sourceMap: true,
              importLoaders: 1,
              localIdentName: "[local]__[hash:base64:5]",
              modules: true
            }
          }
```

webpack 5:
```
"style-loader",
          {
            loader: "css-loader",
            options: {
              sourceMap: true,
              importLoaders: 1,
              modules: {
                localIdentName: "[local]__[hash:base64:5]"
              }
            }
          }
```