### PR TITLE
Change "Immature Staking Returns" labels to "Immature Staking Rewards"

### DIFF
--- a/app/components/views/AccountsPage/Accounts/AccountRow/AccountDetails/AccountDetails.jsx
+++ b/app/components/views/AccountsPage/Accounts/AccountRow/AccountDetails/AccountDetails.jsx
@@ -49,8 +49,8 @@ const AccountsDetails = ({
         </DataLine>
         <DataLine>
           <T
-            id="accounts.immatureStakingReturns"
-            m="Immature Staking Returns"
+            id="accounts.immatureStakingRewards"
+            m="Immature Staking Rewards"
           />
           <Balance flat amount={account.immatureStakeGeneration} />
         </DataLine>

--- a/app/components/views/HomePage/Tabs/BalanceTab/BalanceTab.jsx
+++ b/app/components/views/HomePage/Tabs/BalanceTab/BalanceTab.jsx
@@ -56,8 +56,8 @@ const BalanceTab = () => {
                 amount={lockedByTicketsTotalBalance}
               />
               <T
-                id="home.immatureStakingReturnsBalanceLabel"
-                m="Immature Staking Returns"
+                id="home.immatureStakingRewardsBalanceLabel"
+                m="Immature Staking Rewards"
               />
               :
               <Balance

--- a/app/i18n/docs/en/InfoModals/BalanceOverview.md
+++ b/app/i18n/docs/en/InfoModals/BalanceOverview.md
@@ -10,4 +10,4 @@
 
 **Immature Rewards** These are regular coinbase rewards that are currently maturing (from PoW mining reward for instance).
 
-**Immature Staking Returns** This balance shows the current stake rewards and revocations that are awaiting maturity (256 blocks on mainnet)."
+**Immature Staking Rewards** This balance shows the current stake rewards and revocations that are awaiting maturity (256 blocks on mainnet)."


### PR DESCRIPTION
This diff changes "Immature Staking Returns" labels to "Immature Staking Rewards" as @xaur suggested in #3360.