### PR TITLE
Move get vsp info to setup machine

### DIFF
--- a/app/components/views/GetStartedPage/SetupWallet/hooks.js
+++ b/app/components/views/GetStartedPage/SetupWallet/hooks.js
@@ -46,7 +46,9 @@ export const useWalletSetup = (settingUpWalletRef) => {
     [dispatch]
   );
 
-  const onGetVSPsPubkeys = () => dispatch(getVSPsPubkeys());
+  const onGetVSPsPubkeys = useCallback(() => dispatch(getVSPsPubkeys()), [
+    dispatch
+  ]);
 
   const sendContinue = useCallback(() => {
     send({ type: "CONTINUE" });

--- a/app/components/views/GetStartedPage/SetupWallet/hooks.js
+++ b/app/components/views/GetStartedPage/SetupWallet/hooks.js
@@ -12,7 +12,9 @@ import {
   checkAllAccountsEncrypted,
   setAccountsPass
 } from "actions/ControlActions";
+import { getVSPsPubkeys } from "actions/VSPActions";
 import { ExternalLink } from "shared";
+import { DecredLoading } from "indicators";
 
 export const useWalletSetup = (settingUpWalletRef) => {
   const dispatch = useDispatch();
@@ -44,6 +46,8 @@ export const useWalletSetup = (settingUpWalletRef) => {
     [dispatch]
   );
 
+  const onGetVSPsPubkeys = () => dispatch(getVSPsPubkeys());
+
   const sendContinue = useCallback(() => {
     send({ type: "CONTINUE" });
   }, [send]);
@@ -59,10 +63,30 @@ export const useWalletSetup = (settingUpWalletRef) => {
     send({ type: "BACK" });
   }, [send]);
 
-  const getStateComponent = useCallback(() => {
+  const getStateComponent = useCallback(async () => {
     const { error, isWatchingOnly, isTrezor } = current.context;
 
-    let component, hasLive, hasSoloTickets;
+    let component, hasSoloTickets;
+
+    // check if we have live tickets.
+    const hasLive = Object.keys(stakeTransactions).some((hash) => {
+      const tx = stakeTransactions[hash];
+      // check if the wallet has at least one vsp live ticket.
+      if (
+        tx.status === IMMATURE ||
+        tx.status === LIVE ||
+        tx.status === UNMINED
+      ) {
+        // On old vsp the fee is an input. So if the tx has more than one
+        // input, it means it is an old vsp ticket and have no feeStatus.
+        // So we can skip it.
+        if (tx.txInputs.length !== 1) {
+          return false;
+        }
+        return true;
+      }
+    });
+
     if (previousState && current.value === previousState.value) return;
 
     switch (current.value) {
@@ -130,24 +154,17 @@ export const useWalletSetup = (settingUpWalletRef) => {
           })
           .catch((err) => console.log(err));
         break;
+      case "gettingVSPInfo":
+        // if no live tickets, we can skip it.
+        if (!hasLive) {
+          sendContinue();
+        } else {
+          component = h(DecredLoading);
+          await onGetVSPsPubkeys();
+          sendContinue();
+        }
+        break;
       case "processingManagedTickets":
-        hasLive = Object.keys(stakeTransactions).some((hash) => {
-          const tx = stakeTransactions[hash];
-          // check if the wallet has at least one vsp live ticket.
-          if (
-            tx.status === IMMATURE ||
-            tx.status === LIVE ||
-            tx.status === UNMINED
-          ) {
-            // On old vsp the fee is an input. So if the tx has more than one
-            // input, it means it is an old vsp ticket and have no feeStatus.
-            // So we can skip it.
-            if (tx.txInputs.length !== 1) {
-              return false;
-            }
-            return true;
-          }
-        });
         // if no live tickets, we can skip it.
         if (!hasLive) {
           sendContinue();

--- a/app/components/views/GetStartedPage/SetupWallet/hooks.js
+++ b/app/components/views/GetStartedPage/SetupWallet/hooks.js
@@ -268,7 +268,8 @@ export const useWalletSetup = (settingUpWalletRef) => {
     previousState,
     current,
     onCheckAcctsPass,
-    onProcessAccounts
+    onProcessAccounts,
+    onGetVSPsPubkeys
   ]);
 
   return {

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -17,7 +17,8 @@ import {
   SETVSPDVOTECHOICE_ATTEMPT,
   SETVSPDVOTECHOICE_FAILED,
   SETVSPDVOTECHOICE_SUCCESS,
-  SAVE_AUTOBUYER_SETTINGS
+  SAVE_AUTOBUYER_SETTINGS,
+  GETVSPSPUBKEYS_SUCCESS
 } from "actions/VSPActions";
 import {
   STARTTICKETBUYERV3_ATTEMPT,
@@ -146,6 +147,11 @@ export default function vsp(state = {}, action) {
         account: action.account,
         vsp: action.vsp
       };
+    case GETVSPSPUBKEYS_SUCCESS:
+      return {
+        ...state,
+        availableVSPsPubkeys: action.availableVSPsPubkeys
+      }
     default:
       return state;
   }

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -151,7 +151,7 @@ export default function vsp(state = {}, action) {
       return {
         ...state,
         availableVSPsPubkeys: action.availableVSPsPubkeys
-      }
+      };
     default:
       return state;
   }

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -976,6 +976,9 @@ export const isProcessingUnmanaged = get([
   "vsp",
   "processUnmanagedTicketsAttempt"
 ]);
+
+export const getAvailableVSPsPubkeys = get(["vsp", "availableVSPsPubkeys"]);
+
 // ****************** end of vsp selectors ******************
 
 export const dailyBalancesStats = get(["statistics", "dailyBalances"]);

--- a/app/stateMachines/SetupWalletConfigMachine.js
+++ b/app/stateMachines/SetupWalletConfigMachine.js
@@ -20,6 +20,12 @@ export const SetupWalletConfigMachine = Machine({
     },
     settingMixedAccount: {
       on: {
+        CONTINUE: "gettingVSPInfo"
+      }
+    },
+    gettingVSPInfo: {
+      on: {
+        BACK: "processingManagedTickets",
         CONTINUE: "processingManagedTickets"
       }
     },


### PR DESCRIPTION
This PR adds a new step into the setup wallet state machine, to find available vsp and its pubkeys.

This is being done to separate it from process managed tickets. 