### PR TITLE
[Multi] Confirm access to VSPs via BrowserView dialog

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1321,3 +1321,12 @@ export const stopMonitorLockableAccounts = () => (dispatch, getState) => {
   monitorLockableAccountsTimer && clearInterval(monitorLockableAccountsTimer);
   dispatch({ type: MONITORLOCKACBLEACCOUNTS_STOPPED });
 };
+
+export const CONFIRMATIONDIALOG_REQUESTED = "CONFIRMATIONDIALOG_REQUESTED";
+export const CONFIRMATIONDIALOG_HIDDEN = "CONFIRMATIONDIALOG_HIDDEN";
+
+export const listenForConfirmationDialogRequests = () => (dispatch) => {
+  const requestedCb = () => dispatch({ type: CONFIRMATIONDIALOG_REQUESTED });
+  const hiddenCb = () => dispatch({ type: CONFIRMATIONDIALOG_HIDDEN })
+  wallet.onConfirmationDialogCallbacks(requestedCb, hiddenCb);
+};

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1327,6 +1327,6 @@ export const CONFIRMATIONDIALOG_HIDDEN = "CONFIRMATIONDIALOG_HIDDEN";
 
 export const listenForConfirmationDialogRequests = () => (dispatch) => {
   const requestedCb = () => dispatch({ type: CONFIRMATIONDIALOG_REQUESTED });
-  const hiddenCb = () => dispatch({ type: CONFIRMATIONDIALOG_HIDDEN })
+  const hiddenCb = () => dispatch({ type: CONFIRMATIONDIALOG_HIDDEN });
   wallet.onConfirmationDialogCallbacks(requestedCb, hiddenCb);
 };

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -662,7 +662,7 @@ export const getVSPsPubkeys = () => async (dispatch) => {
       } catch (error) {
         // Skip to the next vsp.
       }
-    };
+    }
     dispatch({ type: GETVSPSPUBKEYS_SUCCESS, availableVSPsPubkeys });
   } catch (error) {
     dispatch({ type: GETVSPSPUBKEYS_FAILED, error });
@@ -816,7 +816,7 @@ export const setVSPDVoteChoices = (passphrase) => async (
       // TODO: this should be tracked so that users know this VSP isn't voting
       // according to their wishes.
     }
-  };
+  }
   try {
     dispatch({ type: SETVSPDVOTECHOICE_ATTEMPT });
     const walletService = sel.walletService(getState());

--- a/app/components/modals/ConfirmationDialogModal/ConfirmationDialogModal.jsx
+++ b/app/components/modals/ConfirmationDialogModal/ConfirmationDialogModal.jsx
@@ -11,10 +11,7 @@ const ConfirmationDialogModal = ({ ...props }) => {
     dispatch(ca.listenForConfirmationDialogRequests());
   }, [dispatch]);
 
-  return (
-    <Modal show={show} { ...props } >
-    </Modal>
-  );
+  return <Modal show={show} {...props}></Modal>;
 };
 
 export default ConfirmationDialogModal;

--- a/app/components/modals/ConfirmationDialogModal/ConfirmationDialogModal.jsx
+++ b/app/components/modals/ConfirmationDialogModal/ConfirmationDialogModal.jsx
@@ -1,0 +1,20 @@
+import { useDispatch, useSelector } from "react-redux";
+import { useEffect } from "react";
+import * as sel from "selectors";
+import * as ca from "actions/ControlActions";
+import Modal from "../Modal";
+
+const ConfirmationDialogModal = ({ ...props }) => {
+  const show = useSelector(sel.confirmationDialogModalVisible);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(ca.listenForConfirmationDialogRequests());
+  }, [dispatch]);
+
+  return (
+    <Modal show={show} { ...props } >
+    </Modal>
+  );
+};
+
+export default ConfirmationDialogModal;

--- a/app/components/modals/ConfirmationDialogModal/index.js
+++ b/app/components/modals/ConfirmationDialogModal/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ConfirmationDialogModal";

--- a/app/components/modals/Modal/Modal.jsx
+++ b/app/components/modals/Modal/Modal.jsx
@@ -16,6 +16,7 @@ const Modal = showCheck(({ children, className, draggable, onCancelModal }) => {
   } = useModal(onCancelModal);
 
   const domNode = document.getElementById("modal-portal");
+  if (!domNode) return null; // modal-portal not mounted yet.
 
   const innerView = (
     <div

--- a/app/components/modals/index.js
+++ b/app/components/modals/index.js
@@ -19,3 +19,4 @@ export { default as ListUTXOsModal } from "./ListUTXOsModal";
 export { default as AutoBuyerSettingsModal } from "./AutoBuyerSettingsModal";
 export { default as SetNewPassphraseModal } from "./SetNewPassphraseModal/SetNewPassphraseModal";
 export { default as AppPassAndPassphraseModal } from "./AppPassAndPassphraseModal/AppPassAndPassphraseModal";
+export { default as ConfirmationDialogModal } from "./ConfirmationDialogModal";

--- a/app/constants/config.js
+++ b/app/constants/config.js
@@ -11,6 +11,7 @@ export const SHOW_SPV_CHOICE = "show_spvchoice";
 export const SHOW_TUTORIAL = "show_tutorial";
 export const SHOW_PRIVACY = "show_privacy";
 export const ALLOWED_EXTERNAL_REQUESTS = "allowed_external_requests";
+export const ALLOWED_VSP_HOSTS = "allowed_vsp_hosts";
 export const PROXY_TYPE = "proxy_type";
 export const PROXY_LOCATION = "proxy_location";
 export const REMOTE_CREDENTIALS = "remote_credentials";
@@ -143,6 +144,7 @@ export const INITIAL_VALUES = {
   [SHOW_TUTORIAL]: true,
   [SHOW_PRIVACY]: true,
   [ALLOWED_EXTERNAL_REQUESTS]: [],
+  [ALLOWED_VSP_HOSTS]: [],
   [PROXY_TYPE]: null,
   [PROXY_LOCATION]: null,
   [REMOTE_CREDENTIALS]: {},

--- a/app/containers/App/App.jsx
+++ b/app/containers/App/App.jsx
@@ -9,7 +9,7 @@ import FatalErrorPage from "components/views/FatalErrorPage/FatalErrorPage";
 import Snackbar from "components/Snackbar";
 import TrezorModals from "components/modals/TrezorModals/TrezorModals";
 import { hot } from "react-hot-loader/root";
-import { CantCloseModals, AboutModal } from "modals";
+import { CantCloseModals, AboutModal, ConfirmationDialogModal } from "modals";
 import { useApp } from "../hooks";
 import styles from "./App.module.css";
 
@@ -47,6 +47,7 @@ const App = () => {
             onCancelModal={hideAboutModalMacOS}></AboutModal>
         </div>
         <TrezorModals />
+        <ConfirmationDialogModal />
         <div id="modal-portal-autobuyer-running">
           <CantCloseModals />
         </div>

--- a/app/index.js
+++ b/app/index.js
@@ -358,7 +358,8 @@ const initialState = {
     aboutModalMacOSVisible: false,
     cantCloseModalVisible: false,
     changeScriptByAccount: {},
-    monitorLockableAccountsTimer: null
+    monitorLockableAccountsTimer: null,
+    confirmationDialogModalVisible: false
   },
   snackbar: {
     messages: Array()

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -563,8 +563,10 @@ const setConfirmBrowserViewBounds = () => {
   const mainBounds = mainWindow.getBounds();
   const maxWidth = 540;
   const maxHeight = 380;
-  const width = mainBounds.width > maxWidth - 20 ? maxWidth : mainBounds.width - 20;
-  const height = mainBounds.height > maxHeight ? maxHeight : mainBounds.height - 20;
+  const width =
+    mainBounds.width > maxWidth - 20 ? maxWidth : mainBounds.width - 20;
+  const height =
+    mainBounds.height > maxHeight ? maxHeight : mainBounds.height - 20;
   const viewBounds = {
     x: Math.trunc((mainBounds.width - width) / 2),
     y: Math.trunc((mainBounds.height - height) / 2),
@@ -575,7 +577,10 @@ const setConfirmBrowserViewBounds = () => {
 };
 
 ipcMain.on("fill-confirmation-dialog-contents", (event, contents) => {
-  confirmBrowserView.webContents.send("fill-confirmation-dialog-contents", contents);
+  confirmBrowserView.webContents.send(
+    "fill-confirmation-dialog-contents",
+    contents
+  );
   mainWindow.setBrowserView(confirmBrowserView);
   confirmBrowserView.setBackgroundColor("#ffffffff");
   setConfirmBrowserViewBounds();
@@ -585,7 +590,10 @@ ipcMain.on("fill-confirmation-dialog-contents", (event, contents) => {
 ipcMain.on("confirmation-dialog-reply", (event, res) => {
   // Sanity check acceptance actually came from the confirmation BrowserView.
   if (event.sender.id !== confirmBrowserView.webContents.id) {
-    logger.log("error", "Confirmation reply came from incorrect sender webcontents");
+    logger.log(
+      "error",
+      "Confirmation reply came from incorrect sender webcontents"
+    );
     return;
   }
 
@@ -789,10 +797,13 @@ app.on("ready", async () => {
   confirmBrowserView.webContents.loadURL(confirmURL);
 
   // Ensure we close the confirmation modal if the main wallet UI Is reloaded.
-  mainWindow.webContents.on("did-start-navigation", (event, url, isInPlace, isMainFrame) => {
-    isMainFrame && !isInPlace && mainWindow.setBrowserView(null);
-    confirmBrowserView.webContents.reload();
-  });
+  mainWindow.webContents.on(
+    "did-start-navigation",
+    (event, url, isInPlace, isMainFrame) => {
+      isMainFrame && !isInPlace && mainWindow.setBrowserView(null);
+      confirmBrowserView.webContents.reload();
+    }
+  );
 
   // Re-center BrowserView on resizes. The events are different for linux and
   // windows/macOS.

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import parseArgs from "minimist";
-import { app, BrowserWindow, Menu, dialog } from "electron";
+import { app, BrowserWindow, Menu, dialog, BrowserView } from "electron";
 import {
   getCurrentBitcoinConfig,
   updateDefaultBitcoinConfig,
@@ -144,6 +144,7 @@ if (err !== null) {
 
 let menu;
 let mainWindow = null;
+let confirmBrowserView;
 let previousWallet = null;
 
 const globalCfg = initGlobalCfg();
@@ -558,6 +559,40 @@ ipcMain.on("get-cli-options", (event) => {
   event.returnValue = cliOptions;
 });
 
+const setConfirmBrowserViewBounds = () => {
+  const mainBounds = mainWindow.getBounds();
+  const maxWidth = 540;
+  const maxHeight = 380;
+  const width = mainBounds.width > maxWidth - 20 ? maxWidth : mainBounds.width - 20;
+  const height = mainBounds.height > maxHeight ? maxHeight : mainBounds.height - 20;
+  const viewBounds = {
+    x: Math.trunc((mainBounds.width - width) / 2),
+    y: Math.trunc((mainBounds.height - height) / 2),
+    width,
+    height
+  };
+  confirmBrowserView.setBounds(viewBounds);
+};
+
+ipcMain.on("fill-confirmation-dialog-contents", (event, contents) => {
+  confirmBrowserView.webContents.send("fill-confirmation-dialog-contents", contents);
+  mainWindow.setBrowserView(confirmBrowserView);
+  confirmBrowserView.setBackgroundColor("#ffffffff");
+  setConfirmBrowserViewBounds();
+  if (debug) confirmBrowserView.webContents.openDevTools();
+});
+
+ipcMain.on("confirmation-dialog-reply", (event, res) => {
+  // Sanity check acceptance actually came from the confirmation BrowserView.
+  if (event.sender.id !== confirmBrowserView.webContents.id) {
+    logger.log("error", "Confirmation reply came from incorrect sender webcontents");
+    return;
+  }
+
+  mainWindow.setBrowserView(null);
+  mainWindow.webContents.send("confirmation-webframe-reply", res);
+});
+
 ipcMain.handle("show-save-dialog", async () => {
   return await dialog.showSaveDialog();
 });
@@ -667,12 +702,14 @@ app.on("ready", async () => {
   }
 
   let url = `file://${__dirname}/dist/app.html`;
+  let confirmURL = `file://${__dirname}/dist/confirmation-dialog.html`;
   const path = require("path"); // eslint-disable-line
   const preloadPath = path.resolve(__dirname, "dist", "wallet-preload.js");
   if (process.env.NODE_ENV === "development") {
     // Load from the webpack dev server with hot module replacement.
     const port = process.env.PORT || 3000;
     url = `http://localhost:${port}/dist/app.html`;
+    confirmURL = `http://localhost:${port}/dist/confirmation-dialog.html`;
   }
 
   let windowOpts = {
@@ -740,6 +777,27 @@ app.on("ready", async () => {
   });
 
   if (stopSecondInstance) return;
+
+  // Load (but not yet display) the confirmation modal BrowserView.
+  confirmBrowserView = new BrowserView({
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+      devTools: debug
+    }
+  });
+  confirmBrowserView.webContents.loadURL(confirmURL);
+
+  // Ensure we close the confirmation modal if the main wallet UI Is reloaded.
+  mainWindow.webContents.on("did-start-navigation", (event, url, isInPlace, isMainFrame) => {
+    isMainFrame && !isInPlace && mainWindow.setBrowserView(null);
+    confirmBrowserView.webContents.reload();
+  });
+
+  // Re-center BrowserView on resizes. The events are different for linux and
+  // windows/macOS.
+  mainWindow.on("resized", setConfirmBrowserViewBounds);
+  mainWindow.on("resize", setConfirmBrowserViewBounds);
 
   setMenuLocale(locale);
 });

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -228,5 +228,5 @@ export const reloadAllowedExternalRequests = () => {
   cfgAllowedRequests.forEach((v) => allowExternalRequest(v));
 
   const cfgAllowedVSPs = globalCfg.get(cfgConstants.ALLOWED_VSP_HOSTS, []);
-  cfgAllowedVSPs.forEach(v => allowVSPRequests(v));
+  cfgAllowedVSPs.forEach((v) => allowVSPRequests(v));
 };

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -226,4 +226,7 @@ export const reloadAllowedExternalRequests = () => {
     []
   );
   cfgAllowedRequests.forEach((v) => allowExternalRequest(v));
+
+  const cfgAllowedVSPs = globalCfg.get(cfgConstants.ALLOWED_VSP_HOSTS, []);
+  cfgAllowedVSPs.forEach(v => allowVSPRequests(v));
 };

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -78,7 +78,9 @@ import {
   UNLOCKANDEXECFN_FAILED,
   UNLOCKANDEXECFN_SUCCESS,
   MONITORLOCKACBLEACCOUNTS_STARTED,
-  MONITORLOCKACBLEACCOUNTS_STOPPED
+  MONITORLOCKACBLEACCOUNTS_STOPPED,
+  CONFIRMATIONDIALOG_REQUESTED,
+  CONFIRMATIONDIALOG_HIDDEN
 } from "../actions/ControlActions";
 import { WALLET_AUTOBUYER_SETTINGS } from "actions/DaemonActions";
 import { CLOSEWALLET_SUCCESS } from "actions/WalletLoaderActions";
@@ -580,6 +582,16 @@ export default function control(state = {}, action) {
       return {
         ...state,
         unlockAndExecFnRunning: false
+      };
+    case CONFIRMATIONDIALOG_REQUESTED:
+      return {
+        ...state,
+        confirmationDialogModalVisible: true
+      };
+    case CONFIRMATIONDIALOG_HIDDEN:
+      return {
+        ...state,
+        confirmationDialogModalVisible: false
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1644,7 +1644,9 @@ export const aboutModalMacOSVisible = get([
 ]);
 export const cantCloseModalVisible = get(["control", "cantCloseModalVisible"]);
 
-export const confirmationDialogModalVisible = bool(get(["control", "confirmationDialogModalVisible"]));
+export const confirmationDialogModalVisible = bool(
+  get(["control", "confirmationDialogModalVisible"])
+);
 
 export const isTrezor = get(["trezor", "enabled"]);
 export const isPerformingTrezorUpdate = get(["trezor", "performingUpdate"]);

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1644,6 +1644,8 @@ export const aboutModalMacOSVisible = get([
 ]);
 export const cantCloseModalVisible = get(["control", "cantCloseModalVisible"]);
 
+export const confirmationDialogModalVisible = bool(get(["control", "confirmationDialogModalVisible"]));
+
 export const isTrezor = get(["trezor", "enabled"]);
 export const isPerformingTrezorUpdate = get(["trezor", "performingUpdate"]);
 

--- a/app/staticPages/confirmation-dialog.html
+++ b/app/staticPages/confirmation-dialog.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      const ipcRenderer = require("electron").ipcRenderer;
+
+      // Setup the callback to fill the contents of the confirmation div with
+      // HTML sent by the wallet preload script.
+      ipcRenderer.on("fill-confirmation-dialog-contents", (event, { title, content, theme }) => {
+        document.getElementById("title").innerHTML = title;
+        document.getElementById("content").innerHTML = content;
+        document.getElementById("body").className = "theme-" + theme;
+      });
+
+      function reply(res) {
+        const buttons = document.getElementById("buttons").getElementsByTagName("button");
+        ipcRenderer.send("confirmation-dialog-reply", res);
+      }
+    </script>
+
+    <style>
+      /*********** General CSS *****************/
+      .root {
+        padding: 0.5em 1em 2em 1em;
+        font-family: 'Source Sans Pro', sans-serif;
+      }
+
+      h1 {
+        font-size: 27px;
+        text-transform: capitalize;
+      }
+
+      #buttons {
+        display: flex;
+        justify-content: flex-end;
+        gap: 10px;
+      }
+
+      #buttons > button {
+        border: none;
+        padding: 12px 30px 14px 30px;
+        border-radius: 5px;
+        outline: none;
+        transition: all 100ms cubic-bezier(0.86, 0, 0.07, 1) 0s;
+        cursor: pointer;
+      }
+
+      .btnReject {
+        background-color: transparent;
+        box-shadow: none;
+      }
+
+      .btnAccept {
+        box-shadow: 0 5px 13px rgba(0, 0, 0, 0.21);
+        background-color: #2970ff;
+      }
+
+      /*********** Theme light *****************/
+
+      .theme-light .root {
+        color: #48566e;
+        background-color: white;
+      }
+
+      .theme-light .btnAccept {
+        color: white;
+      }
+
+      .theme-light .btnAccept:hover {
+        background-color: #1c4eb2;
+      }
+
+      .theme-light .btnReject {
+        color: #8997a5;
+      }
+
+      .theme-light .btnReject:hover {
+        color: #596d81;
+      }
+
+      /*********** Theme dark *****************/
+
+      .theme-dark .root {
+        color: #B7DEEE;
+        background-color: #223767;
+      }
+
+      .theme-dark .btnAccept {
+        color: #E9F8FE;
+      }
+
+      .theme-dark .btnAccept:hover {
+        background-color: #7ea9ff;
+      }
+
+      .theme-dark .btnReject {
+        color: #3C62B0;
+      }
+
+      .theme-dark .btnReject:hover {
+        color: #B7DEEE;
+      }
+    </style>
+  </head>
+
+  <body id="body">
+    <div class="root">
+      <h1 id="title">hey-o</h1>
+      <div id="content">Listen what I'm sayin'-o</div>
+      <div id="buttons">
+        <button class="btnReject" onclick="reply(false)">Reject</button>
+        <button class="btnAccept" onclick="reply(true)">Accept</button>
+      </div>
+    </div>
+    </body>
+</html>

--- a/app/staticPages/confirmation-dialog.html
+++ b/app/staticPages/confirmation-dialog.html
@@ -13,7 +13,6 @@
       });
 
       function reply(res) {
-        const buttons = document.getElementById("buttons").getElementsByTagName("button");
         ipcRenderer.send("confirmation-dialog-reply", res);
       }
     </script>

--- a/app/wallet/config.js
+++ b/app/wallet/config.js
@@ -16,8 +16,7 @@ export const getWalletCfg = (...args) => {
 //
 // TODO: switch to an allowlist mode instead, after identifying the relevant
 // entries and move setting code to the preload layer.
-const disallowedGlobalKeys = new Map().
-  set(cfgConstants.ALLOWED_VSP_HOSTS);
+const disallowedGlobalKeys = new Map().set(cfgConstants.ALLOWED_VSP_HOSTS);
 
 export const getGlobalCfg = (...args) => {
   const c = cfg.getGlobalCfg(...args);

--- a/app/wallet/config.js
+++ b/app/wallet/config.js
@@ -1,5 +1,6 @@
 import * as cfg from "../config";
 import * as paths from "main_dev/paths";
+import * as cfgConstants from "constants/config";
 
 export const getWalletCfg = (...args) => {
   const c = cfg.getWalletCfg(...args);
@@ -10,11 +11,24 @@ export const getWalletCfg = (...args) => {
   };
 };
 
+// This is a map that stores which keys cannot be directly set by UI code and
+// must be set only by preload script functions.
+//
+// TODO: switch to an allowlist mode instead, after identifying the relevant
+// entries and move setting code to the preload layer.
+const disallowedGlobalKeys = new Map().
+  set(cfgConstants.ALLOWED_VSP_HOSTS);
+
 export const getGlobalCfg = (...args) => {
   const c = cfg.getGlobalCfg(...args);
   return {
     get: (...args) => c.get(...args),
-    set: (...args) => c.set(...args),
+    set: (key, value) => {
+      if (disallowedGlobalKeys.has[key]) {
+        throw new Error(`Cannot set global config key '${key}' from UI code`);
+      }
+      c.set(key, value);
+    },
     delete: (...args) => c.delete(...args)
   };
 };

--- a/app/wallet/confirmationDialog/allowVspHost.js
+++ b/app/wallet/confirmationDialog/allowVspHost.js
@@ -1,0 +1,21 @@
+import { showConfirmationDialog, escape } from "./dialog";
+
+export default (host) =>
+  showConfirmationDialog({
+    title: {
+      id: "confDialog.allowVSPHost.title",
+      m: "Confirm Access to VSP Host"
+    },
+
+    content: [
+      "<p>",
+      {
+        id: "confDialog.allowVSPHost.message",
+        m: "Really allow network access to the following VSP host?"
+      },
+      "</p>",
+      "<p><pre>",
+      escape(host),
+      "</pre></p>"
+    ]
+  });

--- a/app/wallet/confirmationDialog/dialog.js
+++ b/app/wallet/confirmationDialog/dialog.js
@@ -1,0 +1,102 @@
+import { ipcRenderer } from "electron";
+import { encode as encodeAsHTML } from "he";
+import { default as locales } from "i18n/locales";
+import { getGlobalCfg } from "config";
+import { LOCALE, THEME } from "constants/config";
+
+let dialogRequestedCb, dialogHiddenCb;
+const globalCfg = getGlobalCfg();
+
+export const onConfirmationDialogCallbacks = (requested, hidden) => {
+  dialogRequestedCb = requested;
+  dialogHiddenCb = hidden;
+};
+
+export const escape = (s) => encodeAsHTML(s, { strict: true });
+
+const formatContent = (content) => {
+  const cfgLocale = globalCfg.get(LOCALE);
+  let locale = locales.find((value) => value.key === cfgLocale);
+  if (!locale) {
+    locale = locales.find((value) => value.key === "en");
+  }
+
+  const fmt = (id, defaultMsg) => {
+    let msg = defaultMsg;
+    if (locale.messages[id]) msg = escape(locale.messages[id]);
+    return msg;
+  };
+
+  const formattedContent = content.content.reduce((acc, v) => {
+    if (typeof v === "string") {
+      return acc + v;
+    }
+    if (typeof v === "object" && v.id && v.m) {
+      return acc + fmt(v.id, v.m);
+    }
+    return acc;
+  }, "");
+
+  return {
+    title: fmt(content.title.id, content.title.m),
+    content: formattedContent,
+    theme: globalCfg.get(THEME)
+  };
+};
+
+let showingConf;
+export const showConfirmationDialog = async (content) => {
+  // Protect against showing multiple instances of the confirmation modal.
+  if (showingConf) {
+    throw new Error("already showing confirmation");
+  }
+  showingConf = true;
+
+  // complete() will cleanup the state once we have a reply from the browser view.
+  const complete = () => {
+    dialogHiddenCb();
+    showingConf = false;
+  };
+
+  // Expose the functions of a promise. This promise will be returned from this
+  // function and its completion will determine whether the modal was accepted
+  // or rejected.
+  let okPromise, failPromise;
+  const resPromise = new Promise((ok, fail) => {
+    okPromise = (res) => {
+      complete();
+      ok(res);
+    };
+    failPromise = (err) => {
+      complete();
+      fail(err);
+    };
+  });
+
+  try {
+    if (!dialogRequestedCb) {
+      throw new Error("Confirmation dialog CB not setup");
+    }
+
+    // Request main UI to show confirmation modal (blurs background).
+    await dialogRequestedCb();
+
+    ipcRenderer.once("confirmation-webframe-reply", (event, res) => {
+      if (!res) {
+        res = new Error("User rejected confirmation");
+      }
+      if (res instanceof Error) {
+        failPromise(res);
+        return;
+      }
+
+      okPromise(res);
+    });
+
+    ipcRenderer.send("fill-confirmation-dialog-contents", formatContent(content));
+  } catch (error) {
+    failPromise(error);
+  }
+
+  return resPromise;
+};

--- a/app/wallet/confirmationDialog/dialog.js
+++ b/app/wallet/confirmationDialog/dialog.js
@@ -93,7 +93,10 @@ export const showConfirmationDialog = async (content) => {
       okPromise(res);
     });
 
-    ipcRenderer.send("fill-confirmation-dialog-contents", formatContent(content));
+    ipcRenderer.send(
+      "fill-confirmation-dialog-contents",
+      formatContent(content)
+    );
   } catch (error) {
     failPromise(error);
   }

--- a/app/wallet/confirmationDialog/index.js
+++ b/app/wallet/confirmationDialog/index.js
@@ -1,0 +1,2 @@
+export { onConfirmationDialogCallbacks } from "./dialog";
+export { default as allowVSPHost } from "./allowVspHost";

--- a/app/wallet/index.js
+++ b/app/wallet/index.js
@@ -14,4 +14,8 @@ export * from "./version";
 export * from "./politeia";
 export * from "./config";
 
+// These exports are named explicitly to ensure the UI isn't given
+// indiscriminate access to the confirmation dialog visibility functions.
+export { onConfirmationDialogCallbacks } from "./confirmationDialog";
+
 export const TransactionType = api.TransactionDetails.TransactionType;

--- a/app/wallet/vsp.js
+++ b/app/wallet/vsp.js
@@ -60,7 +60,7 @@ const addAllowedVSPsInCfg = (hosts) => {
   const c = cfg.getGlobalCfg();
   const newHosts = c.get(cfgConstants.ALLOWED_VSP_HOSTS);
   const oldHostsLen = newHosts.length;
-  hosts.forEach(vsp => newHosts.indexOf(vsp) === -1 && newHosts.push(vsp));
+  hosts.forEach((vsp) => newHosts.indexOf(vsp) === -1 && newHosts.push(vsp));
   if (oldHostsLen !== newHosts.length) {
     c.set(cfgConstants.ALLOWED_VSP_HOSTS, newHosts);
     return true;
@@ -69,41 +69,35 @@ const addAllowedVSPsInCfg = (hosts) => {
   return false;
 };
 
-export const getAllVSPs = withLogNoData(
-  async () => {
-    const res = await new Promise((ok, fail) =>
-      api.getAllVspsInfo((res, err) => (err ? fail(err) : ok(res)))
-    );
+export const getAllVSPs = withLogNoData(async () => {
+  const res = await new Promise((ok, fail) =>
+    api.getAllVspsInfo((res, err) => (err ? fail(err) : ok(res)))
+  );
 
-    // Allow access to all VSPs returned by the official VSP listing endpoint.
-    // This is less then ideal because this endpoint might eventually return
-    // domains that switched owners or that are otherwise available for hijack,
-    // but is needed due to Decrediton (currently) having to iterate over all
-    // existing VSPs to discover their pubkey and sync tickets.
-    //
-    // Eventually this can be further locked down once that iteration isn't
-    // performed any more and VSPs are only accessed when attempting to purchase
-    // a ticket.
-    const hosts = res.map(vsp => "https://"+vsp.host);
-    if (addAllowedVSPsInCfg(hosts)) {
-      await reloadAllowedExternalRequests();
-    }
+  // Allow access to all VSPs returned by the official VSP listing endpoint.
+  // This is less then ideal because this endpoint might eventually return
+  // domains that switched owners or that are otherwise available for hijack,
+  // but is needed due to Decrediton (currently) having to iterate over all
+  // existing VSPs to discover their pubkey and sync tickets.
+  //
+  // Eventually this can be further locked down once that iteration isn't
+  // performed any more and VSPs are only accessed when attempting to purchase
+  // a ticket.
+  const hosts = res.map((vsp) => "https://" + vsp.host);
+  if (addAllowedVSPsInCfg(hosts)) {
+    await reloadAllowedExternalRequests();
+  }
 
-    return res;
-  },
-  "getAllVspsInfo"
-);
+  return res;
+}, "getAllVspsInfo");
 
 // allowVSPHost enables the external request to a specific VSP host.
-export const allowVSPHost = log(
-  async (host) => {
-    // TODO: only ask for confirmation if VSP host is not yet allowed.
-    await confDialogAllowVSPHost(host);
+export const allowVSPHost = log(async (host) => {
+  // TODO: only ask for confirmation if VSP host is not yet allowed.
+  await confDialogAllowVSPHost(host);
 
-    // Store that the user allowed access to this VSP and enable access in the
-    // main process.
-    addAllowedVSPsInCfg([host]);
-    ipcRenderer.sendSync("allow-vsp-host", host);
-  },
-  "Allow VSP Host"
-);
+  // Store that the user allowed access to this VSP and enable access in the
+  // main process.
+  addAllowedVSPsInCfg([host]);
+  ipcRenderer.sendSync("allow-vsp-host", host);
+}, "Allow VSP Host");

--- a/app/wallet/vsp.js
+++ b/app/wallet/vsp.js
@@ -4,6 +4,7 @@ import * as cfg from "../config";
 import * as cfgConstants from "constants/config";
 import { ipcRenderer } from "electron";
 import { reloadAllowedExternalRequests } from "./daemon";
+import { allowVSPHost as confDialogAllowVSPHost } from "./confirmationDialog";
 
 const promisifyReq = (fnName, Req) =>
   log(
@@ -93,8 +94,16 @@ export const getAllVSPs = withLogNoData(
   "getAllVspsInfo"
 );
 
-// allowVSPHost enables the external request to a specif VSP host.
+// allowVSPHost enables the external request to a specific VSP host.
 export const allowVSPHost = log(
-  (host) => Promise.resolve(ipcRenderer.sendSync("allow-vsp-host", host)),
-  "Allow StakePool Host"
+  async (host) => {
+    // TODO: only ask for confirmation if VSP host is not yet allowed.
+    await confDialogAllowVSPHost(host);
+
+    // Store that the user allowed access to this VSP and enable access in the
+    // main process.
+    addAllowedVSPsInCfg([host]);
+    ipcRenderer.sendSync("allow-vsp-host", host);
+  },
+  "Allow VSP Host"
 );

--- a/app/wallet/vsp.js
+++ b/app/wallet/vsp.js
@@ -1,6 +1,9 @@
 import * as api from "../middleware/vspapi";
 import { withLog as log, withLogNoData } from "./index";
+import * as cfg from "../config";
+import * as cfgConstants from "constants/config";
 import { ipcRenderer } from "electron";
+import { reloadAllowedExternalRequests } from "./daemon";
 
 const promisifyReq = (fnName, Req) =>
   log(
@@ -50,9 +53,44 @@ export const getVSPTicketStatus = promisifyReqLogNoData(
   api.getTicketStatus
 );
 
-export const getAllVSPs = promisifyReqLogNoData(
-  "getAllVspsInfo",
-  api.getAllVspsInfo
+// addAllowedVSPsInCfg modifies the config file to allow the given VSP hosts
+// to be accessed. Returns true if the list of allowed hosts changed.
+const addAllowedVSPsInCfg = (hosts) => {
+  const c = cfg.getGlobalCfg();
+  const newHosts = c.get(cfgConstants.ALLOWED_VSP_HOSTS);
+  const oldHostsLen = newHosts.length;
+  hosts.forEach(vsp => newHosts.indexOf(vsp) === -1 && newHosts.push(vsp));
+  if (oldHostsLen !== newHosts.length) {
+    c.set(cfgConstants.ALLOWED_VSP_HOSTS, newHosts);
+    return true;
+  }
+
+  return false;
+};
+
+export const getAllVSPs = withLogNoData(
+  async () => {
+    const res = await new Promise((ok, fail) =>
+      api.getAllVspsInfo((res, err) => (err ? fail(err) : ok(res)))
+    );
+
+    // Allow access to all VSPs returned by the official VSP listing endpoint.
+    // This is less then ideal because this endpoint might eventually return
+    // domains that switched owners or that are otherwise available for hijack,
+    // but is needed due to Decrediton (currently) having to iterate over all
+    // existing VSPs to discover their pubkey and sync tickets.
+    //
+    // Eventually this can be further locked down once that iteration isn't
+    // performed any more and VSPs are only accessed when attempting to purchase
+    // a ticket.
+    const hosts = res.map(vsp => "https://"+vsp.host);
+    if (addAllowedVSPsInCfg(hosts)) {
+      await reloadAllowedExternalRequests();
+    }
+
+    return res;
+  },
+  "getAllVspsInfo"
 );
 
 // allowVSPHost enables the external request to a specif VSP host.

--- a/package.json
+++ b/package.json
@@ -274,6 +274,7 @@
     "electron-fetch": "^1.7.3",
     "electron-store": "^7.0.2",
     "enzyme-adapter-react-16": "^1.15.2",
+    "he": "^1.2.0",
     "ini": "^2.0.0",
     "int64-buffer": "^1.0.0",
     "is-running": "^2.1.0",

--- a/webpack/ui.dev.js
+++ b/webpack/ui.dev.js
@@ -97,6 +97,12 @@ module.exports = merge(baseConfig, {
     new HtmlWebpackPlugin({
       filename: "app.html",
       template: "app/app.development.html"
+    }),
+
+    new HtmlWebpackPlugin({
+      filename: "confirmation-dialog.html",
+      template: "app/staticPages/confirmation-dialog.html",
+      inject: false
     })
   ]
 });

--- a/webpack/ui.prod.js
+++ b/webpack/ui.prod.js
@@ -47,6 +47,12 @@ module.exports = merge(baseConfig, {
       template: "app/app.development.html"
     }),
 
+    new HtmlWebpackPlugin({
+      filename: "confirmation-dialog.html",
+      template: "app/staticPages/confirmation-dialog.html",
+      inject: false
+    }),
+
     new webpack.DefinePlugin({
       "__ELECTRON_ENV": JSON.stringify("renderer")
     })


### PR DESCRIPTION
~**Requires #3509**~

This adds a confirmation dialog entirely controlled by the preload script and the main electron process through the use of a `BrowserView` instance.

The main benefit for this approach is having a confirmation screen that lives outside the main UI and cannot be modified by code running in the UI layer.

The `BrowserView` class is an electron feature that allows overlapping a new rendering frame on top of the existing window, but without adding it to the corresponding document's DOM. All the code loaded in a BrowserView is effectively in a separate window and thus inaccessible to anything except the main electron process.

After splitting the code across the various layers of the app, turning on electron's security features (`nodeIntegration` and `contextIsolation`) and reducing the dependencies of the main and preload layers to a minimum, we can finally introduce this method for confirming external accesses that reduces the ablility of code injected into the main UI layer (for example, via third party dependencies) to exfiltrate data from the wallet.

The confirmation dialog introduced by this PR is intended to be shown whenever a new VSP (using an arbitrary domain) needs to be accessed via the network, thus allowing users to be selective about which services they want to potentially leak metadata to (e.g. times when the user is online and with their wallet open) and works as a deterrence against malicious code attempting to contact a remote server (since accesses will now need explicit permission).

The `BrowserView` based confirmation dialog works as follows:

- The UI code determines that it needs to access a VSP and calls the `allowVSPHost()` function exported by the preload layer. 
- The preload layer builds the html of the confirmation dialog.
- The preload layer sends a message to the main electron layer, which opens the `BrowserView` with the specified contents
- The `BrowserView` window is closed when the user either accepts or rejects the given request
- The reply is sent back to the originating `allowVSPHost()` call

Note that the `confirmation-dialog.html` is using very simple markup and inline scripts and _no external depencies_, including react. This is intentional, given we want this window to not have a chance to include code from third party packages.

Main changes introduced by this PR:

- Fix some VSP-related calls that were in a batched fashion but not correctly waited for
- Add a config entry to track VSP hosts allowed to be contacted and prevent UI code from directly modifying this entry
- Add the new confirmation dialog
- Switch the `allowVSPHost()` call to ask for confirmation via the new confirmation modal

Note to testers: for the moment, to ease testing this PR, confirmation for all VSPs returned by the official VSP listing public API is ask for on every wallet load. This allows viewing the confirmation every time you run the PR. This will be reverted once this PR is closer to being merged.

