### PR TITLE
Fix getCertsPath 

### DIFF
--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -94,7 +94,7 @@ export function getCertsPath(name, custombinpath) {
   const binPath = custombinpath
     ? custombinpath
     : process.env.NODE_ENV === "development"
-    ? path.join(__dirname, "..", "..", "certs")
+    ? path.join(__dirname, "..", "certs")
     : path.join(process.resourcesPath, "certs");
 
   return binPath;


### PR DESCRIPTION
 On the mainnet, the dcrwallet could not start because of the invalid cert path. This diff fixes it. 
~~Also fixes the wallet import in `ExternalButton` component. See: https://github.com/decred/decrediton/pull/3398#issuecomment-856603163~~