### PR TITLE
Dismiss blur effect instantly after ticket purchase modal closing

### DIFF
--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -305,6 +305,11 @@ export default function control(state = {}, action) {
         purchaseTicketsError: null,
         purchaseTicketsRequestAttempt: true,
         numTicketsToBuy: action.numTicketsToBuy,
+        // set modalVisible to false to hide blur effect instantly.
+        // Without this, it is dismissed with delay. Some hint for later
+        // investigation: the redux store updates fine, but the selector reads
+        // the value of `modalVisible` wrong at first, and after some delay,
+        // it is updated with the right value.
         modalVisible: false
       };
     case PURCHASETICKETS_FAILED:

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -304,7 +304,8 @@ export default function control(state = {}, action) {
         ...state,
         purchaseTicketsError: null,
         purchaseTicketsRequestAttempt: true,
-        numTicketsToBuy: action.numTicketsToBuy
+        numTicketsToBuy: action.numTicketsToBuy,
+        modalVisible: false
       };
     case PURCHASETICKETS_FAILED:
       return {


### PR DESCRIPTION
Closes #3368

I'm not very happy with this solution, but I could not figure out what causes the sync delay. The redux store updates fine, but the selector reads the value of `modalVisible` wrong at first, and after some delay, it is updated with the right value. 
I did not notice this blur lingering issue with other modal though.