### PR TITLE
[tickets] Unlock unmixed account for autobuyer

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -517,7 +517,9 @@ export const startTicketBuyerV3Attempt = (
 
   try {
     const accountNum = account.encrypted ? account.value : null;
-    const accountUnlocks = mixedAccount ? [accountNum, changeAccount] : [accountNum];
+    const accountUnlocks = mixedAccount
+      ? [accountNum, changeAccount]
+      : [accountNum];
     const ticketBuyer = await dispatch(
       unlockAcctAndExecFn(
         passphrase,

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -517,10 +517,11 @@ export const startTicketBuyerV3Attempt = (
 
   try {
     const accountNum = account.encrypted ? account.value : null;
+    const accountUnlocks = mixedAccount ? [accountNum, changeAccount] : [accountNum];
     const ticketBuyer = await dispatch(
       unlockAcctAndExecFn(
         passphrase,
-        [accountNum],
+        accountUnlocks,
         () => {
           dispatch(setNeedsVSPdProcessTickets(true));
           return wallet.startTicketAutoBuyerV3(ticketBuyerService, {


### PR DESCRIPTION
Previously, only the selected account was unlocked for the autobuyer.  For privacy autobuyers, we need to unlock the unlocked/change account too.