### PR TITLE
[tickets] Add purchase tickets retry

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -15,6 +15,7 @@ import {
 import { reverseRawHash, rawToHex } from "helpers/byteActions";
 import { listUnspentOutputs } from "./TransactionActions";
 import { updateUsedVSPs } from "./VSPActions";
+import { PURCHASE_TICKET_RETRIES } from "constants";
 
 export const GETNEXTADDRESS_ATTEMPT = "GETNEXTADDRESS_ATTEMPT";
 export const GETNEXTADDRESS_FAILED = "GETNEXTADDRESS_FAILED";
@@ -355,7 +356,8 @@ export const newPurchaseTicketsAttempt = (
   passphrase,
   accountNum,
   numTickets,
-  vsp
+  vsp,
+  attemptCount
 ) => async (dispatch, getState) => {
   const walletService = sel.walletService(getState());
   try {
@@ -398,25 +400,37 @@ export const newPurchaseTicketsAttempt = (
     }
   } catch (error) {
     if (String(error).indexOf("insufficient balance") > 0) {
-      const unspentOutputs = await dispatch(
-        listUnspentOutputs(accountNum.value)
-      );
-      // we need at least one 2 utxo for each ticket, one for paying the fee
-      // and another for the splitTx and ticket purchase.
-      // Note: at least one of them needs to be big enough for ticket purchase.
-      if (unspentOutputs.length < numTickets * 2) {
-        // check if amount is indeed insufficient
-        const ticketPrice = sel.ticketPrice(getState());
-        if (accountNum.spendable > ticketPrice * numTickets) {
+      // Retry 5 times if insufficient balance error received.  This is due
+      // to dcrwallet using random utxo selection.
+      if (attemptCount < PURCHASE_TICKET_RETRIES) {
+        attemptCount += 1;
+        dispatch(
+          newPurchaseTicketsAttempt(
+            passphrase,
+            accountNum,
+            numTickets,
+            vsp,
+            attemptCount
+          )
+        );
+      } else {
+        const unspentOutputs = await dispatch(
+          listUnspentOutputs(accountNum.value)
+        );
+        // we need at least one 2 utxo for each ticket, one for paying the fee
+        // and another for the splitTx and ticket purchase.
+        // Note: at least one of them needs to be big enough for ticket purchase.
+        if (unspentOutputs.length < numTickets * 2) {
           return dispatch({
             error: `Not enough utxo. Need to break the input so one can be reserved
             for paying the fee.`,
             type: PURCHASETICKETS_FAILED
           });
+        } else {
+          dispatch({ error, type: PURCHASETICKETS_FAILED });
         }
       }
     }
-    dispatch({ error, type: PURCHASETICKETS_FAILED });
   }
 };
 

--- a/app/components/views/TicketsPage/PurchaseTab/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/hooks.js
@@ -46,7 +46,7 @@ export const usePurchaseTab = () => {
   const onPurchaseTicketV3 = useCallback(
     (passphrase, account, numTickets, vsp) =>
       dispatch(
-        ca.newPurchaseTicketsAttempt(passphrase, account, numTickets, vsp)
+        ca.newPurchaseTicketsAttempt(passphrase, account, numTickets, vsp, 0)
       ),
     [dispatch]
   );

--- a/app/constants/decrediton.js
+++ b/app/constants/decrediton.js
@@ -97,6 +97,10 @@ export const CSPP_PORT_MAINNET = "5760";
 // MENU_LINKS_PER_ROW is the default number of menu items shown in sidebar when it's located on bottom.
 export const MENU_LINKS_PER_ROW = 4;
 
+// PURCHASE_TICKET_RETRIES is the number of times decrediton will
+// retry ticket purchases in the case of insufficient balance errors.
+export const PURCHASE_TICKET_RETRIES = 5;
+
 // VSP_FEE_PROCESS_STARTED represents the state which process has being
 export const VSP_FEE_PROCESS_STARTED = 0;
 export const VSP_FEE_PROCESS_PAID = 1;


### PR DESCRIPTION
Due to random UTXO selection in dcrwallet for ticket purchases, there is a chance that retrying a few times will have a ticket purchase go through.  Currently set to a default of 5 retries if insufficient balance error is found.