### PR TITLE
Improve tooltip sizes and layouts

### DIFF
--- a/app/components/views/GetStartedPage/CreateWalletPage/CreateWallet.module.css
+++ b/app/components/views/GetStartedPage/CreateWalletPage/CreateWallet.module.css
@@ -9,6 +9,9 @@
   width: 100%;
 }
 
+.goBackScreenButtonWrapper {
+  margin: -20px 0 0 20px;
+}
 .goBackScreenButton {
   height: 12px;
   width: 12px;
@@ -17,7 +20,6 @@
   background-image: var(--x-grey);
   opacity: 1;
   cursor: pointer;
-  margin: -20px 0 0 20px;
 }
 
 .goBackScreenButton:hover {

--- a/app/components/views/GetStartedPage/CreateWalletPage/ExistingSeed/Form.jsx
+++ b/app/components/views/GetStartedPage/CreateWalletPage/ExistingSeed/Form.jsx
@@ -43,9 +43,11 @@ const ExistingSeedForm = ({
         toggleAction={handleToggle}
       />
       {sendBack && (
-        <Tooltip content={<GoBackMsg />}>
-          <div className={styles.goBackScreenButton} onClick={sendBack} />
-        </Tooltip>
+        <div className={styles.goBackScreenButtonWrapper}>
+          <Tooltip content={<GoBackMsg />}>
+            <div className={styles.goBackScreenButton} onClick={sendBack} />
+          </Tooltip>
+        </div>
       )}
     </div>
     <div className={classNames("flex-row", styles.seed)}>

--- a/app/components/views/HomePage/HomePage.module.css
+++ b/app/components/views/HomePage/HomePage.module.css
@@ -116,8 +116,8 @@
 }
 
 .balanceTooltip {
-  width: 31rem;
-  max-width: 31rem !important;
+  width: max-content;
+  max-width: max-content !important;
   left: 90% !important;
 }
 

--- a/app/components/views/TicketsPage/MyTicketsTab/MyTicketsTab.module.css
+++ b/app/components/views/TicketsPage/MyTicketsTab/MyTicketsTab.module.css
@@ -1,11 +1,7 @@
-.sortByTooltip {
-  font-size: 14px;
-  width: 4.5rem;
-}
-
+.sortByTooltip,
 .ticketStatusTooltip {
   font-size: 14px;
-  width: 8rem;
+  width: max-content;
 }
 
 .ticketsButtons {

--- a/app/components/views/TicketsPage/StatisticsTab/Statistics.module.css
+++ b/app/components/views/TicketsPage/StatisticsTab/Statistics.module.css
@@ -118,6 +118,12 @@
   height: 100%;
   margin-left: 42px;
 }
+.myTicketsTooltip,
+.myTicketsVoteTooltip,
+.myTicketsStakeTooltip {
+  font-size: 14px;
+  width: max-content;
+}
 
 @media screen and (max-width: 1179px) {
   .charts {

--- a/app/components/views/TicketsPage/StatisticsTab/StatisticsTab.jsx
+++ b/app/components/views/TicketsPage/StatisticsTab/StatisticsTab.jsx
@@ -29,7 +29,7 @@ const subtitleMenu = ({ allStakePoolStats, hasStats }) => (
     {hasStats && (
       <>
         <Tooltip
-          contentClassName="my-tickets-stake-tooltip"
+          contentClassName={styles.myTicketsStakeTooltip}
           content={
             <T id="mytickets.statistics.stakerewards.link" m="Stake Rewards" />
           }>
@@ -43,7 +43,7 @@ const subtitleMenu = ({ allStakePoolStats, hasStats }) => (
           />
         </Tooltip>
         <Tooltip
-          contentClassName="my-tickets-vote-tooltip"
+          contentClassName={styles.myTicketsVoteTooltip}
           content={<T id="mytickets.statistics.votetime.link" m="Vote Time" />}>
           <Link
             to="/tickets/statistics/voteTime"
@@ -55,7 +55,7 @@ const subtitleMenu = ({ allStakePoolStats, hasStats }) => (
           />
         </Tooltip>
         <Tooltip
-          contentClassName="my-tickets-tooltip"
+          contentClassName={styles.myTicketsTooltip}
           content={<T id="mytickets.statistics.heatmap.link" m="Heatmap" />}>
           <Link
             to="/tickets/statistics/heatmap"

--- a/app/components/views/TicketsPage/VSPTicketsStatusTab/MyTicketsTab.module.css
+++ b/app/components/views/TicketsPage/VSPTicketsStatusTab/MyTicketsTab.module.css
@@ -1,6 +1,6 @@
 .ticketStatusTooltip {
   font-size: 14px;
-  width: 8rem;
+  width: max-content;
 }
 
 .ticketsButtons {


### PR DESCRIPTION
Found and fixed:
- too tight locked balance summary tooltip on the dashboard:
<img width="306" alt="DeepinScreenshot_select-area_20210414212311" src="https://user-images.githubusercontent.com/52497040/114769466-8a75c400-9d6a-11eb-937e-e623dc89fb3f.png">
- on staking statistics page:
<img width="180" alt="DeepinScreenshot_select-area_20210414212252" src="https://user-images.githubusercontent.com/52497040/114769752-e50f2000-9d6a-11eb-8f60-33ca2527a0f5.png">
- on ticket history page:
<img width="96" alt="DeepinScreenshot_select-area_20210414212241" src="https://user-images.githubusercontent.com/52497040/114769895-14259180-9d6b-11eb-9939-57d400990228.png">
<img width="115" alt="DeepinScreenshot_select-area_20210414212217" src="https://user-images.githubusercontent.com/52497040/114770027-3e774f00-9d6b-11eb-8567-5602499baa4b.png">
- on ticket status page:
<img width="83" alt="DeepinScreenshot_select-area_20210414212208" src="https://user-images.githubusercontent.com/52497040/114770050-4931e400-9d6b-11eb-96c1-003c5d53ec29.png">
- back button tooltip on existing seed 
<img width="300" src="https://user-images.githubusercontent.com/52497040/114771957-7f706300-9d6d-11eb-8142-f05eecba0a1f.gif">



