### PR TITLE
[lint] Ignore app/dist/*.css files

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,6 +1,8 @@
 {
   "extends": "stylelint-config-recommended",
 
+  "ignoreFiles": ["app/dist/*.css"],
+
   "rules": {
       "length-zero-no-unit": null,
       "shorthand-property-no-redundant-values": null,


### PR DESCRIPTION
This prevents false positives when the computer already has an app/dist folder.