### PR TITLE
[dex] Improve `dexsite` script compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-renderer": "cross-env NODE_ENV=production node -r @babel/register ./node_modules/webpack/bin/webpack --config webpack.config.production.js --progress=profile --color",
     "build-trezor": "cross-env NODE_ENV=production node -r @babel/register ./node_modules/webpack/bin/webpack --config webpack.config.trezor.js --progress=profile --color",
     "build": "npm run build-trezor && npm run build-main && npm run build-renderer",
-    "dexsite": "rm -rf bin/site && cp -R ./node_modules/dcrdex-assets/dexc/site bin/",
+    "dexsite": "node ./scripts/dexsite.js",
     "rebuild-natives": "node_modules/.bin/electron-rebuild",
     "rebuild-dexc": "cd modules/dex && npm run install",
     "start": "cross-env NODE_ENV=production electron ./app/ --debug --custombinpath=./bin",

--- a/scripts/dexsite.js
+++ b/scripts/dexsite.js
@@ -1,0 +1,10 @@
+var sys = require('sys');
+var exec = require('child_process').exec;
+var os = require('os');
+
+if (os.type() === 'Linux' || os.type() === 'Darwin' ) 
+   exec("rm -rf bin/site && cp -R ./node_modules/dcrdex-assets/dexc/site bin/"); 
+else if (os.type() === 'Windows_NT') 
+    exec("rd /s /q \"bin/site\" && Xcopy /E /I \"./node_modules/dcrdex-assets/dexc/site\" \"bin/site\"");
+else
+   throw new Error("Unsupported OS found: " + os.type());


### PR DESCRIPTION
The `dexsite` script executes this command: `rm -rf bin/site && cp -R ./node_modules/dcrdex-assets/dexc/site bin/` which isn't valid on windows.
This diff introduce `scripts/dexsite.js`. It deletes `bin/site` dir and copy dex site dir with `rd /s /q \"bin/site\" && Xcopy /E /I \"./node_modules/dcrdex-assets/dexc/site\" \"bin/site\"` on windows.