### PR TITLE
require dcrdex v0.2.0 final release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/decrediton
 go 1.16
 
 require (
-	decred.org/dcrdex v0.2.0-rc1
+	decred.org/dcrdex v0.2.0
 	github.com/decred/slog v1.2.0
 	github.com/jrick/logrotate v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 decred.org/cspp v0.3.0/go.mod h1:UygjYilC94dER3BEU65Zzyoqy9ngJfWCD2rdJqvUs2A=
-decred.org/dcrdex v0.2.0-rc1 h1:3x46cK95qH1IGh60ItI9wtuGokS+RWLRGJ2OoHAYYlM=
-decred.org/dcrdex v0.2.0-rc1/go.mod h1:XH8z2N7B0fXOkVhbk4LewzQTJIv1xZ8riHGT7I1/pIE=
+decred.org/dcrdex v0.2.0 h1:lyONE/r26vkWYiJwo57xVzaZl2kNWPmYPTzN++aqbJM=
+decred.org/dcrdex v0.2.0/go.mod h1:XH8z2N7B0fXOkVhbk4LewzQTJIv1xZ8riHGT7I1/pIE=
 decred.org/dcrwallet v1.7.0 h1:U/ew00YBdUlx3rJAynt2OdKDgGzBKK4O89FijBq8iVg=
 decred.org/dcrwallet v1.7.0/go.mod h1:hNOGyvH53gWdgFB601/ubGRzCPfPtWnEVAi9Grs90y4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
This updates the dcrdex require to the final 0.2 release.  Since rc1
this includes a fix to update the frontend's wallet lock icon when
a wallet is automatically unlocked on order placement or other
action that unlocks as needed.