### PR TITLE
[locking] Various account locking issues patched

### DIFF
--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -105,8 +105,7 @@ export const runAccountMixer = ({
       const mixerStreamer = await dispatch(
         unlockAcctAndExecFn(
           passphrase,
-          changeAccount,
-          null,
+          new Array(changeAccount),
           () =>
             runAccountMixerRequest(sel.accountMixerService(getState()), {
               mixedAccount,

--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -105,7 +105,7 @@ export const runAccountMixer = ({
       const mixerStreamer = await dispatch(
         unlockAcctAndExecFn(
           passphrase,
-          new Array(changeAccount),
+          [changeAccount],
           () =>
             runAccountMixerRequest(sel.accountMixerService(getState()), {
               mixedAccount,

--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -106,6 +106,7 @@ export const runAccountMixer = ({
         unlockAcctAndExecFn(
           passphrase,
           changeAccount,
+          null,
           () =>
             runAccountMixerRequest(sel.accountMixerService(getState()), {
               mixedAccount,

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -3,7 +3,6 @@ import * as wallet from "wallet";
 import * as sel from "selectors";
 import { isValidAddress, isValidMasterPubKey } from "helpers";
 import {
-  getStakeInfoAttempt,
   startWalletServices,
   getStartupWalletInfo
 } from "./ClientActions";

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1120,7 +1120,7 @@ export const unlockAcctAndExecFn = (
     await Promise.all(
       // Need to try and lock all since 1 may have unlocked but not another?
       accts.map(async (acctNumber) => {
-        if (dexAccount && acctNumber !== dexAccount.accountNumber) {
+        if (!dexAccount || acctNumber !== dexAccount.accountNumber) {
           try {
             await wallet.lockAccount(walletService, parseInt(acctNumber));
           } catch (e) {
@@ -1148,7 +1148,7 @@ export const unlockAcctAndExecFn = (
   try {
     await Promise.all(
       accts.map(async (acctNumber) => {
-        if (dexAccount && acctNumber !== dexAccount.accountNumber) {
+        if (!dexAccount || acctNumber !== dexAccount.accountNumber) {
           try {
             await wallet.lockAccount(walletService, parseInt(acctNumber));
           } catch (e) {

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -3,6 +3,7 @@ import * as wallet from "wallet";
 import * as sel from "selectors";
 import { isValidAddress, isValidMasterPubKey } from "helpers";
 import {
+  getStakeInfoAttempt,
   startWalletServices,
   getStartupWalletInfo
 } from "./ClientActions";
@@ -464,6 +465,9 @@ export const revokeTicketsAttempt = (passphrase) => async (
       )
     );
     dispatch({ revokeTicketsResponse, type: REVOKETICKETS_SUCCESS });
+    setTimeout(() => {
+      dispatch(getStakeInfoAttempt());
+    }, 4000);
   } catch (error) {
     dispatch({ error, type: REVOKETICKETS_FAILED });
   }

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -243,7 +243,7 @@ export const signTransactionAttempt = (passphrase, rawTx, acctNumber) => async (
   dispatch({ type: SIGNTX_ATTEMPT });
   try {
     const signTransactionResponse = await dispatch(
-      unlockAcctAndExecFn(passphrase, new Array(acctNumber), () =>
+      unlockAcctAndExecFn(passphrase, [acctNumber], () =>
         wallet.signTransaction(sel.walletService(getState()), rawTx, acctNumber)
       )
     );
@@ -463,7 +463,7 @@ export const revokeTicketsAttempt = (passphrase) => async (
   const accountNum = 0;
   try {
     const revokeTicketsResponse = await dispatch(
-      unlockAcctAndExecFn(passphrase, new Array(accountNum), () =>
+      unlockAcctAndExecFn(passphrase, [accountNum], () =>
         wallet.revokeTickets(walletService, passphrase)
       )
     );
@@ -505,7 +505,7 @@ export const startTicketBuyerV3Attempt = (
     const ticketBuyer = await dispatch(
       unlockAcctAndExecFn(
         passphrase,
-        new Array(accountNum),
+        [accountNum],
         () =>
           wallet.startTicketAutoBuyerV3(ticketBuyerService, {
             mixedAccount,
@@ -783,7 +783,7 @@ export const signMessageAttempt = (address, message, passphrase) => async (
     );
     const accountNumber = response.getAccountNumber();
     const getSignMessageResponse = await dispatch(
-      unlockAcctAndExecFn(passphrase, new Array(accountNumber), () =>
+      unlockAcctAndExecFn(passphrase, [accountNumber], () =>
         wallet.signMessage(sel.walletService(getState()), address, message)
       )
     );
@@ -917,7 +917,7 @@ export const startTicketBuyerV2Attempt = (
     request.setVotingAddress(stakepool.TicketAddress);
     const { ticketBuyerService } = getState().grpc;
     const ticketBuyer = await dispatch(
-      unlockAcctAndExecFn(passphrase, new Array(account.value), () =>
+      unlockAcctAndExecFn(passphrase, [account.value], () =>
         ticketBuyerService.runTicketBuyer(request)
       )
     );

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1122,14 +1122,16 @@ export const unlockAcctAndExecFn = (
     );
     dispatch({ type: UNLOCKACCOUNT_SUCCESS });
   } catch (error) {
-    await Promise.all(
-      // Need to try and lock all since 1 may have unlocked but not another?
-      accts.map(async (acctNumber) => {
-        if (dexAccount && acctNumber !== dexAccount.accountNumber) {
-          await wallet.lockAccount(walletService, parseInt(acctNumber));
-        }
-      })
-    );
+    if (String(error).indexOf("invalid passphrase") < 0) {
+      await Promise.all(
+        // Need to try and lock all since 1 may have unlocked but not another?
+        accts.map(async (acctNumber) => {
+          if (dexAccount && acctNumber !== dexAccount.accountNumber) {
+            await wallet.lockAccount(walletService, parseInt(acctNumber));
+          }
+        })
+      );
+    }
     dispatch({ type: UNLOCKACCOUNT_FAILED, error });
     throw error;
   }

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1098,7 +1098,7 @@ export const unlockAcctAndExecFn = (
   const dexAccount = accounts.find(
     (acct) => acct.accountName === dexAccountName
   );
-  accts.map((acctNum) => {
+  accts.forEach((acctNum) => {
     const account = accounts.find((acct) => acct.accountNumber === acctNum);
     if (!account) {
       throw "Account not found";
@@ -1191,7 +1191,7 @@ export const unlockAllAcctAndExecFn = (passphrase, fn, leaveUnlock) => async (
     }
     accountUnlocks.push(acct.accountNumber);
   });
-  console.log(accountUnlocks);
+
   // sanity checks
   // do not allow locking of the dex account, as it isn't supposed to lock.
   const dexAccountName = sel.dexAccount(getState());

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1117,17 +1117,19 @@ export const unlockAcctAndExecFn = (
   try {
     await Promise.all(
       accts.map(async (acctNumber) => {
-      await wallet.unlockAccount(walletService, passphrase, acctNumber);
-    }));
+        await wallet.unlockAccount(walletService, passphrase, acctNumber);
+      })
+    );
     dispatch({ type: UNLOCKACCOUNT_SUCCESS });
   } catch (error) {
     await Promise.all(
-    // Need to try and lock all since 1 may have unlocked but not another?
+      // Need to try and lock all since 1 may have unlocked but not another?
       accts.map(async (acctNumber) => {
         if (dexAccount && acctNumber !== dexAccount.accountNumber) {
           await wallet.lockAccount(walletService, parseInt(acctNumber));
         }
-      }));
+      })
+    );
     dispatch({ type: UNLOCKACCOUNT_FAILED, error });
     throw error;
   }
@@ -1150,7 +1152,8 @@ export const unlockAcctAndExecFn = (
         if (dexAccount && acctNumber !== dexAccount.accountNumber) {
           await wallet.lockAccount(walletService, acctNumber);
         }
-    }));
+      })
+    );
     dispatch({ type: LOCKACCOUNT_SUCCESS });
   } catch (error) {
     // no need to lock as unlock errored.

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -674,7 +674,7 @@ export const updateVoteChoice = (
   dispatch({ type: UPDATEVOTECHOICE_ATTEMPT });
   try {
     const signed = await dispatch(
-      unlockAcctAndExecFn(passphrase, accountNumber, () =>
+      unlockAcctAndExecFn(passphrase, accountNumber, null, () =>
         wallet.signMessages(walletService, messages)
       )
     );

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -674,7 +674,7 @@ export const updateVoteChoice = (
   dispatch({ type: UPDATEVOTECHOICE_ATTEMPT });
   try {
     const signed = await dispatch(
-      unlockAcctAndExecFn(passphrase, accountNumber, null, () =>
+      unlockAcctAndExecFn(passphrase, new Array(accountNumber), () =>
         wallet.signMessages(walletService, messages)
       )
     );

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -674,7 +674,7 @@ export const updateVoteChoice = (
   dispatch({ type: UPDATEVOTECHOICE_ATTEMPT });
   try {
     const signed = await dispatch(
-      unlockAcctAndExecFn(passphrase, new Array(accountNumber), () =>
+      unlockAcctAndExecFn(passphrase, [accountNumber], () =>
         wallet.signMessages(walletService, messages)
       )
     );

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -4,7 +4,7 @@ import { getWalletCfg, updateStakePoolConfig } from "config";
 import {
   importScriptAttempt,
   rescanAttempt,
-  unlockAcctAndExecFn
+  unlockAllAcctAndExecFn
 } from "./ControlActions";
 import { SETVOTECHOICES_SUCCESS } from "./ClientActions";
 import * as sel from "../selectors";
@@ -106,17 +106,8 @@ export const syncVSPTicketsRequest = ({
 }) => async (dispatch, getState) => {
   dispatch({ type: SYNCVSPTICKETS_ATTEMPT });
   try {
-    const accounts = sel.balances(getState());
-    const accountUnlocks = [];
-    accounts.map((acct) => {
-      // just skip if imported account.
-      if (acct.accountNumber === Math.pow(2, 31) - 1) {
-        return;
-      }
-      accountUnlocks.push(acct.accountNumber);
-    });
     await dispatch(
-      unlockAcctAndExecFn(passphrase, accountUnlocks, () =>
+      unlockAllAcctAndExecFn(passphrase, () =>
         wallet.syncVSPTickets(
           getState().grpc.walletService,
           vspHost,
@@ -637,17 +628,8 @@ export const processManagedTickets = (passphrase) => (dispatch, getState) =>
           feeAccount = sel.defaultSpendingAccount(getState()).value;
           changeAccount = sel.defaultSpendingAccount(getState()).value;
         }
-        const accounts = sel.balances(getState());
-        const accountUnlocks = [];
-        accounts.map((acct) => {
-          // just skip if imported account.
-          if (acct.accountNumber === Math.pow(2, 31) - 1) {
-            return;
-          }
-          accountUnlocks.push(acct.accountNumber);
-        });
         await dispatch(
-          unlockAcctAndExecFn(passphrase, accountUnlocks, () =>
+          unlockAllAcctAndExecFn(passphrase, () =>
             Promise.all(
               availableVSPsPubkeys.map(async (vsp) => {
                 await wallet.processManagedTickets(
@@ -715,18 +697,9 @@ export const processUnmanagedTickets = (passphrase, vspHost, vspPubkey) => (
           changeAccount = sel.defaultSpendingAccount(getState()).value;
         }
 
-        const accounts = sel.balances(getState());
-        const accountUnlocks = [];
-        accounts.map((acct) => {
-          // just skip if imported account.
-          if (acct.accountNumber === Math.pow(2, 31) - 1) {
-            return;
-          }
-          accountUnlocks.push(acct.accountNumber);
-        });
         if (passphrase) {
           await dispatch(
-            unlockAcctAndExecFn(passphrase, accountUnlocks, () =>
+            unlockAllAcctAndExecFn(passphrase, () =>
               wallet.processUnmanagedTicketsStartup(
                 walletService,
                 vspHost,

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -106,8 +106,12 @@ export const syncVSPTicketsRequest = ({
 }) => async (dispatch, getState) => {
   dispatch({ type: SYNCVSPTICKETS_ATTEMPT });
   try {
+    let accts = [account];
+    if (account !== 0) {
+      accts.push(0);
+    }
     await dispatch(
-      unlockAcctAndExecFn(passphrase, account, 0, () =>
+      unlockAcctAndExecFn(passphrase, accts, () =>
         wallet.syncVSPTickets(
           getState().grpc.walletService,
           vspHost,
@@ -628,9 +632,12 @@ export const processManagedTickets = (passphrase) => (dispatch, getState) =>
           feeAccount = sel.defaultSpendingAccount(getState()).value;
           changeAccount = sel.defaultSpendingAccount(getState()).value;
         }
-
+        let accts = [feeAccount];
+        if (feeAccount !== 0) {
+          accts.push(0);
+        }
         await dispatch(
-          unlockAcctAndExecFn(passphrase, feeAccount, 0, () =>
+          unlockAcctAndExecFn(passphrase, accts, () =>
             Promise.all(
               availableVSPsPubkeys.map(async (vsp) => {
                 await wallet.processManagedTickets(
@@ -698,9 +705,13 @@ export const processUnmanagedTickets = (passphrase, vspHost, vspPubkey) => (
           changeAccount = sel.defaultSpendingAccount(getState()).value;
         }
 
+        let accts = [feeAccount];
+        if (feeAccount !== 0) {
+          accts.push(0);
+        }
         if (passphrase) {
           await dispatch(
-            unlockAcctAndExecFn(passphrase, feeAccount, 0, () =>
+            unlockAcctAndExecFn(passphrase, accts, () =>
               wallet.processUnmanagedTicketsStartup(
                 walletService,
                 vspHost,

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -106,9 +106,17 @@ export const syncVSPTicketsRequest = ({
 }) => async (dispatch, getState) => {
   dispatch({ type: SYNCVSPTICKETS_ATTEMPT });
   try {
-    const accts = account !== 0 ? [account, 0] : [account];
+    const accounts = sel.balances(getState());
+    const accountUnlocks = [];
+    accounts.map((acct) => {
+      // just skip if imported account.
+      if (acct.accountNumber === Math.pow(2, 31) - 1) {
+        return;
+      }
+      accountUnlocks.push(acct.accountNumber);
+    });
     await dispatch(
-      unlockAcctAndExecFn(passphrase, accts, () =>
+      unlockAcctAndExecFn(passphrase, accountUnlocks, () =>
         wallet.syncVSPTickets(
           getState().grpc.walletService,
           vspHost,
@@ -629,9 +637,17 @@ export const processManagedTickets = (passphrase) => (dispatch, getState) =>
           feeAccount = sel.defaultSpendingAccount(getState()).value;
           changeAccount = sel.defaultSpendingAccount(getState()).value;
         }
-        const accts = feeAccount !== 0 ? [feeAccount, 0] : [feeAccount];
+        const accounts = sel.balances(getState());
+        const accountUnlocks = [];
+        accounts.map((acct) => {
+          // just skip if imported account.
+          if (acct.accountNumber === Math.pow(2, 31) - 1) {
+            return;
+          }
+          accountUnlocks.push(acct.accountNumber);
+        });
         await dispatch(
-          unlockAcctAndExecFn(passphrase, accts, () =>
+          unlockAcctAndExecFn(passphrase, accountUnlocks, () =>
             Promise.all(
               availableVSPsPubkeys.map(async (vsp) => {
                 await wallet.processManagedTickets(
@@ -699,11 +715,18 @@ export const processUnmanagedTickets = (passphrase, vspHost, vspPubkey) => (
           changeAccount = sel.defaultSpendingAccount(getState()).value;
         }
 
-        // Add default account unlock if account isn't default
-        const accts = feeAccount !== 0 ? [feeAccount, 0] : [feeAccount];
+        const accounts = sel.balances(getState());
+        const accountUnlocks = [];
+        accounts.map((acct) => {
+          // just skip if imported account.
+          if (acct.accountNumber === Math.pow(2, 31) - 1) {
+            return;
+          }
+          accountUnlocks.push(acct.accountNumber);
+        });
         if (passphrase) {
           await dispatch(
-            unlockAcctAndExecFn(passphrase, accts, () =>
+            unlockAcctAndExecFn(passphrase, accountUnlocks, () =>
               wallet.processUnmanagedTicketsStartup(
                 walletService,
                 vspHost,

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -106,10 +106,7 @@ export const syncVSPTicketsRequest = ({
 }) => async (dispatch, getState) => {
   dispatch({ type: SYNCVSPTICKETS_ATTEMPT });
   try {
-    let accts = [account];
-    if (account !== 0) {
-      accts.push(0);
-    }
+    const accts = account !== 0 ? [account, 0] : [account];
     await dispatch(
       unlockAcctAndExecFn(passphrase, accts, () =>
         wallet.syncVSPTickets(
@@ -632,10 +629,7 @@ export const processManagedTickets = (passphrase) => (dispatch, getState) =>
           feeAccount = sel.defaultSpendingAccount(getState()).value;
           changeAccount = sel.defaultSpendingAccount(getState()).value;
         }
-        let accts = [feeAccount];
-        if (feeAccount !== 0) {
-          accts.push(0);
-        }
+        const accts = feeAccount !== 0 ? [feeAccount, 0] : [feeAccount];
         await dispatch(
           unlockAcctAndExecFn(passphrase, accts, () =>
             Promise.all(
@@ -705,10 +699,8 @@ export const processUnmanagedTickets = (passphrase, vspHost, vspPubkey) => (
           changeAccount = sel.defaultSpendingAccount(getState()).value;
         }
 
-        let accts = [feeAccount];
-        if (feeAccount !== 0) {
-          accts.push(0);
-        }
+        // Add default account unlock if account isn't default
+        const accts = feeAccount !== 0 ? [feeAccount, 0] : [feeAccount];
         if (passphrase) {
           await dispatch(
             unlockAcctAndExecFn(passphrase, accts, () =>

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -105,16 +105,17 @@ export const syncVSPTicketsRequest = ({
   account
 }) => async (dispatch, getState) => {
   dispatch({ type: SYNCVSPTICKETS_ATTEMPT });
-  try { 
-
-    await dispatch(unlockAcctAndExecFn(passphrase, account, 0, () =>
-      wallet.syncVSPTickets(
-        getState().grpc.walletService,
-        vspHost,
-        vspPubkey,
-        account
+  try {
+    await dispatch(
+      unlockAcctAndExecFn(passphrase, account, 0, () =>
+        wallet.syncVSPTickets(
+          getState().grpc.walletService,
+          vspHost,
+          vspPubkey,
+          account
+        )
       )
-    ));
+    );
     dispatch({ type: SYNCVSPTICKETS_SUCCESS });
     dispatch(getVSPTicketsByFeeStatus(VSP_FEE_PROCESS_ERRORED));
   } catch (error) {

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -885,9 +885,7 @@ export default function snackbar(state = {}, action) {
       type = "Error";
       if (
         action.error &&
-        String(action.error).indexOf(
-          "wallet.Unlock: invalid passphrase:: secretkey.DeriveKey"
-        ) > -1
+        String(action.error).indexOf("invalid passphrase") > -1
       ) {
         // intercepting all wrong passphrase errors, independently of which error
         // state was triggered. Not terribly pretty.

--- a/app/wallet/control.js
+++ b/app/wallet/control.js
@@ -207,10 +207,9 @@ export const purchaseTicketsV3 = (
     });
   });
 
-export const revokeTickets = (walletService, passphrase) =>
+export const revokeTickets = (walletService) =>
   new Promise((ok, fail) => {
     const request = new api.RevokeTicketsRequest();
-    request.setPassphrase(new Uint8Array(Buffer.from(passphrase)));
     walletService.revokeTickets(request, (err, res) =>
       err ? fail(err) : ok(res)
     );

--- a/app/wallet/control.js
+++ b/app/wallet/control.js
@@ -296,41 +296,19 @@ export const getVSPTicketsByFeeStatus = (walletService, feeStatus) =>
     );
   });
 
-export const syncVSPTickets = (
-  walletService,
-  passphrase,
-  vspHost,
-  vspPubkey,
-  account
-) =>
+export const syncVSPTickets = (walletService, vspHost, vspPubkey, account) =>
   new Promise((resolve, reject) => {
-    const unlockReq = new api.UnlockWalletRequest();
-    unlockReq.setPassphrase(new Uint8Array(Buffer.from(passphrase)));
-    // Unlock wallet so we can call the request.
-    walletService.unlockWallet(unlockReq, (error) => {
+    const request = new api.SyncVSPTicketsRequest();
+    request.setAccount(account);
+    request.setVspPubkey(vspPubkey);
+    request.setVspHost("https://" + vspHost);
+
+    // Call the request
+    walletService.syncVSPFailedTickets(request, (error, response) => {
       if (error) {
         reject(error);
       }
-      const request = new api.SyncVSPTicketsRequest();
-      request.setAccount(account);
-      request.setVspPubkey(vspPubkey);
-      request.setVspHost("https://" + vspHost);
-
-      // Call the request
-      walletService.syncVSPFailedTickets(request, (error, response) => {
-        if (error) {
-          reject(error);
-        }
-        const lockReq = new api.LockWalletRequest();
-
-        // Lock wallet and return response from the request.
-        walletService.lockWallet(lockReq, (error) => {
-          if (error) {
-            reject(error);
-          }
-          resolve(response);
-        });
-      });
+      resolve(response);
     });
   });
 


### PR DESCRIPTION
Closes a few of the issues notes in #3423

No longer unlocks whole wallet for Revoke Tickets.

Due to voting address needing to be unlocked for tickets to communicate with the VSPs.  Typically the voting account is currently the default account, but there are certain circumstances if using the Auto-buyer that the voting account is the purchase account.  