### PR TITLE
[dexc] Fix paths to libdexc.so

### DIFF
--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -28,7 +28,6 @@ export const EXTERNALREQUEST_DCRDATA = "EXTERNALREQUEST_DCRDATA";
 export const EXTERNALREQUEST_TREZOR_BRIDGE = "EXTERNALREQUEST_TREZOR_BRIDGE";
 
 export const DEX_LOCALPAGE = "127.0.0.1:5760";
-export const DEX_LOCALPAGE_TESTNET = "127.0.0.2:5760";
 
 // These are the requests allowed when the standard privacy mode is selected.
 export const STANDARD_EXTERNAL_REQUESTS = [
@@ -156,8 +155,6 @@ export const allowExternalRequest = (externalReqType) => {
     case EXTERNALREQUEST_DEX:
       addAllowedURL(`http://${DEX_LOCALPAGE}`);
       addAllowedURL(`ws://${DEX_LOCALPAGE}`);
-      addAllowedURL(`http://${DEX_LOCALPAGE_TESTNET}`);
-      addAllowedURL(`ws://${DEX_LOCALPAGE_TESTNET}`);
       break;
     case EXTERNALREQUEST_NETWORK_STATUS:
       addAllowedURL("https://testnet.decred.org/api/status");

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -62,7 +62,14 @@ let dcrdSocket,
 const callDEX = (func, params) => {
   // TODO: this can be done globally once ipcRenderer doesn't import launch.js anymore.
   const { getNativeFunction, getBufferPointer } = require("sbffi");
-  const dexLibPath = path.resolve("modules/dex/libdexc/libdexc.so");
+  const dexLibPath =
+    process.env.NODE_ENV === "development" || argv.custombinpath
+      ? // yarn dev || yarn start
+        path.resolve("modules/dex/libdexc/libdexc.so")
+      : // yarn package
+        path.resolve(
+          path.join(__dirname, "..", "..", "modules/dex/libdexc/libdexc.so")
+        );
   const dexLibCall = getNativeFunction(dexLibPath, "CallAlt", "int", [
     "char *",
     "char *",

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -36,7 +36,7 @@ import webSocket from "ws";
 import path from "path";
 import ini from "ini";
 import { makeRandomString, makeFileBackup } from "helpers";
-import { DEX_LOCALPAGE, DEX_LOCALPAGE_TESTNET } from "./externalRequests";
+import { DEX_LOCALPAGE } from "./externalRequests";
 
 const argv = parseArgs(process.argv.slice(1), OPTIONS);
 const debug = argv.debug || process.env.NODE_ENV === "development";
@@ -905,7 +905,7 @@ export const launchDex = (walletPath, testnet) => {
     logPath: logPath,
     logFilename: logFilename
   });
-  const serverAddress = testnet ? DEX_LOCALPAGE_TESTNET : DEX_LOCALPAGE;
+  const serverAddress = DEX_LOCALPAGE;
   const sitePath = getSitePath(argv.custombinpath);
   callDEX("startServer", {
     sitedir: sitePath,


### PR DESCRIPTION
This has become necessary due to macOS not properly resolving the path for the packaged version.
Also removes a testnet dex listening address at 127.0.0.2 since macOS doesn't appear to let you bind to those addresses automatically.

Confirmed on linux (yarn dev/start/package)
Confirmed on mac (yarn dev/start/package)
Confirmed on win (yarn start/package)