### PR TITLE
Change "Immature Stake Generation" label to "Immature Staking Returns"

### DIFF
--- a/app/components/views/AccountsPage/Accounts/AccountRow/AccountDetails.jsx
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/AccountDetails.jsx
@@ -54,7 +54,10 @@ const AccountsDetails = ({
           <Balance flat amount={account.votingAuthority} />
         </DataLine>
         <DataLine>
-          <T id="accounts.immatureStake" m="Immature Stake Gen" />
+          <T
+            id="accounts.immatureStakingReturns"
+            m="Immature Staking Returns"
+          />
           <Balance flat amount={account.immatureStakeGeneration} />
         </DataLine>
         <DataLine>

--- a/app/components/views/HomePage/Tabs/BalanceTab/BalanceTab.jsx
+++ b/app/components/views/HomePage/Tabs/BalanceTab/BalanceTab.jsx
@@ -56,8 +56,8 @@ const BalanceTab = () => {
                 amount={lockedByTicketsTotalBalance}
               />
               <T
-                id="home.immatureStakeGenerationBalanceLabel"
-                m="Immature Stake Gen"
+                id="home.immatureStakingReturnsBalanceLabel"
+                m="Immature Staking Returns"
               />
               :
               <Balance

--- a/app/i18n/docs/en/InfoModals/BalanceOverview.md
+++ b/app/i18n/docs/en/InfoModals/BalanceOverview.md
@@ -6,8 +6,8 @@
 
 **Locked By Tickets** This is the balance that is currently locked by tickets for this account. Once the tickets are voted or revoked these funds will be unlocked.
 
-**Voting Authority** This balance shows the total amount that this account has voting authority over.  For example, if you use a voting-only wallet this will show that total amount controlled.
+**Voting Authority** This balance shows the total amount that this account has voting authority over. For example, if you use a voting-only wallet this will show that total amount controlled.
 
 **Immature Rewards** These are regular coinbase rewards that are currently maturing (from PoW mining reward for instance).
 
-**Immature Stake Generation** This balance shows the current stake rewards and revocations that are awaiting maturity (256 blocks on mainnet)."
+**Immature Staking Returns** This balance shows the current stake rewards and revocations that are awaiting maturity (256 blocks on mainnet)."


### PR DESCRIPTION
This diff implements @davecgh idea from matrix:
I wonder if the "Immature Stake Gen" label should be changed to "Immature Vote Returns" or similar.
I suspect "stake gen" is not at all obvious to 99.9999% of people who aren't devs.