### PR TITLE
Show the correct amount of incoming DEX transactions

### DIFF
--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -28,7 +28,7 @@ function mapNonWalletOutput(output) {
 
 function mapNonWalletInput(input) {
   const address = `${input.prevTxId}:${input.outputIndex}`;
-  const amount = input.amountIn;
+  const amount = input.amountIn ?? input.valueIn;
 
   return { address, amount };
 }

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -631,7 +631,9 @@ export const transactionNormalizer = createSelector(
         txHash,
         rawTx,
         outputs,
-        creditAddresses
+        creditAddresses,
+        direction,
+        amount: origAmount
       } = origTx;
       const txUrl = txURLBuilder(txHash);
       const txBlockHash = blockHash
@@ -702,6 +704,16 @@ export const transactionNormalizer = createSelector(
               txDirection: TICKET_FEE,
               txAccountNameCredited: creditedAccountName,
               txAccountNameDebited: debitedAccountName
+            }
+          : totalFundsReceived === 0 &&
+            totalChange > 0 &&
+            origAmount === totalChange &&
+            direction === TRANSACTION_DIR_RECEIVED
+          ? // probably this is an incoming atomic swap
+            {
+              txAmount: totalChange,
+              txDirection: TRANSACTION_DIR_RECEIVED,
+              txAccountName: creditedAccountName
             }
           : {
               txAmount: totalFundsReceived,


### PR DESCRIPTION
I found that the output in the redeeming transactions on DEX is generated as internal. In Decrediton during the tx normalizing the internal outputs are considered as change outputs. 

In this diff, if a received transaction has only one output and it is internal and its value equal to the amount prop of the decoded transaction data, it is assumed as an atomic swap redeem transaction and use its internal output's value as the amount.

The zero inputs (mentioned in #3354) on the transaction details page is a separate bug and it affects other types of transactions too. I handled this issue in this PR too.

Closes #3354.