### PR TITLE
[startup] Add loader to Setup Wallet state

### DIFF
--- a/app/components/indicators/LinearProgress/AnimatedLinearProgressFull.jsx
+++ b/app/components/indicators/LinearProgress/AnimatedLinearProgressFull.jsx
@@ -13,7 +13,8 @@ const AnimatedLinearProgressFull = ({
   error,
   text,
   animationType,
-  initialAnimationType
+  initialAnimationType,
+  hideTextBlock
 }) => {
   const {
     isSPV,
@@ -138,40 +139,42 @@ const AnimatedLinearProgressFull = ({
           </>
         )}
       </div>
-      <div>
-        {getCurrentBlockCount && !getDaemonSynced && (
-          <div className={styles.loaderBarEstimation}>
-            <T
-              id="getStarted.chainLoading.syncEstimation"
-              m="Blockchain download estimated complete: "
-            />
-            <span className={styles.bold}>
-              {finishDateEstimation && (
-                <FormattedRelative value={finishDateEstimation} />
-              )}
-              ({getCurrentBlockCount} / {getNeededBlocks})
-            </span>
-          </div>
-        )}
-        {selectedWalletSelector && syncFetchHeadersLastHeaderTime && (
-          <div className={styles.loaderBarEstimation}>
-            <HeaderTimeMsg />
-            <span className={styles.bold}>
-              <FormattedRelative value={syncFetchHeadersLastHeaderTime} />
-            </span>
-          </div>
-        )}
-        {!getDaemonSynced && lastDcrdLogLine && !selectedWalletSelector && (
-          <div className={styles.lastLogLines}>
-            <div>{lastDcrdLogLine}</div>
-          </div>
-        )}
-        {selectedWalletSelector && lastDcrwalletLogLine && (
-          <div className={styles.lastLogLines}>
-            <div>{lastDcrwalletLogLine}</div>
-          </div>
-        )}
-      </div>
+      {!hideTextBlock && (
+        <div>
+          {getCurrentBlockCount && !getDaemonSynced && (
+            <div className={styles.loaderBarEstimation}>
+              <T
+                id="getStarted.chainLoading.syncEstimation"
+                m="Blockchain download estimated complete: "
+              />
+              <span className={styles.bold}>
+                {finishDateEstimation && (
+                  <FormattedRelative value={finishDateEstimation} />
+                )}
+                ({getCurrentBlockCount} / {getNeededBlocks})
+              </span>
+            </div>
+          )}
+          {selectedWalletSelector && syncFetchHeadersLastHeaderTime && (
+            <div className={styles.loaderBarEstimation}>
+              <HeaderTimeMsg />
+              <span className={styles.bold}>
+                <FormattedRelative value={syncFetchHeadersLastHeaderTime} />
+              </span>
+            </div>
+          )}
+          {!getDaemonSynced && lastDcrdLogLine && !selectedWalletSelector && (
+            <div className={styles.lastLogLines}>
+              <div>{lastDcrdLogLine}</div>
+            </div>
+          )}
+          {selectedWalletSelector && lastDcrwalletLogLine && (
+            <div className={styles.lastLogLines}>
+              <div>{lastDcrwalletLogLine}</div>
+            </div>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/app/components/views/GetStartedPage/GetStartedMachinePage/GetStartedMachinePage.jsx
+++ b/app/components/views/GetStartedPage/GetStartedMachinePage/GetStartedMachinePage.jsx
@@ -1,9 +1,7 @@
 import { classNames } from "pi-ui";
 import { AnimatedLinearProgressFull } from "indicators";
-import { SlateGrayButton } from "buttons";
-import { LearnBasicsMsg, WhatsNewLink, LoaderTitleMsg } from "../messages";
-import { ContentContainer } from "../helpers";
 import styles from "./GetStartedMachinePage.module.css";
+import { Header } from "../helpers";
 
 export default ({
   StateComponent,
@@ -24,17 +22,7 @@ export default ({
   ...props
 }) => (
   <>
-    <ContentContainer>
-      <LoaderTitleMsg />
-    </ContentContainer>
-    <div className={styles.loaderButtons}>
-      <SlateGrayButton
-        onClick={onShowTutorial}
-        className={styles.tutorialButton}>
-        <LearnBasicsMsg />
-      </SlateGrayButton>
-      <WhatsNewLink {...{ onShowReleaseNotes, appVersion }} />
-    </div>
+    <Header {...{ onShowTutorial, onShowReleaseNotes, appVersion }} />
     <div className={styles.loaderBar}>
       <AnimatedLinearProgressFull
         {...{

--- a/app/components/views/GetStartedPage/SetupWallet/SetupWallet.jsx
+++ b/app/components/views/GetStartedPage/SetupWallet/SetupWallet.jsx
@@ -32,7 +32,8 @@ const SetupWallet = ({
             <AnimatedLinearProgressFull
               {...{
                 text: <T id="setupwallet.progressLabel" m="Setup Wallet" />,
-                animationType: styles.setupWallet
+                animationType: styles.setupWallet,
+                hideTextBlock: true
               }}
             />
           </div>

--- a/app/components/views/GetStartedPage/SetupWallet/SetupWallet.jsx
+++ b/app/components/views/GetStartedPage/SetupWallet/SetupWallet.jsx
@@ -2,8 +2,17 @@ import { injectIntl } from "react-intl";
 import { withRouter } from "react-router";
 import { useEffect } from "react";
 import { useWalletSetup } from "./hooks";
+import { FormattedMessage as T } from "react-intl";
+import { AnimatedLinearProgressFull } from "indicators";
+import { Header } from "../helpers";
+import styles from "./SetupWallet.module.css";
 
-const SetupWallet = ({ settingUpWalletRef }) => {
+const SetupWallet = ({
+  settingUpWalletRef,
+  appVersion,
+  onShowTutorial,
+  onShowReleaseNotes
+}) => {
   const { getStateComponent, StateComponent } = useWalletSetup(
     settingUpWalletRef
   );
@@ -14,12 +23,21 @@ const SetupWallet = ({ settingUpWalletRef }) => {
 
   return (
     <div>
-      {StateComponent &&
-        (React.isValidElement(StateComponent) ? (
-          StateComponent
-        ) : (
-          <StateComponent />
-        ))}
+      {StateComponent && React.isValidElement(StateComponent) ? (
+        StateComponent
+      ) : (
+        <>
+          <Header {...{ onShowTutorial, onShowReleaseNotes, appVersion }} />
+          <div className={styles.loaderBar}>
+            <AnimatedLinearProgressFull
+              {...{
+                text: <T id="setupwallet.progressLabel" m="Setup Wallet" />,
+                animationType: styles.setupWallet
+              }}
+            />
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/app/components/views/GetStartedPage/SetupWallet/SetupWallet.module.css
+++ b/app/components/views/GetStartedPage/SetupWallet/SetupWallet.module.css
@@ -3,17 +3,12 @@
   width: 100%;
   margin-bottom: 20px;
 }
-
-.launchError {
-  margin: 0 300px 20px 0;
-  color: var(--error-text-color);
-  overflow-wrap: break-word;
+.setupWallet {
+  padding-left: 56px;
+  background-image: var(--loader-animation-finalizing-setup) !important;
+  background-position: 15px 15px;
+  background-size: 30px;
 }
-
-.daemonWarning {
-  padding: 10px;
-}
-
 @media screen and (max-width: 768px) {
   .loaderBar {
     margin-bottom: 0;
@@ -22,10 +17,5 @@
     left: 0;
     display: flex;
     flex-direction: column;
-  }
-
-  .launchError {
-    margin: 0 0 20px 0;
-    width: 315px;
   }
 }

--- a/app/components/views/GetStartedPage/helpers/Header/Header.jsx
+++ b/app/components/views/GetStartedPage/helpers/Header/Header.jsx
@@ -1,0 +1,21 @@
+import styles from "./Header.module.css";
+import ContentContainer from "../ContentContainer";
+import { SlateGrayButton } from "buttons";
+import { LearnBasicsMsg, WhatsNewLink, LoaderTitleMsg } from "../../messages";
+
+const Header = ({ appVersion, onShowTutorial, onShowReleaseNotes }) => (
+  <>
+    <ContentContainer>
+      <LoaderTitleMsg />
+    </ContentContainer>
+    <div className={styles.loaderButtons}>
+      <SlateGrayButton
+        onClick={onShowTutorial}
+        className={styles.tutorialButton}>
+        <LearnBasicsMsg />
+      </SlateGrayButton>
+      <WhatsNewLink {...{ onShowReleaseNotes, appVersion }} />
+    </div>
+  </>
+);
+export default Header;

--- a/app/components/views/GetStartedPage/helpers/Header/Header.module.css
+++ b/app/components/views/GetStartedPage/helpers/Header/Header.module.css
@@ -1,0 +1,17 @@
+.loaderButtons {
+  float: left;
+  margin-bottom: 90px;
+  width: 100%;
+}
+.tutorialButton {
+  background-color: var(--info-modal-button-bg);
+  color: var(--back-button-dark-text);
+}
+.tutorialButton:hover {
+  background-color: var(--title-text-and-button-background-hovered);
+}
+@media screen and (max-width: 768px) {
+  .loaderButtons {
+    margin-bottom: 50px;
+  }
+}

--- a/app/components/views/GetStartedPage/helpers/Header/index.js
+++ b/app/components/views/GetStartedPage/helpers/Header/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Header";

--- a/app/components/views/GetStartedPage/helpers/index.js
+++ b/app/components/views/GetStartedPage/helpers/index.js
@@ -9,3 +9,4 @@ export { default as Content } from "./Content";
 export { default as Title } from "./Title";
 export { default as SubTitle } from "./SubTitle";
 export { default as ContentContainer } from "./ContentContainer";
+export { default as Header } from "./Header";

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -513,7 +513,10 @@ export const useGetStarted = () => {
       }
       if (key === "settingUpWallet") {
         PageComponent = h(SettingUpWalletMachine, {
-          settingUpWalletRef
+          settingUpWalletRef,
+          appVersion,
+          onShowTutorial,
+          onShowReleaseNotes
         });
       }
 


### PR DESCRIPTION
On wallet startup during Setup Wallet state, some tasks need time to finish: #3433
This diff doesn't try to optimize the background tasks but shows a loading bar instead of the blank page.