### PR TITLE
[governance] Use correct cast vote params

### DIFF
--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -644,7 +644,7 @@ export const updateVoteChoice = (
   // politeiavoter.
   const messages = walletEligibleTickets.map((t) => ({
     address: t.address,
-    message: `${token}${t.txHash}${voteChoice.bits.toString(16)}`
+    message: `${token}${t.ticket}${voteChoice.bits.toString(16)}`
   }));
 
   const updatePropRef = (proposals, token, newProposal) => {
@@ -680,8 +680,8 @@ export const updateVoteChoice = (
         return;
       }
       const hexSig = Buffer.from(signature.getSignature()).toString("hex");
-      const voteBit = voteChoice.bits.toString(16);
-      const vote = { token, ticket: t.ticket, voteBit, signature: hexSig };
+      const votebit = voteChoice.bits.toString(16);
+      const vote = { token, ticket: t.ticket, votebit, signature: hexSig };
       votes.push(vote);
     });
 


### PR DESCRIPTION
This diff fixes some issues noticed when casting votes. The `castvotes` request returned an unexpected "signature invalid" error due to an invalid param on message encoding.

Due to that, votes were not being cast, but the GUI returned a successful action notification.

Depends on https://github.com/decred/politeia/pull/1399