### PR TITLE
[multi] Reduce dependencies in main and preload layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ app/i18n/extracted/app
 /*.node
 coverage/
 .yarncache/
+deps-graphs

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -579,7 +579,7 @@ export const checkNetworkMatch = () => (dispatch, getState) =>
           wallet.dropDcrd();
           return reject(DIFF_CONNECTION_ERROR);
         }
-        dispatch({ type: CHECK_NETWORKMATCH_SUCCESS });
+        dispatch({ daemonInfo, type: CHECK_NETWORKMATCH_SUCCESS });
         resolve(daemonInfo);
       })
       .catch((error) => {

--- a/app/config.js
+++ b/app/config.js
@@ -3,7 +3,6 @@ import Store from "electron-store";
 import ini from "ini";
 import path from "path";
 import { stakePoolInfo } from "./middleware/vspapi";
-import { isArray } from "lodash";
 import {
   getGlobalCfgPath,
   getWalletPath,
@@ -136,7 +135,7 @@ export function getDcrdCert(dcrdCertPath) {
 export function updateStakePoolConfig(config, foundStakePoolConfigs) {
   const currentStakePoolConfigs =
     config.has(cfgConstants.STAKEPOOLS) &&
-    isArray(config.get(cfgConstants.STAKEPOOLS))
+    Array.isArray(config.get(cfgConstants.STAKEPOOLS))
       ? config.get(cfgConstants.STAKEPOOLS)
       : [];
 

--- a/app/config.js
+++ b/app/config.js
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "fs";
 import Store from "electron-store";
 import ini from "ini";
 import path from "path";
@@ -317,8 +317,8 @@ export const updateDefaultBitcoinConfig = (
         !fs.existsSync(path.join(getDefaultBitcoinDirectory(), "bitcoin.conf"))
       ) {
         // check to see if directory exists, if not make it
-        fs.pathExistsSync(getDefaultBitcoinDirectory()) ||
-          fs.mkdirsSync(getDefaultBitcoinDirectory());
+        fs.existsSync(getDefaultBitcoinDirectory()) ||
+          fs.mkdirSync(getDefaultBitcoinDirectory(), { recursive: true });
         newDefaultBitcoinConfig(
           rpcuser,
           rpcpassword,

--- a/app/helpers/files.js
+++ b/app/helpers/files.js
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "fs";
 import path from "path";
 
 // readFileBackward reads a file backward and if maxSize is specified it will

--- a/app/helpers/strings.js
+++ b/app/helpers/strings.js
@@ -1,6 +1,10 @@
-import { isString } from "lodash";
-
-// @flow
+// isPlainString returns whether s is a plain (native) string. Note this differs
+// from lodash's isString because that function also checks not just for plain
+// strings but also string-convertible objects (i.e. objects which have a
+// toString() method or function field).
+export function isPlainString(s) {
+  return typeof s === "string";
+}
 
 // This function adds spaces around text to fix an issue with double-clicking to select it
 // when it's rendered inside of a floated element. Without the spaces, double-clicking will
@@ -28,7 +32,7 @@ export function restrictToStdDecimalNumber(s) {
 // This function does **not** pad the string if less than maxFracDigits are
 // present.
 export function limitFractionalDigits(s, maxFracDigits) {
-  if (!isString(s)) return s;
+  if (!isPlainString(s)) return s;
 
   const match = s.match(/(\d+)\.(\d*)/);
   if (!match) return s;

--- a/app/i18n/locales/index.js
+++ b/app/i18n/locales/index.js
@@ -1,19 +1,5 @@
 import staticDefaults from "../extracted/static";
 
-// TODO: This polyfill can probably be removed after we update to a version of
-// electron with support to Intl.RelativeTimeFormat.
-import "@formatjs/intl-relativetimeformat/polyfill";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/ar";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/de";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/en";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/es";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/fr";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/it";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/ja";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/pl";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/pt";
-import "@formatjs/intl-relativetimeformat/dist/locale-data/zh";
-
 // Extra formats. May be customized by each locale.
 export const defaultFormats = {
   number: {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -242,9 +242,12 @@ if (process.env.NODE_ENV === "development") {
 }
 
 // Check that wallets directory has been created, if not, make it.
-fs.existsSync(walletsDirectory) || fs.mkdirSync(walletsDirectory, { recursive: true });
-fs.existsSync(mainnetWalletsPath) || fs.mkdirSync(mainnetWalletsPath, { recursive: true });
-fs.existsSync(testnetWalletsPath) || fs.mkdirSync(testnetWalletsPath, { recursive: true });
+fs.existsSync(walletsDirectory) ||
+  fs.mkdirSync(walletsDirectory, { recursive: true });
+fs.existsSync(mainnetWalletsPath) ||
+  fs.mkdirSync(mainnetWalletsPath, { recursive: true });
+fs.existsSync(testnetWalletsPath) ||
+  fs.mkdirSync(testnetWalletsPath, { recursive: true });
 
 checkAndInitWalletCfg(true);
 checkAndInitWalletCfg(false);

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "fs";
 import path from "path";
 import parseArgs from "minimist";
 import { app, BrowserWindow, Menu, dialog } from "electron";
@@ -242,9 +242,9 @@ if (process.env.NODE_ENV === "development") {
 }
 
 // Check that wallets directory has been created, if not, make it.
-fs.pathExistsSync(walletsDirectory) || fs.mkdirsSync(walletsDirectory);
-fs.pathExistsSync(mainnetWalletsPath) || fs.mkdirsSync(mainnetWalletsPath);
-fs.pathExistsSync(testnetWalletsPath) || fs.mkdirsSync(testnetWalletsPath);
+fs.existsSync(walletsDirectory) || fs.mkdirSync(walletsDirectory, { recursive: true });
+fs.existsSync(mainnetWalletsPath) || fs.mkdirSync(mainnetWalletsPath, { recursive: true });
+fs.existsSync(testnetWalletsPath) || fs.mkdirSync(testnetWalletsPath, { recursive: true });
 
 checkAndInitWalletCfg(true);
 checkAndInitWalletCfg(false);

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -89,7 +89,7 @@ import {
 } from "./main_dev/templates";
 import { readFileBackward } from "./helpers/files";
 import electron from "electron";
-import { isString } from "./fp";
+import { isPlainString as isString } from "./helpers/strings";
 import {
   OPTIONS,
   BOTH_CONNECTION_ERR_MESSAGE,

--- a/app/main_dev/constants.js
+++ b/app/main_dev/constants.js
@@ -1,9 +1,8 @@
-import * as wallet from "wallet";
+import { app } from "electron";
 
-export const USAGE_MESSAGE = wallet.app
-  ? `${wallet.app.name} version ${wallet.app.version}
+export const USAGE_MESSAGE = `${app.name} version ${app.getVersion()}
 Usage
-  $ ${wallet.app.name} [OPTIONS]
+  $ ${app.name} [OPTIONS]
 
 Options
   --help -h          Show help and exit.
@@ -20,9 +19,6 @@ Options
   --rpcconnect       Specify RPC connection in 'host:port' or 'host' format (latter uses the default RPC port). Note that different ports are used for RPC and SPV connections.
   --extrawalletargs  Pass extra arguments to dcrwallet.
   --custombinpath    Custom path for dcrd/dcrwallet/dcrctl binaries.
-`
-  : null;
+`;
 
-export const VERSION_MESSAGE = wallet.app
-  ? `${wallet.app.name} version ${wallet.app.version}`
-  : null;
+export const VERSION_MESSAGE = `${app.name} version ${app.getVersion()}`;

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -6,7 +6,7 @@
  * allowed by passing the appropriate url to the ipcMain message "allowURL".
  */
 import { session } from "electron";
-import { getGlobalCfg } from "config";
+import { getGlobalCfg } from "../config";
 import {
   POLITEIA_URL_TESTNET,
   POLITEIA_URL_MAINNET

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -6,7 +6,6 @@
  * allowed by passing the appropriate url to the ipcMain message "allowURL".
  */
 import { session } from "electron";
-import { isRegExp } from "lodash";
 import { getGlobalCfg } from "config";
 import {
   POLITEIA_URL_TESTNET,
@@ -151,7 +150,7 @@ export const installSessionHandlers = (mainLogger) => {
 };
 
 const addAllowedURL = (url) => {
-  if (!isRegExp(url)) url = new RegExp(url);
+  if (!(url instanceof RegExp)) url = new RegExp(url);
   allowedURLs.push(url);
 };
 

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -7,7 +7,7 @@ import {
   newWalletConfigCreation,
   getWalletCfg,
   checkNoLegacyWalletConfig
-} from "config";
+} from "../config";
 import {
   launchDCRD,
   launchDCRWallet,

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -83,7 +83,11 @@ export const deleteDaemon = (appData, testnet) => {
   );
   try {
     if (fs.existsSync(removeDaemonDirectoryData)) {
-      fs.rmSync(removeDaemonDirectoryData, { force: true, recursive: true, maxRetries: 30 });
+      fs.rmSync(removeDaemonDirectoryData, {
+        force: true,
+        recursive: true,
+        maxRetries: 30
+      });
       logger.log("info", "removing " + removeDaemonDirectoryData);
     }
     return true;
@@ -148,7 +152,11 @@ export const removeWallet = (testnet, walletPath) => {
   const removeWalletDirectory = getWalletPath(testnet, walletPath);
   try {
     if (fs.existsSync(removeWalletDirectory)) {
-      fs.rmSync(removeWalletDirectory, { force: true, recursive: true, maxRetries: 30 });
+      fs.rmSync(removeWalletDirectory, {
+        force: true,
+        recursive: true,
+        maxRetries: 30
+      });
       return true;
     }
     return false;

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "fs";
 import path from "path";
 import { createLogger } from "./logging";
 import { getWalletPath, getWalletDb, getDcrdPath } from "./paths";
@@ -58,7 +58,7 @@ export const getAvailableWallets = (network) => {
     const isTrezor = cfg.get(cfgConstants.TREZOR);
     const isPrivacy = cfg.get(cfgConstants.MIXED_ACCOUNT_CFG);
     const walletDbFilePath = getWalletDb(isTestNet, wallet);
-    const finished = fs.pathExistsSync(walletDbFilePath);
+    const finished = fs.existsSync(walletDbFilePath);
     availableWallets.push({
       network,
       wallet,
@@ -82,8 +82,8 @@ export const deleteDaemon = (appData, testnet) => {
     testnet ? "testnet3" : MAINNET
   );
   try {
-    if (fs.pathExistsSync(removeDaemonDirectoryData)) {
-      fs.removeSync(removeDaemonDirectoryData);
+    if (fs.existsSync(removeDaemonDirectoryData)) {
+      fs.rmSync(removeDaemonDirectoryData, { force: true, recursive: true, maxRetries: 30 });
       logger.log("info", "removing " + removeDaemonDirectoryData);
     }
     return true;
@@ -129,8 +129,8 @@ export const startDaemon = async (params, testnet, reactIPC) => {
 export const createWallet = (testnet, walletPath) => {
   const newWalletDirectory = getWalletPath(testnet, walletPath);
   try {
-    if (!fs.pathExistsSync(newWalletDirectory)) {
-      fs.mkdirsSync(newWalletDirectory);
+    if (!fs.existsSync(newWalletDirectory)) {
+      fs.mkdirSync(newWalletDirectory, { recursive: true });
 
       // create new configs for new wallet
       initWalletCfg(testnet, walletPath);
@@ -147,8 +147,8 @@ export const removeWallet = (testnet, walletPath) => {
   if (!walletPath) return;
   const removeWalletDirectory = getWalletPath(testnet, walletPath);
   try {
-    if (fs.pathExistsSync(removeWalletDirectory)) {
-      fs.removeSync(removeWalletDirectory);
+    if (fs.existsSync(removeWalletDirectory)) {
+      fs.rmSync(removeWalletDirectory, { force: true, recursive: true, maxRetries: 30 });
       return true;
     }
     return false;
@@ -409,8 +409,8 @@ export const removeDcrlnd = (walletName, testnet) => {
   const walletPath = getWalletPath(testnet, walletName);
   const dcrlndRoot = path.join(walletPath, "dcrlnd");
   try {
-    if (fs.pathExistsSync(dcrlndRoot)) {
-      fs.removeSync(dcrlndRoot);
+    if (fs.existsSync(dcrlndRoot)) {
+      fs.rmSync(dcrlndRoot, { recursive: true, force: true, maxRetries: 30 });
       return true;
     }
     return false;

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -1129,22 +1129,22 @@ export const connectRpcDaemon = async (mainWindow, rpcCreds) => {
 
     return new Promise((ok, fail) => {
       let resData = "";
-      const req = https.request(`https://${url}/`, opts, res => {
-          res.on("data", chunk => resData += chunk);
-          res.on("end", () => {
-            try {
-              if (res.statusCode !== 200) {
-                throw new Error("Not ok response: " + res.statusMessage);
-              }
-              const parsedRes = JSON.parse(resData);
-              if (parsedRes.error && parsedRes.error.message) {
-                throw new Error(parsedRes.error.message);
-              }
-              ok(parsedRes.result);
-            } catch (error) {
-              fail(error);
+      const req = https.request(`https://${url}/`, opts, (res) => {
+        res.on("data", (chunk) => (resData += chunk));
+        res.on("end", () => {
+          try {
+            if (res.statusCode !== 200) {
+              throw new Error("Not ok response: " + res.statusMessage);
             }
-          });
+            const parsedRes = JSON.parse(resData);
+            if (parsedRes.error && parsedRes.error.message) {
+              throw new Error(parsedRes.error.message);
+            }
+            ok(parsedRes.result);
+          } catch (error) {
+            fail(error);
+          }
+        });
       });
       req.end(reqData);
     });
@@ -1152,7 +1152,7 @@ export const connectRpcDaemon = async (mainWindow, rpcCreds) => {
 
   // Return a promise that will resolve once we can query the dcrd instance.
   return (async () => {
-    const sleep = (ms) => new Promise(ok => setTimeout(ok, ms));
+    const sleep = (ms) => new Promise((ok) => setTimeout(ok, ms));
     for (let i = 0; i < 300; i++) {
       try {
         await getDaemonInfo();

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -26,7 +26,7 @@ import parseArgs from "minimist";
 import { OPTIONS, UPGD_ELECTRON8 } from "constants";
 import * as cfgConstants from "constants/config";
 import os from "os";
-import fs from "fs-extra";
+import fs from "fs";
 import { format } from "util";
 import { spawn } from "child_process";
 import isRunning from "is-running";

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -35,7 +35,7 @@ import { concat, isString } from "../fp";
 import webSocket from "ws";
 import path from "path";
 import ini from "ini";
-import { makeRandomString } from "helpers";
+import { makeRandomString } from "helpers/strings";
 import { makeFileBackup } from "helpers/files";
 import { DEX_LOCALPAGE } from "./externalRequests";
 

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -8,7 +8,7 @@ import {
   getCertsPath,
   getSitePath
 } from "./paths";
-import { getWalletCfg, getGlobalCfg } from "config";
+import { getWalletCfg, getGlobalCfg } from "../config";
 import {
   createLogger,
   AddToDcrdLog,

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -31,11 +31,10 @@ import { format } from "util";
 import { spawn } from "child_process";
 import isRunning from "is-running";
 import stringArgv from "string-argv";
-import { concat, isString } from "../fp";
 import webSocket from "ws";
 import path from "path";
 import ini from "ini";
-import { makeRandomString } from "helpers/strings";
+import { makeRandomString, isPlainString as isString } from "helpers/strings";
 import { makeFileBackup } from "helpers/files";
 import { DEX_LOCALPAGE } from "./externalRequests";
 
@@ -616,7 +615,7 @@ export const launchDCRWallet = async (
   )
     ? `--configfile=${dcrwalletConf(getWalletPath(testnet, walletPath))}`
     : "";
-  let args = [confFile];
+  const args = [confFile];
 
   // add needed dcrwallet flags
   if (disableCoinTypeUpgrades === true) {
@@ -718,7 +717,7 @@ export const launchDCRWallet = async (
 
   // Add any extra args if defined.
   if (argv.extrawalletargs !== undefined && isString(argv.extrawalletargs)) {
-    args = concat(args, stringArgv(argv.extrawalletargs));
+    args.push(...stringArgv(argv.extrawalletargs));
   }
 
   logger.log("info", `Starting ${dcrwExe} with ${args}`);

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -1,7 +1,7 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
-import { initWalletCfg, newWalletConfigCreation } from "config";
+import { initWalletCfg, newWalletConfigCreation } from "../config";
 import { TESTNET, MAINNET } from "constants";
 
 // In all the functions below the Windows path is constructed based on

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -127,11 +127,10 @@ export function checkAndInitWalletCfg(testnet) {
     testnet ? "testnet3" : MAINNET
   );
 
-  if (
-    !fs.existsSync(walletDirectory) &&
-    fs.existsSync(oldWalletDbPath)
-  ) {
-    fs.mkdirSync(path.join(walletDirectory, testnet ? "testnet3" : MAINNET), { recursive: true });
+  if (!fs.existsSync(walletDirectory) && fs.existsSync(oldWalletDbPath)) {
+    fs.mkdirSync(path.join(walletDirectory, testnet ? "testnet3" : MAINNET), {
+      recursive: true
+    });
     fs.copyFileSync(
       path.join(oldWalletDbPath, "wallet.db"),
       path.join(walletDirectory, testnet ? "testnet3" : MAINNET, "wallet.db")

--- a/app/main_dev/paths.js
+++ b/app/main_dev/paths.js
@@ -1,6 +1,6 @@
 import path from "path";
 import os from "os";
-import fs from "fs-extra";
+import fs from "fs";
 import { initWalletCfg, newWalletConfigCreation } from "config";
 import { TESTNET, MAINNET } from "constants";
 
@@ -128,18 +128,18 @@ export function checkAndInitWalletCfg(testnet) {
   );
 
   if (
-    !fs.pathExistsSync(walletDirectory) &&
-    fs.pathExistsSync(oldWalletDbPath)
+    !fs.existsSync(walletDirectory) &&
+    fs.existsSync(oldWalletDbPath)
   ) {
-    fs.mkdirsSync(walletDirectory);
-    fs.copySync(
+    fs.mkdirSync(path.join(walletDirectory, testnet ? "testnet3" : MAINNET), { recursive: true });
+    fs.copyFileSync(
       path.join(oldWalletDbPath, "wallet.db"),
       path.join(walletDirectory, testnet ? "testnet3" : MAINNET, "wallet.db")
     );
 
     // copy over existing config.json if it exists
-    if (fs.pathExistsSync(getGlobalCfgPath())) {
-      fs.copySync(getGlobalCfgPath(), configJson);
+    if (fs.existsSync(getGlobalCfgPath())) {
+      fs.copyFileSync(getGlobalCfgPath(), configJson);
     }
 
     // create new configs for default mainnet wallet
@@ -156,17 +156,17 @@ export function getPoliteiaPath() {
 // setPoliteiaPath sets the politeia path which proposals are cached.
 export function setPoliteiaPath() {
   const politeiaPath = getPoliteiaPath();
-  if (fs.pathExistsSync(politeiaPath)) {
+  if (fs.existsSync(politeiaPath)) {
     return;
   }
-  fs.mkdirSync(politeiaPath, { mode: 0o700 });
+  fs.mkdirSync(politeiaPath, { recursive: true, mode: 0o700 });
 }
 
 // getProposalPathFromPoliteia gets a proposal by its token or return empty string
 // if proposal is not foud.
 function getProposalPathFromPoliteia(token) {
   const proposalPath = path.join(getPoliteiaPath(), token);
-  if (fs.pathExistsSync(proposalPath)) {
+  if (fs.existsSync(proposalPath)) {
     return proposalPath;
   }
   return "";
@@ -175,11 +175,11 @@ function getProposalPathFromPoliteia(token) {
 // setPoliteiaProposalPath mkdir if directory of proposal does not exists.
 export function setPoliteiaProposalPath(token) {
   let proposalPath = getProposalPathFromPoliteia(token);
-  if (fs.pathExistsSync(proposalPath)) {
+  if (fs.existsSync(proposalPath)) {
     return;
   }
   proposalPath = path.join(getPoliteiaPath(), token);
-  fs.mkdirSync(proposalPath, { mode: 0o700 });
+  fs.mkdirSync(proposalPath, { recursive: true, mode: 0o700 });
   return proposalPath;
 }
 
@@ -188,7 +188,7 @@ export function setPoliteiaProposalPath(token) {
 // and write a eligibletickets.json file, with { eligibleTickets: [tickets]) }
 export function saveEligibleTickets(token, eligibleTickets) {
   let proposalPath = getProposalPathFromPoliteia(token);
-  if (!fs.pathExistsSync(proposalPath)) {
+  if (!fs.existsSync(proposalPath)) {
     proposalPath = setPoliteiaProposalPath(token);
   }
   const fullPath = path.join(proposalPath, "eligibletickets.json");
@@ -203,7 +203,7 @@ export function getEligibleTickets(token) {
     return null;
   }
   const fullPath = path.join(proposalPath, "eligibletickets.json");
-  if (!fs.pathExistsSync(fullPath)) {
+  if (!fs.existsSync(fullPath)) {
     return null;
   }
   const eligibleTickets = fs.readFileSync(fullPath);
@@ -217,10 +217,10 @@ function getWalletPiPath(testnet, walletName) {
     getWalletPath(testnet, walletName),
     "politeia"
   );
-  if (fs.pathExistsSync(walletPiPath)) {
+  if (fs.existsSync(walletPiPath)) {
     return walletPiPath;
   }
-  fs.mkdirSync(walletPiPath, { mode: 0o700 });
+  fs.mkdirSync(walletPiPath, { recursive: true, mode: 0o700 });
   return walletPiPath;
 }
 
@@ -231,11 +231,11 @@ function getWalletPiPath(testnet, walletName) {
 export function savePiVote(vote, token, testnet, walletName) {
   const walletPath = getWalletPiPath(testnet, walletName);
   const proposalPath = path.join(walletPath, token);
-  if (!fs.pathExistsSync(proposalPath)) {
-    fs.mkdirSync(proposalPath, { mode: 0o700 });
+  if (!fs.existsSync(proposalPath)) {
+    fs.mkdirSync(proposalPath, { recursive: true, mode: 0o700 });
   }
   const fullPath = path.join(proposalPath, "vote.json");
-  if (!fs.pathExistsSync(fullPath)) {
+  if (!fs.existsSync(fullPath)) {
     fs.writeFile(fullPath, JSON.stringify(vote), { mode: 0o600 });
   }
 }
@@ -244,7 +244,7 @@ export function savePiVote(vote, token, testnet, walletName) {
 export function getProposalWalletVote(token, testnet, walletName) {
   const walletPath = getWalletPiPath(testnet, walletName);
   const proposalPath = path.join(walletPath, token);
-  if (!fs.pathExistsSync(proposalPath)) {
+  if (!fs.existsSync(proposalPath)) {
     return null;
   }
   const fullPath = path.join(proposalPath, "vote.json");

--- a/app/main_dev/proxy.js
+++ b/app/main_dev/proxy.js
@@ -1,4 +1,4 @@
-import { getGlobalCfg } from "config";
+import { getGlobalCfg } from "../config";
 import { session } from "electron";
 import * as cfgConstants from "constants/config";
 

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -2,7 +2,7 @@ process.env["GRPC_SSL_CIPHER_SUITES"] = "HIGH+ECDSA";
 
 const grpc = require("@grpc/grpc-js");
 
-import { getWalletCert } from "config";
+import { getWalletCert } from "../../config.js";
 import { getWalletPath } from "main_dev/paths.js";
 
 const proto = require("../walletrpc/api_grpc_pb.js");

--- a/app/wallet/app.js
+++ b/app/wallet/app.js
@@ -138,11 +138,6 @@ export const openExternalURL = (url) => {
   shell.openExternal(url);
 };
 
-export const appInfo = {
-  name: app?.name,
-  version: app?.getVersion()
-};
-
 export const showSaveDialog = (opts) => invoke("show-save-dialog", opts);
 
 export const showOpenDialog = (opts) => invoke("show-open-dialog", opts);

--- a/app/wallet/app.js
+++ b/app/wallet/app.js
@@ -1,4 +1,4 @@
-import { ipcRenderer, clipboard, shell, app } from "electron";
+import { ipcRenderer, clipboard, shell } from "electron";
 import { invoke } from "helpers/electronRenderer";
 import {
   isObject,

--- a/app/wallet/config.js
+++ b/app/wallet/config.js
@@ -1,4 +1,4 @@
-import * as cfg from "config";
+import * as cfg from "../config";
 import * as paths from "main_dev/paths";
 
 export const getWalletCfg = (...args) => {

--- a/app/wallet/control.js
+++ b/app/wallet/control.js
@@ -4,7 +4,6 @@ import {
   VSP_FEE_PROCESS_PAID,
   VSP_FEE_PROCESS_ERRORED
 } from "constants";
-import { isUndefined } from "lodash";
 import { rawHashToHex, rawToHex } from "../helpers/byteActions";
 import { shimStreamedResponse } from "helpers/electronRenderer";
 import { getClient } from "middleware/grpc/clientTracking";
@@ -568,7 +567,7 @@ export const startTicketAutoBuyerV3 = (
         !changeAccount ||
         !csppServer ||
         !csppPort ||
-        isUndefined(mixedAcctBranch)
+        (mixedAcctBranch === undefined)
       ) {
         throw "missing cspp argument";
       }

--- a/app/wallet/control.js
+++ b/app/wallet/control.js
@@ -567,7 +567,7 @@ export const startTicketAutoBuyerV3 = (
         !changeAccount ||
         !csppServer ||
         !csppPort ||
-        (mixedAcctBranch === undefined)
+        mixedAcctBranch === undefined
       ) {
         throw "missing cspp argument";
       }

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -1,6 +1,6 @@
 import { ipcRenderer } from "electron";
 import { withLog as log, logOptionNoResponseData } from "./app";
-import { isString } from "lodash";
+import { isPlainString as isString } from "helpers/strings";
 import { invoke } from "helpers/electronRenderer";
 
 export const getHeightSynced = () => ipcRenderer.sendSync("get-height-synced");

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -20,15 +20,17 @@ import {
 import {
   _blake256,
   selializeNoWitnessEncode,
-  decodeRawTransaction as decodeHelper,
-  extractPkScriptAddrs,
+  decodeRawTransaction as decodeHelper
+} from "../helpers/msgTx";
+import { extractPkScriptAddrs } from "../helpers/scripts";
+import { addrFromSStxPkScrCommitment } from "../helpers/tickets";
+import {
   hexToBytes,
-  addrFromSStxPkScrCommitment,
+  rawHashToHex,
   reverseHash,
   strHashToRaw,
   rawToHex
-} from "helpers";
-import { rawHashToHex } from "../helpers/byteActions";
+} from "../helpers/byteActions";
 
 const promisify = (fn) => (...args) =>
   new Promise((ok, fail) =>

--- a/babel.config.js
+++ b/babel.config.js
@@ -33,8 +33,7 @@ module.exports = function (api) {
         "root": [ "./app" ],
         "extensions": [ ".js" ],
         "alias": {
-          "constants": "./app/constants",
-          "config": "./app/config"
+          "constants": "./app/constants"
         }
       } ]
     ],

--- a/package.json
+++ b/package.json
@@ -255,7 +255,6 @@
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.13.10",
-    "@formatjs/intl-relativetimeformat": "^4.5.9",
     "@formatjs/intl-utils": "^1.6.0",
     "@grpc/grpc-js": "^1.2.5",
     "@hot-loader/react-dom": "^16.13.0",
@@ -274,7 +273,6 @@
     "electron-fetch": "^1.7.3",
     "electron-store": "^7.0.2",
     "enzyme-adapter-react-16": "^1.15.2",
-    "fs-extra": "^9.1.0",
     "ini": "^2.0.0",
     "int64-buffer": "^1.0.0",
     "is-running": "^2.1.0",
@@ -316,7 +314,6 @@
     "utf-8-validate": "^5.0.5",
     "winston": "^3.3.3",
     "worker-loader": "^3.0.8",
-    "ws": "^7.4.4",
     "xstate": "^4.17.1"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -238,6 +238,8 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",
     "jest-date-mock": "^1.0.8",
+    "json-stable-stringify": "^1.0.1",
+    "madge": "^4.0.2",
     "mini-css-extract-plugin": "^1.4.0",
     "node-loader": "^1.0.2",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "i18n-check-docs": "node ./scripts/docsTranslationStatus.js",
     "i18n-check-dupes": "node ./scripts/checkDuplicateTranslationIds.js",
     "prettify": "prettier --write 'app/**/*.{js,jsx,css,json}' 'test/**/*.js'",
-    "prettify:diff": "prettier --list-different 'app/**/*.{js,jsx,css,json}' 'test/**/*.js'"
+    "prettify:diff": "prettier --list-different 'app/**/*.{js,jsx,css,json}' 'test/**/*.js'",
+    "deps-graphs": "node ./scripts/generateDepGraphs"
   },
   "jest": {
     "verbose": true,

--- a/scripts/generateDepGraphs.js
+++ b/scripts/generateDepGraphs.js
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Script to generate the dependency graph for the various layers of the
+ * application.
+ *
+ * For each (electron,preload,ui) layer, this generates:
+ *
+ *    - A sorted json file with individual file dependencies in the app;
+ *    - A corresponding svg visualization of the dependencies;
+ *    - A list of top-level dependencies of that layer;
+ *    - A link to npmgraph.js.org to see the corresponding dependency graph.
+ *
+ * This script is useful to keep track of dependencies on each layer, in
+ * particular of the main (i.e. electron) layer and the preload layer which
+ * should have as few dependencies as possible.
+ ******************************************************************************/
+const path = require("path");
+const outputDir = path.resolve("./deps-graphs");
+const fs = require("fs");
+const madge = require("madge");
+const stringify = require("json-stable-stringify");
+const packageJson = require(path.resolve("package.json"));
+const allDeps = { ...packageJson.dependencies, ...packageJson.devDependencies };
+
+// The main electron and preload layers implicitly require electron, so
+// ignore those as dependencies since it clears up the graphs a bit.
+const ignoreImportsElectron = ["electron", "electron-devtools-installer"];
+const ignoreImportsPreload = ["electron"];
+const ignoreImportsUI = [];
+
+if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir);
+
+async function genDepGraph(layer, entryPointRel, ignoreImports) {
+  const webpackCfg = `webpack/${layer}.prod.js`;
+  const entryPoint = path.resolve(entryPointRel);
+  const outImg = path.resolve(path.join(outputDir, `${layer}.svg`));
+  const outJson = path.resolve(path.join(outputDir, `${layer}.json`));
+  const madgeCfg = { includeNpm: true, webpackCfg };
+
+  if (layer == "ui") {
+    madgeCfg.excludeRegExp = [/\.css$/, /\.ttf$/, /\.json$/, /\.svg$/, /\.gif$/,
+      /\.png$/];
+  }
+
+  const processed = await madge(entryPoint, madgeCfg);
+  await processed.image(outImg);
+  const processedObj = processed.obj();
+  fs.writeFileSync(outJson, stringify(processedObj, { space: "\t" }));
+
+  // Figure out all individual imports from node_modules.
+  const nodeModulesImports = {};
+  Object.keys(processedObj).forEach((key) => {
+    processedObj[key].forEach(importName => {
+      const matches = importName.match(/node_modules\/([^/]*)\/.*$/);
+      if (!matches) return;
+      const moduleName = matches[1];
+      if (ignoreImports.indexOf(moduleName) > -1) return;
+      nodeModulesImports[moduleName] = allDeps[moduleName] ? `@${allDeps[moduleName]}` : "";
+    });
+  });
+
+  // Print a comma-separated list of top-level npm modules imported by this layer.
+  const importModules = Object.entries(nodeModulesImports).map(v => v[0]+v[1]);
+  const importNames = importModules.sort().join(",");
+  console.log(`Top-level node modules for ${layer}:`,  importNames);
+  console.log("https://npmgraph.js.org/?q=" + encodeURIComponent(importNames));
+}
+
+async function main() {
+  await genDepGraph("electron", "./app/main.development.js", ignoreImportsElectron);
+  console.log("\n");
+  await genDepGraph("preload", "./app/wallet-preload.js", ignoreImportsPreload);
+  console.log("\n");
+  await genDepGraph("ui", "./app/index.js", ignoreImportsUI);
+}
+
+main().then().catch(err => console.error(err));

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,19 +162,12 @@
   dependencies:
     "@babel/types" "^7.13.0"
 
-"@babel/helper-module-imports@^7.0.0":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13":
   version "7.13.12"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
   integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
   dependencies:
     "@babel/types" "^7.13.12"
-
-"@babel/helper-module-imports@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz#ec67e4404f41750463e455cc3203f6a32e93fcb0"
-  integrity sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
-  dependencies:
-    "@babel/types" "^7.12.13"
 
 "@babel/helper-module-transforms@^7.13.0":
   version "7.13.0"
@@ -272,16 +265,7 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/highlight@^7.10.4":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
-  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.12.13":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.0.tgz#3197e375711ef6bf834e67d0daec88e4f46113cf"
   integrity sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
@@ -290,15 +274,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0", "@babel/parser@^7.13.10":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.5.tgz#4cd2f346261061b2518873ffecdf1612cb032829"
   integrity sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==
-
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0", "@babel/parser@^7.13.10":
-  version "7.13.11"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.11.tgz#f93ebfc99d21c1772afbbaa153f47e7ce2f50b88"
-  integrity sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==
 
 "@babel/plugin-proposal-async-generator-functions@^7.13.8":
   version "7.13.8"
@@ -1040,14 +1019,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
-  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
@@ -1078,16 +1050,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.17", "@babel/types@^7.13.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.0.tgz#74424d2816f0171b4100f0ab34e9a374efdf7f80"
-  integrity sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
-    lodash "^4.17.19"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.12.13", "@babel/types@^7.13.12":
+"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.17", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.14.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.4.tgz#bfd6980108168593b38b3eb48a24aa026b919bc0"
   integrity sha512-lCj4aIs0xUefJFQnwwQv2Bxg7Omd6bgquZ6LGC+gGMh6/s5qDVfjuCMlDmYQ15SLsWHd9n+X3E75lKIhl5Lkiw==
@@ -1700,7 +1663,7 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@testing-library/dom@>=5":
+"@testing-library/dom@>=5", "@testing-library/dom@^7.21.3":
   version "7.31.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
   integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
@@ -1726,20 +1689,6 @@
     dom-accessibility-api "^0.3.0"
     pretty-format "^25.1.0"
     wait-for-expect "^3.0.2"
-
-"@testing-library/dom@^7.21.3":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.0.tgz#60b18065bab50a5cde21fe80275a47a43024d9cc"
-  integrity sha512-0hhuJSmw/zLc6ewR9cVm84TehuTd7tbqBX9pRNSp8znJ9gTmSgesdbiGZtt8R6dL+2rgaPFp9Yjr7IU1HWm49w==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.4"
-    lz-string "^1.4.4"
-    pretty-format "^26.6.2"
 
 "@testing-library/jest-dom@^4.2.4":
   version "4.2.4"
@@ -2010,20 +1959,20 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/node@*":
+"@types/node@*", "@types/node@>=12.12.47":
   version "15.12.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.1.tgz#9b60797dee1895383a725f828a869c86c6caa5c2"
   integrity sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw==
-
-"@types/node@>=12.12.47", "@types/node@^14.6.2":
-  version "14.14.35"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
-  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
 "@types/node@^10.1.0":
   version "10.17.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.17.tgz#7a183163a9e6ff720d86502db23ba4aade5999b8"
   integrity sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==
+
+"@types/node@^14.6.2":
+  version "14.14.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
+  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -3702,12 +3651,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.4:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
-
-classnames@^2.2.5:
+classnames@^2.2.4, classnames@^2.2.5:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -4361,12 +4305,7 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.2.0:
-  version "2.6.14"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.14.tgz#004822a4050345b55ad4dcc00be1d9cf2f4296de"
-  integrity sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==
-
-csstype@^2.5.2:
+csstype@^2.2.0, csstype@^2.5.2:
   version "2.6.17"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.17.tgz#4cf30eb87e1d1a005d8b6510f95292413f6a1c0e"
   integrity sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==
@@ -4851,7 +4790,7 @@ dom-accessibility-api@^0.3.0:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
   integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
 
-dom-accessibility-api@^0.5.4, dom-accessibility-api@^0.5.6:
+dom-accessibility-api@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz#3f5d43b52c7a3bd68b5fb63fa47b4e4c1fdf65a9"
   integrity sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==
@@ -5166,14 +5105,7 @@ encodeurl@^1.0.2, encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
-encoding@^0.1.13:
+encoding@^0.1.11, encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -5215,18 +5147,10 @@ engine.io-parser@~2.2.0:
     blob "0.0.5"
     has-binary2 "~1.0.2"
 
-enhanced-resolve@^5.3.2:
+enhanced-resolve@^5.3.2, enhanced-resolve@^5.7.0:
   version "5.8.2"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
   integrity sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
-
-enhanced-resolve@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz#525c5d856680fbd5052de453ac83e32049958b5c"
-  integrity sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -6825,7 +6749,7 @@ iconv-corefoundation@^1.1.5:
     cli-truncate "^1.1.0"
     node-addon-api "^1.6.3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -8878,11 +8802,6 @@ nanoassert@^1.0.0:
   resolved "https://registry.yarnpkg.com/nanoassert/-/nanoassert-1.1.0.tgz#4f3152e09540fde28c76f44b19bbcd1d5a42478d"
   integrity sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40=
 
-nanoid@^3.1.20:
-  version "3.1.22"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
-  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
-
 nanoid@^3.1.23:
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
@@ -9915,7 +9834,7 @@ postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^8.1.7:
+postcss@^8.1.7, postcss@^8.2.8:
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.3.tgz#ef412a7a67e85c5b2c9f0ab3c4d9e8a3814d55cc"
   integrity sha512-gnXd9C4bGKevvlNFd80I8WfxHX+g6MR+W2h19PlDNHUuT9248rHTvCIDeZI3Hvs5mB3gzXiNDwVK3S153WJbZA==
@@ -9923,15 +9842,6 @@ postcss@^8.1.7:
     colorette "^1.2.2"
     nanoid "^3.1.23"
     source-map-js "^0.6.2"
-
-postcss@^8.2.8:
-  version "8.2.8"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.8.tgz#0b90f9382efda424c4f0f69a2ead6f6830d08ece"
-  integrity sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==
-  dependencies:
-    colorette "^1.2.2"
-    nanoid "^3.1.20"
-    source-map "^0.6.1"
 
 prebuild-install@^5.3.4:
   version "5.3.6"
@@ -11346,14 +11256,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.2, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
-  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.3.5:
+semver@^7.1.2, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -13213,7 +13116,7 @@ write-file-atomic@^3.0.0, write-file-atomic@^3.0.3:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.2.0, ws@^7.2.3, ws@^7.4.0, ws@^7.4.4, ws@~7.4.2:
+ws@^7.2.0, ws@^7.2.3, ws@^7.4.0, ws@~7.4.2:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,6 +290,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.0.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.5.tgz#4cd2f346261061b2518873ffecdf1612cb032829"
+  integrity sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.12.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0", "@babel/parser@^7.13.10":
   version "7.13.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.11.tgz#f93ebfc99d21c1772afbbaa153f47e7ce2f50b88"
@@ -2132,6 +2137,32 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript-eslint/types@4.26.1":
+  version "4.26.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.26.1.tgz#9e7c523f73c34b04a765e4167ca5650436ef1d38"
+  integrity sha512-STyMPxR3cS+LaNvS8yK15rb8Y0iL0tFXq0uyl6gY45glyI7w0CsyqyEXl/Fa0JlQy+pVANeK3sbwPneCbWE7yg==
+
+"@typescript-eslint/typescript-estree@^4.8.2":
+  version "4.26.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.1.tgz#b2ce2e789233d62283fae2c16baabd4f1dbc9633"
+  integrity sha512-l3ZXob+h0NQzz80lBGaykdScYaiEbFqznEs99uwzm8fPHhDjwaBFfQkjUC/slw6Sm7npFL8qrGEAMxcfBsBJUg==
+  dependencies:
+    "@typescript-eslint/types" "4.26.1"
+    "@typescript-eslint/visitor-keys" "4.26.1"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/visitor-keys@4.26.1":
+  version "4.26.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.1.tgz#0d55ea735cb0d8903b198017d6d4f518fdaac546"
+  integrity sha512-IGouNSSd+6x/fHtYRyLOM6/C+QxMDzWlDtN41ea+flWuSF9g02iqcIlX8wM53JkfljoIjP0U+yp7SiTS1onEkw==
+  dependencies:
+    "@typescript-eslint/types" "4.26.1"
+    eslint-visitor-keys "^2.0.0"
+
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.0.tgz#a5aa679efdc9e51707a4207139da57920555961f"
@@ -2511,6 +2542,11 @@ app-builder-lib@22.10.5:
     semver "^7.3.4"
     temp-file "^3.3.7"
 
+app-module-path@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/app-module-path/-/app-module-path-2.2.0.tgz#641aa55dfb7d6a6f0a8141c4b9c0aa50b6c24dd5"
+  integrity sha1-ZBqlXft9am8KgUHEucCqULbCTdU=
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -2692,6 +2728,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+ast-module-types@^2.3.2, ast-module-types@^2.4.0, ast-module-types@^2.7.0, ast-module-types@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/ast-module-types/-/ast-module-types-2.7.1.tgz#3f7989ef8dfa1fdb82dfe0ab02bdfc7c77a57dd3"
+  integrity sha512-Rnnx/4Dus6fn7fTqdeLEAn5vUll5w7/vts0RN608yFa6si/rDOUonlIIiwugHBFWjylHjxm9owoSZn71KwG4gw==
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -3873,7 +3914,7 @@ commander@2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.15.1, commander@^2.19.0, commander@^2.20.0:
+commander@^2.15.1, commander@^2.16.0, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3887,6 +3928,11 @@ commander@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
+commander@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commander@^7.0.0:
   version "7.1.0"
@@ -4471,6 +4517,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decomment@^0.9.3:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/decomment/-/decomment-0.9.4.tgz#fa40335bd90e3826d5c1984276e390525ff856d5"
+  integrity sha512-8eNlhyI5cSU4UbBlrtagWpR03dqXcE5IR9zpe7PnO6UzReXDskucsD8usgrzUmQ6qJ3N82aws/p/mu/jqbURWw==
+  dependencies:
+    esprima "4.0.1"
+
 decompress-response@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
@@ -4573,6 +4626,17 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dependency-tree@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/dependency-tree/-/dependency-tree-8.1.1.tgz#1a309f5a860b3285f7b1638c98ce48c8906ae6e6"
+  integrity sha512-bl5U16VQpaYxD0xvcnCH/dTctCiWnsVWymh9dNjbm4T00Hm21flu1VLnNueKCj7+3uusbcJhKKKtiWrpU0I+Nw==
+  dependencies:
+    commander "^2.20.3"
+    debug "^4.3.1"
+    filing-cabinet "^3.0.0"
+    precinct "^8.0.0"
+    typescript "^3.9.7"
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -4600,6 +4664,93 @@ detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+
+detective-amd@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detective-amd/-/detective-amd-3.1.0.tgz#92daee3214a0ca4522646cf333cac90a3fca6373"
+  integrity sha512-G7wGWT6f0VErjUkE2utCm7IUshT7nBh7aBBH2VBOiY9Dqy2DMens5iiOvYCuhstoIxRKLrnOvVAz4/EyPIAjnw==
+  dependencies:
+    ast-module-types "^2.7.0"
+    escodegen "^2.0.0"
+    get-amd-module-type "^3.0.0"
+    node-source-walk "^4.0.0"
+
+detective-cjs@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/detective-cjs/-/detective-cjs-3.1.1.tgz#18da3e39a002d2098a1123d45ce1de1b0d9045a0"
+  integrity sha512-JQtNTBgFY6h8uT6pgph5QpV3IyxDv+z3qPk/FZRDT9TlFfm5dnRtpH39WtQEr1khqsUxVqXzKjZHpdoQvQbllg==
+  dependencies:
+    ast-module-types "^2.4.0"
+    node-source-walk "^4.0.0"
+
+detective-es6@^2.1.0, detective-es6@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/detective-es6/-/detective-es6-2.2.0.tgz#8f2baba3f8cd90a5cfd748f5ac436f0158ed2585"
+  integrity sha512-fSpNY0SLER7/sVgQZ1NxJPwmc9uCTzNgdkQDhAaj8NPYwr7Qji9QBcmbNvtMCnuuOGMuKn3O7jv0An+/WRWJZQ==
+  dependencies:
+    node-source-walk "^4.0.0"
+
+detective-less@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/detective-less/-/detective-less-1.0.2.tgz#a68af9ca5f69d74b7d0aa190218b211d83b4f7e3"
+  integrity sha512-Rps1xDkEEBSq3kLdsdnHZL1x2S4NGDcbrjmd4q+PykK5aJwDdP5MBgrJw1Xo+kyUHuv3JEzPqxr+Dj9ryeDRTA==
+  dependencies:
+    debug "^4.0.0"
+    gonzales-pe "^4.2.3"
+    node-source-walk "^4.0.0"
+
+detective-postcss@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detective-postcss/-/detective-postcss-4.0.0.tgz#24e69b465e5fefe7a6afd05f7e894e34595dbf51"
+  integrity sha512-Fwc/g9VcrowODIAeKRWZfVA/EufxYL7XfuqJQFroBKGikKX83d2G7NFw6kDlSYGG3LNQIyVa+eWv1mqre+v4+A==
+  dependencies:
+    debug "^4.1.1"
+    is-url "^1.2.4"
+    postcss "^8.1.7"
+    postcss-values-parser "^2.0.1"
+
+detective-sass@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/detective-sass/-/detective-sass-3.0.1.tgz#496b819efd1f5c4dd3f0e19b43a8634bdd6927c4"
+  integrity sha512-oSbrBozRjJ+QFF4WJFbjPQKeakoaY1GiR380NPqwdbWYd5wfl5cLWv0l6LsJVqrgWfFN1bjFqSeo32Nxza8Lbw==
+  dependencies:
+    debug "^4.1.1"
+    gonzales-pe "^4.2.3"
+    node-source-walk "^4.0.0"
+
+detective-scss@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detective-scss/-/detective-scss-2.0.1.tgz#06f8c21ae6dedad1fccc26d544892d968083eaf8"
+  integrity sha512-VveyXW4WQE04s05KlJ8K0bG34jtHQVgTc9InspqoQxvnelj/rdgSAy7i2DXAazyQNFKlWSWbS+Ro2DWKFOKTPQ==
+  dependencies:
+    debug "^4.1.1"
+    gonzales-pe "^4.2.3"
+    node-source-walk "^4.0.0"
+
+detective-stylus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detective-stylus/-/detective-stylus-1.0.0.tgz#50aee7db8babb990381f010c63fabba5b58e54cd"
+  integrity sha1-UK7n24uruZA4HwEMY/q7pbWOVM0=
+
+detective-typescript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/detective-typescript/-/detective-typescript-6.0.0.tgz#394062118d7c7da53425647ca41e0081169aa2b3"
+  integrity sha512-vTidcSDK3QostdbrH2Rwf9FhvrgJ4oIaVw5jbolgruTejexk6nNa9DShGpuS8CFVDb1IP86jct5BaZt1wSxpkA==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "^4.8.2"
+    ast-module-types "^2.7.1"
+    node-source-walk "^4.2.0"
+    typescript "^3.9.7"
+
+detective-typescript@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/detective-typescript/-/detective-typescript-7.0.0.tgz#8c8917f2e51d9e4ee49821abf759ff512dd897f2"
+  integrity sha512-y/Ev98AleGvl43YKTNcA2Q+lyFmsmCfTTNWy4cjEJxoLkbobcXtRS0Kvx06daCgr2GdtlwLfNzL553BkktfJoA==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "^4.8.2"
+    ast-module-types "^2.7.1"
+    node-source-walk "^4.2.0"
+    typescript "^3.9.7"
 
 dex@./modules/dex:
   version "1.0.0"
@@ -5064,6 +5215,14 @@ engine.io-parser@~2.2.0:
     blob "0.0.5"
     has-binary2 "~1.0.2"
 
+enhanced-resolve@^5.3.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
+  integrity sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enhanced-resolve@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz#525c5d856680fbd5052de453ac83e32049958b5c"
@@ -5262,6 +5421,18 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+escodegen@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
+  integrity sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-config-prettier@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz#4ef1eaf97afe5176e6a75ddfb57c335121abc5a6"
@@ -5380,7 +5551,7 @@ espree@^7.3.0, espree@^7.3.1:
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
 
-esprima@^4.0.0, esprima@^4.0.1:
+esprima@4.0.1, esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -5717,6 +5888,25 @@ filelist@^1.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+filing-cabinet@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/filing-cabinet/-/filing-cabinet-3.0.0.tgz#08f9ceec5134f4a662926dd45b8a26eca1b5f622"
+  integrity sha512-o8Qac5qxZ1uVidR4Sd7ZQbbqObFZlqXU4xu1suAYg9PQPcQFNTzOmxQa/MehIDMgIvXHTb42mWPNV9l3eHBPSw==
+  dependencies:
+    app-module-path "^2.2.0"
+    commander "^2.20.3"
+    debug "^4.3.1"
+    decomment "^0.9.3"
+    enhanced-resolve "^5.3.2"
+    is-relative-path "^1.0.2"
+    module-definition "^3.3.1"
+    module-lookup-amd "^7.0.0"
+    resolve "^1.19.0"
+    resolve-dependency-path "^2.0.0"
+    sass-lookup "^3.0.0"
+    stylus-lookup "^3.0.1"
+    typescript "^3.9.7"
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -5810,6 +6000,11 @@ flatted@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
+
+flatten@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
+  integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
 fn.name@1.x.x:
   version "1.1.0"
@@ -5972,6 +6167,14 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+get-amd-module-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-amd-module-type/-/get-amd-module-type-3.0.0.tgz#bb334662fa04427018c937774570de495845c288"
+  integrity sha512-99Q7COuACPfVt18zH9N4VAMyb81S6TUgJm2NgV6ERtkh9VIkAaByZkW530wl3lLN5KTtSrK9jVLxYsoP5hQKsw==
+  dependencies:
+    ast-module-types "^2.3.2"
+    node-source-walk "^4.0.0"
+
 get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -5985,6 +6188,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
+  integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
 
 get-stdin@^8.0.0:
   version "8.0.0"
@@ -6166,7 +6374,7 @@ globjoin@^0.1.4:
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
 
-gonzales-pe@^4.3.0:
+gonzales-pe@^4.2.3, gonzales-pe@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.3.0.tgz#fe9dec5f3c557eead09ff868c65826be54d067b3"
   integrity sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==
@@ -6251,6 +6459,13 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3, 
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
+
+graphviz@0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/graphviz/-/graphviz-0.0.9.tgz#0bbf1df588c6a92259282da35323622528c4bbc4"
+  integrity sha512-SmoY2pOtcikmMCqCSy2NO1YsRfu9OO0wpTlOYW++giGjfX1a6gax/m1Fo8IdUd0/3H15cTOfR1SMKwohj4LKsg==
+  dependencies:
+    temp "~0.4.0"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -7032,6 +7247,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
 is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
@@ -7072,10 +7292,20 @@ is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.2:
     call-bind "^1.0.2"
     has-symbols "^1.0.1"
 
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+
 is-regexp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-2.1.0.tgz#cd734a56864e23b956bf4e7c66c396a4c0b22c2d"
   integrity sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==
+
+is-relative-path@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-relative-path/-/is-relative-path-1.0.2.tgz#091b46a0d67c1ed0fe85f1f8cfdde006bb251d46"
+  integrity sha1-CRtGoNZ8HtD+hfH4z93gBrslHUY=
 
 is-running@^2.1.0:
   version "2.1.0"
@@ -7129,6 +7359,11 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -8140,6 +8375,34 @@ lzma-native@^6.0.1:
     readable-stream "^2.3.5"
     rimraf "^2.7.1"
 
+madge@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/madge/-/madge-4.0.2.tgz#56a3aff8021a5844f8713e0789f6ee94095f2f41"
+  integrity sha512-l5bnA2dvyk0azLKDbOTCI+wDZ6nB007PhvPdmiYlPmqwVi49JPbhQrH/t4u8E6Akp3gwji1GZuA+v/F5q6yoWQ==
+  dependencies:
+    chalk "^4.1.0"
+    commander "^6.2.1"
+    commondir "^1.0.1"
+    debug "^4.0.1"
+    dependency-tree "^8.0.0"
+    detective-amd "^3.0.1"
+    detective-cjs "^3.1.1"
+    detective-es6 "^2.1.0"
+    detective-less "^1.0.2"
+    detective-postcss "^4.0.0"
+    detective-sass "^3.0.1"
+    detective-scss "^2.0.1"
+    detective-stylus "^1.0.0"
+    detective-typescript "^7.0.0"
+    graphviz "0.0.9"
+    ora "^5.1.0"
+    pluralize "^8.0.0"
+    precinct "^7.0.0"
+    pretty-ms "^7.0.0"
+    rc "^1.2.7"
+    typescript "^3.9.5"
+    walkdir "^0.4.1"
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -8557,6 +8820,25 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+module-definition@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/module-definition/-/module-definition-3.3.1.tgz#fedef71667713e36988b93d0626a4fe7b35aebfc"
+  integrity sha512-kLidGPwQ2yq484nSD+D3JoJp4Etc0Ox9P0L34Pu/cU4X4HcG7k7p62XI5BBuvURWMRX3RPyuhOcBHbKus+UH4A==
+  dependencies:
+    ast-module-types "^2.7.1"
+    node-source-walk "^4.0.0"
+
+module-lookup-amd@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/module-lookup-amd/-/module-lookup-amd-7.0.1.tgz#d67c1a93f2ff8e38b8774b99a638e9a4395774b2"
+  integrity sha512-w9mCNlj0S8qviuHzpakaLVc+/7q50jl9a/kmJ/n8bmXQZgDPkQHnPBb8MUOYh3WpAYkXuNc2c+khsozhIp/amQ==
+  dependencies:
+    commander "^2.8.1"
+    debug "^4.1.0"
+    glob "^7.1.6"
+    requirejs "^2.3.5"
+    requirejs-config-file "^4.0.0"
+
 moo@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
@@ -8600,6 +8882,11 @@ nanoid@^3.1.20:
   version "3.1.22"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
   integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
+
+nanoid@^3.1.23:
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
+  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -8833,6 +9120,13 @@ node-releases@^1.1.71:
   version "1.1.72"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.72.tgz#14802ab6b1039a79a0c7d662b610a5bbd76eacbe"
   integrity sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==
+
+node-source-walk@^4.0.0, node-source-walk@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/node-source-walk/-/node-source-walk-4.2.0.tgz#c2efe731ea8ba9c03c562aa0a9d984e54f27bc2c"
+  integrity sha512-hPs/QMe6zS94f5+jG3kk9E7TNm4P2SulrKiLWMzKszBfNZvL/V6wseHlTd7IvfW0NZWqPtK3+9yYNr+3USGteA==
+  dependencies:
+    "@babel/parser" "^7.0.0"
 
 nomnom@1.8.1:
   version "1.8.1"
@@ -9295,6 +9589,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 parse-uri@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/parse-uri/-/parse-uri-1.0.3.tgz#f3c24a74907a4e357c1741e96ca9faadecfd6db5"
@@ -9481,6 +9780,11 @@ plist@^3.0.1:
     xmlbuilder "^9.0.7"
     xmldom "^0.5.0"
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 pngjs@^3.3.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
@@ -9593,6 +9897,15 @@ postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
+postcss-values-parser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f"
+  integrity sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
 postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.6:
   version "7.0.35"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
@@ -9601,6 +9914,15 @@ postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.1.7:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.3.tgz#ef412a7a67e85c5b2c9f0ab3c4d9e8a3814d55cc"
+  integrity sha512-gnXd9C4bGKevvlNFd80I8WfxHX+g6MR+W2h19PlDNHUuT9248rHTvCIDeZI3Hvs5mB3gzXiNDwVK3S153WJbZA==
+  dependencies:
+    colorette "^1.2.2"
+    nanoid "^3.1.23"
+    source-map-js "^0.6.2"
 
 postcss@^8.2.8:
   version "8.2.8"
@@ -9631,6 +9953,44 @@ prebuild-install@^5.3.4:
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
+
+precinct@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/precinct/-/precinct-7.1.0.tgz#a0311e0b59029647eaf57c2d30b8efa9c85d129a"
+  integrity sha512-I1RkW5PX51/q6Xl39//D7x9NgaKNGHpR5DCNaoxP/b2+KbzzXDNhauJUMV17KSYkJA41CSpwYUPRtRoNxbshWA==
+  dependencies:
+    commander "^2.20.3"
+    debug "^4.3.1"
+    detective-amd "^3.0.1"
+    detective-cjs "^3.1.1"
+    detective-es6 "^2.2.0"
+    detective-less "^1.0.2"
+    detective-postcss "^4.0.0"
+    detective-sass "^3.0.1"
+    detective-scss "^2.0.1"
+    detective-stylus "^1.0.0"
+    detective-typescript "^6.0.0"
+    module-definition "^3.3.1"
+    node-source-walk "^4.2.0"
+
+precinct@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/precinct/-/precinct-8.1.0.tgz#6b8f2389ba2ca61c466731390b0d7e25da3fd996"
+  integrity sha512-oeZBR9IdER42Ef6Rz11z1oOUqicsI5J1Qffj6tYghKLhxN2UnHy7uE1axxNr0VZRevPK2HWkROk36uXrbJwHFA==
+  dependencies:
+    commander "^2.20.3"
+    debug "^4.3.1"
+    detective-amd "^3.0.1"
+    detective-cjs "^3.1.1"
+    detective-es6 "^2.2.0"
+    detective-less "^1.0.2"
+    detective-postcss "^4.0.0"
+    detective-sass "^3.0.1"
+    detective-scss "^2.0.1"
+    detective-stylus "^1.0.0"
+    detective-typescript "^7.0.0"
+    module-definition "^3.3.1"
+    node-source-walk "^4.2.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -9689,6 +10049,13 @@ pretty-format@^26.6.2:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
+
+pretty-ms@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.1.tgz#7d903eaab281f7d8e03c66f867e239dc32fb73e8"
+  integrity sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==
+  dependencies:
+    parse-ms "^2.1.0"
 
 private@^0.1.8:
   version "0.1.8"
@@ -10604,6 +10971,19 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+requirejs-config-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/requirejs-config-file/-/requirejs-config-file-4.0.0.tgz#4244da5dd1f59874038cc1091d078d620abb6ebc"
+  integrity sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw==
+  dependencies:
+    esprima "^4.0.0"
+    stringify-object "^3.2.1"
+
+requirejs@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.6.tgz#e5093d9601c2829251258c0b9445d4d19fa9e7c9"
+  integrity sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==
+
 reselect@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
@@ -10626,6 +11006,11 @@ resolve-cwd@^3.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
+resolve-dependency-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-dependency-path/-/resolve-dependency-path-2.0.0.tgz#11700e340717b865d216c66cabeb4a2a3c696736"
+  integrity sha512-DIgu+0Dv+6v2XwRaNWnumKu7GPufBBOr5I1gRPJHkvghrfCGOooJODFvgFimX/KRxk9j0whD2MnKHzM1jYvk9w==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -10646,7 +11031,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.9.0:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -10860,6 +11245,13 @@ sanitize-filename@^1.6.2, sanitize-filename@^1.6.3:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
+sass-lookup@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/sass-lookup/-/sass-lookup-3.0.0.tgz#3b395fa40569738ce857bc258e04df2617c48cac"
+  integrity sha512-TTsus8CfFRn1N44bvdEai1no6PqdmDiQUiqW5DlpmtT+tYnIt1tXtDIph5KA1efC+LmioJXSnCtUVpcK9gaKIg==
+  dependencies:
+    commander "^2.16.0"
+
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -10958,6 +11350,13 @@ semver@^7.1.2, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -11223,6 +11622,11 @@ source-list-map@^2.0.0, source-list-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -11483,6 +11887,15 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-object@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -11637,6 +12050,14 @@ stylis@^3.5.0:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
+stylus-lookup@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stylus-lookup/-/stylus-lookup-3.0.2.tgz#c9eca3ff799691020f30b382260a67355fefdddd"
+  integrity sha512-oEQGHSjg/AMaWlKe7gqsnYzan8DLcGIHe0dUaFkucZZ14z4zjENRlQMCHT4FNsiWnJf17YN9OvrCfCoi7VvOyg==
+  dependencies:
+    commander "^2.8.1"
+    debug "^4.1.0"
+
 sugarss@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-2.0.0.tgz#ddd76e0124b297d40bf3cca31c8b22ecb43bc61d"
@@ -11763,6 +12184,11 @@ temp-file@^3.3.7:
   dependencies:
     async-exit-hook "^2.0.1"
     fs-extra "^8.1.0"
+
+temp@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.4.0.tgz#671ad63d57be0fe9d7294664b3fc400636678a60"
+  integrity sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -11984,7 +12410,7 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -11993,6 +12419,13 @@ tslib@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@^0.0.1:
   version "0.0.1"
@@ -12084,6 +12517,11 @@ typeforce@^1.11.3:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
+
+typescript@^3.9.5, typescript@^3.9.7:
+  version "3.9.9"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
+  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"
@@ -12453,7 +12891,7 @@ wait-for-expect@^3.0.2:
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
   integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
-walkdir@^0.4.0:
+walkdir@^0.4.0, walkdir@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.4.1.tgz#dc119f83f4421df52e3061e514228a2db20afa39"
   integrity sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==


### PR DESCRIPTION
This reduces the dependencies to third party packages in the main electron and preload script layers of the application. 

This improves the codebase by relying less on third party code, slightly reduces compilation time and improves security by reducing the attack surface of a possible supply chain attack.

The main changes introduced by this PR are:
  - Add a script that can generate graphs for the dependency tree of each layer of the application
    - This was added as the first commit so that dependencies before and after the refactor can be checked by doing a `node ./scripts/generateDepGraphs.js`
  - Remove the now unneeded (due to updated electron version) intl-relativetimeformat polyfill
  - Reduce (but not yet eliminate) dependency on lodash by performing specific imports and functions
  - Remove the need to import the `wallet` by moving the single outstanding dependency directly into the `main_dev` package
  - Remove the dependency to the `websocket' (`ws`) library by using the `jsonrpc` api on dcrd in post mode (instead of websocket mode)
- Switch from using the `fs-extra` package to the node standard `fs` (we don't use any of the additional features offered by `fs-extra`)
- Run `yarn-deduplicate`

The script added to generate graphs of the app's dependencies generates a link to [npmgraphs.js.org](https://npmgraphs.js.org) which can be used to compare transitive dependencies as specified in the npm registry:

### Before this PR

- [Main electron layer](https://npmgraph.js.org/?q=%40formatjs%2C%40grpc%2Cbs58%40%5E4.0.1%2Cbs58check%40%5E2.1.1%2Cdom-helpers%40%5E3.4.0%2Celectron-store%40%5E7.0.2%2Cfs-extra%40%5E9.1.0%2Cgoogle-protobuf%40%5E3.15.6%2Cini%40%5E2.0.0%2Cint64-buffer%40%5E1.0.0%2Cis-running%40%5E2.1.0%2Clodash%40%5E4.17.14%2Clogform%2Cminimist%40%5E1.2.3%2Cqr-image%40%5E3.2.0%2Creact-dom%40%5E16.13.0%2Creact%40%5E16.13.0%2Creselect%40%5E4.0.0%2Cstring-argv%40%5E0.3.1%2Cwinston%40%5E3.3.3%2Cws%40%5E7.4.4) - 104 Modules
- [Preload layer](https://npmgraph.js.org/?q=%40grpc%2Cblake-hash%40%5E2.0.0%2Cbs58%40%5E4.0.1%2Cbs58check%40%5E2.1.1%2Cdom-helpers%40%5E3.4.0%2Cfs-extra%40%5E9.1.0%2Cgoogle-protobuf%40%5E3.15.6%2Cint64-buffer%40%5E1.0.0%2Clodash%40%5E4.17.14%2Cqr-image%40%5E3.2.0%2Creact-dom%40%5E16.13.0%2Creact%40%5E16.13.0) - 38 Modules

### After this PR:

- [Main electron layer](https://npmgraph.js.org/?q=electron-store%40%5E7.0.2%2Cini%40%5E2.0.0%2Cis-running%40%5E2.1.0%2Clogform%2Cminimist%40%5E1.2.3%2Cstring-argv%40%5E0.3.1%2Cwinston%40%5E3.3.3) - 71 Modules
- [Preload layer](https://npmgraph.js.org/?q=%40grpc%2Cblake-hash%40%5E2.0.0%2Cbs58%40%5E4.0.1%2Cbs58check%40%5E2.1.1%2Cgoogle-protobuf%40%5E3.15.6%2Cint64-buffer%40%5E1.0.0%2Clodash%40%5E4.17.14%2Cqr-image%40%5E3.2.0) - 22 Modules

Note that the dependency to `electron` (and `electron-devtools-installer` in the main layer) are ignored in the graphs due to them being implicitly required, and their absence making the graphs slightly easier to read.

After this PR, the main electron layer only has two top-level dependencies which themselves have a large number of transitive deps: `winston` and `electron-store`. Given those two are going to demand slightly more work to replace, I've left them to be refactored in future PRs.