### PR TITLE
Receive tab: automated tests

### DIFF
--- a/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/QRCodeModal/index.js
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/QRCodeModal/index.js
@@ -1,0 +1,1 @@
+export { default } from "./QRCodeModal";

--- a/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.jsx
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.jsx
@@ -4,8 +4,8 @@ import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
 import { ReceiveAccountsSelect, DcrInput } from "inputs";
 import { Subtitle } from "shared";
 import { KeyBlueButton, SmallButton } from "buttons";
-import QRCodeModal from "./QRCodeModal/QRCodeModal";
-import { classNames } from "pi-ui";
+import QRCodeModal from "./QRCodeModal";
+import { classNames, Tooltip } from "pi-ui";
 import style from "./ReceivePage.module.css";
 
 const messages = defineMessages({
@@ -115,18 +115,26 @@ const ReceivePage = ({
               </div>
             </div>
           </div>
-          <SmallButton
-            className={style.receiveContentCopyButton}
-            onClick={() => {
-              copy(nextAddress);
-              setTooltipText(false);
-              showTooltip();
-            }}
-          />
-          <SmallButton
-            className={style.receiveContentQRButton}
-            onClick={() => setModal(true)}
-          />
+          <div>
+            <Tooltip content={<T id="receiveTab.copy" m="Copy" />}>
+              <SmallButton
+                className={style.receiveContentCopyButton}
+                onClick={() => {
+                  copy(nextAddress);
+                  setTooltipText(false);
+                  showTooltip();
+                }}
+              />
+            </Tooltip>
+          </div>
+          <div>
+            <Tooltip content={<T id="receiveTab.QRCode" m="QR code" />}>
+              <SmallButton
+                className={style.receiveContentQRButton}
+                onClick={() => setModal(true)}
+              />
+            </Tooltip>
+          </div>
         </div>
       </div>
       <div className={style.generateButton}>

--- a/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/index.js
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ReceivePage";

--- a/app/components/views/TransactionsPage/ReceiveTab/ReceiveTab.jsx
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceiveTab.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { FormattedMessage as T } from "react-intl";
 import ErrorScreen from "ErrorScreen";
-import ReceivePage from "./ReceivePage/ReceivePage";
+import ReceivePage from "./ReceivePage";
 import { DescriptionHeader } from "layout";
 import { useService } from "hooks";
 import { useReceiveTab } from "./hooks";

--- a/app/components/views/TransactionsPage/ReceiveTab/index.js
+++ b/app/components/views/TransactionsPage/ReceiveTab/index.js
@@ -1,0 +1,1 @@
+export { default as ReceiveTab, ReceiveTabHeader } from "./ReceiveTab";

--- a/app/components/views/TransactionsPage/TransactionsPage.jsx
+++ b/app/components/views/TransactionsPage/TransactionsPage.jsx
@@ -1,11 +1,8 @@
 import { TabbedPage, TabbedPageTab as Tab, TitleHeader } from "layout";
 import { Switch, Redirect } from "react-router-dom";
 import { FormattedMessage as T } from "react-intl";
+import { ReceiveTab, ReceiveTabHeader } from "./ReceiveTab";
 import { SendTab, SendTabHeader } from "./SendTab";
-import {
-  default as ReceiveTab,
-  ReceiveTabHeader
-} from "./ReceiveTab/ReceiveTab";
 import {
   default as HistoryTab,
   HistoryTabHeader

--- a/app/containers/Wallet/Wallet.jsx
+++ b/app/containers/Wallet/Wallet.jsx
@@ -8,7 +8,7 @@ import WalletError from "components/views/WalletError";
 import ErrorScreen from "components/ErrorScreen";
 import InvalidRPCVersion from "components/views/InvalidRPCVersion";
 import PrivacyPage from "components/views/PrivacyPage/PrivacyPage";
-import TransactionsPage from "components/views/TransactionsPage/TransactionsPage";
+import TransactionsPage from "components/views/TransactionsPage";
 import TransactionPage from "components/views/TransactionPage/TransactionPage";
 import TicketsPage from "components/views/TicketsPage/TicketsPage";
 import TutorialsPage from "components/views/TutorialsPage/TutorialsPage";

--- a/test/unit/components/views/TransactionsPage/ReceiveTab/ReceiveTab.spec.js
+++ b/test/unit/components/views/TransactionsPage/ReceiveTab/ReceiveTab.spec.js
@@ -1,0 +1,191 @@
+import { ReceiveTab } from "components/views/TransactionsPage/ReceiveTab";
+import TransactionsPage from "components/views/TransactionsPage/";
+import { render } from "test-utils.js";
+import user from "@testing-library/user-event";
+import { screen, wait } from "@testing-library/react";
+import * as sel from "selectors";
+import * as ca from "actions/ControlActions";
+import * as wl from "wallet";
+import { DCR } from "constants";
+import { fireEvent } from "@testing-library/react";
+import copy from "clipboard-copy";
+jest.mock("clipboard-copy");
+export const GETNEXTADDRESS_SUCCESS = "GETNEXTADDRESS_SUCCESS";
+
+let mockCopy;
+const mockMixedAccountValue = 6;
+const mockDefaultAccount = {
+  hidden: false,
+  label: "default: 19 DCR",
+  name: "default",
+  spendable: 1900000000,
+  spendableAndUnit: "19 DCR",
+  total: 1900000000,
+  value: 0
+};
+const mockAccount2 = {
+  hidden: false,
+  label: "account-2: 7.4998063 DCR",
+  name: "account-2",
+  spendable: 749980630,
+  spendableAndUnit: "7.4998063 DCR",
+  total: 749980630,
+  value: 2
+};
+const mockEmptyAccount = {
+  hidden: false,
+  label: "empty: 0.0000000 DCR",
+  name: "empty",
+  spendable: 0,
+  spendableAndUnit: "0.00000 DCR",
+  total: 0,
+  value: 3
+};
+const mockMixedAccount = {
+  hidden: false,
+  label: "mixed: 249.79547928 DCR",
+  name: "mixed",
+  spendable: 24979547928,
+  spendableAndUnit: "249.79547928 DCR",
+  total: 24979547928,
+  value: mockMixedAccountValue
+};
+const mockVisibleAccounts = [
+  mockDefaultAccount,
+  mockAccount2,
+  mockMixedAccount,
+  mockEmptyAccount
+];
+const mockSpendingAccounts = [
+  mockDefaultAccount,
+  mockAccount2,
+  mockMixedAccount,
+  mockEmptyAccount
+];
+const mockNextAddress = "TsiTfsjizPgzBrPxovheccayb4UbLRmQAqY";
+
+let mockIsTestNet;
+let mockIsMainNet;
+let mockWalletService;
+let mockGetNextAddressAttempt;
+let mockGenQRCodeSVG;
+
+const selectors = sel;
+const controlActions = ca;
+const wallet = wl;
+
+beforeEach(() => {
+  mockCopy = copy.mockImplementation(() => true);
+
+  mockIsTestNet = selectors.isTestNet = jest.fn(() => false);
+  mockIsMainNet = selectors.isMainNet = jest.fn(() => false);
+  mockWalletService = selectors.walletService = jest.fn(() => {
+    return {};
+  });
+
+  selectors.defaultSpendingAccount = jest.fn(() => mockDefaultAccount);
+  selectors.visibleAccounts = jest.fn(() => mockVisibleAccounts);
+  selectors.spendingAccounts = jest.fn(() => mockSpendingAccounts);
+  selectors.getMixedAccount = jest.fn(() => mockMixedAccountValue);
+  selectors.nextAddress = jest.fn(() => mockNextAddress);
+  selectors.nextAddressAccount = jest.fn(() => mockDefaultAccount);
+  selectors.currencyDisplay = jest.fn(() => DCR);
+  mockGenQRCodeSVG = wallet.genQRCodeSVG = jest.fn(() => {});
+  mockGetNextAddressAttempt = controlActions.getNextAddressAttempt = jest.fn(
+    () => (dispatch) => {
+      const res = {
+        address: "mock-next-address",
+        accountNumber: mockAccount2.value
+      };
+      dispatch({
+        getNextAddressResponse: res,
+        type: GETNEXTADDRESS_SUCCESS
+      });
+      Promise.resolve(res);
+    }
+  );
+});
+
+const getAmountInput = () => screen.getByLabelText("Requested Amount");
+const getCopyButton = () => screen.getByText("Copy").nextElementSibling;
+const getQRCodeButton = () => screen.getByText("QR code").nextElementSibling;
+const getModalCloseButton = () => screen.getByText("Close");
+
+test("render ReceiveTab within its parent", () => {
+  render(<TransactionsPage />);
+  user.click(screen.getByText("Receive"));
+
+  expect(
+    screen.getByText(/Each time you request a payment/i).textContent
+  ).toMatchInlineSnapshot(
+    '"Each time you request a payment, create a new address to protect your privacy."'
+  );
+});
+
+test("change destination account", async () => {
+  render(<ReceiveTab />);
+  selectors.nextAddressAccount = jest.fn(() => mockAccount2);
+  expect(screen.getByText(mockNextAddress)).toBeInTheDocument();
+
+  user.click(screen.getByText(mockDefaultAccount.name));
+  expect(screen.getByText(mockEmptyAccount.name)).toBeInTheDocument();
+  expect(screen.getByText(mockAccount2.name)).toBeInTheDocument();
+  expect(screen.getAllByText(mockDefaultAccount.name).length).toBe(2);
+  user.click(screen.getByText(mockAccount2.name));
+  await wait(() =>
+    expect(screen.getAllByText(mockAccount2.name).length).toBe(1)
+  );
+  expect(mockGetNextAddressAttempt).toHaveBeenCalled();
+});
+
+test("generate new address", () => {
+  render(<ReceiveTab />);
+  user.click(screen.getByText(/generate new address/i));
+  expect(mockGetNextAddressAttempt).toHaveBeenCalled();
+});
+
+test("show error when there is no walletService", () => {
+  mockWalletService = selectors.walletService = jest.fn(() => {});
+  render(<ReceiveTab />);
+  expect(
+    screen.getByText("Something went wrong, please go back")
+  ).toBeInTheDocument();
+  expect(screen.getByText(/back to home/i)).toBeInTheDocument();
+
+  expect(mockIsTestNet).toHaveBeenCalled();
+  expect(mockIsMainNet).toHaveBeenCalled();
+  expect(mockWalletService).toHaveBeenCalled();
+});
+
+test("test copy button", () => {
+  render(<ReceiveTab />);
+  user.click(getCopyButton());
+  expect(mockCopy).toHaveBeenCalledWith(mockNextAddress);
+});
+
+test("test QR button", () => {
+  render(<ReceiveTab />);
+  user.click(getQRCodeButton());
+  expect(mockGenQRCodeSVG).toHaveBeenCalledWith(`decred:${mockNextAddress}`);
+  expect(screen.getAllByText(mockNextAddress).length).toBe(2); // + modal
+  user.click(getModalCloseButton());
+
+  // set amount
+  mockGenQRCodeSVG.mockClear();
+  const amountInput = getAmountInput();
+  expect(amountInput).toBeInTheDocument();
+  expect(amountInput.value).toBe("");
+  const mockAmountValue = "12";
+  fireEvent.change(amountInput, {
+    target: { value: mockAmountValue }
+  });
+  expect(amountInput.value).toBe(mockAmountValue);
+
+  user.click(getQRCodeButton());
+  expect(mockGenQRCodeSVG).toHaveBeenCalledWith(
+    `decred:${mockNextAddress}?amount=${mockAmountValue}`
+  );
+  expect(screen.getAllByText(mockNextAddress).length).toBe(2); // + modal
+  user.click(getModalCloseButton());
+  expect(screen.getAllByText(mockNextAddress).length).toBe(1); // modal has been disappeared
+});


### PR DESCRIPTION
This is the continuation of #3489. I've covered the ReceiveTab view:
- app/components/views/TransactionsPage/ReceiveTab/*
- app/components/views/TransactionsPage/ReceiveTab/ReceivePage/*
- app/components/views/TransactionsPage/ReceiveTab/ReceivePage/QRCodeModal/*
