### PR TITLE
README: Set recommended node version to 14.16.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ production.
 
 The current recommended versions for the main tools are:
 
-  - Node: 10.2+
+  - Node: 14.16.1
   - Npm: 6.4+
   - Yarn: 1.12+
   - Electron: 3.0.6


### PR DESCRIPTION
As stated in #3478, yarn install on node version 16.2.0 at least does not work on a clean installation. When inquiring what node version to use, I was recommended 14.16.1. Set that in the readme.