### PR TITLE
Disabled Dex menu with tooltip in SPV mode

### DIFF
--- a/app/components/SideBar/MenuLinks/MenuLinks.jsx
+++ b/app/components/SideBar/MenuLinks/MenuLinks.jsx
@@ -25,7 +25,9 @@ const MenuLinks = () => {
         )}>
         {menuLinks.map((menuLink, index) => {
           const menuLinkLabel = () => (
-            <div className={styles.menuContent}>
+            <div
+              className={styles.menuContent}
+              data-testid={`menuLinkContent-${menuLink.icon}`}>
               <div
                 className={classNames(
                   styles.icon,
@@ -33,11 +35,7 @@ const MenuLinks = () => {
                 )}
               />
               {expandSideBar && !sidebarOnBottom && (
-                <div
-                  className={styles.menuLinkLabel}
-                  data-testid={`menuLinkLabel-${menuLink.icon}`}>
-                  {menuLink.link}
-                </div>
+                <div className={styles.menuLinkLabel}>{menuLink.link}</div>
               )}
             </div>
           );

--- a/app/components/SideBar/MenuLinks/MenuLinks.jsx
+++ b/app/components/SideBar/MenuLinks/MenuLinks.jsx
@@ -24,19 +24,30 @@ const MenuLinks = () => {
           sidebarOnBottom && styles.onBottom
         )}>
         {menuLinks.map((menuLink, index) => {
-          const menuLinkLabel = (text) => (
-            <div
-              className={styles.menuLinkLabel}
-              data-testid={`menuLinkLabel-${menuLink.icon}`}>
-              {text}
+          const menuLinkLabel = () => (
+            <div className={styles.menuContent}>
+              <div
+                className={classNames(
+                  styles.icon,
+                  styles[`${menuLink.icon}Icon`]
+                )}
+              />
+              {expandSideBar && !sidebarOnBottom && (
+                <div
+                  className={styles.menuLinkLabel}
+                  data-testid={`menuLinkLabel-${menuLink.icon}`}>
+                  {menuLink.link}
+                </div>
+              )}
             </div>
           );
           const label =
-            expandSideBar && !sidebarOnBottom ? (
-              menuLinkLabel(menuLink.link)
+            expandSideBar && !sidebarOnBottom && !menuLink.disabled ? (
+              menuLinkLabel()
             ) : (
               <Tooltip
-                content={menuLink.link}
+                contentClassName={styles.tooltip}
+                content={menuLink.tooltip ?? menuLink.link}
                 placement={sidebarOnBottom ? "top" : "right"}>
                 {menuLinkLabel()}
               </Tooltip>
@@ -50,10 +61,10 @@ const MenuLinks = () => {
                 key={menuLink.path}
                 className={classNames(
                   styles.tab,
-                  styles[`${menuLink.icon}Icon`],
                   expandSideBar && styles.expanded,
                   sidebarOnBottom && styles.onBottom,
-                  menuLink.notifProp && styles.notificationIcon
+                  menuLink.notifProp && styles.notificationIcon,
+                  menuLink.disabled && styles.disabled
                 )}
               />
             )

--- a/app/components/SideBar/MenuLinks/MenuLinks.module.css
+++ b/app/components/SideBar/MenuLinks/MenuLinks.module.css
@@ -1,9 +1,6 @@
 .tabs {
   overflow: visible !important;
 }
-.tabs.expanded {
-  overflow: auto !important;
-}
 .tabs.onBottom.expanded {
   overflow: visible !important;
 }
@@ -29,14 +26,14 @@
   padding-left: 0 !important;
 }
 .icon {
-  background-position: 13px 50%;
+  background-position: 50%;
   background-size: 22px;
   background-repeat: no-repeat;
   width: 56px;
   height: 56px;
 }
 .tab.disabled .icon {
-  opacity: 0.4;
+  opacity: 0.2;
 }
 .icon.ticketsIcon {
   background-image: var(--menu-tickets);
@@ -95,6 +92,11 @@
   white-space: break-spaces;
   text-align: center;
 }
+.tab.disabled .menuLinkLabel {
+  opacity: 0.2;
+  color: initial;
+}
+
 @media screen and (max-width: 768px) {
   .tabs {
     margin: 0 auto;

--- a/app/components/SideBar/MenuLinks/MenuLinks.module.css
+++ b/app/components/SideBar/MenuLinks/MenuLinks.module.css
@@ -35,7 +35,7 @@
   width: 56px;
   height: 56px;
 }
-.tab.disabled .icon{
+.tab.disabled .icon {
   opacity: 0.4;
 }
 .icon.ticketsIcon {
@@ -91,9 +91,9 @@
   padding-right: 10px;
 }
 .tab.disabled .tooltip {
-    width: 18rem;
-    white-space: break-spaces;
-    text-align: center;
+  width: 18rem;
+  white-space: break-spaces;
+  text-align: center;
 }
 @media screen and (max-width: 768px) {
   .tabs {
@@ -105,10 +105,10 @@
     margin-right: 0 !important;
     padding: 0 !important;
   }
-.icon {
-background-position: 50% 60%;
+  .icon {
+    background-position: 50% 60%;
     width: 64px;
-}
+  }
   .tab.notificationIcon::before {
     margin-left: 33px;
     margin-top: -14px;

--- a/app/components/SideBar/MenuLinks/MenuLinks.module.css
+++ b/app/components/SideBar/MenuLinks/MenuLinks.module.css
@@ -93,8 +93,8 @@
   text-align: center;
 }
 .tab.disabled .menuLinkLabel {
-  opacity: 0.2;
-  color: initial;
+  opacity: 0.3;
+  color: var(--text-color) !important;
 }
 
 @media screen and (max-width: 768px) {

--- a/app/components/SideBar/MenuLinks/MenuLinks.module.css
+++ b/app/components/SideBar/MenuLinks/MenuLinks.module.css
@@ -8,9 +8,6 @@
   overflow: visible !important;
 }
 .tab {
-  background-position: 13px 50%;
-  background-size: 22px;
-  background-repeat: no-repeat;
   height: 56px;
   min-height: 56px !important;
   margin-top: 0 !important;
@@ -18,37 +15,54 @@
   padding-left: 0 !important;
   font-size: 15px !important;
 }
-.tabs.expanded .tab span {
-  padding-left: 55px !important;
+.tab span {
+  height: inherit;
+}
+.tab.disabled {
+  cursor: not-allowed;
+}
+.menuContent {
+  display: flex;
+  flex-direction: row;
 }
 .tabs.onBottom.expanded .tab span {
   padding-left: 0 !important;
 }
-.tab.ticketsIcon {
+.icon {
+  background-position: 13px 50%;
+  background-size: 22px;
+  background-repeat: no-repeat;
+  width: 56px;
+  height: 56px;
+}
+.tab.disabled .icon{
+  opacity: 0.4;
+}
+.icon.ticketsIcon {
   background-image: var(--menu-tickets);
 }
-.tab.transactionsIcon {
+.icon.transactionsIcon {
   background-image: var(--menu-transactions);
 }
-.tab.trezorIcon {
+.icon.trezorIcon {
   background-image: var(--menu-trezor);
 }
-.tab.accountsIcon {
+.icon.accountsIcon {
   background-image: var(--menu-accounts);
 }
-.tab.securitycntrIcon {
+.icon.securitycntrIcon {
   background-image: var(--menu-privacy);
 }
-.tab.overviewIcon {
+.icon.overviewIcon {
   background-image: var(--menu-overview);
 }
-.tab.governanceIcon {
+.icon.governanceIcon {
   background-image: var(--menu-governance);
 }
-.tab.lnIcon {
+.icon.lnIcon {
   background-image: var(--menu-ln);
 }
-.tab.dexIcon {
+.icon.dexIcon {
   background-image: var(--menu-dex);
 }
 .tab.notificationIcon::before {
@@ -68,9 +82,18 @@
   background-color: var(--stroke-color-focused);
 }
 .menuLinkLabel {
-  width: 56px;
+  width: 55px;
   height: 56px;
   line-height: 56px;
+}
+.tabs.expanded .menuLinkLabel {
+  width: auto;
+  padding-right: 10px;
+}
+.tab.disabled .tooltip {
+    width: 18rem;
+    white-space: break-spaces;
+    text-align: center;
 }
 @media screen and (max-width: 768px) {
   .tabs {
@@ -79,10 +102,13 @@
   .tab {
     height: 64px;
     width: 64px;
-    background-position: 50%;
     margin-right: 0 !important;
     padding: 0 !important;
   }
+.icon {
+background-position: 50% 60%;
+    width: 64px;
+}
   .tab.notificationIcon::before {
     margin-left: 33px;
     margin-top: -14px;

--- a/app/components/SideBar/MenuLinks/hooks.js
+++ b/app/components/SideBar/MenuLinks/hooks.js
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import * as sel from "selectors";
 import { linkList, TREZOR_KEY, LN_KEY, DEX_KEY } from "./Links";
 import { useHistory } from "react-router-dom";
+import { FormattedMessage as T } from "react-intl";
 
 export function useMenuLinks() {
   const location = useSelector(sel.location);
@@ -39,8 +40,22 @@ export function useMenuLinks() {
     if (!lnEnabled) {
       links = links.filter((l) => l.key !== LN_KEY);
     }
-    if (isSPV || isTrezor) {
+    if (isTrezor) {
       links = links.filter((l) => l.key !== DEX_KEY);
+    }
+    if (isSPV) {
+      links = links.map((l) => {
+        if (l.key === DEX_KEY) {
+          l.disabled = true;
+          l.tooltip = (
+            <T
+              id="sidebar.link.disabledDexTooltip"
+              m="SPV needs to be switched off"
+            />
+          );
+        }
+        return l;
+      });
     }
 
     return links;
@@ -56,8 +71,10 @@ export function useMenuLinks() {
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const history = useHistory();
   const onSelectTab = (index) => {
-    setActiveTabIndex(index);
-    history.push(menuLinks[index].path);
+    if (!menuLinks[index].disabled) {
+      setActiveTabIndex(index);
+      history.push(menuLinks[index].path);
+    }
   };
 
   useEffect(() => {

--- a/app/components/SideBar/MenuLinks/hooks.js
+++ b/app/components/SideBar/MenuLinks/hooks.js
@@ -50,7 +50,7 @@ export function useMenuLinks() {
           l.tooltip = (
             <T
               id="sidebar.link.disabledDexTooltip"
-              m="SPV needs to be switched off"
+              m="DEX not available while using SPV. Please go to settings and disable SPV to access the DEX."
             />
           );
         }

--- a/app/components/SideBar/SideBar.module.css
+++ b/app/components/SideBar/SideBar.module.css
@@ -32,13 +32,8 @@
 .sidebarMain {
   position: relative;
   flex: 1;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
-}
-
-.sidebar.sidebarReduced .sidebarMain {
-  overflow: visible;
 }
 
 .watchOnlyIcon {

--- a/test/unit/components/SideBar/Sidebar.spec.js
+++ b/test/unit/components/SideBar/Sidebar.spec.js
@@ -72,15 +72,15 @@ const testBalances = [
   }
 ];
 const mockBalances = (selectors.balances = jest.fn(() => testBalances));
-const getMenuLinkByTestId = (testId, sidebarOnBottom, expandSideBar) => {
-  const menuLinkLabel = screen.getByTestId(testId);
-  let menuLink = menuLinkLabel.parentNode.parentNode.parentNode;
+const getMenuContentByTestId = (testId, sidebarOnBottom, expandSideBar) => {
+  const menuLinkContent = screen.getByTestId(testId);
+  let menuLink = menuLinkContent.parentNode.parentNode.parentNode;
   if (!sidebarOnBottom && expandSideBar) {
-    menuLink = menuLinkLabel.parentNode.parentNode;
+    menuLink = menuLinkContent.parentNode.parentNode;
   }
   return {
     menuLink,
-    menuLinkLabel
+    menuLinkContent
   };
 };
 const expectToHaveDefaultMenuLinks = (params) => {
@@ -92,19 +92,19 @@ const expectToHaveDefaultMenuLinks = (params) => {
   } = params || {};
 
   const expectToHaveMenuLink = (testId, name, className, path) => {
-    const { menuLinkLabel, menuLink } = getMenuLinkByTestId(
+    const { menuLinkContent, menuLink } = getMenuContentByTestId(
       testId,
       sidebarOnBottom,
       expandSideBar
     );
     if (!sidebarOnBottom && expandSideBar) {
-      expect(menuLinkLabel).toHaveTextContent(name);
+      expect(menuLinkContent).toHaveTextContent(name);
     }
     // check tooltip
     if (!expandSideBar) {
-      expect(menuLinkLabel.previousSibling).toHaveTextContent(name);
+      expect(menuLinkContent.previousSibling).toHaveTextContent(name);
     }
-    expect(menuLink).toHaveClass(className);
+    expect(menuLinkContent.firstChild).toHaveClass(className);
     // test clicking
     expect(menuLink).toHaveStyle(defaultMenuLinkBorderColor);
     user.click(menuLink);
@@ -113,65 +113,64 @@ const expectToHaveDefaultMenuLinks = (params) => {
   };
 
   expectToHaveMenuLink(
-    "menuLinkLabel-overview",
+    "menuLinkContent-overview",
     "Overview",
     "overviewIcon",
     "/home"
   );
   expectToHaveMenuLink(
-    "menuLinkLabel-transactions",
+    "menuLinkContent-transactions",
     "On-chain Transactions",
     "transactionsIcon",
     "/transactions"
   );
   expectToHaveMenuLink(
-    "menuLinkLabel-governance",
+    "menuLinkContent-governance",
     "Governance",
     "governanceIcon",
     "/governance"
   );
   if (!sidebarOnBottom || expandSideBar) {
     expectToHaveMenuLink(
-      "menuLinkLabel-tickets",
+      "menuLinkContent-tickets",
       "Staking",
       "ticketsIcon",
       "/tickets"
     );
     expectToHaveMenuLink(
-      "menuLinkLabel-accounts",
+      "menuLinkContent-accounts",
       "Accounts",
       "accountsIcon",
       "/accounts"
     );
     expectToHaveMenuLink(
-      "menuLinkLabel-securitycntr",
+      "menuLinkContent-securitycntr",
       "Privacy and Security",
       "securitycntrIcon",
       "/privacy"
     );
     if (isTrezorEnabled) {
       expectToHaveMenuLink(
-        "menuLinkLabel-trezor",
+        "menuLinkContent-trezor",
         "Trezor",
         "trezorIcon",
         "/trezor"
       );
     } else {
       expect(
-        screen.queryByTestId("menuLinkLabel-trezor")
+        screen.queryByTestId("menuLinkContent-trezor")
       ).not.toBeInTheDocument();
     }
   }
-
   if (isLnEnabled) {
     expectToHaveMenuLink(
-      "menuLinkLabel-ln",
+      "menuLinkContent-ln",
       "Lightning Transactions",
       "lnIcon",
       "/ln"
     );
   } else {
-    expect(screen.queryByTestId("menuLinkLabel-ln")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("menuLinkContent-ln")).not.toBeInTheDocument();
   }
 };
 
@@ -466,11 +465,10 @@ test("tests tooltip on Logo when accountMixerRunning mode is active", () => {
 });
 
 test("tests notification icon on the menu link", () => {
-  const mockNewProposalsStartedVoting = (selectors.newProposalsStartedVoting = jest.fn(
-    () => true
-  ));
+  const mockNewProposalsStartedVoting = (selectors.newProposalsStartedVoting =
+    jest.fn(() => true));
   render(<SideBar />);
-  const { menuLink } = getMenuLinkByTestId("menuLinkLabel-governance");
+  const { menuLink } = getMenuContentByTestId("menuLinkContent-governance");
   expect(menuLink).toHaveClass("notificationIcon");
   expect(mockNewProposalsStartedVoting).toHaveBeenCalled();
   mockNewProposalsStartedVoting.mockRestore();
@@ -478,7 +476,7 @@ test("tests notification icon on the menu link", () => {
 
 test("tests tabbedPage location", () => {
   const { history } = render(<SideBar />);
-  const { menuLink } = getMenuLinkByTestId("menuLinkLabel-transactions");
+  const { menuLink } = getMenuContentByTestId("menuLinkContent-transactions");
   expect(menuLink).toHaveStyle(defaultMenuLinkBorderColor);
   history.push("transactions/send");
   expect(menuLink).toHaveStyle(activeMenuLinkBorderColor);
@@ -486,18 +484,18 @@ test("tests tabbedPage location", () => {
 
 test("none of the menu links should be selected when clicking on the settings button", () => {
   render(<SideBar />);
-  let menuLinkLabels = screen.getAllByTestId(/menuLinkLabel-/i);
-  menuLinkLabels.map((menuLinkLabel) => {
-    const menuLink = menuLinkLabel.parentNode.parentNode.parentNode;
+  let menuLinkContents = screen.getAllByTestId(/menuLinkContent-/i);
+  menuLinkContents.map((menuLinkContent) => {
+    const menuLink = menuLinkContent.parentNode.parentNode.parentNode;
     expect(menuLink).toHaveStyle(defaultMenuLinkBorderColor);
   });
-  const { menuLink } = getMenuLinkByTestId("menuLinkLabel-tickets");
+  const { menuLink } = getMenuContentByTestId("menuLinkContent-tickets");
   user.click(menuLink);
 
   // click on Staking
-  menuLinkLabels = screen.getAllByTestId(/menuLinkLabel-/i);
-  menuLinkLabels.map((menuLinkLabel) => {
-    const menuLink = menuLinkLabel.parentNode.parentNode.parentNode;
+  menuLinkContents = screen.getAllByTestId(/menuLinkContent-/i);
+  menuLinkContents.map((menuLinkContent) => {
+    const menuLink = menuLinkContent.parentNode.parentNode.parentNode;
     if (menuLink.textContent == "Staking") {
       expect(menuLink).toHaveStyle(activeMenuLinkBorderColor);
     } else {
@@ -507,9 +505,9 @@ test("none of the menu links should be selected when clicking on the settings bu
 
   // click on settings
   user.click(screen.getByRole("link", { name: "settings" }));
-  menuLinkLabels = screen.getAllByTestId(/menuLinkLabel-/i);
-  menuLinkLabels.map((menuLinkLabel) => {
-    const menuLink = menuLinkLabel.parentNode.parentNode.parentNode;
+  menuLinkContents = screen.getAllByTestId(/menuLinkContent-/i);
+  menuLinkContents.map((menuLinkContent) => {
+    const menuLink = menuLinkContent.parentNode.parentNode.parentNode;
     expect(menuLink).toHaveStyle(defaultMenuLinkBorderColor);
   });
 });

--- a/test/unit/components/SideBar/Sidebar.spec.js
+++ b/test/unit/components/SideBar/Sidebar.spec.js
@@ -186,7 +186,9 @@ const expectToHaveDefaultMenuLinks = (params) => {
         "DEX",
         "dexIcon",
         "/dex",
-        isSPV ? "SPV needs to be switched off" : "DEX",
+        isSPV
+          ? "DEX not available while using SPV. Please go to settings and disable SPV to access the DEX."
+          : "DEX",
         isSPV
       );
     }


### PR DESCRIPTION
This diff implements @jholdstock's idea on the matrix: "Maybe decrediton in SPV mode should just gray out the Dex tab, with a tooltip to explain that SPV needs to be switched off. Hiding it completely has caught a lot of people out)"