### PR TITLE
[main] Add menu toggle devtools in conf window

### DIFF
--- a/app/i18n/extracted/static/menus.json
+++ b/app/i18n/extracted/static/menus.json
@@ -24,6 +24,10 @@
     "defaultMessage": "Toggle Developer Tools"
   },
   {
+    "id": "appMenu.developerToolsConfWindow",
+    "defaultMessage": "Toggle Developer Tools for Confirmation Window"
+  },
+  {
     "id": "appMenu.showWalletLog",
     "defaultMessage": "Show Wallet Log Files"
   },

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -584,7 +584,6 @@ ipcMain.on("fill-confirmation-dialog-contents", (event, contents) => {
   mainWindow.setBrowserView(confirmBrowserView);
   confirmBrowserView.setBackgroundColor("#ffffffff");
   setConfirmBrowserViewBounds();
-  if (debug) confirmBrowserView.webContents.openDevTools();
 });
 
 ipcMain.on("confirmation-dialog-reply", (event, res) => {
@@ -668,7 +667,7 @@ function setMenuLocale(locale) {
     }
   });
 
-  const template = initTemplate(mainWindow, locale);
+  const template = initTemplate(mainWindow, confirmBrowserView, locale);
 
   menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);

--- a/app/main_dev/templates.js
+++ b/app/main_dev/templates.js
@@ -122,7 +122,7 @@ const darwinTemplate = (mainWindow, locale) => [
   }
 ];
 
-const regularTemplate = (mainWindow, locale) => [
+const regularTemplate = (mainWindow, confirmBrowserView, locale) => [
   {
     label: locale.messages["appMenu.file"],
     submenu: [
@@ -158,18 +158,24 @@ const regularTemplate = (mainWindow, locale) => [
         click() {
           mainWindow.toggleDevTools();
         }
+      },
+      {
+        label: locale.messages["appMenu.developerToolsConfWindow"],
+        click() {
+          confirmBrowserView.webContents.toggleDevTools();
+        }
       }
     ]
   }
 ];
 
-export const initTemplate = (mainWindow, locale) => {
+export const initTemplate = (mainWindow, confirmBrowserView, locale) => {
   let template;
 
   if (process.platform === "darwin") {
     template = darwinTemplate(mainWindow, locale);
   } else {
-    template = regularTemplate(mainWindow, locale);
+    template = regularTemplate(mainWindow, confirmBrowserView, locale);
   }
 
   return template;


### PR DESCRIPTION
This makes it so that the devtools for the confirmation window doesn't show up automatically, but still allows opening it from the main menu for debugging.