### PR TITLE
[locks]  Fix incorrect passphrase allowing to continue

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1026,7 +1026,7 @@ const setAccountPassphrase = (
     acct.locked = true;
     return dispatch({ type: SETACCOUNTPASSPHRASE_SUCCESS, accounts });
   } catch (error) {
-    return error;
+    throw error;
   }
 };
 

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1026,6 +1026,7 @@ const setAccountPassphrase = (
     acct.locked = true;
     return dispatch({ type: SETACCOUNTPASSPHRASE_SUCCESS, accounts });
   } catch (error) {
+    dispatch({ type: SETACCOUNTPASSPHRASE_FAILED, error });
     throw error;
   }
 };


### PR DESCRIPTION
Incorrect passphrase during account security migration allowed users to proceed without completing the migration.