### PR TITLE
Fix details of transactions

### DIFF
--- a/app/selectors.js
+++ b/app/selectors.js
@@ -425,7 +425,7 @@ export const ticketNormalizer = createSelector(
         blockHash,
         rawTx,
         isStake,
-        timestamp,
+        height,
         feeStatus
       } = ticket;
       // TODO refactor same code to be used in tickets and regular tx normalizers.
@@ -437,7 +437,7 @@ export const ticketNormalizer = createSelector(
       const txOutputs = [];
       const hasSpender = spender && spender.hash;
       const isVote = status === VOTED;
-      const isPending = !timestamp;
+      const isPending = height <= 0;
       // Some legacy vsp fees wallet will have tickets without `ticket` field
       // and only with `spender` so we use it as fallback
       const ticketTx = ticket.ticket || ticket.spender;
@@ -739,7 +739,7 @@ export const transactionNormalizer = createSelector(
         txHeight: height,
         txType,
         timestamp,
-        isPending: !timestamp,
+        isPending: height <= 0,
         txFee: fee,
         txInputs,
         txOutputs,

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -268,7 +268,7 @@ export const getTransaction = (walletService, txHash) =>
       const block = {
         getHash: resp.getBlockHash,
         getHeight: () => -1,
-        getTimestamp: () => -1
+        getTimestamp: () => null
       };
       const index = -1; // wallet.GetTransaction doesn't return the index
       const tx = formatTransaction(block, resp.getTransaction(), index);


### PR DESCRIPTION
Closes #3507

In this diff:
- tx's `isPending` property is determined from the block height instead of timestamp. 
- from `getTransaction` (service.js) the `formatTransaction` function is called with `null` block timestamp instead of -1 making sure that timestamp will be set using transaction's timestamp here: https://github.com/decred/decrediton/blob/7a152c1bae5bd914ee7f0e482bfaef13efdccb06/app/wallet/service.js#L156-L158