### PR TITLE
[tickets] Only ProcessManaged at startup if needed

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -449,7 +449,9 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
       const mixedAccountBranch = walletCfg.get(cfgConstants.MIXED_ACC_BRANCH);
       const isLegacy = walletCfg.get(cfgConstants.VSP_IS_LEGACY);
       const rememberedVspHost = walletCfg.get(cfgConstants.REMEMBERED_VSP_HOST);
-      const needsVSPdProcessManaged = walletCfg.get(cfgConstants.NEEDS_VSPD_PROCESS_TICKETS);
+      const needsVSPdProcessManaged = walletCfg.get(
+        cfgConstants.NEEDS_VSPD_PROCESS_TICKETS
+      );
 
       const autobuyerSettings = walletCfg.get(cfgConstants.AUTOBUYER_SETTINGS);
       dispatch({

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -449,6 +449,7 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
       const mixedAccountBranch = walletCfg.get(cfgConstants.MIXED_ACC_BRANCH);
       const isLegacy = walletCfg.get(cfgConstants.VSP_IS_LEGACY);
       const rememberedVspHost = walletCfg.get(cfgConstants.REMEMBERED_VSP_HOST);
+      const needsVSPdProcessManaged = walletCfg.get(cfgConstants.NEEDS_VSPD_PROCESS_TICKETS);
 
       const autobuyerSettings = walletCfg.get(cfgConstants.AUTOBUYER_SETTINGS);
       dispatch({
@@ -491,7 +492,8 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
         enableDex,
         dexAccount,
         rpcCreds,
-        btcWalletName
+        btcWalletName,
+        needsVSPdProcessManaged
       });
       selectedWallet.value.isTrezor && dispatch(enableTrezor());
       await dispatch(getVersionServiceAttempt());

--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -3,6 +3,7 @@ import { getWalletCfg, getGlobalCfg } from "config";
 import { isTestNet } from "selectors";
 import { equalElements } from "helpers";
 import * as wallet from "wallet";
+import * as sel from "selectors";
 import { closeWalletRequest } from "actions/WalletLoaderActions";
 import { closeDaemonRequest, backToCredentials } from "actions/DaemonActions";
 import {
@@ -204,4 +205,11 @@ export const updateStateVoteSettingsChanged = (settings) => (
   } else {
     dispatch({ tempSettings: currentSettings, type: SETTINGS_UNCHANGED });
   }
+};
+
+export const setNeedsVSPdProcessTickets = (value) => (dispatch, getState) => {
+  const walletName = sel.getWalletName(getState());
+  const isTestNet = sel.isTestNet(getState());
+  const walletConfig = getWalletCfg(isTestNet, walletName);
+  walletConfig.set(configConstants.NEEDS_VSPD_PROCESS_TICKETS, value);
 };

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -675,68 +675,63 @@ export const PROCESSMANAGEDTICKETS_FAILED = "PROCESSMANAGEDTICKETS_FAILED";
 
 // processManagedTickets gets all vsp and check for tickets which still not
 // synced, and sync them.
-export const processManagedTickets = (passphrase) => (dispatch, getState) =>
-  new Promise((resolve, reject) => {
-    const asyncProcess = async () => {
-      const walletService = sel.walletService(getState());
-      const availableVSPsPubkeys = sel.getAvailableVSPsPubkeys(getState());
-      try {
-        dispatch({ type: PROCESSMANAGEDTICKETS_ATTEMPT });
-        let feeAccount, changeAccount;
-        const mixedAccount = sel.getMixedAccount(getState());
-        if (mixedAccount) {
-          feeAccount = mixedAccount;
-          changeAccount = sel.getChangeAccount(getState());
-        } else {
-          feeAccount = sel.defaultSpendingAccount(getState()).value;
-          changeAccount = sel.defaultSpendingAccount(getState()).value;
-        }
-        await dispatch(
-          unlockAllAcctAndExecFn(passphrase, async () => {
-            // Process all managed tickets on all VSPs.
-            await Promise.all(
-              availableVSPsPubkeys.map((vsp) =>
-                wallet.processManagedTickets(
-                  walletService,
-                  vsp.host,
-                  vsp.pubkey,
-                  feeAccount,
-                  changeAccount
-                )
-              )
-            );
-
-            // Update the list of dcrwallet tracked VSP tickets. This figures out
-            // which accounts need to be left unlocked.
-            await dispatch(getVSPTrackedTickets());
-          })
+export const processManagedTickets = (passphrase) => async (
+  dispatch,
+  getState
+) => {
+  const walletService = sel.walletService(getState());
+  const availableVSPsPubkeys = sel.getAvailableVSPsPubkeys(getState());
+  try {
+    dispatch({ type: PROCESSMANAGEDTICKETS_ATTEMPT });
+    let feeAccount, changeAccount;
+    const mixedAccount = sel.getMixedAccount(getState());
+    if (mixedAccount) {
+      feeAccount = mixedAccount;
+      changeAccount = sel.getChangeAccount(getState());
+    } else {
+      feeAccount = sel.defaultSpendingAccount(getState()).value;
+      changeAccount = sel.defaultSpendingAccount(getState()).value;
+    }
+    await dispatch(
+      unlockAllAcctAndExecFn(passphrase, async () => {
+        // Process all managed tickets on all VSPs.
+        await Promise.all(
+          availableVSPsPubkeys.map((vsp) =>
+            wallet.processManagedTickets(
+              walletService,
+              vsp.host,
+              vsp.pubkey,
+              feeAccount,
+              changeAccount
+            )
+          )
         );
 
-        // get vsp tickets fee status errored so we can resync them
-        await dispatch(getVSPTicketsByFeeStatus(VSP_FEE_PROCESS_ERRORED));
-        await dispatch(getVSPTicketsByFeeStatus(VSP_FEE_PROCESS_STARTED));
-        await dispatch(getVSPTicketsByFeeStatus(VSP_FEE_PROCESS_PAID));
-        dispatch({ type: PROCESSMANAGEDTICKETS_SUCCESS });
-        resolve(true);
-      } catch (error) {
-        dispatch({ type: PROCESSMANAGEDTICKETS_FAILED, error });
-        if (
-          String(error).indexOf(
-            "wallet.Unlock: invalid passphrase:: secretkey.DeriveKey"
-          ) > 0
-        ) {
-          reject("Invalid private passphrase, please try again.");
-          return;
-        }
-        reject(error);
-        return;
-      }
-    };
+        // Update the list of dcrwallet tracked VSP tickets. This figures out
+        // which accounts need to be left unlocked.
+        await dispatch(getVSPTrackedTickets());
+      })
+    );
 
-    asyncProcess()
-      .then((r) => resolve(r))
-      .catch((error) => reject(error));
-  });
+    // get vsp tickets fee status errored so we can resync them
+    await dispatch(getVSPTicketsByFeeStatus(VSP_FEE_PROCESS_ERRORED));
+    await dispatch(getVSPTicketsByFeeStatus(VSP_FEE_PROCESS_STARTED));
+    await dispatch(getVSPTicketsByFeeStatus(VSP_FEE_PROCESS_PAID));
+    console.log("YYYYYY gonna start sleeping");
+    await new Promise((ok) => setTimeout(ok, 30000));
+    dispatch({ type: PROCESSMANAGEDTICKETS_SUCCESS });
+  } catch (error) {
+    dispatch({ type: PROCESSMANAGEDTICKETS_FAILED, error });
+    if (
+      String(error).indexOf(
+        "wallet.Unlock: invalid passphrase:: secretkey.DeriveKey"
+      ) > 0
+    ) {
+      throw "Invalid private passphrase, please try again.";
+    }
+    throw error;
+  }
+};
 
 export const PROCESSUNMANAGEDTICKETS_ATTEMPT =
   "PROCESSUNMANAGEDTICKETS_ATTEMPT";
@@ -880,4 +875,9 @@ export const saveAutoBuyerSettings = ({ balanceToMaintain, account, vsp }) => (
     type: SET_AUTOBUYER_SETTINGS,
     autobuyerSettings
   });
+};
+
+export const SET_CANDISABLEPROCESSMANAGED = "SET_CANDISABLEPROCESSMANAGED";
+export const setCanDisableProcessManaged = (value) => (dispatch) => {
+  dispatch({ type: SET_CANDISABLEPROCESSMANAGED, value });
 };

--- a/app/components/views/GetStartedPage/SetupWallet/ProcessManagedTickets/ProcessManagedTickets.jsx
+++ b/app/components/views/GetStartedPage/SetupWallet/ProcessManagedTickets/ProcessManagedTickets.jsx
@@ -41,6 +41,8 @@ export default ({
     }
   }, [vsp, noVspSelection]);
 
+  console.log("LLLLLLL processing managed", isProcessingManaged);
+
   return (
     <div className={styles.content}>
       <BackButtonArea>

--- a/app/components/views/GetStartedPage/SetupWallet/hooks.js
+++ b/app/components/views/GetStartedPage/SetupWallet/hooks.js
@@ -28,7 +28,8 @@ export const useWalletSetup = (settingUpWalletRef) => {
     goToHome,
     onProcessUnmanagedTickets,
     isProcessingUnmanaged,
-    isProcessingManaged
+    isProcessingManaged,
+    needsProcessManagedTickets
   } = useDaemonStartup();
 
   const { mixedAccount } = useAccounts();
@@ -73,8 +74,8 @@ export const useWalletSetup = (settingUpWalletRef) => {
 
     let component, hasSoloTickets;
 
-    // check if we have live tickets.
-    const hasLive = Object.keys(stakeTransactions).some((hash) => {
+    // Check if we have live, vspd-based tickets.
+    const hasLiveVSPdTickets = Object.keys(stakeTransactions).some((hash) => {
       const tx = stakeTransactions[hash];
       // check if the wallet has at least one vsp live ticket.
       if (
@@ -160,7 +161,7 @@ export const useWalletSetup = (settingUpWalletRef) => {
         break;
       case "gettingVSPInfo":
         // if no live tickets, we can skip it.
-        if (!hasLive) {
+        if (!hasLiveVSPdTickets) {
           sendContinue();
         } else {
           component = h(DecredLoading);
@@ -170,7 +171,7 @@ export const useWalletSetup = (settingUpWalletRef) => {
         break;
       case "processingManagedTickets":
         // if no live tickets, we can skip it.
-        if (!hasLive) {
+        if (!hasLiveVSPdTickets || !needsProcessManagedTickets) {
           sendContinue();
         } else {
           component = h(ProcessManagedTickets, {
@@ -193,7 +194,7 @@ export const useWalletSetup = (settingUpWalletRef) => {
                 id="getstarted.processManagedTickets.description"
                 m={`Your wallet appears to have live tickets. Processing managed
                 tickets confirms with the VSPs that all of your submitted tickets
-                are currently known and paid for by the VSPs. If you've already 
+                are currently known and paid for by the VSPs. If you've already
                 confirmed your tickets then you may skip this step.`}
               />
             )
@@ -266,6 +267,7 @@ export const useWalletSetup = (settingUpWalletRef) => {
     sendContinue,
     isProcessingManaged,
     isProcessingUnmanaged,
+    needsProcessManagedTickets,
     onProcessUnmanagedTickets,
     onSendBack,
     onSendError,

--- a/app/components/views/GetStartedPage/SetupWallet/hooks.js
+++ b/app/components/views/GetStartedPage/SetupWallet/hooks.js
@@ -12,7 +12,10 @@ import {
   checkAllAccountsEncrypted,
   setAccountsPass
 } from "actions/ControlActions";
-import { getVSPsPubkeys } from "actions/VSPActions";
+import {
+  getVSPsPubkeys,
+  setCanDisableProcessManaged
+} from "actions/VSPActions";
 import { ExternalLink } from "shared";
 import { DecredLoading } from "indicators";
 
@@ -65,6 +68,11 @@ export const useWalletSetup = (settingUpWalletRef) => {
   const onSendBack = useCallback(() => {
     send({ type: "BACK" });
   }, [send]);
+
+  const onSkipProcessManaged = useCallback(() => {
+    dispatch(setCanDisableProcessManaged(false));
+    send({ type: "BACK" });
+  }, [send, dispatch]);
 
   const getStateComponent = useCallback(async () => {
     const ctx = current.context;
@@ -179,7 +187,7 @@ export const useWalletSetup = (settingUpWalletRef) => {
             onSendContinue: sendContinue,
             onSendError,
             send,
-            cancel: onSendBack,
+            cancel: onSkipProcessManaged,
             onProcessTickets: onProcessManagedTickets,
             title: (
               <T
@@ -275,7 +283,8 @@ export const useWalletSetup = (settingUpWalletRef) => {
     current,
     onCheckAcctsPass,
     onProcessAccounts,
-    onGetVSPsPubkeys
+    onGetVSPsPubkeys,
+    onSkipProcessManaged
   ]);
 
   return {

--- a/app/constants/config.js
+++ b/app/constants/config.js
@@ -84,6 +84,7 @@ export const DEXWALLET_RPCUSERNAME = "dexwallet_rpcuser";
 export const DEXWALLET_RPCPASSWORD = "dexwallet_rpcpass";
 export const DEXWALLET_HOSTPORT = "dexwallet_host";
 export const BTCWALLET_NAME = "btcwallet_name";
+export const NEEDS_VSPD_PROCESS_TICKETS = "needs_vspd_process_tickets";
 
 export const WALLET_INITIAL_VALUE = {
   [ENABLE_TICKET_BUYER]: false,
@@ -124,7 +125,11 @@ export const WALLET_INITIAL_VALUE = {
   [AUTOBUYER_SETTINGS]: null,
   // STAKEPOOLS is a legacy code which can be deleted after stopping giving
   // support for old vsp versions.
-  [STAKEPOOLS]: []
+  [STAKEPOOLS]: [],
+
+  // Force as true to ensure wallets with tickets prior to when this config was
+  // introduced trigger a view of the "process managed tickets" page.
+  [NEEDS_VSPD_PROCESS_TICKETS]: true
 };
 
 export const INITIAL_VALUES = {

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -48,7 +48,9 @@ const useDaemonStartup = () => {
   const stakeTransactions = useSelector(sel.stakeTransactions);
   const isProcessingManaged = useSelector(sel.isProcessingManaged);
   const isProcessingUnmanaged = useSelector(sel.isProcessingUnmanaged);
-  const needsProcessManagedTickets = useSelector(sel.needsProcessManagedTickets);
+  const needsProcessManagedTickets = useSelector(
+    sel.needsProcessManagedTickets
+  );
   // end of vsp selectors
 
   // sync dcrwallet spv or rpc selectors

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -48,6 +48,7 @@ const useDaemonStartup = () => {
   const stakeTransactions = useSelector(sel.stakeTransactions);
   const isProcessingManaged = useSelector(sel.isProcessingManaged);
   const isProcessingUnmanaged = useSelector(sel.isProcessingUnmanaged);
+  const needsProcessManagedTickets = useSelector(sel.needsProcessManagedTickets);
   // end of vsp selectors
 
   // sync dcrwallet spv or rpc selectors
@@ -303,7 +304,8 @@ const useDaemonStartup = () => {
     stakeTransactions,
     rememberedVspHost,
     isProcessingManaged,
-    isProcessingUnmanaged
+    isProcessingUnmanaged,
+    needsProcessManagedTickets
   };
 };
 

--- a/app/index.js
+++ b/app/index.js
@@ -86,7 +86,8 @@ const initialState = {
     processUnmanagedTicketsError: null,
     processManagedTicketsAttempt: false,
     processManagedTicketsError: null,
-    trackedTickets: {}
+    trackedTickets: {},
+    needsProcessManagedTickets: true
   },
   daemon: {
     networkMatch: false,

--- a/app/index.js
+++ b/app/index.js
@@ -87,7 +87,8 @@ const initialState = {
     processManagedTicketsAttempt: false,
     processManagedTicketsError: null,
     trackedTickets: {},
-    needsProcessManagedTickets: true
+    needsProcessManagedTickets: true,
+    canDisableProcessManaged: true
   },
   daemon: {
     networkMatch: false,

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -19,7 +19,8 @@ import {
   SETVSPDVOTECHOICE_SUCCESS,
   SET_AUTOBUYER_SETTINGS,
   GETVSPSPUBKEYS_SUCCESS,
-  GETVSPTRACKEDTICKETS_SUCCESS
+  GETVSPTRACKEDTICKETS_SUCCESS,
+  SET_CANDISABLEPROCESSMANAGED
 } from "actions/VSPActions";
 import {
   STARTTICKETBUYERV3_ATTEMPT,
@@ -160,11 +161,17 @@ export default function vsp(state = {}, action) {
         ...state,
         trackedTickets: action.trackedTickets
       };
+    case SET_CANDISABLEPROCESSMANAGED:
+      return {
+        ...state,
+        canDisableProcessManaged: action.value
+      };
     case WALLET_LOADER_SETTINGS:
       return {
-      ...state,
-      needsProcessManagedTickets: action.needsVSPdProcessManaged
-    };
+        ...state,
+        needsProcessManagedTickets: action.needsVSPdProcessManaged,
+        canDisableProcessManaged: true
+      };
     case CLOSEWALLET_SUCCESS:
       return {
         ...state,

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -28,6 +28,7 @@ import {
   STOPTICKETBUYER_SUCCESS
 } from "actions/ControlActions";
 import { CLOSEWALLET_SUCCESS } from "actions/WalletLoaderActions";
+import { WALLET_LOADER_SETTINGS } from "actions/DaemonActions";
 
 export default function vsp(state = {}, action) {
   switch (action.type) {
@@ -159,10 +160,16 @@ export default function vsp(state = {}, action) {
         ...state,
         trackedTickets: action.trackedTickets
       };
+    case WALLET_LOADER_SETTINGS:
+      return {
+      ...state,
+      needsProcessManagedTickets: action.needsVSPdProcessManaged
+    };
     case CLOSEWALLET_SUCCESS:
       return {
         ...state,
-        trackedTickets: {}
+        trackedTickets: {},
+        needsProcessManagedTickets: true
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -917,7 +917,14 @@ export const getAvailableVSPs = get(["vsp", "availableVSPs"]);
 export const getDiscoverAvailableVSPError = get(["vsp", "availableVSPsError"]);
 
 export const isSyncingTickets = get(["vsp", "syncVSPRequestAttempt"]);
-export const needsProcessManagedTickets = get(["vsp", "needsProcessManagedTickets"]);
+export const needsProcessManagedTickets = get([
+  "vsp",
+  "needsProcessManagedTickets"
+]);
+export const canDisableProcessManaged = get([
+  "vsp",
+  "canDisableProcessManaged"
+]);
 
 // ticket auto buyer
 export const getTicketAutoBuyerRunning = get(["vsp", "ticketAutoBuyerRunning"]);

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -917,6 +917,7 @@ export const getAvailableVSPs = get(["vsp", "availableVSPs"]);
 export const getDiscoverAvailableVSPError = get(["vsp", "availableVSPsError"]);
 
 export const isSyncingTickets = get(["vsp", "syncVSPRequestAttempt"]);
+export const needsProcessManagedTickets = get(["vsp", "needsProcessManagedTickets"]);
 
 // ticket auto buyer
 export const getTicketAutoBuyerRunning = get(["vsp", "ticketAutoBuyerRunning"]);


### PR DESCRIPTION
This adds a new config flag that can be used (when toggled to false) to skip the "Process Managed Tickets" view.

The `needs_vspd_process_managed` flag starts out as true by default and is also set as true whenever a ticket is purchased or the autobuyer is turned on.

During ticket monitoring, if no tickets are found to be tracked by the VSP and the autobuyer is off and the PMT view wasn't previously skipped, then the flag is set to false, to signal that processing is no longer needed.

The skip check is there to avoid skipping once then never seeing the PMT screen again.