### PR TITLE
Improved `running in background` animation.

### DIFF
--- a/app/components/SideBar/Logo/Logo.jsx
+++ b/app/components/SideBar/Logo/Logo.jsx
@@ -9,8 +9,7 @@ const Logo = React.memo(
     expandSideBar,
     onReduceSideBar,
     onExpandSideBar,
-    isWatchingOnly,
-    getRunningIndicator
+    isWatchingOnly
   }) => (
     <div className={expandSideBar ? styles.logo : styles.reducedLogo}>
       {isWatchingOnly && (
@@ -35,21 +34,6 @@ const Logo = React.memo(
             : styles[MAINNET]
         }
       />
-      {getRunningIndicator && (
-        <Tooltip
-          contentClassName={styles.backgroundJobTooltip}
-          placement="bottom"
-          content={
-            <T
-              id="sidebar.mixer.running"
-              m={`One or more of the following decrediton's features running in 
-              the background: Privacy Mixer, Ticket Auto Buyer, Purchase Ticket 
-              Attempt`}
-            />
-          }>
-          <div className={styles.mixerOn} />
-        </Tooltip>
-      )}
       {expandSideBar && (
         <button
           aria-label="Reduce sidebar"

--- a/app/components/SideBar/Logo/Logo.module.css
+++ b/app/components/SideBar/Logo/Logo.module.css
@@ -26,21 +26,6 @@
   flex-direction: column;
 }
 
-.mixerOn {
-  margin: 5px;
-  width: 16px;
-  height: 16px;
-  border: none;
-  outline: none;
-  background-color: transparent;
-  background-image: var(--menu-mixer-icon);
-  background-size: 16px 16px;
-  cursor: pointer;
-  /* XXX Need a different animation method due to performance of this
-   animation: spin 1s linear infinite; 
-  */
-}
-
 .backgroundJobTooltip {
   width: 20rem;
 }

--- a/app/components/SideBar/MenuLinks/Links.jsx
+++ b/app/components/SideBar/MenuLinks/Links.jsx
@@ -8,59 +8,65 @@ export const linkList = [
   {
     path: "/home",
     link: <T id="sidebar.link.home" m="Overview" />,
-    icon: "overview",
-    ariaLabel: "Overview"
+    type: "overview",
+    ariaLabel: "Overview",
+    backgroundBusy: false
   },
   {
     path: "/transactions",
     link: <T id="sidebar.link.transactions" m="On-chain Transactions" />,
-    icon: "transactions",
-    ariaLabel: "On-chain Transactions"
+    type: "transactions",
+    ariaLabel: "On-chain Transactions",
+    backgroundBusy: false
   },
   {
     path: "/ln",
     link: <T id="sidebar.link.ln" m="Lightning Transactions" />,
-    icon: LN_KEY,
-    key: LN_KEY,
-    ariaLabel: "Lightning Transactions"
+    type: LN_KEY,
+    ariaLabel: "Lightning Transactions",
+    backgroundBusy: false
   },
   {
     path: "/governance",
     link: <T id="sidebar.link.governance" m="Governance" />,
-    icon: "governance",
+    type: "governance",
     notifProp: "newProposalsStartedVoting",
-    ariaLabel: "Governance"
+    ariaLabel: "Governance",
+    backgroundBusy: false
   },
   {
     path: "/tickets",
     link: <T id="sidebar.link.staking" m="Staking" />,
-    icon: "tickets",
-    ariaLabel: "Staking"
+    type: "tickets",
+    ariaLabel: "Staking",
+    backgroundBusy: false
   },
   {
     path: "/privacy",
     link: <T id="sidebar.link.privacy" m="Privacy and Security" />,
-    icon: "securitycntr",
-    ariaLabel: "Privacy"
+    type: "privacy",
+    ariaLabel: "Privacy",
+    backgroundBusy: false
   },
   {
     path: "/accounts",
     link: <T id="sidebar.link.accounts" m="Accounts" />,
-    icon: "accounts",
-    ariaLabel: "Accounts"
+    type: "accounts",
+    ariaLabel: "Accounts",
+    backgroundBusy: false
   },
   {
     path: "/trezor",
     link: <T id="sidebar.link.trezor" m="Trezor" />,
-    icon: TREZOR_KEY,
-    key: TREZOR_KEY,
-    ariaLabel: "Trezor"
+    type: TREZOR_KEY,
+    ariaLabel: "Trezor",
+    backgroundBusy: false
   },
   {
     path: "/dex",
     link: <T id="sidebar.link.dex" m="DEX" />,
-    icon: DEX_KEY,
-    key: DEX_KEY,
-    ariaLabel: "DEX"
+    type: DEX_KEY,
+    ariaLabel: "DEX",
+    backgroundBusy: false
   }
 ];

--- a/app/components/SideBar/MenuLinks/MenuLinks.jsx
+++ b/app/components/SideBar/MenuLinks/MenuLinks.jsx
@@ -23,42 +23,45 @@ const MenuLinks = () => {
           expandSideBar && styles.expanded,
           sidebarOnBottom && styles.onBottom
         )}>
-        {menuLinks.map((menuLink, index) => {
-          const menuLinkLabel = (text) => (
-            <div
-              className={styles.menuLinkLabel}
-              data-testid={`menuLinkLabel-${menuLink.icon}`}>
-              {text}
-            </div>
-          );
-          const label =
-            expandSideBar && !sidebarOnBottom ? (
-              menuLinkLabel(menuLink.link)
-            ) : (
-              <Tooltip
-                content={menuLink.link}
-                placement={sidebarOnBottom ? "top" : "right"}>
-                {menuLinkLabel()}
-              </Tooltip>
+        {menuLinks.map(
+          ({ type, link, path, notifProp, backgroundBusy }, index) => {
+            const menuLinkLabel = (text) => (
+              <div
+                className={styles.menuLinkLabel}
+                data-testid={`menuLinkLabel-${type}`}>
+                {text}
+              </div>
             );
-          return (
-            (index < MENU_LINKS_PER_ROW ||
-              expandSideBar ||
-              !sidebarOnBottom) && (
-              <Tab
-                label={label}
-                key={menuLink.path}
-                className={classNames(
-                  styles.tab,
-                  styles[`${menuLink.icon}Icon`],
-                  expandSideBar && styles.expanded,
-                  sidebarOnBottom && styles.onBottom,
-                  menuLink.notifProp && styles.notificationIcon
-                )}
-              />
-            )
-          );
-        })}
+            const label =
+              expandSideBar && !sidebarOnBottom ? (
+                menuLinkLabel(link)
+              ) : (
+                <Tooltip
+                  content={link}
+                  placement={sidebarOnBottom ? "top" : "right"}>
+                  {menuLinkLabel()}
+                </Tooltip>
+              );
+            return (
+              (index < MENU_LINKS_PER_ROW ||
+                expandSideBar ||
+                !sidebarOnBottom) && (
+                <Tab
+                  label={label}
+                  key={path}
+                  className={classNames(
+                    styles.tab,
+                    styles[`${type}Icon`],
+                    expandSideBar && styles.expanded,
+                    sidebarOnBottom && styles.onBottom,
+                    notifProp && styles.notificationIcon,
+                    backgroundBusy && styles.backgroundBusy
+                  )}
+                />
+              )
+            );
+          }
+        )}
       </Tabs>
     </>
   );

--- a/app/components/SideBar/MenuLinks/MenuLinks.module.css
+++ b/app/components/SideBar/MenuLinks/MenuLinks.module.css
@@ -17,7 +17,22 @@
   border-width: 5px !important;
   padding-left: 0 !important;
   font-size: 15px !important;
+  position: relative;
 }
+
+.tab.backgroundBusy::before {
+  content: "";
+  height: 20px;
+  width: 20px;
+  background-image: var(--pending-animation);
+  background-size: 20px;
+  background-position: 50%;
+  background-repeat: no-repeat;
+  position: absolute;
+  left: 35px;
+  top: 4px;
+}
+
 .tabs.expanded .tab span {
   padding-left: 55px !important;
 }
@@ -36,7 +51,7 @@
 .tab.accountsIcon {
   background-image: var(--menu-accounts);
 }
-.tab.securitycntrIcon {
+.tab.privacyIcon {
   background-image: var(--menu-privacy);
 }
 .tab.overviewIcon {

--- a/app/components/SideBar/SideBar.jsx
+++ b/app/components/SideBar/SideBar.jsx
@@ -23,7 +23,6 @@ const SideBar = () => {
     expandSideBar,
     isWatchingOnly,
     sidebarOnBottom,
-    getRunningIndicator,
     rescanRequest,
     onExpandSideBar,
     onReduceSideBar,
@@ -50,8 +49,7 @@ const SideBar = () => {
           sidebarOnBottom,
           onReduceSideBar,
           onExpandSideBar,
-          isWatchingOnly,
-          getRunningIndicator
+          isWatchingOnly
         }}
       />
       <div

--- a/app/components/SideBar/hooks.js
+++ b/app/components/SideBar/hooks.js
@@ -3,9 +3,8 @@ import { useSelector, useDispatch } from "react-redux";
 import * as sel from "selectors";
 import * as sba from "../../actions/SidebarActions";
 
-export function useSideBar() {
+export const useSideBar = () => {
   const [isShowingAccounts, setIsShowingAccounts] = useState(false);
-
   const accountsListRef = useRef(null);
 
   const onAccountsListWheel = useCallback(
@@ -27,7 +26,6 @@ export function useSideBar() {
   const expandSideBar = useSelector(sel.expandSideBar);
   const isWatchingOnly = useSelector(sel.isWatchingOnly);
   const sidebarOnBottom = useSelector(sel.sidebarOnBottom);
-  const getRunningIndicator = useSelector(sel.getRunningIndicator);
   const rescanRequest = useSelector(sel.rescanRequest);
   const isSPV = useSelector(sel.isSPV);
   const peersCount = useSelector(sel.getPeersCount);
@@ -55,7 +53,6 @@ export function useSideBar() {
     expandSideBar,
     isWatchingOnly,
     sidebarOnBottom,
-    getRunningIndicator,
     rescanRequest,
     onExpandSideBar,
     onReduceSideBar,
@@ -65,4 +62,4 @@ export function useSideBar() {
     onAccountsListWheel,
     uiAnimations
   };
-}
+};

--- a/app/components/modals/CantCloseModals/hooks.js
+++ b/app/components/modals/CantCloseModals/hooks.js
@@ -4,7 +4,7 @@ import * as da from "actions/DaemonActions";
 import { useSelector, useDispatch } from "react-redux";
 
 export function useCantCloseModal() {
-  const autoBuyerRunning = useSelector(sel.isTicketAutoBuyerEnabled);
+  const legacyAutoBuyerRunning = useSelector(sel.isTicketAutoBuyerEnabled);
   const hasUnpaidFee = useSelector(sel.getHasTicketFeeError);
   const cantCloseModalVisible = useSelector(sel.cantCloseModalVisible);
   const accountMixerRunning = useSelector(sel.getAccountMixerRunning);
@@ -17,7 +17,7 @@ export function useCantCloseModal() {
   const shutdownApp = () => dispatch(da.shutdownApp());
 
   return {
-    autoBuyerRunning: autoBuyerRunning || ticketAutoBuyerRunning,
+    autoBuyerRunning: legacyAutoBuyerRunning || ticketAutoBuyerRunning,
     hasUnpaidFee,
     cantCloseModalVisible,
     onHideCantCloseModal,

--- a/app/components/shared/SendTransaction/Form.jsx
+++ b/app/components/shared/SendTransaction/Form.jsx
@@ -78,10 +78,7 @@ const Form = ({
                     m="Privacy Mixer, Autobuyer or Purchase Ticket Attempt running, please shut them off before sending a transaction."
                   />
                 }>
-                <SendTransactionButton
-                  disabled={true}
-                  buttonLabel={sendButtonLabel}
-                />
+                <SendTransactionButton disabled buttonLabel={sendButtonLabel} />
               </Tooltip>
             ) : (
               <SendTransactionButton
@@ -110,7 +107,7 @@ const Form = ({
                       {outputs.map((output, index) => (
                         <div
                           className={styles.passphraseModalAddress}
-                          key={"confirm-" + index}>
+                          key={`confirm-${index}`}>
                           {output.data.destination}
                         </div>
                       ))}

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_Tickets/Tickets.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_Tickets/Tickets.jsx
@@ -30,48 +30,46 @@ const Tickets = ({
   notMixedAccounts,
   getRunningIndicator,
   ...props
-}) => {
-  return (
-    <div className={styles.purchaseTicketArea}>
-      <StakeInfo {...{ sidebarOnBottom }} />
-      <Subtitle
-        title={<T id="purchase.subtitle.legacy" m="Purchase Tickets" />}
-        children={getTitleIcon()}
-        className={classNames(styles.isRow, styles.subtitle)}
-      />
-      {spvMode && blocksNumberToNextTicket === 2 ? (
-        <ShowWarning
-          warn={
-            <T
-              id="spv.purchase.warn.legacy"
-              m="Purchase Tickets is not available right now, because we are at the end of a ticket interval. After one block it will be available again."
-            />
-          }
-        />
-      ) : (
-        <PurchaseTickets
-          {...{
-            ...props,
-            notMixedAccounts,
-            getRunningIndicator,
-            toggleIsLegacy
-          }}
-        />
-      )}
-      {isWatchingOnly ? (
-        <UnsignedTickets {...{ ...props }} />
-      ) : spvMode ? (
-        <div>
+}) => (
+  <div className={styles.purchaseTicketArea}>
+    <StakeInfo {...{ sidebarOnBottom }} />
+    <Subtitle
+      title={<T id="purchase.subtitle.legacy" m="Purchase Tickets" />}
+      children={getTitleIcon()}
+      className={classNames(styles.isRow, styles.subtitle)}
+    />
+    {spvMode && blocksNumberToNextTicket === 2 ? (
+      <ShowWarning
+        warn={
           <T
-            id="spv.auto.buyer.warn"
-            m="Ticket Auto Buyer not available while using SPV"
+            id="spv.purchase.warn.legacy"
+            m="Purchase Tickets is not available right now, because we are at the end of a ticket interval. After one block it will be available again."
           />
-        </div>
-      ) : (
-        <TicketAutoBuyer />
-      )}
-    </div>
-  );
-};
+        }
+      />
+    ) : (
+      <PurchaseTickets
+        {...{
+          ...props,
+          notMixedAccounts,
+          getRunningIndicator,
+          toggleIsLegacy
+        }}
+      />
+    )}
+    {isWatchingOnly ? (
+      <UnsignedTickets {...{ ...props }} />
+    ) : spvMode ? (
+      <div>
+        <T
+          id="spv.auto.buyer.warn"
+          m="Ticket Auto Buyer not available while using SPV"
+        />
+      </div>
+    ) : (
+      <TicketAutoBuyer />
+    )}
+  </div>
+);
 
 export default Tickets;

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/PurchasePage.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/PurchasePage.jsx
@@ -78,7 +78,6 @@ const PurchasePage = ({
     addCustomStakePool,
     onEnableTicketAutoBuyer,
     onDisableTicketAutoBuyer,
-    isTicketAutoBuyerEnabled,
     notMixedAccounts,
     getRunningIndicator,
     isPurchasingTickets
@@ -127,7 +126,6 @@ const PurchasePage = ({
         configuredStakePools,
         onEnableTicketAutoBuyer,
         onDisableTicketAutoBuyer,
-        isTicketAutoBuyerEnabled,
         notMixedAccounts,
         getRunningIndicator,
         ...props

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/hooks.js
@@ -63,8 +63,6 @@ export function useLegacyPurchasePage(toggleShowVsp) {
     [dispatch]
   );
 
-  const isTicketAutoBuyerEnabled = useSelector(sel.isTicketAutoBuyerEnabled);
-
   const onShowAddStakePool = useCallback(() => {
     setIsAdding(true);
   }, []);
@@ -205,7 +203,6 @@ export function useLegacyPurchasePage(toggleShowVsp) {
     addCustomStakePool,
     onEnableTicketAutoBuyer,
     onDisableTicketAutoBuyer,
-    isTicketAutoBuyerEnabled,
     notMixedAccounts,
     getRunningIndicator,
     isPurchasingTickets

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/Page.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/Page.jsx
@@ -43,7 +43,7 @@ const EnableVSP = ({ onEnableVSP }) => (
   </div>
 );
 
-export function PurchasePage({
+export const PurchasePage = ({
   spvMode,
   blocksNumberToNextTicket,
   sidebarOnBottom,
@@ -75,53 +75,51 @@ export function PurchasePage({
   onEnableVSPListing,
   getRunningIndicator,
   ...props
-}) {
-  return (
-    <div className={styles.purchaseTicketArea}>
-      <StakeInfo {...{ sidebarOnBottom }} />
-      {!isVSPListingEnabled && <EnableVSP onEnableVSP={onEnableVSPListing} />}
-      <Subtitle title={<T id="purchase.subtitle" m="Purchase Tickets" />} />
-      {mixedAccount && changeAccount && <PrivacyInfo />}
-      {spvMode && blocksNumberToNextTicket === 2 ? (
-        <ShowWarning
-          warn={
-            <T
-              id="spv.purchase.warn"
-              m="Purchase Tickets is not available right now, because we are at the end of a ticket interval. After one block it will be available again."
-            />
-          }
-        />
-      ) : (
-        <PurchaseTicketsForm
-          {...{
-            notMixedAccounts,
-            ticketPrice,
-            setAccount,
-            handleOnKeyDown,
-            availableVSPs,
-            account,
-            numTicketsToBuy,
-            onIncrementNumTickets,
-            onDecrementNumTickets,
-            onChangeNumTickets,
-            setVSP,
-            vsp,
-            vspFee,
-            setVspFee,
-            isValid,
-            onPurchaseTickets: onV3PurchaseTicket,
-            isLoading,
-            rememberedVspHost,
-            toggleRememberVspHostCheckBox,
-            onRevokeTickets,
-            getRunningIndicator,
-            toggleIsLegacy,
-            isLegacy: false
-          }}
-        />
-      )}
-      {isWatchingOnly && <UnsignedTickets {...{ ...props }} />}
-      <TicketAutoBuyer />
-    </div>
-  );
-}
+}) => (
+  <div className={styles.purchaseTicketArea}>
+    <StakeInfo {...{ sidebarOnBottom }} />
+    {!isVSPListingEnabled && <EnableVSP onEnableVSP={onEnableVSPListing} />}
+    <Subtitle title={<T id="purchase.subtitle" m="Purchase Tickets" />} />
+    {mixedAccount && changeAccount && <PrivacyInfo />}
+    {spvMode && blocksNumberToNextTicket === 2 ? (
+      <ShowWarning
+        warn={
+          <T
+            id="spv.purchase.warn"
+            m="Purchase Tickets is not available right now, because we are at the end of a ticket interval. After one block it will be available again."
+          />
+        }
+      />
+    ) : (
+      <PurchaseTicketsForm
+        {...{
+          notMixedAccounts,
+          ticketPrice,
+          setAccount,
+          handleOnKeyDown,
+          availableVSPs,
+          account,
+          numTicketsToBuy,
+          onIncrementNumTickets,
+          onDecrementNumTickets,
+          onChangeNumTickets,
+          setVSP,
+          vsp,
+          vspFee,
+          setVspFee,
+          isValid,
+          onPurchaseTickets: onV3PurchaseTicket,
+          isLoading,
+          rememberedVspHost,
+          toggleRememberVspHostCheckBox,
+          onRevokeTickets,
+          getRunningIndicator,
+          toggleIsLegacy,
+          isLegacy: false
+        }}
+      />
+    )}
+    {isWatchingOnly && <UnsignedTickets {...{ ...props }} />}
+    <TicketAutoBuyer />
+  </div>
+);

--- a/app/components/views/TicketsPage/PurchaseTab/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/hooks.js
@@ -2,7 +2,6 @@ import { useSelector, useDispatch } from "react-redux";
 import { useCallback } from "react";
 import { useSettings } from "hooks";
 import { EXTERNALREQUEST_STAKEPOOL_LISTING } from "main_dev/externalRequests";
-
 import * as vspa from "actions/VSPActions";
 import * as ca from "actions/ControlActions.js";
 import { listUnspentOutputs } from "actions/TransactionActions";

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1753,12 +1753,13 @@ export const trezorWalletCreationMasterPubkeyAttempt = get([
 
 // selectors for checking if decrediton can be closed.
 
-// TODO remove duplicated auto buyer running selector
+// XXX remove legacy ticket autobuyer V1 & V2 running selector
 const startAutoBuyerResponse = get(["control", "startAutoBuyerResponse"]);
 export const isTicketAutoBuyerEnabled = bool(startAutoBuyerResponse);
 
-// getRunningIndicator is a indicator for indicate something is runnning on
-// decrediton, like the ticket auto buyer or the mixer.
+// getRunningIndicator indicates that one of the following features is running
+// in the background: legacy ticket autobuyer, v3 ticket autobuyer, the mixer
+// or ticket purchase attempt.
 export const getRunningIndicator = or(
   getAccountMixerRunning,
   getTicketAutoBuyerRunning,

--- a/app/style/themes/darkTheme.js
+++ b/app/style/themes/darkTheme.js
@@ -172,7 +172,6 @@ const darkTheme = {
   "menu-trezor": url(require("style/icons/trezorActiveDark.svg")),
   "menu-hamburger": url(require("style/icons/hamburgerDark.svg")),
   "menu-arrow": url(require("style/icons/arrowDark.svg")),
-  "menu-mixer-icon": url(require("style/icons/menuMixerDark.svg")),
   "menu-spvon-icon": url(require("style/icons/menuSpvOnDark.svg")),
   "menu-spvoff-icon": url(require("style/icons/menuSpvOffDark.svg")),
   "menu-block-synced-icon": url(require("style/icons/blockSyncedDark.svg")),

--- a/app/style/themes/lightTheme.js
+++ b/app/style/themes/lightTheme.js
@@ -172,7 +172,6 @@ const lightTheme = {
   "menu-trezor": url(require("style/icons/trezorActive.svg")),
   "menu-hamburger": url(require("style/icons/hamburger.svg")),
   "menu-arrow": url(require("style/icons/arrow.svg")),
-  "menu-mixer-icon": url(require("style/icons/menuMixer.svg")),
   "menu-spvon-icon": url(require("style/icons/menuSpvOn.svg")),
   "menu-spvoff-icon": url(require("style/icons/menuSpvOff.svg")),
   "menu-dex": url(require("style/icons/dex.svg")),

--- a/test/unit/components/SideBar/Sidebar.spec.js
+++ b/test/unit/components/SideBar/Sidebar.spec.js
@@ -448,23 +448,6 @@ test("tests tooltip on Logo when isWatchingOnly mode is active", () => {
   mockIsWatchingOnly.mockRestore();
 });
 
-test("tests tooltip on Logo when accountMixerRunning mode is active", () => {
-  const mockGetAccountMixerRunning = (selectors.getRunningIndicator = jest.fn(
-    () => true
-  ));
-
-  render(<SideBar />);
-  expect(screen.getByText(/in the background/i).textContent)
-    .toMatchInlineSnapshot(`
-    "One or more of the following decrediton's features running in 
-                  the background: Privacy Mixer, Ticket Auto Buyer, Purchase Ticket 
-                  Attempt"
-  `);
-
-  expect(mockGetAccountMixerRunning).toHaveBeenCalled();
-  mockGetAccountMixerRunning.mockRestore();
-});
-
 test("tests notification icon on the menu link", () => {
   const mockNewProposalsStartedVoting = (selectors.newProposalsStartedVoting = jest.fn(
     () => true

--- a/test/unit/components/SideBar/Sidebar.spec.js
+++ b/test/unit/components/SideBar/Sidebar.spec.js
@@ -144,9 +144,9 @@ const expectToHaveDefaultMenuLinks = (params) => {
       "/accounts"
     );
     expectToHaveMenuLink(
-      "menuLinkLabel-securitycntr",
+      "menuLinkLabel-privacy",
       "Privacy and Security",
-      "securitycntrIcon",
+      "privacyIcon",
       "/privacy"
     );
     if (isTrezorEnabled) {


### PR DESCRIPTION
As discussed in https://github.com/decred/decrediton/issues/3243#issuecomment-825651503:
This uses the new animation suggested in #3243 - shows the indicator next to the `Privacy and Security` menu item when the mixer is on, but next to the `Staking` when the ticket autobuyer is on or there is a ticket purchase attempt.

Closes #3243.