### PR TITLE
[logger] Fix log crash from winston upgrade

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -445,11 +445,10 @@ ipcMain.on("get-dcrlnd-logs", (event) => {
 });
 
 ipcMain.on("get-decrediton-logs", (event) => {
-  const logTransport = logger.transports.find(transport => {
-    return transport.filename === 'decrediton.log'
+  const logTransport = logger.transports.find((transport) => {
+    return transport.filename === "decrediton.log";
   });
-  const logFileName =
-    logTransport.dirname + "/" + logTransport.filename;
+  const logFileName = logTransport.dirname + "/" + logTransport.filename;
   readFileBackward(logFileName, MAX_LOG_LENGTH, (err, data) => {
     if (err) {
       logger.log("error", "Error reading log: " + err);

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -445,8 +445,11 @@ ipcMain.on("get-dcrlnd-logs", (event) => {
 });
 
 ipcMain.on("get-decrediton-logs", (event) => {
+  const logTransport = logger.transports.find(transport => {
+    return transport.filename === 'decrediton.log'
+  });
   const logFileName =
-    logger.transports.file.dirname + "/" + logger.transports.file.filename;
+    logTransport.dirname + "/" + logTransport.filename;
   readFileBackward(logFileName, MAX_LOG_LENGTH, (err, data) => {
     if (err) {
       logger.log("error", "Error reading log: " + err);


### PR DESCRIPTION
When going to Logs on the Launcher or under Settings was causing a crash due to a change to winston logging transports.