### PR TITLE
[tickets] Remember ticket auto buyer settings

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -16,7 +16,11 @@ import {
   DEX_LOGOUT_FAILED,
   logoutDex
 } from "./DexActions";
-import { TOGGLE_ISLEGACY, SET_REMEMBERED_VSP_HOST } from "./VSPActions";
+import {
+  TOGGLE_ISLEGACY,
+  SET_REMEMBERED_VSP_HOST,
+  SET_AUTOBUYER_SETTINGS
+} from "./VSPActions";
 import * as wallet from "wallet";
 import { push as pushHistory, goBack } from "connected-react-router";
 import { ipcRenderer } from "electron";
@@ -445,6 +449,12 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
       const mixedAccountBranch = walletCfg.get(cfgConstants.MIXED_ACC_BRANCH);
       const isLegacy = walletCfg.get(cfgConstants.VSP_IS_LEGACY);
       const rememberedVspHost = walletCfg.get(cfgConstants.REMEMBERED_VSP_HOST);
+
+      const autobuyerSettings = walletCfg.get(cfgConstants.AUTOBUYER_SETTINGS);
+      dispatch({
+        type: SET_AUTOBUYER_SETTINGS,
+        autobuyerSettings
+      });
 
       walletCfg.set(cfgConstants.LAST_ACCESS, Date.now());
       dispatch({

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -792,14 +792,23 @@ export const setVSPDVoteChoices = (passphrase) => async (
   }
 };
 
-export const SAVE_AUTOBUYER_SETTINGS = "SAVE_AUTOBUYER_SETTINGS";
+export const SET_AUTOBUYER_SETTINGS = "SET_AUTOBUYER_SETTINGS";
 export const saveAutoBuyerSettings = ({ balanceToMaintain, account, vsp }) => (
-  dispatch
+  dispatch,
+  getState
 ) => {
-  dispatch({
-    type: SAVE_AUTOBUYER_SETTINGS,
-    balanceToMaintain,
-    account,
+  const {
+    daemon: { walletName }
+  } = getState();
+  const walletCfg = getWalletCfg(sel.isTestNet(getState()), walletName);
+  const autobuyerSettings = {
+    balanceToMaintain: parseInt(balanceToMaintain.atomValue),
+    account: account.name,
     vsp
+  };
+  walletCfg.set(cfgConstants.AUTOBUYER_SETTINGS, autobuyerSettings);
+  dispatch({
+    type: SET_AUTOBUYER_SETTINGS,
+    autobuyerSettings
   });
 };

--- a/app/components/shared/TicketAutoBuyerForm/TicketAutoBuyerForm.jsx
+++ b/app/components/shared/TicketAutoBuyerForm/TicketAutoBuyerForm.jsx
@@ -100,6 +100,7 @@ const TicketAutoBuyerForm = ({
       </div>
       <button
         aria-label="Ticket Autobuyer Settings"
+        disabled={isRunning}
         className={styles.settingsButton}
         onClick={showSettingsModal}
       />

--- a/app/components/shared/TicketAutoBuyerForm/TicketAutoBuyerForm.module.css
+++ b/app/components/shared/TicketAutoBuyerForm/TicketAutoBuyerForm.module.css
@@ -32,6 +32,10 @@
   border: none;
   cursor: pointer;
 }
+.settingsButton:disabled {
+  cursor: default;
+  opacity: 0.8;
+}
 .orangeWarning {
   position: inherit;
 }

--- a/app/components/views/TicketsPage/PurchaseTab/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/hooks.js
@@ -24,9 +24,6 @@ export const usePurchaseTab = () => {
   const isLoading = useSelector(sel.purchaseTicketsRequestAttempt);
   const notMixedAccounts = useSelector(sel.getNotMixedAccounts);
 
-  const buyerVSP = useSelector(sel.buyerVSP);
-  const buyerBalanceToMaintain = useSelector(sel.buyerBalanceToMaintain);
-  const buyerAccount = useSelector(sel.buyerAccount);
   const rememberedVspHost = useSelector(sel.getRememberedVspHost);
   const visibleAccounts = useSelector(sel.visibleAccounts);
 
@@ -119,9 +116,6 @@ export const usePurchaseTab = () => {
     onDisableTicketAutoBuyer,
     getTicketStatus,
     ticketAutoBuyerRunning,
-    buyerVSP,
-    buyerAccount,
-    buyerBalanceToMaintain,
     getVSPTicketsByFeeStatus,
     isLegacy,
     toggleIsLegacy,

--- a/app/constants/config.js
+++ b/app/constants/config.js
@@ -77,6 +77,7 @@ export const LAST_ACCESS = "lastaccess";
 export const STAKEPOOLS = "stakepools";
 export const LN_WALLET_EXISTS = "ln_wallet_exists";
 export const USED_VSPS = "used_vsps";
+export const AUTOBUYER_SETTINGS = "autobuyer_settings";
 export const DEX_ACCOUNT = "dex_account";
 export const ENABLE_DEX = "enableddex";
 export const DEXWALLET_RPCUSERNAME = "dexwallet_rpcuser";
@@ -120,6 +121,7 @@ export const WALLET_INITIAL_VALUE = {
   [DEXWALLET_RPCPASSWORD]: "",
   [DEXWALLET_HOSTPORT]: "",
   [DEX_ACCOUNT]: null,
+  [AUTOBUYER_SETTINGS]: null,
   // STAKEPOOLS is a legacy code which can be deleted after stopping giving
   // support for old vsp versions.
   [STAKEPOOLS]: []

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -17,7 +17,7 @@ import {
   SETVSPDVOTECHOICE_ATTEMPT,
   SETVSPDVOTECHOICE_FAILED,
   SETVSPDVOTECHOICE_SUCCESS,
-  SAVE_AUTOBUYER_SETTINGS,
+  SET_AUTOBUYER_SETTINGS,
   GETVSPSPUBKEYS_SUCCESS
 } from "actions/VSPActions";
 import {
@@ -140,12 +140,12 @@ export default function vsp(state = {}, action) {
         ...state,
         setVspdVoteChoicesRequestAttempt: false
       };
-    case SAVE_AUTOBUYER_SETTINGS:
+    case SET_AUTOBUYER_SETTINGS:
       return {
         ...state,
-        balanceToMaintain: action.balanceToMaintain,
-        account: action.account,
-        vsp: action.vsp
+        balanceToMaintain: action.autobuyerSettings?.balanceToMaintain,
+        account: action.autobuyerSettings?.account,
+        vsp: action.autobuyerSettings?.vsp
       };
     case GETVSPSPUBKEYS_SUCCESS:
       return {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -924,9 +924,6 @@ export const legacyBuyerBalanceToMaintain = get([
   "legacyBalanceToMaintain"
 ]);
 export const legacyBuyerAccount = get(["control", "legacyAccount"]);
-export const buyerVSP = get(["vsp", "vsp"]);
-export const buyerBalanceToMaintain = get(["vsp", "balanceToMaintain"]);
-export const buyerAccount = get(["vsp", "account"]);
 export const getHasVSPTicketsError = get(["vsp", "hasVSPTicketsError"]);
 export const getIsLegacy = get(["vsp", "isLegacy"]);
 export const getRememberedVspHost = get(["vsp", "rememberedVspHost"]);
@@ -1120,6 +1117,24 @@ export const spendingAccounts = createSelector(
       balances
     )
 );
+
+/* autobuyerSettings */
+export const buyerBalanceToMaintain = createSelector(
+  [get(["vsp", "balanceToMaintain"])],
+  (balanceToMaintain) =>
+    balanceToMaintain
+      ? {
+          atomValue: balanceToMaintain,
+          value: parseInt(balanceToMaintain) / UNIT_DIVISOR
+        }
+      : null
+);
+export const buyerAccount = createSelector(
+  [get(["vsp", "account"]), visibleAccounts],
+  (buyerAccountName, visibleAccounts) =>
+    visibleAccounts.filter(({ name }) => name === buyerAccountName)[0]
+);
+export const buyerVSP = get(["vsp", "vsp"]);
 
 const getNextAddressResponse = get(["control", "getNextAddressResponse"]);
 const nextAddressAccountNumber = compose(

--- a/test/unit/components/TicketsPage/PurchaseTab/PurchasePage.spec.js
+++ b/test/unit/components/TicketsPage/PurchaseTab/PurchasePage.spec.js
@@ -276,6 +276,7 @@ test("test autobuyer", async () => {
   // set account
   user.click(screen.getByText("Select account"));
   user.click(screen.getByText(mockMixedAccount.name));
+  selectors.buyerAccount = jest.fn(() => mockMixedAccount);
   user.click(saveButton);
 
   // check settings


### PR DESCRIPTION
This diff saves the new (not legacy) auto buyer settings to wallet config, so users don't need to refill the form again after close and re-open the application.

Closes #3211
Closes #3410