### PR TITLE
Politeia: Migrate to new API.

### DIFF
--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -533,7 +533,6 @@ export const getProposalDetails = (token) => async (dispatch, getState) => {
     proposal = {
       ...proposal,
       ...p,
-      creator: p.username,
       token,
       hasEligibleTickets: false
     };

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -688,7 +688,6 @@ export const updateVoteChoice = (
     const sigs = signed.replies;
     walletEligibleTickets.forEach((t, i) => {
       const { signature } = sigs[i];
-      if (signature.error != "") {
       if (signature.error) {
         throw signature.error;
       }
@@ -699,7 +698,6 @@ export const updateVoteChoice = (
 
     // cast vote into pi server
     const response = await pi.castBallot({ piURL, votes });
-    const { error: voteCastError } =
     const { errorcontext: voteCastError } =
       response.data.receipts.find(({ errorcontext }) => errorcontext) || {};
 

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -612,7 +612,9 @@ export const getProposalDetails = (token) => async (dispatch, getState) => {
             votingSinceLastAccess: false,
             walletEligibleTickets,
             hasEligibleTickets,
-            eligibleTicketCount: walletEligibleTickets.length,
+            eligibleTicketCount: walletEligibleTickets
+              ? walletEligibleTickets.length
+              : 0,
             currentVoteChoice
           };
           return (proposals[key][i] = { ...proposal });

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -548,14 +548,17 @@ export const getProposalDetails = (token) => async (dispatch, getState) => {
     );
     // if voteAndEligibleTickets are already cached we just get them.
     // Otherwise we get them from politea server and cache.
+
+    // XXX we could skip the following eligible tickets logic if proposal is
+    // still in discussion phase.
     if (voteAndEligibleTickets) {
       walletEligibleTickets = voteAndEligibleTickets.walletEligibleTickets;
       currentVoteChoice = voteAndEligibleTickets.voteChoice;
       hasEligibleTickets =
         walletEligibleTickets && walletEligibleTickets.length > 0;
     } else {
-      const voteReq = await pi.getProposalVotes({ piURL, token });
-      const { startvotereply, castvotes } = voteReq.data;
+      const { data } = await pi.getProposalVotes({ piURL, token });
+      const { startvotereply, castvotes } = data;
       walletEligibleTickets = await getProposalEligibleTickets(
         proposal.token,
         startvotereply.eligibletickets,
@@ -688,7 +691,7 @@ export const updateVoteChoice = (
     });
 
     // cast vote into pi server
-    const response = await pi.castVotes({ piURL, votes });
+    const response = await pi.castBallot({ piURL, votes });
     const { error: voteCastError } =
       response.data.receipts.find(({ error }) => error) || {};
 

--- a/app/actions/GovernanceActions.js
+++ b/app/actions/GovernanceActions.js
@@ -91,9 +91,11 @@ const fillVoteSummary = (
 const ticketHashesToByte = (hashes) =>
   hashes && hashes.map(hexReversedHashToArray);
 
-// getProposalEligibleTickets gets the wallet eligible tickets from a specific proposal.
-// if the proposal directory already exists it only returns the cached information,
-// otherwise it gets the eligible tickets from politeia and caches it.
+// getProposalEligibleTickets gets the wallet eligible tickets for a specific
+// proposal.
+// if the proposal directory already exists it only returns the cached
+// information, otherwise it gets the eligible tickets from politeia and caches
+// it.
 const getProposalEligibleTickets = async (
   token,
   allEligibleTickets,
@@ -103,6 +105,7 @@ const getProposalEligibleTickets = async (
   // Aux function to get the tickets from the wallet that are eligible to vote
   // (committed tickets) for a given proposal (given a list of eligible tickets
   // returned from an activevotes call)
+  console.log({ token, allEligibleTickets, shouldCache, walletService });
   const getWalletEligibleTickets = async (eligibleTickets, walletService) => {
     const commitedTicketsResp = await wallet.committedTickets(
       walletService,
@@ -112,14 +115,16 @@ const getProposalEligibleTickets = async (
   };
 
   const eligibleTicketsObj = getEligibleTickets(token);
+  console.log({ eligibleTicketsObj });
   if (eligibleTicketsObj) {
     const { eligibleTickets } = eligibleTicketsObj;
     return await getWalletEligibleTickets(eligibleTickets, walletService);
   }
-
+  console.log({ shouldCache });
   if (shouldCache) {
     saveEligibleTickets(token, { eligibleTickets: allEligibleTickets });
   }
+  console.log(1111);
   return await getWalletEligibleTickets(allEligibleTickets, walletService);
 };
 

--- a/app/components/views/AgendaDetailsPage/helpers/AgendaCard/AgendaCard.module.css
+++ b/app/components/views/AgendaDetailsPage/helpers/AgendaCard/AgendaCard.module.css
@@ -25,10 +25,6 @@
   font-size: 16px;
 }
 
-.creator {
-  font-weight: 600;
-}
-
 .tooltipTitle {
   width: max-content;
   max-width: max-content !important;

--- a/app/components/views/GovernancePage/Proposals/ProposalsListItem/ProposalsListItem.jsx
+++ b/app/components/views/GovernancePage/Proposals/ProposalsListItem/ProposalsListItem.jsx
@@ -21,7 +21,7 @@ const ProposalsListItem = ({
   totalVotes,
   endTimestamp,
   blocksLeft,
-  creator,
+  username,
   proposalStatus,
   version
 }) => {
@@ -63,7 +63,7 @@ const ProposalsListItem = ({
           endTimestamp,
           blocksLeft,
           name,
-          creator,
+          username,
           timestamp,
           tsDate,
           version,

--- a/app/components/views/GovernancePage/Proposals/hooks.js
+++ b/app/components/views/GovernancePage/Proposals/hooks.js
@@ -178,7 +178,6 @@ const onLoadMoreProposals = async (
   getProposalsAndUpdateVoteStatus,
   proposallistpagesize = PROPOSALS_MAX_PAGE_SIZE
 ) => {
-  const proposalLength = proposals.length;
   const numOfProposals = proposals.length;
   let pageSize;
   if (inventory.length <= proposallistpagesize) {

--- a/app/components/views/GovernancePage/Proposals/hooks.js
+++ b/app/components/views/GovernancePage/Proposals/hooks.js
@@ -81,7 +81,7 @@ export function useProposalsList(tab) {
   const proposals = useSelector(sel.proposals);
   const inventory = useSelector(sel.inventory);
   const getProposalError = useSelector(sel.getProposalError);
-  const inventoryError = useSelector(sel.getTokenInventoryError);
+  const inventoryError = useSelector(sel.getVotesInventoryError);
   const dispatch = useDispatch();
   const getProposalsAndUpdateVoteStatus = (proposalBatch) =>
     dispatch(gov.getProposalsAndUpdateVoteStatus(proposalBatch));

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -4,7 +4,12 @@ import { PoliteiaLink } from "shared";
 import { ProposalBody, VoteSection, ProposalCard } from "./helpers";
 import { useProposalDetails } from "./hooks";
 import styles from "./ProposalDetails.module.css";
-import { PROPOSAL_VOTING_ACTIVE, PROPOSAL_VOTING_FINISHED , PROPOSAL_VOTING_APPROVED, PROPOSAL_VOTING_REJECTED} from "constants";
+import {
+  PROPOSAL_VOTING_ACTIVE,
+  PROPOSAL_VOTING_FINISHED,
+  PROPOSAL_VOTING_APPROVED,
+  PROPOSAL_VOTING_REJECTED
+} from "constants";
 
 const ProposalDetails = ({
   viewedProposalDetails,
@@ -29,8 +34,6 @@ const ProposalDetails = ({
     description
   },
   showPurchaseTicketsPage,
-  setVoteOption,
-  newVoteChoice,
   goBackHistory,
   linkedProposal,
   isDarkTheme
@@ -41,7 +44,8 @@ const ProposalDetails = ({
   const proposalPath = `/record/${shortToken}`;
   const isVoteActive = voteStatus === PROPOSAL_VOTING_ACTIVE;
   const isVoteActiveOrFinished =
-    isVoteActive || voteStatus === PROPOSAL_VOTING_FINISHED ||
+    isVoteActive ||
+    voteStatus === PROPOSAL_VOTING_FINISHED ||
     voteStatus === PROPOSAL_VOTING_APPROVED ||
     voteStatus === PROPOSAL_VOTING_REJECTED;
 
@@ -90,8 +94,6 @@ const ProposalDetails = ({
             proposalStatus,
             voteStatus,
             currentVoteChoice,
-            newVoteChoice,
-            setVoteOption,
             voteOptions,
             showPurchaseTicketsPage
           }}

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -14,7 +14,7 @@ import {
 const ProposalDetails = ({
   viewedProposalDetails,
   viewedProposalDetails: {
-    creator,
+    username,
     timestamp,
     endTimestamp,
     currentVoteChoice,
@@ -67,7 +67,7 @@ const ProposalDetails = ({
             endTimestamp,
             blocksLeft,
             name,
-            creator,
+            username,
             timestamp,
             tsDate,
             version,

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -26,7 +26,7 @@ const ProposalDetails = ({
     linkto,
     blocksLeft,
     approved,
-    body
+    description
   },
   showPurchaseTicketsPage,
   setVoteOption,
@@ -96,7 +96,7 @@ const ProposalDetails = ({
         />
       )}
       <div className={styles.detailsText}>
-        <ProposalBody body={body} />
+        <ProposalBody body={description} />
       </div>
       <div className={styles.piButtonWrapper}>
         <PoliteiaLink

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.jsx
@@ -4,7 +4,7 @@ import { PoliteiaLink } from "shared";
 import { ProposalBody, VoteSection, ProposalCard } from "./helpers";
 import { useProposalDetails } from "./hooks";
 import styles from "./ProposalDetails.module.css";
-import { PROPOSAL_VOTING_ACTIVE, PROPOSAL_VOTING_FINISHED } from "constants";
+import { PROPOSAL_VOTING_ACTIVE, PROPOSAL_VOTING_FINISHED , PROPOSAL_VOTING_APPROVED, PROPOSAL_VOTING_REJECTED} from "constants";
 
 const ProposalDetails = ({
   viewedProposalDetails,
@@ -41,7 +41,9 @@ const ProposalDetails = ({
   const proposalPath = `/record/${shortToken}`;
   const isVoteActive = voteStatus === PROPOSAL_VOTING_ACTIVE;
   const isVoteActiveOrFinished =
-    isVoteActive || voteStatus === PROPOSAL_VOTING_FINISHED;
+    isVoteActive || voteStatus === PROPOSAL_VOTING_FINISHED ||
+    voteStatus === PROPOSAL_VOTING_APPROVED ||
+    voteStatus === PROPOSAL_VOTING_REJECTED;
 
   return (
     <div>

--- a/app/components/views/ProposalDetailsPage/helpers/ProposalCard/ProposalCard.jsx
+++ b/app/components/views/ProposalDetailsPage/helpers/ProposalCard/ProposalCard.jsx
@@ -19,7 +19,7 @@ const ProposalCard = ({
   endTimestamp,
   blocksLeft,
   name,
-  creator,
+  username,
   timestamp,
   tsDate,
   version,
@@ -59,8 +59,8 @@ const ProposalCard = ({
             </div>
           )}
           <Join className={classNames("margin-top-s", styles.subTitle)}>
-            <span className={classNames("color-primary", styles.creator)}>
-              {creator}
+            <span className={classNames("color-primary", styles.username)}>
+              {username}
             </span>
             <Event
               eventType={PROPOSAL_UPDATED_EVENT}

--- a/app/components/views/ProposalDetailsPage/helpers/ProposalCard/ProposalCard.module.css
+++ b/app/components/views/ProposalDetailsPage/helpers/ProposalCard/ProposalCard.module.css
@@ -28,7 +28,7 @@
   font-size: 16px;
 }
 
-.creator {
+.username {
   font-weight: 600;
 }
 

--- a/app/components/views/ProposalDetailsPage/helpers/VoteInfo.jsx
+++ b/app/components/views/ProposalDetailsPage/helpers/VoteInfo.jsx
@@ -21,8 +21,6 @@ const VoteInfo = memo(
     hasTickets,
     currentVoteChoice,
     viewedProposalDetails,
-    newVoteChoice,
-    setVoteOption,
     showPurchaseTicketsPage,
     voteOptions
   }) => {
@@ -55,8 +53,6 @@ const VoteInfo = memo(
           {...{
             viewedProposalDetails,
             voteOptions,
-            setVoteOption,
-            newVoteChoice,
             eligibleTicketCount,
             currentVoteChoice,
             votingComplete: false

--- a/app/components/views/ProposalDetailsPage/helpers/VoteInfo.jsx
+++ b/app/components/views/ProposalDetailsPage/helpers/VoteInfo.jsx
@@ -2,6 +2,8 @@ import { memo } from "react";
 import {
   PROPOSAL_VOTING_ACTIVE,
   PROPOSAL_VOTING_FINISHED,
+  PROPOSAL_VOTING_APPROVED,
+  PROPOSAL_VOTING_REJECTED,
   PROPOSAL_STATUS_ABANDONED
 } from "constants";
 import {
@@ -28,7 +30,11 @@ const VoteInfo = memo(
     if (proposalStatus === PROPOSAL_STATUS_ABANDONED) {
       return <ProposalAbandoned />;
     }
-    if (voteStatus === PROPOSAL_VOTING_FINISHED) {
+    if (
+      voteStatus === PROPOSAL_VOTING_FINISHED ||
+      voteStatus === PROPOSAL_VOTING_REJECTED ||
+      voteStatus === PROPOSAL_VOTING_APPROVED
+    ) {
       return (
         <VotePreference
           {...{ voteOptions, currentVoteChoice, votingComplete: true }}

--- a/app/components/views/ProposalDetailsPage/helpers/VotePreferenceWrapper/VotePreference/VotePreference.jsx
+++ b/app/components/views/ProposalDetailsPage/helpers/VotePreferenceWrapper/VotePreference/VotePreference.jsx
@@ -31,7 +31,7 @@ const VotePreference = React.memo(
             value: o.id
           }))}
           onChange={(option) => setVoteOption(option.value)}
-          value={newVoteChoice || currentVoteChoice.id}
+          value={newVoteChoice || currentVoteChoice?.id}
           disabled={votingComplete || votedSuccessfully}
           optionsClassName={voteOptions.map((o) => styles[o.id])}
         />

--- a/app/components/views/ProposalDetailsPage/helpers/VotePreferenceWrapper/hooks.js
+++ b/app/components/views/ProposalDetailsPage/helpers/VotePreferenceWrapper/hooks.js
@@ -2,7 +2,7 @@ import { useDispatch } from "react-redux";
 import { useState, useCallback, useMemo } from "react";
 import { useMachine } from "@xstate/react";
 import { fetchMachine } from "stateMachines/FetchStateMachine";
-import * as gov from "actions/GovernanceActions";
+import { updateVoteChoice } from "actions/GovernanceActions";
 import { isString, isObject } from "lodash";
 
 const getError = (error) => {
@@ -21,11 +21,7 @@ export const useVotePreference = (viewedProposalDetails) => {
   const dispatch = useDispatch();
   const onUpdateVoteChoice = (privatePassphrase) =>
     dispatch(
-      gov.updateVoteChoice(
-        viewedProposalDetails,
-        newVoteChoice,
-        privatePassphrase
-      )
+      updateVoteChoice(viewedProposalDetails, newVoteChoice, privatePassphrase)
     );
   const [state, send] = useMachine(fetchMachine, {
     actions: {

--- a/app/components/views/ProposalDetailsPage/helpers/VoteSection/VoteSection.jsx
+++ b/app/components/views/ProposalDetailsPage/helpers/VoteSection/VoteSection.jsx
@@ -8,8 +8,6 @@ const VoteSection = ({
   proposalStatus,
   voteStatus,
   currentVoteChoice,
-  newVoteChoice,
-  setVoteOption,
   voteOptions,
   showPurchaseTicketsPage
 }) => {
@@ -23,8 +21,6 @@ const VoteSection = ({
           voteStatus,
           currentVoteChoice,
           viewedProposalDetails,
-          newVoteChoice,
-          setVoteOption,
           showPurchaseTicketsPage,
           voteOptions
         }}

--- a/app/components/views/ProposalDetailsPage/utils.js
+++ b/app/components/views/ProposalDetailsPage/utils.js
@@ -4,7 +4,8 @@ import {
   PROPOSAL_VOTING_NOT_AUTHORIZED,
   PROPOSAL_VOTING_AUTHORIZED,
   PROPOSAL_VOTING_ACTIVE,
-  PROPOSAL_VOTING_FINISHED
+  PROPOSAL_VOTING_REJECTED,
+  PROPOSAL_VOTING_APPROVED
 } from "constants";
 
 /**
@@ -48,8 +49,8 @@ export const isApprovedProposal = (proposal, voteSummary) => {
   if (!proposal || !voteSummary || !isPublicProposal(proposal)) {
     return false;
   }
-  const { approved } = voteSummary;
-  return approved;
+  const { status } = voteSummary;
+  return status === PROPOSAL_VOTING_APPROVED;
 };
 
 export const getProposalStatusTagProps = (
@@ -74,15 +75,13 @@ export const getProposalStatusTagProps = (
         };
       case PROPOSAL_VOTING_ACTIVE:
         return { type: "bluePending", text: "Active" };
-      case PROPOSAL_VOTING_FINISHED:
-        if (isApprovedProposal(proposal, voteSummary)) {
-          return { type: "greenCheck", text: "Finished" };
-        } else {
-          return {
-            type: isDarkTheme ? "blueNegative" : "grayNegative",
-            text: "Finished"
-          };
-        }
+      case PROPOSAL_VOTING_APPROVED:
+        return { type: "greenCheck", text: "Approved" };
+      case PROPOSAL_VOTING_REJECTED:
+        return {
+          type: isDarkTheme ? "blueNegative" : "grayNegative",
+          text: "Rejected"
+        };
       default:
         break;
     }

--- a/app/constants/governance.js
+++ b/app/constants/governance.js
@@ -5,8 +5,13 @@ export const PROPOSAL_VOTING_ACTIVE = 3;
 export const PROPOSAL_VOTING_FINISHED = 4;
 
 // Proposal statuses.
-export const PROPOSAL_STATUS_PUBLIC = 4;
-export const PROPOSAL_STATUS_ABANDONED = 6;
+export const PROPOSAL_STATUS_PUBLIC = 2;
+export const PROPOSAL_STATUS_ABANDONED = 4;
 
 // Proposal markdown index file name.
 export const PROPOSAL_INDEX_MD_FILE = "index.md";
+export const PROPOSAL_METADATA_FILE = "proposalmetadata.json";
+export const PROPOSAL_VOTE_METADATA_FILE = "votemetadata.json";
+
+// XXX get from politeia's API.
+export const PROPOSALS_MAX_PAGE_SIZE = 5;

--- a/app/constants/governance.js
+++ b/app/constants/governance.js
@@ -3,6 +3,8 @@ export const PROPOSAL_VOTING_NOT_AUTHORIZED = 1;
 export const PROPOSAL_VOTING_AUTHORIZED = 2;
 export const PROPOSAL_VOTING_ACTIVE = 3;
 export const PROPOSAL_VOTING_FINISHED = 4;
+export const PROPOSAL_VOTING_APPROVED = 5;
+export const PROPOSAL_VOTING_REJECTED = 6;
 
 // Proposal statuses.
 export const PROPOSAL_STATUS_PUBLIC = 2;

--- a/app/helpers/politeia.js
+++ b/app/helpers/politeia.js
@@ -6,11 +6,11 @@ import {
   PROPOSAL_VOTE_METADATA_FILE
 } from "constants";
 
-export const atou = (str) => decodeURIComponent(escape(window.atob(str)));
+const atou = (str) => decodeURIComponent(escape(window.atob(str)));
 
 // parseProposalStatuses iterate over proposal's status changes array returned
 // from BE and returns proposal's timestamps accordingly
-export const parseProposalStatuses = (sChanges) => {
+const parseProposalStatuses = (sChanges) => {
   let publishedat = 0,
     abandonedat = 0;
 
@@ -30,7 +30,7 @@ export const parseProposalStatuses = (sChanges) => {
 //
 // censored proposals won't have metadata, in this case this function will
 // return an empty object
-export const parseProposalMetadata = (proposal = {}) => {
+const parseProposalMetadata = (proposal = {}) => {
   const metadata =
     proposal.files &&
     proposal.files.find((f) => f.name === PROPOSAL_METADATA_FILE);
@@ -42,7 +42,7 @@ export const parseProposalMetadata = (proposal = {}) => {
 //
 // censored proposals won't have metadata, in this case this function will
 // return an empty object
-export const parseVoteMetadata = (proposal = {}) => {
+const parseVoteMetadata = (proposal = {}) => {
   const metadata =
     proposal.files &&
     proposal.files.find((f) => f.name === PROPOSAL_VOTE_METADATA_FILE);
@@ -51,7 +51,7 @@ export const parseVoteMetadata = (proposal = {}) => {
 
 // This function extracts the content of index.md's payload which includes the
 // propsoal description.
-export const getTextFromIndexMd = (file = {}) => {
+const getTextFromIndexMd = (file = {}) => {
   if (!file.payload) return "";
   return atou(file.payload);
 };
@@ -61,7 +61,7 @@ export const getTextFromIndexMd = (file = {}) => {
 //
 // censored proposals won't have metadata, in this case this function will
 // return an empty object
-export const parseProposalIndexFile = (proposal = {}) => {
+const parseProposalIndexFile = (proposal = {}) => {
   const index =
     proposal.files &&
     proposal.files.find((f) => f.name === PROPOSAL_INDEX_MD_FILE);

--- a/app/helpers/politeia.js
+++ b/app/helpers/politeia.js
@@ -8,15 +8,6 @@ import {
 
 export const atou = (str) => decodeURIComponent(escape(window.atob(str)));
 
-// politeiaMarkdownIndexMd returns markdown text from the payload of a politeia
-// proposal file that corresponds to its index.md). This was extracted from the
-// helpers.js file of politeia. Assumes the payload has been converted from
-// base64 into bytes.
-export const politeiaMarkdownIndexMd = (payload) => {
-  const text = decodeURIComponent(escape(payload));
-  return text.substring(text.indexOf("\n") + 1);
-};
-
 // parseProposalStatuses iterate over proposal's status changes array returned
 // from BE and returns proposal's timestamps accordingly
 export const parseProposalStatuses = (sChanges) => {

--- a/app/helpers/politeia.js
+++ b/app/helpers/politeia.js
@@ -1,3 +1,13 @@
+import {
+  PROPOSAL_STATUS_PUBLIC,
+  PROPOSAL_STATUS_ABANDONED,
+  PROPOSAL_INDEX_MD_FILE,
+  PROPOSAL_METADATA_FILE,
+  PROPOSAL_VOTE_METADATA_FILE
+} from "constants";
+
+export const atou = (str) => decodeURIComponent(escape(window.atob(str)));
+
 // politeiaMarkdownIndexMd returns markdown text from the payload of a politeia
 // proposal file that corresponds to its index.md). This was extracted from the
 // helpers.js file of politeia. Assumes the payload has been converted from
@@ -5,4 +15,87 @@
 export const politeiaMarkdownIndexMd = (payload) => {
   const text = decodeURIComponent(escape(payload));
   return text.substring(text.indexOf("\n") + 1);
+};
+
+// parseProposalStatuses iterate over proposal's status changes array returned
+// from BE and returns proposal's timestamps accordingly
+export const parseProposalStatuses = (sChanges) => {
+  let publishedat = 0,
+    abandonedat = 0;
+
+  sChanges.forEach(({ status, timestamp }) => {
+    if (status === PROPOSAL_STATUS_PUBLIC) {
+      publishedat = timestamp;
+    }
+    if (status === PROPOSAL_STATUS_ABANDONED) {
+      abandonedat = timestamp;
+    }
+  });
+  return { publishedat, abandonedat };
+};
+
+// parseProposalMetadata accepts a proposal object parses it's metadata
+// and returns it as object of the form { name }
+//
+// censored proposals won't have metadata, in this case this function will
+// return an empty object
+export const parseProposalMetadata = (proposal = {}) => {
+  const metadata =
+    proposal.files &&
+    proposal.files.find((f) => f.name === PROPOSAL_METADATA_FILE);
+  return metadata ? JSON.parse(atob(metadata.payload)) : {};
+};
+
+// parseVoteMetadata accepts a proposal object parses it's metadata
+// and returns it as object of the form { linkto, linkby }
+//
+// censored proposals won't have metadata, in this case this function will
+// return an empty object
+export const parseVoteMetadata = (proposal = {}) => {
+  const metadata =
+    proposal.files &&
+    proposal.files.find((f) => f.name === PROPOSAL_VOTE_METADATA_FILE);
+  return metadata ? JSON.parse(atob(metadata.payload)) : {};
+};
+
+// This function extracts the content of index.md's payload which includes the
+// propsoal description.
+export const getTextFromIndexMd = (file = {}) => {
+  if (!file.payload) return "";
+  return atou(file.payload);
+};
+
+// parseProposalIndexFile accepts a proposal object parses it's metadata
+// and returns it as object of the form { description }
+//
+// censored proposals won't have metadata, in this case this function will
+// return an empty object
+export const parseProposalIndexFile = (proposal = {}) => {
+  const index =
+    proposal.files &&
+    proposal.files.find((f) => f.name === PROPOSAL_INDEX_MD_FILE);
+  return index ? { description: getTextFromIndexMd(index) } : {};
+};
+
+// parseRawProposal accepts raw proposal object received from BE and parses
+// it's metadata & status changes.
+export const parseRawProposal = (proposal) => {
+  // Parse statuses.
+  const { publishedat, abandonedat } = parseProposalStatuses(
+    proposal.statuses || []
+  );
+  // Parse metdata.
+  // Censored proposal's metadata isn't available.
+  const { name } = parseProposalMetadata(proposal);
+  const { linkby, linkto } = parseVoteMetadata(proposal);
+  const { description } = parseProposalIndexFile(proposal);
+  return {
+    ...proposal,
+    description: description || proposal.description,
+    name: name || proposal.name,
+    linkby,
+    linkto,
+    publishedat,
+    abandonedat
+  };
 };

--- a/app/index.js
+++ b/app/index.js
@@ -10,7 +10,13 @@ import "pi-ui/dist/index.css";
 import "./style/main.css";
 import "./style/ReactSelectGlobal.css";
 import pkg from "./package.json";
-import { DCR, THEME, LOCALE, NETWORK } from "constants";
+import {
+  DCR,
+  THEME,
+  LOCALE,
+  NETWORK,
+  PROPOSALS_MAX_PAGE_SIZE
+} from "constants";
 import * as cfgConstants from "constants/config";
 import { wallet } from "wallet-preload-shim";
 import { AppContainer } from "react-hot-loader";
@@ -378,11 +384,17 @@ const initialState = {
   governance: {
     getProposalsAttempt: false,
     inventory: null,
-    proposals: null,
+    proposals: {
+      abandonedVote: [],
+      activeVote: [],
+      approvedVote: [],
+      finishedVote: [],
+      preVote: [],
+      rejectedVote: []
+    },
     proposalsDetails: {},
     getProposalError: null,
-    // TODO: Get proposallistpagesize from politeia's request: /v1/policy
-    proposallistpagesize: 20
+    proposallistpagesize: PROPOSALS_MAX_PAGE_SIZE
   },
   trezor: {
     enabled: false,

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -49,17 +49,20 @@ export const installSessionHandlers = (mainLogger) => {
   // to allow electron to accept the self-signed cert as valid.
   // This MUST NOT go enabled into production, as it's a possible security
   // vulnerability, so any PRs enabling this by default will be rejected.
-  // if (process.env.NODE_ENV === "development") {
-  //   const app = require("electron").app;
-  //   app.on("certificate-error", (event, webContents, url, error, certificate, callback) => {
-  //     if (url.match(/^https:\/\/localhost:4443\/.*$/)) {
-  //       event.preventDefault();
-  //       callback(true);
-  //     } else {
-  //       callback(false);
-  //     }
-  //   });
-  // }
+  if (process.env.NODE_ENV === "development") {
+    const app = require("electron").app;
+    app.on(
+      "certificate-error",
+      (event, webContents, url, error, certificate, callback) => {
+        if (url.match(/^https:\/\/localhost:4443\/.*$/)) {
+          event.preventDefault();
+          callback(true);
+        } else {
+          callback(false);
+        }
+      }
+    );
+  }
 
   // TODO: check if this filtering is working even when multiple windows are
   // created (relevant to multi-wallet usage)

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -49,20 +49,17 @@ export const installSessionHandlers = (mainLogger) => {
   // to allow electron to accept the self-signed cert as valid.
   // This MUST NOT go enabled into production, as it's a possible security
   // vulnerability, so any PRs enabling this by default will be rejected.
-  if (process.env.NODE_ENV === "development") {
-    const app = require("electron").app;
-    app.on(
-      "certificate-error",
-      (event, webContents, url, error, certificate, callback) => {
-        if (url.match(/^https:\/\/localhost:4443\/.*$/)) {
-          event.preventDefault();
-          callback(true);
-        } else {
-          callback(false);
-        }
-      }
-    );
-  }
+  // if (process.env.NODE_ENV === "development") {
+  //   const app = require("electron").app;
+  //   app.on("certificate-error", (event, webContents, url, error, certificate, callback) => {
+  //     if (url.match(/^https:\/\/localhost:4443\/.*$/)) {
+  //       event.preventDefault();
+  //       callback(true);
+  //     } else {
+  //       callback(false);
+  //     }
+  //   });
+  // }
 
   // TODO: check if this filtering is working even when multiple windows are
   // created (relevant to multi-wallet usage)

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -237,7 +237,9 @@ export function savePiVote(vote, token, testnet, walletName) {
   }
   const fullPath = path.join(proposalPath, "vote.json");
   if (!fs.existsSync(fullPath)) {
-    fs.writeFile(fullPath, JSON.stringify(vote), { mode: 0o600 });
+    fs.writeFile(fullPath, JSON.stringify(vote), { mode: 0o600 }, (err) => {
+      if (err) throw err;
+    });
   }
 }
 
@@ -249,8 +251,16 @@ export function getProposalWalletVote(token, testnet, walletName) {
     return null;
   }
   const fullPath = path.join(proposalPath, "vote.json");
-  const vote = fs.readFileSync(fullPath);
-  return JSON.parse(vote);
+  try {
+    const vote = fs.readFileSync(fullPath);
+    return JSON.parse(vote);
+  } catch (err) {
+    if (err.message?.includes("ENOENT: no such file or directory")) {
+      return null;
+    } else {
+      throw err;
+    }
+  }
 }
 
 // removeCachedProposals gets a batch of proposal's token, makes a diff with

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -191,7 +191,9 @@ export function saveEligibleTickets(token, eligibleTickets) {
     proposalPath = setPoliteiaProposalPath(token);
   }
   const fullPath = path.join(proposalPath, "eligibletickets.json");
-  fs.writeFile(fullPath, JSON.stringify(eligibleTickets), { mode: 0o600 });
+  fs.writeFile(fullPath, JSON.stringify(eligibleTickets), (err) => {
+    if (err) throw err;
+  });
 }
 
 // getEligibleTickets get the eligibletickets.json from the proposal Path

--- a/app/middleware/politeiaapi.js
+++ b/app/middleware/politeiaapi.js
@@ -3,12 +3,12 @@ import { postJSON } from "helpers/fetch";
 // Uncomment this and comment the following definition to test locally.
 // Also uncomment a code part at externalRequests.js, as politeia is a ssl-enabled
 // service and decrediton will fail to fetch locally with a self signed cert.
-export const POLITEIA_URL_TESTNET = "https://localhost:4443";
+// export const POLITEIA_URL_TESTNET = "https://localhost:4443";
 
 // Politeia doc source:
 // https://github.com/decred/politeia/blob/master/politeiawww/api/www/v1/api.md
 
-//export const POLITEIA_URL_TESTNET = "https://test-proposals.decred.org/api";
+export const POLITEIA_URL_TESTNET = "https://test-proposals.decred.org/api";
 export const POLITEIA_URL_MAINNET = "https://proposals.decred.org/api";
 
 const POST = (piURL, path, payload = {}) =>

--- a/app/middleware/politeiaapi.js
+++ b/app/middleware/politeiaapi.js
@@ -33,8 +33,8 @@ export const getVotesInventory = ({ piURL }, cb) =>
     .catch((error) => cb(null, error));
 
 // votes must be an array of Vote()-produced objects.
-export const castVotes = ({ piURL, votes }, cb) =>
-  POST(piURL, "/v1/proposals/castvotes", { votes })
+export const castBallot = ({ piURL, votes }, cb) =>
+  POST(piURL, "/ticketvote/v1/castballot", { votes })
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 

--- a/app/middleware/politeiaapi.js
+++ b/app/middleware/politeiaapi.js
@@ -42,7 +42,7 @@ export const getProposalsBatch = ({ piURL, requests }, cb) =>
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 
-export const getProposalsVoteStatusBatch = ({ piURL, tokens }, cb) =>
-  POST(piURL, "/v1/proposals/batchvotesummary", { tokens })
+export const getProposalsVoteSummaryBatch = ({ piURL, tokens }, cb) =>
+  POST(piURL, "/ticketvote/v1/summaries", { tokens })
     .then((response) => cb(response))
     .catch((error) => cb(null, error));

--- a/app/middleware/politeiaapi.js
+++ b/app/middleware/politeiaapi.js
@@ -1,4 +1,4 @@
-import { getJSON, postJSON } from "helpers/fetch";
+import { postJSON } from "helpers/fetch";
 
 // Uncomment this and comment the following definition to test locally.
 // Also uncomment a code part at externalRequests.js, as politeia is a ssl-enabled

--- a/app/middleware/politeiaapi.js
+++ b/app/middleware/politeiaapi.js
@@ -3,18 +3,20 @@ import { getJSON, postJSON } from "helpers/fetch";
 // Uncomment this and comment the following definition to test locally.
 // Also uncomment a code part at externalRequests.js, as politeia is a ssl-enabled
 // service and decrediton will fail to fetch locally with a self signed cert.
-// export const POLITEIA_URL_TESTNET = "https://localhost:4443";
+export const POLITEIA_URL_TESTNET = "https://localhost:4443";
 
 // Politeia doc source:
 // https://github.com/decred/politeia/blob/master/politeiawww/api/www/v1/api.md
 
-export const POLITEIA_URL_TESTNET = "https://test-proposals.decred.org/api";
+//export const POLITEIA_URL_TESTNET = "https://test-proposals.decred.org/api";
 export const POLITEIA_URL_MAINNET = "https://proposals.decred.org/api";
 
 const GET = (piURL, path) => getJSON(`${piURL}${path}`);
 
-const POST = (piURL, path, payload) => postJSON(`${piURL}${path}`, payload);
+const POST = (piURL, path, payload = {}) =>
+  postJSON(`${piURL}${path}`, payload);
 
+// XXX no details route anymore, we should use only records batch route.
 export const getProposal = ({ piURL, token }, cb) =>
   GET(piURL, `/v1/proposals/${token}`)
     .then((response) => cb(response))
@@ -25,8 +27,8 @@ export const getProposalVotes = ({ piURL, token }, cb) =>
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 
-export const getTokenInventory = ({ piURL }, cb) =>
-  GET(piURL, "/v1/proposals/tokeninventory")
+export const getVotesInventory = ({ piURL }, cb) =>
+  POST(piURL, "/ticketvote/v1/inventory")
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 

--- a/app/middleware/politeiaapi.js
+++ b/app/middleware/politeiaapi.js
@@ -32,15 +32,14 @@ export const getVotesInventory = ({ piURL }, cb) =>
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 
-// votes must be an array of Vote()-produced objects.
 export const castBallot = ({ piURL, votes }, cb) =>
   POST(piURL, "/ticketvote/v1/castballot", { votes })
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 
 // tokens is an array of tokens to be fetched.
-export const getProposalsBatch = ({ piURL, tokens }, cb) =>
-  POST(piURL, "/v1/proposals/batch", { tokens })
+export const getProposalsBatch = ({ piURL, requests }, cb) =>
+  POST(piURL, "/records/v1/records", { requests })
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 

--- a/app/middleware/politeiaapi.js
+++ b/app/middleware/politeiaapi.js
@@ -11,8 +11,6 @@ export const POLITEIA_URL_TESTNET = "https://localhost:4443";
 //export const POLITEIA_URL_TESTNET = "https://test-proposals.decred.org/api";
 export const POLITEIA_URL_MAINNET = "https://proposals.decred.org/api";
 
-const GET = (piURL, path) => getJSON(`${piURL}${path}`);
-
 const POST = (piURL, path, payload = {}) =>
   postJSON(`${piURL}${path}`, payload);
 
@@ -21,8 +19,13 @@ export const getProposalDetails = ({ piURL, token }, cb) =>
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 
-export const getProposalVotes = ({ piURL, token }, cb) =>
-  GET(piURL, `/v1/proposals/${token}/votes`)
+export const getProposalVoteDetails = ({ piURL, token }, cb) =>
+  POST(piURL, "/ticketvote/v1/details", { token })
+    .then((response) => cb(response))
+    .catch((error) => cb(null, error));
+
+export const getProposalVoteResults = ({ piURL, token }, cb) =>
+  POST(piURL, "/ticketvote/v1/results", { token })
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 

--- a/app/middleware/politeiaapi.js
+++ b/app/middleware/politeiaapi.js
@@ -16,9 +16,8 @@ const GET = (piURL, path) => getJSON(`${piURL}${path}`);
 const POST = (piURL, path, payload = {}) =>
   postJSON(`${piURL}${path}`, payload);
 
-// XXX no details route anymore, we should use only records batch route.
-export const getProposal = ({ piURL, token }, cb) =>
-  GET(piURL, `/v1/proposals/${token}`)
+export const getProposalDetails = ({ piURL, token }, cb) =>
+  POST(piURL, "/records/v1/details", { token })
     .then((response) => cb(response))
     .catch((error) => cb(null, error));
 

--- a/app/reducers/governance.js
+++ b/app/reducers/governance.js
@@ -1,50 +1,50 @@
 import {
   UPDATEVOTECHOICE_SUCCESS,
-  GETTOKEN_INVENTORY_SUCCESS,
   GETPROPROSAL_UPDATEVOTESTATUS_ATTEMPT,
   GETPROPOSAL_ATTEMPT,
   GETPROPOSAL_FAILED,
   GETPROPOSAL_SUCCESS,
   REMOVED_PROPOSALS_FROM_LIST,
-  GETTOKEN_INVENTORY_ATTEMPT,
   DISABLE_POLITEIA_SUCCESS,
   COMPARE_INVENTORY_SUCCESS,
   GETPROPROSAL_UPDATEVOTESTATUS_SUCCESS,
   GETPROPROSAL_UPDATEVOTESTATUS_FAILED,
-  GETTOKEN_INVENTORY_FAILED
+  GETVOTES_INVENTORY_ATTEMPT,
+  GETVOTES_INVENTORY_SUCCESS,
+  GETVOTES_INVENTORY_FAILED
 } from "actions/GovernanceActions";
 import { CLOSEWALLET_SUCCESS } from "actions/WalletLoaderActions";
 import { WALLETREADY } from "actions/DaemonActions";
 
 export default function governance(state = {}, action) {
   switch (action.type) {
-    case GETTOKEN_INVENTORY_ATTEMPT:
+    case GETVOTES_INVENTORY_ATTEMPT:
       return {
         ...state,
         getProposalsAttempt: true,
-        getTokenInventoryError: null
+        getVotesInventoryError: null
       };
-    case GETTOKEN_INVENTORY_SUCCESS:
+    case GETVOTES_INVENTORY_SUCCESS:
       return {
         ...state,
         inventory: action.inventory,
         getProposalsAttempt: false,
-        getTokenInventoryError: null
+        getVotesInventoryError: null
+      };
+    case GETVOTES_INVENTORY_FAILED:
+      return {
+        ...state,
+        getProposalsAttempt: false,
+        getVotesInventoryError: action.error
       };
     case CLOSEWALLET_SUCCESS:
       return {
         ...state,
         getProposalsAttempt: false,
         getProposalError: null,
-        getTokenInventoryError: null,
+        getVotesInventoryError: null,
         proposals: null,
         inventory: null
-      };
-    case GETTOKEN_INVENTORY_FAILED:
-      return {
-        ...state,
-        getProposalsAttempt: false,
-        getTokenInventoryError: action.error
       };
     case GETPROPROSAL_UPDATEVOTESTATUS_ATTEMPT:
       return { ...state, getProposalsAttempt: true };

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1754,9 +1754,9 @@ export const newProposalsStartedVoting = compose(
 );
 
 export const getProposalError = get(["governance", "getProposalError"]);
-export const getTokenInventoryError = get([
+export const getVotesInventoryError = get([
   "governance",
-  "getTokenInventoryError"
+  "getVotesInventoryError"
 ]);
 export const proposalsDetails = get(["governance", "proposalsDetails"]);
 export const lastPoliteiaAccessBlock = get([

--- a/app/wallet/politeia.js
+++ b/app/wallet/politeia.js
@@ -41,7 +41,7 @@ export const getProposalsBatch = promisifyReqLogNoData(
   api.getProposalsBatch
 );
 
-export const getProposalsVoteStatusBatch = promisifyReqLogNoData(
-  "getProposalsVoteStatusBatch",
-  api.getProposalsVoteStatusBatch
+export const getProposalsVoteSummaryBatch = promisifyReqLogNoData(
+  "getProposalsVoteSummaryBatch",
+  api.getProposalsVoteSummaryBatch
 );

--- a/app/wallet/politeia.js
+++ b/app/wallet/politeia.js
@@ -23,9 +23,14 @@ export const getProposalDetails = promisifyReqLogNoData(
   api.getProposalDetails
 );
 
-export const getProposalVotes = promisifyReqLogNoData(
-  "getProposalVotes",
-  api.getProposalVotes
+export const getProposalVoteDetails = promisifyReqLogNoData(
+  "getProposalVoteDetails",
+  api.getProposalVoteDetails
+);
+
+export const getProposalVoteResults = promisifyReqLogNoData(
+  "getProposalVoteResults",
+  api.getProposalVoteResults
 );
 
 export const getVotesInventory = promisifyReqLogNoData(

--- a/app/wallet/politeia.js
+++ b/app/wallet/politeia.js
@@ -29,9 +29,9 @@ export const getProposalVotes = promisifyReqLogNoData(
   api.getProposalVotes
 );
 
-export const getTokenInventory = promisifyReqLogNoData(
-  "getTokenInventory",
-  api.getTokenInventory
+export const getVotesInventory = promisifyReqLogNoData(
+  "getVotesInventory",
+  api.getVotesInventory
 );
 
 export const castVotes = promisifyReqLogNoData("castVotes", api.castVotes);

--- a/app/wallet/politeia.js
+++ b/app/wallet/politeia.js
@@ -9,15 +9,14 @@ export {
   removeCachedProposals
 } from "main_dev/paths";
 
-const promisifyReqLogNoData = (fnName, Req) => {
-  return withLogNoData(
+const promisifyReqLogNoData = (fnName, Req) =>
+  withLogNoData(
     (...args) =>
       new Promise((ok, fail) =>
         Req(...args, (res, err) => (err ? fail(err) : ok(res)))
       ),
     fnName
   );
-};
 
 export const getProposalDetails = promisifyReqLogNoData(
   "getProposalDetails",

--- a/app/wallet/politeia.js
+++ b/app/wallet/politeia.js
@@ -19,9 +19,9 @@ const promisifyReqLogNoData = (fnName, Req) => {
   );
 };
 
-export const getProposal = promisifyReqLogNoData(
-  "getProposal",
-  api.getProposal
+export const getProposalDetails = promisifyReqLogNoData(
+  "getProposalDetails",
+  api.getProposalDetails
 );
 
 export const getProposalVotes = promisifyReqLogNoData(

--- a/app/wallet/politeia.js
+++ b/app/wallet/politeia.js
@@ -34,7 +34,7 @@ export const getVotesInventory = promisifyReqLogNoData(
   api.getVotesInventory
 );
 
-export const castVotes = promisifyReqLogNoData("castVotes", api.castVotes);
+export const castBallot = promisifyReqLogNoData("castBallot", api.castBallot);
 
 export const getProposalsBatch = promisifyReqLogNoData(
   "getProposalsBatch",


### PR DESCRIPTION
Closes #3391.

**Note:** The new API supports paginated vote inventory calls, I decided to keep the pagination work to a separate 
future PR to try maintain incermental easily reviewable PRs.

**Testing against local PI**
 
 To run against local PI instance add the following commented out code:
  - https://github.com/decred/decrediton/blob/master/app/main_dev/externalRequests.js#L52-L62
  - https://github.com/decred/decrediton/blob/master/app/middleware/politeiaapi.js#L6 