### PR TITLE
[Wallet] Confirm seed via BrowserView dialog

### DIFF
--- a/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
+++ b/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback, createElement as h } from "react";
 import { useService } from "@xstate/react";
-import { sendParent } from "xstate";
 import { withRouter } from "react-router";
 import { injectIntl } from "react-intl";
 import CreateWallet from "./CreateWallet";
@@ -87,7 +86,7 @@ const CreateWalletPage = ({ createWalletRef, onSendBack }) => {
     if (!(seed && passPhrase)) return;
     createWalletRequest(pubpass, passPhrase, seed, newWallet)
       .then(() => sendEvent({ type: "WALLET_CREATED" }))
-      .catch((error) => sendParent({ type: "ERROR", error }));
+      .catch((error) => sendEvent({ type: "ERROR", error }));
     // we send a continue so we go to loading state
     sendContinue();
   }, [

--- a/app/helpers/seed.js
+++ b/app/helpers/seed.js
@@ -1,0 +1,21 @@
+import wordlist from "./wordlist";
+
+const seedWord = (b, index) => {
+  let bb = b * 2;
+  if (index % 2 !== 0) {
+    bb++;
+  }
+  return wordlist[bb];
+};
+
+export const encodeMnemonic = async (hexSeed) => {
+  const seed = new Uint8Array(Buffer.from(hexSeed, "hex"));
+  const words = [];
+  seed.forEach((b, index) => words.push(seedWord(b, index)));
+  const sha256 = async (data) =>
+    new Uint8Array(await crypto.subtle.digest("SHA-256", data));
+  const checksumByte = (await sha256(await sha256(seed)))[0];
+  const checksumWord = seedWord(checksumByte, seed.length);
+  words.push(checksumWord);
+  return words;
+};

--- a/app/stateMachines/CreateWalletStateMachine.js
+++ b/app/stateMachines/CreateWalletStateMachine.js
@@ -131,6 +131,16 @@ export const CreateWalletMachine = Machine({
     },
     loading: {
       on: {
+        ERROR: {
+          target: "walletCreated",
+          actions: [
+            assign({ completed: true }),
+            sendParent((ctx, event) => ({
+              type: event.type,
+              passPhrase: ctx.passPhrase
+            }))
+          ]
+        },
         WALLET_CREATED: {
           target: "walletCreated",
           actions: [

--- a/app/staticPages/confirmation-dialog.html
+++ b/app/staticPages/confirmation-dialog.html
@@ -54,6 +54,27 @@
         background-color: #2970ff;
       }
 
+      .seed, .hex-seed {
+        font-family: 'Source Code Pro', monospace;
+        margin-bottom: 20px;
+        -webkit-user-select: none;
+        user-select: none;
+        -webkit-user-drag: none;
+        -webkit-app-region: no-drag;
+        cursor: default;
+      }
+
+      .hex-seed {
+        word-break: break-word;
+      }
+
+      .seed {
+        font-size: 1.7ex;
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+        column-gap: 10px;
+      }
+
       /*********** Theme light *****************/
 
       .theme-light .root {

--- a/app/wallet/confirmationDialog/index.js
+++ b/app/wallet/confirmationDialog/index.js
@@ -1,3 +1,4 @@
 export { onConfirmationDialogCallbacks } from "./dialog";
 export { default as allowVSPHost } from "./allowVspHost";
 export { default as signTx } from "./signTx";
+export { default as seed } from "./seed";

--- a/app/wallet/confirmationDialog/seed.js
+++ b/app/wallet/confirmationDialog/seed.js
@@ -1,0 +1,19 @@
+import { showConfirmationDialog, escape } from "./dialog";
+
+export default (seed) =>
+  showConfirmationDialog({
+    title: {
+      id: "confDialog.seed.title",
+      m: "Create wallet with the following seed"
+    },
+
+    content: [
+      seed instanceof Array
+        ? [
+            '<div class="seed">',
+            seed.map((w) => ["<div>", escape(w), "</div>"]),
+            "</div>"
+          ]
+        : ['<div class="hex-seed">', escape(seed), "</div>"]
+    ]
+  });

--- a/package.json
+++ b/package.json
@@ -259,6 +259,7 @@
     "@formatjs/intl-utils": "^1.6.0",
     "@grpc/grpc-js": "^1.2.5",
     "@hot-loader/react-dom": "^16.13.0",
+    "@peculiar/webcrypto": "^1.1.7",
     "@xstate/react": "^0.8.1",
     "blake-hash": "^2.0.0",
     "bs58": "^4.0.1",

--- a/test/mocks/walletMock.js
+++ b/test/mocks/walletMock.js
@@ -27,3 +27,11 @@ export const showSaveDialog = jest.fn(() => null);
 export const getGlobalCfg = jest.fn(() => new MockElectronStore());
 export const getWalletCfg = jest.fn(() => new MockElectronStore());
 export const updateStakePoolConfig = jest.fn(() => null);
+export const getDcrwalletLastLogLine = jest.fn(() =>
+  Promise.resolve("last dcrwallet log line")
+);
+export const getDcrdLastLogLine = jest.fn(() =>
+  Promise.resolve("last dcrd log line")
+);
+export const getAvailableWallets = jest.fn(() => []);
+export const getPreviousWallet = jest.fn(() => null);

--- a/test/setup.js
+++ b/test/setup.js
@@ -2,8 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import { configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
+import { webcrypto } from "crypto";
 
 global.React = React;
 global.PropTypes = PropTypes;
+global.crypto = webcrypto;
 
 configure({ adapter: new Adapter() });

--- a/test/setup.js
+++ b/test/setup.js
@@ -2,10 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 import { configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import { webcrypto } from "crypto";
+
+// TODO: Can be removed once we move past node v14.
+import { Crypto } from "@peculiar/webcrypto";
 
 global.React = React;
 global.PropTypes = PropTypes;
-global.crypto = webcrypto;
+global.crypto = new Crypto();
 
 configure({ adapter: new Adapter() });

--- a/test/unit/components/views/GetStaredPage/CreateWallet.spec.js
+++ b/test/unit/components/views/GetStaredPage/CreateWallet.spec.js
@@ -338,9 +338,9 @@ test("pasting valid seed words on existing seed view and receive decode error an
   user.click(screen.getByText(/create wallet/i));
   expect(mockCreateWallet).toHaveBeenCalled();
   expect(mockCreateWalletRequest).toHaveBeenCalled();
-  await wait(() =>
-    expect(screen.getByTestId("decred-loading")).not.toHaveClass("hidden")
-  );
+
+  // A check needs to be added here after
+  // https://github.com/decred/decrediton/issues/3524 is fixed.
 });
 
 test("pasting valid seed words on existing seed view and successfully create wallet", async () => {

--- a/test/unit/helpers/seed.spec.js
+++ b/test/unit/helpers/seed.spec.js
@@ -1,0 +1,157 @@
+import { expect } from "@jest/globals";
+import { encodeMnemonic } from "helpers/seed";
+
+const TEST_DATA = [
+  {
+    hex: "",
+    seed: ["exceed"]
+  },
+  {
+    hex: "00",
+    seed: ["aardvark", "belowground"]
+  },
+  {
+    hex: "ff",
+    seed: ["Zulu", "recipe"]
+  },
+  {
+    hex: "0000",
+    seed: ["aardvark", "adroitness", "crackdown"]
+  },
+  {
+    hex: "ffff",
+    seed: ["Zulu", "Yucatan", "watchword"]
+  },
+  {
+    hex: "e58294f2e9a227486e8b061b31cc528fd7fa3f19",
+    seed: [
+      "topmost",
+      "Istanbul",
+      "Pluto",
+      "vagabond",
+      "treadmill",
+      "Pacific",
+      "brackish",
+      "dictator",
+      "goldfish",
+      "Medusa",
+      "afflict",
+      "bravado",
+      "chatter",
+      "revolver",
+      "Dupont",
+      "midsummer",
+      "stopwatch",
+      "whimsical",
+      "cowbell",
+      "bottomless",
+      "fracture"
+    ]
+  },
+  {
+    hex: "d1d464c004f00fb5c9a4c8d8e433e7fb7ff56256",
+    seed: [
+      "stairway",
+      "souvenir",
+      "flytrap",
+      "recipe",
+      "adrift",
+      "upcoming",
+      "artist",
+      "positive",
+      "spearhead",
+      "Pandora",
+      "spaniel",
+      "stupendous",
+      "tonic",
+      "concurrent",
+      "transit",
+      "Wichita",
+      "lockup",
+      "visitor",
+      "flagpole",
+      "escapade",
+      "merit"
+    ]
+  },
+  {
+    hex: "e34cd132128c1929ec96865ced5c4d0bf40a5d021fcef58d27dbfee371d210",
+    seed: [
+      "tissue",
+      "disbelief",
+      "stairway",
+      "component",
+      "atlas",
+      "megaton",
+      "bedlamp",
+      "certify",
+      "tumor",
+      "monument",
+      "necklace",
+      "fascinate",
+      "tunnel",
+      "fascinate",
+      "dreadful",
+      "armistice",
+      "upshot",
+      "Apollo",
+      "exceed",
+      "aftermath",
+      "billiard",
+      "sardonic",
+      "vapor",
+      "microscope",
+      "brackish",
+      "suspicious",
+      "woodlark",
+      "torpedo",
+      "hamlet",
+      "sensation",
+      "assume",
+      "recipe"
+    ]
+  },
+  {
+    hex: "00000000000000000000000000000000000000000000000000000000000000",
+    seed: [
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "adroitness",
+      "aardvark",
+      "insurgent"
+    ]
+  }
+];
+
+TEST_DATA.forEach((tc) =>
+  test("hex seed " + tc.hex, async () =>
+    expect(await encodeMnemonic(tc.hex)).toStrictEqual(tc.seed)
+  )
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,6 +1472,34 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@peculiar/asn1-schema@^2.0.27", "@peculiar/asn1-schema@^2.0.32":
+  version "2.0.36"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.0.36.tgz#ca7978f43ffa4f35fbb74436c3f983c10a69ac27"
+  integrity sha512-x7fdMR6bzOBct2a0PLukrmVrrehHX5uisKRDWN2Bs1HojXd5nCi7MAQeV+umRxPK1oSJDstTBhGq3sLzDbL8Vw==
+  dependencies:
+    "@types/asn1js" "^2.0.0"
+    asn1js "^2.1.1"
+    pvtsutils "^1.1.7"
+    tslib "^2.2.0"
+
+"@peculiar/json-schema@^1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@peculiar/json-schema/-/json-schema-1.1.12.tgz#fe61e85259e3b5ba5ad566cb62ca75b3d3cd5339"
+  integrity sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==
+  dependencies:
+    tslib "^2.0.0"
+
+"@peculiar/webcrypto@^1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.1.7.tgz#ff02008612e67ab7cc2a92fce04a7f0e2a04b71c"
+  integrity sha512-aCNLYdHZkvGH+T8/YBOY33jrVGVuLIa3bpizeHXqwN+P4ZtixhA+kxEEWM1amZwUY2nY/iuj+5jdZn/zB7EPPQ==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.0.32"
+    "@peculiar/json-schema" "^1.1.12"
+    pvtsutils "^1.1.6"
+    tslib "^2.2.0"
+    webcrypto-core "^1.2.0"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -1771,6 +1799,11 @@
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
   integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
+
+"@types/asn1js@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/asn1js/-/asn1js-2.0.0.tgz#10ca75692575744d0117098148a8dc84cbee6682"
+  integrity sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.3", "@types/babel__core@^7.1.7":
   version "7.1.12"
@@ -2657,6 +2690,13 @@ asn1@~0.2.3:
   integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   dependencies:
     safer-buffer "~2.1.0"
+
+asn1js@^2.0.26, asn1js@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-2.1.1.tgz#bb3896191ebb5fb1caeda73436a6c6e20a2eedff"
+  integrity sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==
+  dependencies:
+    pvutils latest
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -10116,6 +10156,18 @@ pushdata-bitcoin@^1.0.1:
   dependencies:
     bitcoin-ops "^1.3.0"
 
+pvtsutils@^1.1.2, pvtsutils@^1.1.6, pvtsutils@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.1.7.tgz#39a65ccb3b7448c974f6a6141ce2aad037b3f13c"
+  integrity sha512-faOiD/XpB/cIebRzYwzYjCmYgiDd53YEBni+Mt1+8/HlrARHYBpsU2OHOt3EZ1ZhfRNxPL0dH3K/vKaMgNWVGA==
+  dependencies:
+    tslib "^2.2.0"
+
+pvutils@latest:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.0.17.tgz#ade3c74dfe7178944fe44806626bd2e249d996bf"
+  integrity sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==
+
 qr-image@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/qr-image/-/qr-image-3.2.0.tgz#9fa8295beae50c4a149cf9f909a1db464a8672e8"
@@ -12318,6 +12370,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
 tslib@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
@@ -12827,6 +12884,17 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+webcrypto-core@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.2.0.tgz#44fda3f9315ed6effe9a1e47466e0935327733b5"
+  integrity sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.0.27"
+    "@peculiar/json-schema" "^1.1.12"
+    asn1js "^2.0.26"
+    pvtsutils "^1.1.2"
+    tslib "^2.1.0"
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
**Requires #3519**

This adds a final confirmation window to the wallet creation flow which displays the seed that is about to be used to create the wallet via the recently introduced, BrowserView based confirmation dialog.

This prevents UI code from tampering with the seed without user acknowledgement. 

Seeds that are exactly 256 bits long (standard decred seeds) are displayed with the usual 33 word mnemonic sequence. Seeds of different length are displayed as raw hexadecimal.

Please note that rejecting the seed currently breaks wallet setup. This is not specifically related to this PR, but rather the fact that any errors during the final wallet setup aren't being correctly handled right now. This will need to be fixed in a separate PR.

Thanks to @vctt94 for some help in fixing the reject flow.