### PR TITLE
[electron] Enable WebSecurity

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,5 +1,4 @@
 import fs from "fs-extra";
-import os from "os";
 import path from "path";
 import parseArgs from "minimist";
 import { app, BrowserWindow, Menu, dialog } from "electron";
@@ -673,10 +672,6 @@ app.on("ready", async () => {
     url = `http://localhost:${port}/dist/app.html`;
   }
 
-  // enable remote module on windows, as decrediton will crash, otherwise, but
-  // avoid it on other systems, as electron is moving away from it.
-  const enableRemoteModule = os.platform() == "win32" ? true : false;
-
   let windowOpts = {
     show: false,
     minWidth: 350,
@@ -688,7 +683,7 @@ app.on("ready", async () => {
       devTools: true,
       contextIsolation: true,
       webSecurity: false,
-      enableRemoteModule,
+      enableRemoteModule: false,
       preload: preloadPath
     },
     icon: __dirname + "/icon.png"

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -682,7 +682,7 @@ app.on("ready", async () => {
       nodeIntegration: false,
       devTools: true,
       contextIsolation: true,
-      webSecurity: false,
+      webSecurity: true,
       enableRemoteModule: false,
       preload: preloadPath
     },


### PR DESCRIPTION
~**Rebased on top of #3492**~

This re-disables the remote module on windows and enables the `webSecurity` feature.

`webSecurity` is used to tighten up external requests by enabling same-origin policy and disallowing mixed content. 

In order to enable this in development mode, external requests are modified in to return a `Allow-Origin: http://localhost:3000` header so that the main wallet page loaded via the HMR server is allowed to perform them. Additionally, we fix the `OPTIONS` request performed as a prefetch step to politeia servers when performing a `POST` request to always return a 200 response.