### PR TITLE
[overview] TxHistory: fix unmined ticket alignement.

### DIFF
--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -162,7 +162,7 @@
 }
 
 .tooltip {
-  display: flex;
+  display: flex !important;
   justify-content: flex-end;
 }
 


### PR DESCRIPTION
As follow up for #3347;  this adds missing `!important` in `TxHistory` styling to fix unmined ticket alignment. 

Before:
![image](https://user-images.githubusercontent.com/10324528/113180114-09daa200-9259-11eb-920b-78581a3bdaee.png)


After:
![image](https://user-images.githubusercontent.com/10324528/113180147-119a4680-9259-11eb-951d-ba2eca0b3f75.png)
