### PR TITLE
[wallet] Use BrowserView ConfirmDialog on SignTx

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -77,6 +77,7 @@ const startWalletServicesTrigger = () => (dispatch, getState) =>
       await dispatch(refreshStakepoolPurchaseInformation());
       await dispatch(getVotingServiceAttempt());
       await dispatch(getAgendaServiceAttempt());
+      await dispatch(getDecodeMessageServiceAttempt());
       await dispatch(getStakepoolStats());
       await dispatch(getStartupWalletInfo());
       await dispatch(transactionNtfnsStart());
@@ -585,6 +586,34 @@ export const getVotingServiceAttempt = () => (dispatch, getState) => {
       dispatch({ votingService, type: GETVOTINGSERVICE_SUCCESS })
     )
     .catch((error) => dispatch({ error, type: GETVOTINGSERVICE_FAILED }));
+};
+
+export const GETDECODEMSGSERVICE_ATTEMPT = "GETDECODEMSGSERVICE_ATTEMPT";
+export const GETDECODEMSGSERVICE_FAILED = "GETDECODEMSGSERVICE_FAILED";
+export const GETDECODEMSGSERVICE_SUCCESS = "GETDECODEMSGSERVICE_SUCCESS";
+
+export const getDecodeMessageServiceAttempt = () => (dispatch, getState) => {
+  const {
+    grpc: { address, port }
+  } = getState();
+  const {
+    daemon: { walletName }
+  } = getState();
+  dispatch({ type: GETDECODEMSGSERVICE_ATTEMPT });
+  const grpcCertAndKey = wallet.getDcrwalletGrpcKeyCert();
+  wallet
+    .getDecodeMessageService(
+      sel.isTestNet(getState()),
+      walletName,
+      address,
+      port,
+      grpcCertAndKey,
+      grpcCertAndKey
+    )
+    .then((decodeMessageService) =>
+      dispatch({ decodeMessageService, type: GETDECODEMSGSERVICE_SUCCESS })
+    )
+    .catch((error) => dispatch({ error, type: GETDECODEMSGSERVICE_FAILED }));
 };
 
 export const GETAGENDAS_ATTEMPT = "GETAGENDAS_ATTEMPT";

--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -234,7 +234,11 @@ export const signTransactionAttempt = (passphrase, rawTx, acctNumber) => async (
   try {
     const signTransactionResponse = await dispatch(
       unlockAcctAndExecFn(passphrase, [acctNumber], () =>
-        wallet.signTransaction(sel.walletService(getState()), rawTx, acctNumber)
+        wallet.signTransaction(
+          sel.walletService(getState()),
+          sel.decodeMessageService(getState()),
+          rawTx
+        )
       )
     );
 

--- a/app/middleware/grpc/client.js
+++ b/app/middleware/grpc/client.js
@@ -64,3 +64,6 @@ export const getMessageVerificationService = getServiceClient(
 export const getAccountMixerService = getServiceClient(
   services.AccountMixerService
 );
+export const getDecodeMessageService = getServiceClient(
+  services.DecodeMessageService
+);

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -55,7 +55,10 @@ import {
   ABANDONTRANSACTION_ATTEMPT,
   ABANDONTRANSACTION_SUCCESS,
   ABANDONTRANSACTION_FAILED,
-  MIXERACCOUNTS_SPENDABLE_BALANCE
+  MIXERACCOUNTS_SPENDABLE_BALANCE,
+  GETDECODEMSGSERVICE_ATTEMPT,
+  GETDECODEMSGSERVICE_FAILED,
+  GETDECODEMSGSERVICE_SUCCESS
 } from "../actions/ClientActions";
 import { DAEMONSYNCED, WALLETREADY } from "../actions/DaemonActions";
 import { NEWBLOCKCONNECTED } from "../actions/NotificationActions";
@@ -504,6 +507,24 @@ export default function grpc(state = {}, action) {
         ...state,
         getVotingServiceRequestAttempt: false,
         votingService: action.votingService
+      };
+    case GETDECODEMSGSERVICE_ATTEMPT:
+      return {
+        ...state,
+        getDecodeMessageServiceError: null,
+        getDecodeMessageServiceAttempt: true
+      };
+    case GETDECODEMSGSERVICE_FAILED:
+      return {
+        ...state,
+        getDecodeMessageServiceError: String(action.error),
+        getDecodeMessageServiceAttempt: false
+      };
+    case GETDECODEMSGSERVICE_SUCCESS:
+      return {
+        ...state,
+        getDecodeMessageServiceAttempt: false,
+        decodeMessageService: action.decodeMessageService
       };
     case SIGNMESSAGE_ATTEMPT:
       return {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -204,6 +204,7 @@ export const walletService = get(["grpc", "walletService"]);
 export const agendaService = get(["grpc", "agendaService"]);
 export const votingService = get(["grpc", "votingService"]);
 export const accountMixerService = get(["grpc", "accountMixerService"]);
+export const decodeMessageService = get(["grpc", "decodeMessageService"]);
 
 // TODO review selectors that are not being used anymore.
 export const getBalanceRequestAttempt = get([

--- a/app/wallet/confirmationDialog/dialog.js
+++ b/app/wallet/confirmationDialog/dialog.js
@@ -20,6 +20,10 @@ const formatContent = (content) => {
   if (!locale) {
     locale = locales.find((value) => value.key === "en");
   }
+  const dcrFormat = new Intl.NumberFormat(undefined, {
+    useGrouping: true,
+    maximumFractionDigits: 8
+  });
 
   const fmt = (id, defaultMsg) => {
     let msg = defaultMsg;
@@ -27,15 +31,23 @@ const formatContent = (content) => {
     return msg;
   };
 
-  const formattedContent = content.content.reduce((acc, v) => {
+  const fmtReduce = (acc, v) => {
     if (typeof v === "string") {
       return acc + v;
+    }
+    if (v instanceof Array) {
+      return acc + v.reduce(fmtReduce, "");
     }
     if (typeof v === "object" && v.id && v.m) {
       return acc + fmt(v.id, v.m);
     }
+    if (typeof v === "object" && v.atoms) {
+      return acc + dcrFormat.format(v.atoms / 1e8) + " DCR";
+    }
     return acc;
-  }, "");
+  };
+
+  const formattedContent = content.content.reduce(fmtReduce, "");
 
   return {
     title: fmt(content.title.id, content.title.m),

--- a/app/wallet/confirmationDialog/index.js
+++ b/app/wallet/confirmationDialog/index.js
@@ -1,2 +1,3 @@
 export { onConfirmationDialogCallbacks } from "./dialog";
 export { default as allowVSPHost } from "./allowVspHost";
+export { default as signTx } from "./signTx";

--- a/app/wallet/confirmationDialog/signTx.js
+++ b/app/wallet/confirmationDialog/signTx.js
@@ -1,0 +1,52 @@
+import { showConfirmationDialog, escape } from "./dialog";
+
+const outputRow = (output) => [
+  "<li>",
+  "<samp>",
+  escape(output.address),
+  ": </samp>&nbsp;",
+  '<samp class="amount">',
+  { atoms: output.amount },
+  "</samp>",
+  "</li>"
+];
+
+export default (totalOutAmount, outputs) =>
+  showConfirmationDialog({
+    title: {
+      id: "confDialog.signTx.title",
+      m: "Sign Transaction"
+    },
+
+    content: [
+      "<p>",
+      {
+        id: "confDialog.signTransaction.message",
+        m: "Really sign the given transaction?"
+      },
+      "</p>",
+
+      "<p>",
+      {
+        id: "confDialog.signTransaction.totalOutLabel",
+        m: "Total Spent Amount:"
+      },
+      '<samp class="amount"> ',
+      { atoms: totalOutAmount },
+      "</samp>",
+      "</p>",
+
+      "<p>",
+      outputs.length > 0
+        ? {
+            id: "confDialog.signTransaction.outputs",
+            m: "Non-wallet outputs:"
+          }
+        : "",
+      "</p>",
+
+      "<ul>",
+      outputs.map(outputRow),
+      "</ul>"
+    ]
+  });

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -46,6 +46,9 @@ export const getMessageVerificationService = promisify(
 );
 export const getSeedService = promisify(client.getSeedService);
 export const getAccountMixerService = promisify(client.getAccountMixerService);
+export const getDecodeMessageService = promisify(
+  client.getDecodeMessageService
+);
 
 export const getNextAddress = log(
   (walletService, accountNum, kind) =>


### PR DESCRIPTION
~**Requires #3515**~

This switches the wallet's `SignTx` function to confirm with the user the transaction to be signed via the recently introduced confirmation dialog that runs in a BrowserView.

This ensures that any attempts by UI code to modify the transaction are visible to the user before the tx is sent to the underlying wallet to be signed.

The dialog is formatted such that only outputs and amounts that are not returning to the wallet (i.e. addresses in outputs that do _not_ correspond to one of the wallet's BIP0044 account) are shown.