### PR TITLE
Improve `Mixer Settings` modal layout.

### DIFF
--- a/app/components/modals/MixerSettingsModal/MixerSettingsModal.module.css
+++ b/app/components/modals/MixerSettingsModal/MixerSettingsModal.module.css
@@ -1,8 +1,6 @@
 .mixerSettings {
   background-image: none;
   padding: 30px 40px 20px 40px;
-  min-width: 620px;
-  overflow-x: hidden;
   position: relative;
 }
 .title {

--- a/app/components/shared/PrivacyForm/PrivacyForm.module.css
+++ b/app/components/shared/PrivacyForm/PrivacyForm.module.css
@@ -1,9 +1,7 @@
 .privacyForm {
   margin-top: 20px;
   display: grid;
-  grid-template-columns:
-    max-content 123px minmax(max-content, 1fr) 123px minmax(max-content, 1fr)
-    30px;
+  grid-template-columns: max-content 123px max-content 123px;
   grid-column-gap: 10px;
   grid-row-gap: 20px;
   align-items: center;


### PR DESCRIPTION
**Before:** 
See #3415.

**After:**
![image](https://user-images.githubusercontent.com/10324528/116326252-aa76a000-a7cc-11eb-9c21-d1b5208ae538.png)


Closes #3415.