### PR TITLE
[governance] parse & store proposal's body on redux level.

### DIFF
--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -34,12 +34,12 @@ const ProposalDetails = ({
     walletEligibleTickets,
     linkto,
     blocksLeft,
-    approved
+    approved,
+    body
   },
   showPurchaseTicketsPage,
   setVoteOption,
   newVoteChoice,
-  body,
   goBackHistory,
   linkedProposal,
   isDarkTheme

--- a/app/components/views/ProposalDetailsPage/ProposalDetailsPage.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetailsPage.jsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import ProposalDetails from "./ProposalDetails";
-import { politeiaMarkdownIndexMd } from "./utils";
 import { Header } from "./helpers";
 import { PoliteiaLoading } from "indicators";
 import { StandalonePage } from "layout";
@@ -22,7 +21,6 @@ const ProposalDetailsPage = () => {
   const { eligibleTicketCount } = viewedProposalDetails || {};
 
   const stateComponent = useMemo(() => {
-    let body = "";
     switch (votingStatus) {
       case "idle":
         return <></>;
@@ -33,17 +31,9 @@ const ProposalDetailsPage = () => {
           </div>
         );
       case "success":
-        // XXX this should move to redux logic, we should parse proposal body
-        // when fetching and store the body as part of the proposal info.
-        viewedProposalDetails.files.forEach((f) => {
-          if (f.name === "index.md") {
-            body += politeiaMarkdownIndexMd(f.payload);
-          }
-        });
         return (
           <ProposalDetails
             {...{
-              body,
               viewedProposalDetails,
               goBackHistory,
               showPurchaseTicketsPage,

--- a/app/components/views/ProposalDetailsPage/utils.js
+++ b/app/components/views/ProposalDetailsPage/utils.js
@@ -7,15 +7,6 @@ import {
   PROPOSAL_VOTING_FINISHED
 } from "constants";
 
-// politeiaMarkdownIndexMd returns markdown text from the payload of a politeia
-// proposal file that corresponds to its index.md). This was extracted from the
-// helpers.js file of politeia. Assumes the payload has been converted from
-// base64 into bytes.
-export const politeiaMarkdownIndexMd = (payload) => {
-  const text = decodeURIComponent(escape(payload));
-  return text.substring(text.indexOf("\n") + 1);
-};
-
 /**
  * Converts the vote counts {"yes": x, "no": y} obj into an array of data
  * that can be used to render the StatusBar

--- a/app/constants/governance.js
+++ b/app/constants/governance.js
@@ -7,3 +7,6 @@ export const PROPOSAL_VOTING_FINISHED = 4;
 // Proposal statuses.
 export const PROPOSAL_STATUS_PUBLIC = 4;
 export const PROPOSAL_STATUS_ABANDONED = 6;
+
+// Proposal markdown index file name.
+export const PROPOSAL_INDEX_MD_FILE = "index.md";

--- a/app/helpers/index.js
+++ b/app/helpers/index.js
@@ -8,6 +8,7 @@ export * from "./dom.js";
 export * from "./transactions";
 export * from "./msgTx";
 export * from "./files";
+export * from "./politeia";
 
 // kidCheck takes a component and returns a component that only renders if it
 // has children.

--- a/app/helpers/politeia.js
+++ b/app/helpers/politeia.js
@@ -1,0 +1,9 @@
+// politeiaMarkdownIndexMd returns markdown text from the payload of a politeia
+// proposal file that corresponds to its index.md). This was extracted from the
+// helpers.js file of politeia. Assumes the payload has been converted from
+// base64 into bytes.
+export const politeiaMarkdownIndexMd = (payload) => {
+  const text = decodeURIComponent(escape(payload));
+  console.log(text);
+  return text.substring(text.indexOf("\n") + 1);
+};

--- a/app/helpers/politeia.js
+++ b/app/helpers/politeia.js
@@ -4,6 +4,5 @@
 // base64 into bytes.
 export const politeiaMarkdownIndexMd = (payload) => {
   const text = decodeURIComponent(escape(payload));
-  console.log(text);
   return text.substring(text.indexOf("\n") + 1);
 };


### PR DESCRIPTION
This is a small followup after #3345 moving proposal body parsing logic from component
to governance redux actions layer. 

After this commit `ProposalDetailsPage` gets the proposal's body as part objects returned from the custom hook.