### PR TITLE
SetupWallet: Check selectedWallet.value for isTrezor.

### DIFF
--- a/app/components/views/GetStartedPage/SetupWallet/hooks.js
+++ b/app/components/views/GetStartedPage/SetupWallet/hooks.js
@@ -66,7 +66,10 @@ export const useWalletSetup = (settingUpWalletRef) => {
   }, [send]);
 
   const getStateComponent = useCallback(async () => {
-    const { error, isWatchingOnly, isTrezor } = current.context;
+    const ctx = current.context;
+    const { selectedWallet } = ctx;
+    const { error } = ctx;
+    const { isWatchingOnly, isTrezor } = selectedWallet.value;
 
     let component, hasSoloTickets;
 


### PR DESCRIPTION
This fixes the issue for me, but I think this is the second time this has happened. I don't know why there are these two sets of values, but I think I will use another pr to get to the bottom of it and make sure the code base only has to deal with one of these and this doesn't happen again.

closes #3431