### PR TITLE
PreCreateWallet: Replace more name chars.

### DIFF
--- a/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
@@ -48,8 +48,12 @@ const PreCreateWallet = ({
     (newWalletName) => {
       setHasFailedAttemptName(true);
       let nameAvailable = true;
-      // replace all special path symbols
-      newWalletName = newWalletName.replace(/[/\\.;:~]/g, "");
+      const replaceNameChars = /[`!@#$%^&*()=[\]{};'"\\|,.<>/?~]/;
+      // Replace all special path symbols except for space, _, -, :, and +.
+      newWalletName = newWalletName.replace(replaceNameChars, "");
+      // Remove leading spaces.
+      if (newWalletName.length > 0 && newWalletName[0] === " ")
+        newWalletName = newWalletName.slice(1);
       for (let i = 0; i < availableWallets.length; i++) {
         if (newWalletName == availableWallets[i].value.wallet) {
           nameAvailable = false;

--- a/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
@@ -48,8 +48,16 @@ const PreCreateWallet = ({
     (newWalletName) => {
       setHasFailedAttemptName(true);
       let nameAvailable = true;
-      const replaceNameChars = /[`!@#$%^&*()=[\]{};'"\\|,.<>/?~]/;
-      // Replace all special path symbols except for space, _, -, :, and +.
+      // Users should be able to (at least in principle) use any wallet name
+      // they so choose. However, certain special chars need to be explicitly
+      // filtered due to us directly using the wallet name as part of the path
+      // to the wallet's files. The list of chars that need to be filtered out
+      // are:
+      //
+      // Filesystem related chars: /\.:
+      // Escaped when stored in dcrwallet.conf ini files: ;#[]
+      // Specially handled by dcrwallet: $%~
+      const replaceNameChars = /[/\\.:;#[\]$%~]/;
       newWalletName = newWalletName.replace(replaceNameChars, "");
       // Remove leading spaces.
       if (newWalletName.length > 0 && newWalletName[0] === " ")

--- a/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
+++ b/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
@@ -10,7 +10,7 @@ import * as trza from "actions/TrezorActions";
 import * as ca from "actions/ControlActions";
 
 const testWalletName = "test-wallet-name";
-const invalidCharacters = "/.;:~";
+const invalidCharacters = "`!@#$%^&*()=[]{};'\"\\|,.<>/?~";
 const testWalletCreateErrorMsg = "test-error-msg";
 const usedTestWalletName = "usedTestWalletName";
 const testWalletCreationMasterPubKey = "test-wallet-creation-master-pubkey";

--- a/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
+++ b/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
@@ -10,7 +10,7 @@ import * as trza from "actions/TrezorActions";
 import * as ca from "actions/ControlActions";
 
 const testWalletName = "test-wallet-name";
-const invalidCharacters = "`!@#$%^&*()=[]{};'\"\\|,.<>/?~";
+const invalidCharacters = "/\\.:;#[]$%~";
 const testWalletCreateErrorMsg = "test-error-msg";
 const usedTestWalletName = "usedTestWalletName";
 const testWalletCreationMasterPubKey = "test-wallet-creation-master-pubkey";


### PR DESCRIPTION
    Disallow some problematic characters in wallet names.

closes #3359

This works in the same way it did before, just adds a few more characters to the replace and doesn't allow for leading spaces. space, +, -, _, and : look to be fine on linux, but Windows may be more restrictive. Will test there if noone else can. Parenthesis and brackets may also be fine and used by some people. Allow?