### PR TITLE
[launcher] Add advanced options to Restore wallet

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -400,7 +400,9 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
       const walletStarted = await wallet.startWallet(
         selectedWallet.value.wallet,
         isTestnet,
-        rpcCreds
+        rpcCreds,
+        selectedWallet.value.gapLimit,
+        selectedWallet.value.disableCoinTypeUpgrades
       );
       const { port } = walletStarted;
       wallet.setPreviousWallet(selectedWallet);

--- a/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
+++ b/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
@@ -82,17 +82,10 @@ const CreateWalletPage = ({ createWalletRef, onSendBack }) => {
 
   const onCreateWallet = useCallback(() => {
     const pubpass = ""; // Temporarily disabled?
-    const { seed, passPhrase, gapLimit, disableCoinTypeUpgrades } = current.context;
+    const { seed, passPhrase } = current.context;
 
     if (!(seed && passPhrase)) return;
-    createWalletRequest(
-      pubpass,
-      passPhrase,
-      seed,
-      newWallet,
-      gapLimit,
-      disableCoinTypeUpgrades
-    )
+    createWalletRequest(pubpass, passPhrase, seed, newWallet)
       .then(() => sendEvent({ type: "WALLET_CREATED" }))
       .catch((error) => sendParent({ type: "ERROR", error }));
     // we send a continue so we go to loading state

--- a/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
+++ b/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
@@ -82,10 +82,17 @@ const CreateWalletPage = ({ createWalletRef, onSendBack }) => {
 
   const onCreateWallet = useCallback(() => {
     const pubpass = ""; // Temporarily disabled?
-    const { seed, passPhrase } = current.context;
+    const { seed, passPhrase, gapLimit, disableCoinTypeUpgrades } = current.context;
 
     if (!(seed && passPhrase)) return;
-    createWalletRequest(pubpass, passPhrase, seed, newWallet)
+    createWalletRequest(
+      pubpass,
+      passPhrase,
+      seed,
+      newWallet,
+      gapLimit,
+      disableCoinTypeUpgrades
+    )
       .then(() => sendEvent({ type: "WALLET_CREATED" }))
       .catch((error) => sendParent({ type: "ERROR", error }));
     // we send a continue so we go to loading state

--- a/app/components/views/GetStartedPage/CreateWalletPage/hooks.js
+++ b/app/components/views/GetStartedPage/CreateWalletPage/hooks.js
@@ -22,8 +22,17 @@ export const useCreateWallet = () => {
     [dispatch]
   );
   const createWalletRequest = useCallback(
-    (pubpass, passPhrase, seed, isNew) =>
-      dispatch(wla.createWalletRequest(pubpass, passPhrase, seed, isNew)),
+    (pubpass, passPhrase, seed, isNew, gapLimit, disableCoinTypeUpgrades) =>
+      dispatch(
+        wla.createWalletRequest(
+          pubpass,
+          passPhrase,
+          seed,
+          isNew,
+          gapLimit,
+          disableCoinTypeUpgrades
+        )
+      ),
     [dispatch]
   );
   const isTestNet = useSelector(sel.isTestNet);

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.jsx
@@ -1,6 +1,6 @@
 import { FormattedMessage as T, defineMessages } from "react-intl";
 import { classNames, Checkbox, Tooltip } from "pi-ui";
-import { TextInput } from "inputs";
+import { TextInput, NumericInput } from "inputs";
 import { KeyBlueButton, InvisibleButton } from "buttons";
 import { Collapse, ExternalLink } from "shared";
 import { NewSeedTabMsg, RestoreTabMsg } from "../../messages";
@@ -38,6 +38,11 @@ const messages = defineMessages({
   messageWalletDupeNameError: {
     id: "createwallet.dupeWalletName.error",
     defaultMessage: "Please choose an unused wallet name"
+  },
+  messageDisablecointypeupgrades: {
+    id: "createwallet.disablecointypeupgrades.description",
+    defaultMessage:
+      "Never upgrade from legacy to SLIP0044 coin type keys"
   }
 });
 
@@ -59,7 +64,11 @@ const CreateWalletForm = ({
   toggleTrezor,
   onShowTrezorConfig,
   isCreateNewWallet,
-  creatingWallet
+  creatingWallet,
+  disableCoinTypeUpgrades,
+  toggleDisableCoinTypeUpgrades,
+  gapLimit,
+  setGapLimit
 }) => (
   <>
     {isCreateNewWallet ? (
@@ -179,6 +188,36 @@ const CreateWalletForm = ({
                   checked={isTrezor}
                   onChange={toggleTrezor}
                 />
+              </div>
+              <div className={styles.advancedOption}>
+                <Checkbox
+                  label={
+                    <T
+                      id="createwallet.disableCoinTypeUpgrades.label"
+                      m="Disable coin type upgrades"
+                    />
+                  }
+                  id="disableCoinTypeUpgrades"
+                  description={intl.formatMessage(
+                    messages.messageDisablecointypeupgrades
+                  )}
+                  checked={disableCoinTypeUpgrades}
+                  onChange={toggleDisableCoinTypeUpgrades}
+                />
+              </div>
+              <div className={styles.advancedOption}>
+                <label id="gap-limit-input" className={styles.gapLimitlabel}>
+                  <T id="createwallet.gapLimit.label" m="Gap Limit" />
+                  <div className={styles.gapLimitInput}>
+                    <NumericInput
+                      value={gapLimit}
+                      ariaLabelledBy="gap-limit-input"
+                      onChange={(e) =>
+                        setGapLimit(e.target.value)
+                      }
+                    />
+                  </div>
+                </label>
               </div>
             </>
           }

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.jsx
@@ -41,8 +41,7 @@ const messages = defineMessages({
   },
   messageDisablecointypeupgrades: {
     id: "createwallet.disablecointypeupgrades.description",
-    defaultMessage:
-      "Never upgrade from legacy to SLIP0044 coin type keys"
+    defaultMessage: "Never upgrade from legacy to SLIP0044 coin type keys"
   },
   messageGapLimit: {
     id: "createwallet.gaplimit.description",
@@ -223,9 +222,9 @@ const CreateWalletForm = ({
                   onChange={(e) => setGapLimit(e.target.value)}
                 />
               </div>
-                <div className={styles.gapLimitDesc}>
-                  {intl.formatMessage(messages.messageGapLimit)}
-                </div>
+              <div className={styles.gapLimitDesc}>
+                {intl.formatMessage(messages.messageGapLimit)}
+              </div>
             </>
           }
         />

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.jsx
@@ -1,6 +1,6 @@
 import { FormattedMessage as T, defineMessages } from "react-intl";
 import { classNames, Checkbox, Tooltip } from "pi-ui";
-import { TextInput, NumericInput } from "inputs";
+import { TextInput, IntegerInput } from "inputs";
 import { KeyBlueButton, InvisibleButton } from "buttons";
 import { Collapse, ExternalLink } from "shared";
 import { NewSeedTabMsg, RestoreTabMsg } from "../../messages";
@@ -43,6 +43,11 @@ const messages = defineMessages({
     id: "createwallet.disablecointypeupgrades.description",
     defaultMessage:
       "Never upgrade from legacy to SLIP0044 coin type keys"
+  },
+  messageGapLimit: {
+    id: "createwallet.gaplimit.description",
+    defaultMessage:
+      "Allowed unused address gap between used addresses of accounts"
   }
 });
 
@@ -205,20 +210,22 @@ const CreateWalletForm = ({
                   onChange={toggleDisableCoinTypeUpgrades}
                 />
               </div>
-              <div className={styles.advancedOption}>
-                <label id="gap-limit-input" className={styles.gapLimitlabel}>
-                  <T id="createwallet.gapLimit.label" m="Gap Limit" />
-                  <div className={styles.gapLimitInput}>
-                    <NumericInput
-                      value={gapLimit}
-                      ariaLabelledBy="gap-limit-input"
-                      onChange={(e) =>
-                        setGapLimit(e.target.value)
-                      }
-                    />
-                  </div>
+              <div
+                className={classNames(styles.advancedOption, styles.gapLimit)}>
+                <label id="gap-limit-input">
+                  <T id="createwallet.gapLimit.label" m="Gap Limit" />:
                 </label>
+                <IntegerInput
+                  id="gap-limit-input"
+                  className={styles.gapLimitInput}
+                  value={gapLimit}
+                  ariaLabelledBy="gap-limit-input"
+                  onChange={(e) => setGapLimit(e.target.value)}
+                />
               </div>
+                <div className={styles.gapLimitDesc}>
+                  {intl.formatMessage(messages.messageGapLimit)}
+                </div>
             </>
           }
         />

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.module.css
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.module.css
@@ -85,7 +85,7 @@
 }
 
 .gapLimitDesc {
-  margin-left: 8rem;
+  margin-left: 1.1rem;
   margin-top: 0.5rem;
   color: var(--text-secondary-color);
   font-size: var(--font-size-small);

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.module.css
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.module.css
@@ -73,3 +73,21 @@
   text-align: right;
   max-width: 600px;
 }
+
+.gapLimit {
+  display: flex;
+  flex-direction: row;
+}
+
+.gapLimitInput {
+  width: 100px;
+  margin-left: 10px;
+}
+
+.gapLimitDesc {
+  margin-left: 8rem;
+  margin-top: 0.5rem;
+  color: var(--text-secondary-color);
+  font-size: var(--font-size-small);
+  font-style: italic;
+}

--- a/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
@@ -34,6 +34,8 @@ const PreCreateWallet = ({
   const [isTrezor, setIsTrezor] = useState(false);
   const [hasFailedAttemptName, setHasFailedAttemptName] = useState(false);
   const [hasFailedAttemptPubKey, setHasFailedAttemptPubKey] = useState(false);
+  const [disableCoinTypeUpgrades, setDisableCoinTypeUpgrades] = useState(false);
+  const [gapLimit, setGapLimit] = useState(null);
 
   const hideCreateWalletForm = useCallback(() => {
     if (isTrezor) {
@@ -77,6 +79,9 @@ const PreCreateWallet = ({
     setIsWatchingOnly(false);
   }, [isTrezor, trezorEnable, trezorDisable]);
 
+  const toggleDisableCoinTypeUpgrades = () =>
+    setDisableCoinTypeUpgrades((value) => !value);
+
   const createWallet = useCallback(() => {
     const isNew = isCreateNewWallet;
     const walletSelected = {
@@ -86,7 +91,9 @@ const PreCreateWallet = ({
         isWatchingOnly,
         isTrezor,
         isNew,
-        network: isTestNet ? "testnet" : "mainnet"
+        network: isTestNet ? "testnet" : "mainnet",
+        gapLimit,
+        disableCoinTypeUpgrades
       }
     };
 
@@ -136,7 +143,9 @@ const PreCreateWallet = ({
     trezorDevice,
     trezorGetWalletCreationMasterPubKey,
     walletMasterPubKey,
-    walletNameError
+    walletNameError,
+    gapLimit,
+    disableCoinTypeUpgrades
   ]);
 
   const onChangeCreateWalletMasterPubKey = useCallback(
@@ -179,7 +188,11 @@ const PreCreateWallet = ({
         toggleWatchOnly,
         toggleTrezor,
         onChangeCreateWalletMasterPubKey,
-        intl
+        intl,
+        disableCoinTypeUpgrades,
+        toggleDisableCoinTypeUpgrades,
+        gapLimit,
+        setGapLimit
       }}
     />
   );

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -362,20 +362,25 @@ ipcMain.on("stop-wallet", (event) => {
   event.returnValue = stopWallet();
 });
 
-handle("start-wallet", (walletPath, testnet, rpcCreds) => {
-  const { rpcUser, rpcPass, rpcListen, rpcCert } = rpcCreds;
-  return startWallet(
-    mainWindow,
-    daemonIsAdvanced,
-    testnet,
-    walletPath,
-    mainWindow.webContents,
-    rpcUser,
-    rpcPass,
-    rpcListen,
-    rpcCert
-  );
-});
+handle(
+  "start-wallet",
+  (walletPath, testnet, rpcCreds, gapLimit, disableCoinTypeUpgrades) => {
+    const { rpcUser, rpcPass, rpcListen, rpcCert } = rpcCreds;
+    return startWallet(
+      mainWindow,
+      daemonIsAdvanced,
+      testnet,
+      walletPath,
+      mainWindow.webContents,
+      rpcUser,
+      rpcPass,
+      rpcListen,
+      rpcCert,
+      gapLimit,
+      disableCoinTypeUpgrades
+    );
+  }
+);
 
 handle("start-dcrlnd", startDcrlnd);
 

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -167,7 +167,9 @@ export const startWallet = async (
   rpcUser,
   rpcPass,
   rpcHost,
-  rpcListen
+  rpcListen,
+  gapLimit,
+  disableCoinTypeUpgrades
 ) => {
   if (GetDcrwPID()) {
     logger.log("info", "dcrwallet already started " + GetDcrwPID());
@@ -189,7 +191,9 @@ export const startWallet = async (
       rpcUser,
       rpcPass,
       rpcHost,
-      rpcListen
+      rpcListen,
+      gapLimit,
+      disableCoinTypeUpgrades
     );
   } catch (e) {
     logger.log("error", "error launching dcrwallet: " + e);

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -606,7 +606,9 @@ export const launchDCRWallet = async (
   rpcUser,
   rpcPass,
   rpcListen,
-  rpcCert
+  rpcCert,
+  gapLimit,
+  disableCoinTypeUpgrades
 ) => {
   const cfg = getWalletCfg(testnet, walletPath);
   const confFile = fs.existsSync(
@@ -617,7 +619,12 @@ export const launchDCRWallet = async (
   let args = [confFile];
 
   // add needed dcrwallet flags
-  args.push("--gaplimit=" + cfg.get(cfgConstants.GAP_LIMIT));
+  if (disableCoinTypeUpgrades === true) {
+    args.push("--disablecointypeupgrades");
+  }
+  args.push(
+    `--gaplimit=${gapLimit ? gapLimit : cfg.get(cfgConstants.GAP_LIMIT)}`
+  );
   args.push("--issueclientcert");
 
   // example of debug level case needed

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -89,8 +89,15 @@ export const stopWallet = log(
 );
 
 export const startWallet = log(
-  (walletPath, testnet, rpcCreds) =>
-    invoke("start-wallet", walletPath, testnet, rpcCreds),
+  (walletPath, testnet, rpcCreds, gapLimit, disableCoinTypeUpgrades) =>
+    invoke(
+      "start-wallet",
+      walletPath,
+      testnet,
+      rpcCreds,
+      gapLimit,
+      disableCoinTypeUpgrades
+    ),
   "Start Wallet"
 );
 

--- a/test/unit/components/views/GetStaredPage/CreateWallet.spec.js
+++ b/test/unit/components/views/GetStaredPage/CreateWallet.spec.js
@@ -21,7 +21,9 @@ const testSelectedWallet = {
     isTrezor: false,
     isWatchingOnly: false,
     network: "mainnet",
-    wallet: testWalletName
+    wallet: testWalletName,
+    gapLimit: null,
+    disableCoinTypeUpgrades: false
   }
 };
 

--- a/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
+++ b/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
@@ -21,7 +21,9 @@ const testSelectedWallet = {
     isTrezor: false,
     isWatchingOnly: false,
     network: "mainnet",
-    wallet: testWalletName
+    wallet: testWalletName,
+    gapLimit: null,
+    disableCoinTypeUpgrades: false
   }
 };
 const selectors = sel;
@@ -406,6 +408,38 @@ test("test testnet logo on restore wallet view", async () => {
 
   user.type(screen.getByPlaceholderText(/choose a name/i), testWalletName);
   user.click(screen.getByText(/continue/i));
+  await wait(() =>
+    expect(mockCreateWallet).toHaveBeenCalledWith(testRestoreSelectedWallet)
+  );
+});
+
+test("test disable coin type upgrades and gap limit inputs on restore wallet", async () => {
+  const testRestoreSelectedWallet = {
+    ...testSelectedWallet,
+    value: {
+      ...testSelectedWallet.value,
+      isNew: false,
+      disableCoinTypeUpgrades: true,
+      gapLimit: "1001"
+    }
+  };
+
+  await goToRestoreWalletView();
+  user.click(screen.getByText("Advanced Options"));
+  const continueButton = screen.getByText(/continue/i);
+  const walletNameInput = screen.getByPlaceholderText(/choose a name/i);
+  user.type(walletNameInput, testWalletName);
+
+  const disableCoinTypeUpgradesSwitch = screen.getByLabelText(
+    /disable coin type upgrades/i
+  );
+  user.click(disableCoinTypeUpgradesSwitch);
+  expect(disableCoinTypeUpgradesSwitch.checked).toBe(true);
+
+  const gapLimitInput = screen.getByLabelText(/gap limit:/i);
+  user.type(gapLimitInput, testRestoreSelectedWallet.value.gapLimit);
+
+  user.click(continueButton);
   await wait(() =>
     expect(mockCreateWallet).toHaveBeenCalledWith(testRestoreSelectedWallet)
   );


### PR DESCRIPTION
This diff adds two new (`disablecointtypeupgrades` and `gaplimit`) advanced options to the restoring wallet view then use these options for next dcrwallet spawn.

<img width="468" alt="DeepinScreenshot_select-area_20210526151227" src="https://user-images.githubusercontent.com/52497040/119665538-c9e90300-be34-11eb-8933-854c7ec9f67c.png">


Closes #3482