### PR TITLE
Simplify layout breakpoints

### DIFF
--- a/app/components/buttons/DangerButton/DangerButton.module.css
+++ b/app/components/buttons/DangerButton/DangerButton.module.css
@@ -6,24 +6,3 @@
 .dangerButton:hover {
   background-color: var(--error-red-hover);
 }
-
-@media screen and (max-width: 511px) {
-  .dangerButton {
-    margin-left: 145px;
-    margin-top: 18px;
-  }
-}
-
-@media screen and (max-width: 409px) {
-  .dangerButton {
-    margin-left: 55px;
-    width: 122px;
-  }
-}
-
-@media screen and (max-width: 299px) {
-  .dangerButton {
-    margin-left: 55px;
-    width: 122px;
-  }
-}

--- a/app/components/buttons/HelpLink/HelpLink.module.css
+++ b/app/components/buttons/HelpLink/HelpLink.module.css
@@ -93,7 +93,7 @@
   background-image: var(--help-forum);
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .icon {
     margin-right: 10px;
     margin-bottom: 10px;

--- a/app/components/buttons/KeyBlueButton/KeyBlueButton.module.css
+++ b/app/components/buttons/KeyBlueButton/KeyBlueButton.module.css
@@ -9,9 +9,3 @@
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2);
   background-color: var(--input-color-hover);
 }
-@media screen and (max-width: 299px) {
-  .keyBlueButton {
-    position: absolute;
-    bottom: 18px;
-  }
-}

--- a/app/components/charts/Charts.module.css
+++ b/app/components/charts/Charts.module.css
@@ -90,7 +90,7 @@
 .recharts-tooltip-cursor {
   fill: var(--chart-cursor-color);
 }
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .meteredTicksArea {
     margin-left: 60px;
   }

--- a/app/components/indicators/VotingProgress/VotingProgress.module.css
+++ b/app/components/indicators/VotingProgress/VotingProgress.module.css
@@ -15,7 +15,7 @@
   background-color: var(--vote-no-color);
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .votingProgressIndicator {
     width: 120px;
   }

--- a/app/components/inputs/VSPSelect/VSPSelect.modules.css
+++ b/app/components/inputs/VSPSelect/VSPSelect.modules.css
@@ -20,7 +20,7 @@
   transition: 0.1s all ease;
 }
 
-@media screen and (max-width: 765px) {
+@media screen and (max-width: 768px) {
   .tooltip {
     width: 150px;
     padding: 0 10px 0 0;

--- a/app/components/layout/PageBody/PageBody.module.css
+++ b/app/components/layout/PageBody/PageBody.module.css
@@ -43,6 +43,7 @@
     height: calc(100% - 40px);
   }
 
+  .pageBody.getstarted.testnetBody::before,
   .pageBody.getstarted::before {
     background-image: var(--small-logo);
     background-size: 30px;

--- a/app/components/layout/StandaloneHeader/StandaloneHeader.module.css
+++ b/app/components/layout/StandaloneHeader/StandaloneHeader.module.css
@@ -3,7 +3,7 @@
   padding: 40px 60px 30px 60px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .header {
     padding-left: 20px;
   }

--- a/app/components/layout/StandalonePageBody/StandalonePageBody.module.css
+++ b/app/components/layout/StandalonePageBody/StandalonePageBody.module.css
@@ -5,7 +5,7 @@
   background-color: var(--background-container);
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .body {
     padding-left: 20px;
     padding-right: 20px;

--- a/app/components/layout/TabbedPage/TabbedPage.module.css
+++ b/app/components/layout/TabbedPage/TabbedPage.module.css
@@ -39,7 +39,7 @@
   background-color: transparent;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .tabbedPageHeader {
     padding-left: 20px;
   }

--- a/app/components/layout/TitleHeader/TitleHeader.module.css
+++ b/app/components/layout/TitleHeader/TitleHeader.module.css
@@ -1,5 +1,5 @@
 .container {
-  width: 750px;
+  width: 740px;
   position: relative;
   justify-content: space-between;
   align-items: center;
@@ -81,9 +81,9 @@
   margin-left: auto;
 }
 
-@media screen and (max-width: 1106px) {
+@media screen and (max-width: 1180px) {
   .container {
-    width: 649px;
+    width: 667px;
   }
 }
 

--- a/app/components/modals/AboutModal/AboutModal.module.css
+++ b/app/components/modals/AboutModal/AboutModal.module.css
@@ -85,13 +85,13 @@
   color: var(--input-color-hover);
 }
 
-@media screen and (max-width: 955px) {
+@media screen and (max-width: 1000px) {
   .about {
     width: inherit;
   }
 }
 
-@media screen and (max-width: 588px) {
+@media screen and (max-width: 560px) {
   .about {
     width: 455px !important;
     height: 290px;
@@ -104,12 +104,14 @@
   }
   .about .icon {
     margin-top: 20px;
+    margin-left: 20px;
     height: 66px;
     width: 66px;
     background-size: 59px;
     border-radius: 23px;
   }
   .about .bottomArea {
-    width: 413px;
+    width: 453px;
+    padding: 0 20px 20px 20px;
   }
 }

--- a/app/components/modals/AutoBuyerSettingsModal/AutoBuyerSettingsModal.module.css
+++ b/app/components/modals/AutoBuyerSettingsModal/AutoBuyerSettingsModal.module.css
@@ -53,7 +53,7 @@
   font-size: 16px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .modal {
     width: 421px;
   }

--- a/app/components/modals/CantCloseModals/CantCloseModals.module.css
+++ b/app/components/modals/CantCloseModals/CantCloseModals.module.css
@@ -35,8 +35,3 @@
   font-size: 13px;
   line-height: 17px;
 }
-@media screen and (max-width: 420px) {
-  .confirm {
-    max-height: 60%;
-  }
-}

--- a/app/components/modals/ConfirmModal/ConfirmModal.module.css
+++ b/app/components/modals/ConfirmModal/ConfirmModal.module.css
@@ -36,8 +36,3 @@
   font-size: 13px;
   line-height: 17px;
 }
-@media screen and (max-width: 420px) {
-  .confirm {
-    max-height: 60%;
-  }
-}

--- a/app/components/modals/DocumentationInfoModal/DocumentationInfoModal.module.css
+++ b/app/components/modals/DocumentationInfoModal/DocumentationInfoModal.module.css
@@ -4,8 +4,7 @@
 }
 
 @media screen and (max-width: 560px) {
-.infoDocumentation:not(.constitution) {
-  column-count: 1;
+  .infoDocumentation:not(.constitution) {
+    column-count: 1;
+  }
 }
-}
-

--- a/app/components/modals/DocumentationInfoModal/DocumentationInfoModal.module.css
+++ b/app/components/modals/DocumentationInfoModal/DocumentationInfoModal.module.css
@@ -2,3 +2,10 @@
   column-count: 2;
   margin-bottom: 20px;
 }
+
+@media screen and (max-width: 560px) {
+.infoDocumentation:not(.constitution) {
+  column-count: 1;
+}
+}
+

--- a/app/components/modals/InfoModal/InfoModal.module.css
+++ b/app/components/modals/InfoModal/InfoModal.module.css
@@ -90,12 +90,14 @@
   align-self: flex-end;
 }
 @media screen and (max-width: 768px) {
+  .info,
   .info.double {
-    width: 300px !important;
+    width: 400px !important;
   }
 }
-@media screen and (max-width: 420px) {
+@media screen and (max-width: 560px) {
+  .info,
   .info.double {
-    width: 250px !important;
+    width: 300px !important;
   }
 }

--- a/app/components/modals/MixerSettingsModal/MixerSettingsModal.module.css
+++ b/app/components/modals/MixerSettingsModal/MixerSettingsModal.module.css
@@ -32,7 +32,7 @@
   float: right;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .mixerSettings {
     width: 594px !important;
   }

--- a/app/components/modals/PassphraseModal/PassphraseModal.module.css
+++ b/app/components/modals/PassphraseModal/PassphraseModal.module.css
@@ -38,7 +38,7 @@
   height: 44px;
   float: right;
 }
-@media screen and (max-width: 420px) {
+@media screen and (max-width: 560px) {
   .passphrase {
     max-height: 60%;
   }

--- a/app/components/modals/SeedCopyConfirmModal/SeedCopyConfirmModal.module.css
+++ b/app/components/modals/SeedCopyConfirmModal/SeedCopyConfirmModal.module.css
@@ -62,7 +62,7 @@
     column-count: 1;
   }
 }
-@media screen and (max-width: 420px) {
+@media screen and (max-width: 560px) {
   .confirmSeedCopy {
     max-height: 60%;
   }

--- a/app/components/modals/SetNewPassphraseModal/SetNewPassModalContent/SetNewPassModalContent.module.css
+++ b/app/components/modals/SetNewPassphraseModal/SetNewPassModalContent/SetNewPassModalContent.module.css
@@ -38,7 +38,7 @@
   height: 44px;
   float: right;
 }
-@media screen and (max-width: 420px) {
+@media screen and (max-width: 560px) {
   .passphrase {
     max-height: 60%;
   }

--- a/app/components/modals/SyncVSPFailedTickets/SyncVSPFailedTickets.module.css
+++ b/app/components/modals/SyncVSPFailedTickets/SyncVSPFailedTickets.module.css
@@ -7,7 +7,7 @@
   margin-top: 3px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .inputSelect {
     width: 220px;
   }

--- a/app/components/modals/TrezorModals/TrezorModals.module.css
+++ b/app/components/modals/TrezorModals/TrezorModals.module.css
@@ -71,7 +71,7 @@ h1 {
   flex-direction: row-reverse;
 }
 
-@media screen and (max-width: 375px) {
+@media screen and (max-width: 560px) {
   .pinModal,
   .passphraseModal,
   .togglePassphraseConfirmModal,

--- a/app/components/shared/Log/Log.module.css
+++ b/app/components/shared/Log/Log.module.css
@@ -77,9 +77,3 @@ textarea {
     padding-left: 20px;
   }
 }
-
-@media screen and (max-width: 375px) {
-  .logArea {
-    width: 100%;
-  }
-}

--- a/app/components/shared/Log/Log.module.css
+++ b/app/components/shared/Log/Log.module.css
@@ -53,7 +53,7 @@ textarea {
   background-size: 5px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .logArea {
     width: 634px;
   }

--- a/app/components/shared/PurchaseTicketsForm/PurchaseTicketsForm.module.css
+++ b/app/components/shared/PurchaseTicketsForm/PurchaseTicketsForm.module.css
@@ -178,7 +178,7 @@
   margin-bottom: 5px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .buttonsArea {
     width: 667px;
   }

--- a/app/components/shared/Subtitle/Subtitle.module.css
+++ b/app/components/shared/Subtitle/Subtitle.module.css
@@ -12,7 +12,7 @@
   margin-top: -20px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .tabbedPageSubtitle {
     margin-left: 0;
     width: 667px;

--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -308,7 +308,7 @@
   display: none !important;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .info {
     grid-template-columns: 0.5fr 3.5fr 10fr 2.5fr;
   }

--- a/app/components/views/AccountsPage/Accounts/AccountsList/AccountsList.module.css
+++ b/app/components/views/AccountsPage/Accounts/AccountsList/AccountsList.module.css
@@ -3,7 +3,7 @@
   width: 740px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .contentNest {
     width: 667px;
   }

--- a/app/components/views/AgendaDetailsPage/AgendaDetails.module.css
+++ b/app/components/views/AgendaDetailsPage/AgendaDetails.module.css
@@ -60,7 +60,7 @@
   font-weight: var(--font-weight-semi-bold) !important;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .detailsText {
     width: 674px;
   }

--- a/app/components/views/AgendaDetailsPage/helpers/AgendaCard/AgendaCard.module.css
+++ b/app/components/views/AgendaDetailsPage/helpers/AgendaCard/AgendaCard.module.css
@@ -140,7 +140,7 @@
   color: var(--main-dark-blue);
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .overview {
     width: 634px;
   }

--- a/app/components/views/AgendaDetailsPage/helpers/VoteSection/VoteSection.module.css
+++ b/app/components/views/AgendaDetailsPage/helpers/VoteSection/VoteSection.module.css
@@ -72,7 +72,7 @@
   top: 0.4rem !important;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .votePreference {
     flex-basis: 70%;
   }

--- a/app/components/views/DexPage/CreateDexAcctPage/CreateDexAcctPage.module.css
+++ b/app/components/views/DexPage/CreateDexAcctPage/CreateDexAcctPage.module.css
@@ -18,7 +18,7 @@
   grid-template-columns: max-content auto max-content max-content;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .dexContent {
     width: 634px;
   }

--- a/app/components/views/DexPage/RegisterPage/SendOutputRow/SendOutputRow.module.css
+++ b/app/components/views/DexPage/RegisterPage/SendOutputRow/SendOutputRow.module.css
@@ -31,7 +31,7 @@
 .tooltipSendToSelf {
   width: 18rem;
 }
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .sendOutputContainer {
     grid-template-columns: max-content 240px minmax(max-content, 1fr) 240px;
     padding: 7px 0 26px 0;

--- a/app/components/views/GetStartedPage/CreateWalletPage/helpers/Section/Section.module.css
+++ b/app/components/views/GetStartedPage/CreateWalletPage/helpers/Section/Section.module.css
@@ -2,7 +2,7 @@
   margin-bottom: 30px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .section {
     margin-left: 0;
   }

--- a/app/components/views/GetStartedPage/Logs/Logs.jsx
+++ b/app/components/views/GetStartedPage/Logs/Logs.jsx
@@ -2,10 +2,11 @@ import { Tooltip } from "pi-ui";
 import { LogsTab } from "views/SettingsPage/LogsTab/LogsTab";
 import { GoBackMsg } from "../messages";
 import { BackButton, BackButtonArea } from "../helpers";
+import styles from "./Logs.module.css";
 
 export default ({ onSendBack }) => (
   <>
-    <BackButtonArea>
+    <BackButtonArea className={styles.backButtonArea}>
       <Tooltip content={<GoBackMsg />}>
         <BackButton onClick={onSendBack} />
       </Tooltip>

--- a/app/components/views/GetStartedPage/Logs/Logs.module.css
+++ b/app/components/views/GetStartedPage/Logs/Logs.module.css
@@ -4,7 +4,6 @@
   right: 0;
 }
 
-
 @media screen and (max-width: 1180px) {
   .backButtonArea {
     left: 622px;

--- a/app/components/views/GetStartedPage/Logs/Logs.module.css
+++ b/app/components/views/GetStartedPage/Logs/Logs.module.css
@@ -1,0 +1,20 @@
+.backButtonArea {
+  position: absolute;
+  top: 66px;
+  right: 0;
+}
+
+
+@media screen and (max-width: 1180px) {
+  .backButtonArea {
+    left: 622px;
+    right: initial;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .backButtonArea {
+    top: 30px;
+    left: 342px;
+  }
+}

--- a/app/components/views/GetStartedPage/PrivacyPage/PrivacyOption/PrivacyOption.module.css
+++ b/app/components/views/GetStartedPage/PrivacyPage/PrivacyOption/PrivacyOption.module.css
@@ -68,7 +68,7 @@
   background-image: var(--disable-spv);
 }
 
-@media screen and (max-width: 710px) {
+@media screen and (max-width: 768px) {
   .option {
     width: 100%;
     margin: 0 0 10px 0;

--- a/app/components/views/GetStartedPage/PrivacyPage/PrivacyOptions/PrivacyOptions.module.css
+++ b/app/components/views/GetStartedPage/PrivacyPage/PrivacyOptions/PrivacyOptions.module.css
@@ -1,20 +1,19 @@
 .options {
   display: flex;
-  justify-content: center;
   margin-left: 35px;
   padding-right: 2em;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 1180px) {
   .options {
     margin: 0 -10px;
+    margin: 0;
+    padding: 0;
   }
 }
 
-@media screen and (max-width: 710px) {
+@media screen and (max-width: 768px) {
   .options {
     flex-direction: column;
-    margin: 0;
-    padding: 0;
   }
 }

--- a/app/components/views/GetStartedPage/PrivacyPage/TopLevelOptions/TopLevelOptions.module.css
+++ b/app/components/views/GetStartedPage/PrivacyPage/TopLevelOptions/TopLevelOptions.module.css
@@ -1,4 +1,4 @@
-@media screen and (max-width: 978px) {
+@media screen and (max-width: 1000px) {
   .wide {
     justify-content: flex-start;
     margin-left: 0;
@@ -11,19 +11,40 @@
 
   .icon {
     background-size: 114px;
-    width: 114;
+    width: 114px;
     height: 114px;
   }
 
   .textContainer {
     margin: 0 20px;
   }
-}
 
-@media screen and (max-width: 710px) {
   .wide {
-    flex-direction: column;
     margin: 0;
     padding: 0;
   }
 }
+
+@media screen and (max-width: 768px) {
+  .wide {
+    flex-direction: column;
+    justify-content: flex-start;
+    margin-left: 0;
+  }
+
+  .icon {
+    background-size: 40px;
+    width: 40px;
+    height: 40px;
+    margin-left: 20px;
+  }
+
+  .option {
+    min-width: 355px;
+  }
+
+  .textContainer {
+    margin: 20px;
+  }
+}
+

--- a/app/components/views/GetStartedPage/PrivacyPage/TopLevelOptions/TopLevelOptions.module.css
+++ b/app/components/views/GetStartedPage/PrivacyPage/TopLevelOptions/TopLevelOptions.module.css
@@ -1,7 +1,8 @@
 @media screen and (max-width: 1000px) {
   .wide {
     justify-content: flex-start;
-    margin-left: 0;
+    margin: 0;
+    padding: 0;
   }
 
   .option {
@@ -17,11 +18,6 @@
 
   .textContainer {
     margin: 0 20px;
-  }
-
-  .wide {
-    margin: 0;
-    padding: 0;
   }
 }
 
@@ -47,4 +43,3 @@
     margin: 20px;
   }
 }
-

--- a/app/components/views/GetStartedPage/ReleaseNotes/Form/Form.module.css
+++ b/app/components/views/GetStartedPage/ReleaseNotes/Form/Form.module.css
@@ -80,7 +80,7 @@
   background-image: var(--release-image-v160);
 }
 
-@media screen and (max-width: 1140px) {
+@media screen and (max-width: 1180px) {
   .image {
     flex: 1;
     margin-top: 14px;
@@ -92,7 +92,7 @@
   }
 }
 
-@media screen and (max-width: 890px) {
+@media screen and (max-width: 1000px) {
   .text {
     max-width: inherit;
     margin-left: 15px;

--- a/app/components/views/GetStartedPage/Settings/Settings.module.css
+++ b/app/components/views/GetStartedPage/Settings/Settings.module.css
@@ -5,28 +5,21 @@
   right: initial;
 }
 
-@media screen and (max-width: 1919px) {
+@media screen and (max-width: 1920px) {
   .backButtonArea {
     left: 1230px;
   }
 }
 
-@media screen and (max-width: 1679px) {
+@media screen and (max-width: 1680px) {
   .backButtonArea {
     left: 988px;
   }
 }
 
-@media screen and (max-width: 1439px) {
+@media screen and (max-width: 1400px) {
   .backButtonArea {
     left: 726px;
-  }
-}
-
-@media screen and (max-width: 1180px) {
-  .backButtonArea {
-    left: 636px;
-    top: 112px;
   }
 }
 

--- a/app/components/views/GetStartedPage/TutorialPage/Tutorial.module.css
+++ b/app/components/views/GetStartedPage/TutorialPage/Tutorial.module.css
@@ -90,26 +90,21 @@ video {
 }
 
 @media screen and (max-width: 768px) {
-  .tutorial .mainText {
-    max-height: 650px;
-  }
-
   .tutorialMainToolbar {
     justify-content: space-between;
     flex-wrap: nowrap;
   }
 
   .skipButton {
-    margin-top: 0 !important;
+    margin: 0 0 0 30px !important;
     height: inherit;
     width: 26px;
     padding: 0;
   }
 
   .nextButton {
-    margin-left: 10px !important;
     padding: 5px 20px 6px 20px;
-    margin-top: 0px !important;
+    margin: 0 30px 0 10px !important;
   }
 
   .stepIndicator {
@@ -127,6 +122,7 @@ video {
     margin: 0;
   }
   .tutorial .mainText {
+    max-height: 650px;
     padding-right: 0;
     padding-bottom: 0;
     margin-bottom: 0;
@@ -134,10 +130,6 @@ video {
   }
   .tutorial {
     flex-direction: column;
-  }
-
-  .mainText {
-    max-height: inherit;
   }
 
   h1 {
@@ -166,14 +158,6 @@ video {
     padding: 0;
     width: 100%;
     box-shadow: 0px -5px 21px 0px var(--onboard-toolbar-shadow);
-  }
-
-  .nextButton {
-    margin: 0 30px 0 0;
-  }
-
-  .skipButton {
-    margin: 0 0 0 30px;
   }
 }
 

--- a/app/components/views/GetStartedPage/TutorialPage/Tutorial.module.css
+++ b/app/components/views/GetStartedPage/TutorialPage/Tutorial.module.css
@@ -96,7 +96,6 @@ video {
 
   .nextButton {
     margin-left: 10px !important;
-    height: 16px;
     padding: 5px 20px 6px 20px;
     margin-top: 0px !important;
   }

--- a/app/components/views/GetStartedPage/TutorialPage/Tutorial.module.css
+++ b/app/components/views/GetStartedPage/TutorialPage/Tutorial.module.css
@@ -77,7 +77,19 @@ video {
   width: 34px;
 }
 
-@media screen and (max-width: 670px) {
+@media screen and (max-width: 1000px) {
+  .tutorial .main {
+    top: 88px;
+    left: 21px;
+    padding-top: 5vh;
+  }
+  .tutorial .main-text {
+    column-count: 1;
+    padding-right: 55px;
+  }
+}
+
+@media screen and (max-width: 768px) {
   .tutorial .mainText {
     max-height: 650px;
   }
@@ -114,37 +126,12 @@ video {
   .step.checked {
     margin: 0;
   }
-}
-@media screen and (max-width: 916px) {
-  .tutorial .main {
-    top: 88px;
-    left: 21px;
-  }
-}
-
-@media screen and (max-width: 768px) {
-  .tutorial .main {
-    padding-top: 10vh;
-  }
-  .tutorial .main-text {
-    column-count: 1;
-    padding-right: 55px;
-  }
-}
-
-@media screen and (max-width: 541px) {
-  .main {
-    top: 8px;
-  }
   .tutorial .mainText {
     padding-right: 0;
     padding-bottom: 0;
     margin-bottom: 0;
     min-height: inherit;
   }
-}
-
-@media screen and (max-width: 500px) {
   .tutorial {
     flex-direction: column;
   }
@@ -158,19 +145,15 @@ video {
   }
 
   .side {
-    height: 42vh;
+    height: 48vh;
     width: 100%;
   }
 
-  video {
-    height: 336px;
-  }
-
-  .main {
+  .tutorial .main {
     top: 25px;
     width: inherit;
     padding: 30px;
-    height: 42vh;
+    height: 48vh;
   }
 
   .mainToolbar {
@@ -194,14 +177,7 @@ video {
   }
 }
 
-@media (max-height: 700px) {
-  .main {
-    padding-top: 10vh;
-    height: 89vh;
-  }
-}
-
-@media (max-height: 460px) {
+@media (max-height: 560px) {
   .mainToolbar {
     height: 80px;
   }

--- a/app/components/views/GetStartedPage/helpers/BackButtonArea/BackButtonArea.module.css
+++ b/app/components/views/GetStartedPage/helpers/BackButtonArea/BackButtonArea.module.css
@@ -6,7 +6,7 @@
   line-height: 14px;
 }
 
-@media screen and (max-width: 430px) {
+@media screen and (max-width: 560px) {
   .backButtonArea {
     right: 59px;
   }

--- a/app/components/views/GetStartedPage/helpers/Content/Content.module.css
+++ b/app/components/views/GetStartedPage/helpers/Content/Content.module.css
@@ -4,14 +4,14 @@
   padding-top: 106px;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 1180px) {
   .content {
-    padding: 86px 0 0 0;
+    padding: 56px 0 0 0;
   }
 }
 
-@media screen and (max-width: 375px) {
+@media screen and (max-width: 768px) {
   .content {
-    padding: 64px 0 0 0;
+    padding: 40px 0 0 0;
   }
 }

--- a/app/components/views/GetStartedPage/helpers/Title/Title.module.css
+++ b/app/components/views/GetStartedPage/helpers/Title/Title.module.css
@@ -1,11 +1,11 @@
 .title {
   font-size: 27px;
   line-height: 34px;
-  margin-bottom: 35px;
+  margin-bottom: 6px;
   width: 100%;
 }
 
-@media screen and (max-width: 375px) {
+@media screen and (max-width: 768px) {
   .title {
     font-size: 23px;
   }

--- a/app/components/views/GovernancePage/Blockchain/Blockchain.module.css
+++ b/app/components/views/GovernancePage/Blockchain/Blockchain.module.css
@@ -56,7 +56,7 @@
   width: max-content;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .agendaWrapper {
     margin-left: 35px;
   }

--- a/app/components/views/GovernancePage/PageHeader/PageHeader.module.css
+++ b/app/components/views/GovernancePage/PageHeader/PageHeader.module.css
@@ -23,7 +23,7 @@
   color: var(--main-dark-blue);
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .header {
     width: 696px;
     padding-left: 55px;

--- a/app/components/views/GovernancePage/Proposals/ProposalsList/ProposalsList.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsList/ProposalsList.module.css
@@ -39,7 +39,7 @@
   overflow: auto;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .proposalList {
     margin-left: 35px;
   }

--- a/app/components/views/GovernancePage/Proposals/ProposalsListItem/ProposalsListItem.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsListItem/ProposalsListItem.module.css
@@ -105,7 +105,7 @@
   background-color: var(--vote-no-color);
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .listItem {
     width: 700px;
   }

--- a/app/components/views/GovernancePage/Proposals/ProposalsTab.module.css
+++ b/app/components/views/GovernancePage/Proposals/ProposalsTab.module.css
@@ -75,7 +75,7 @@
   background-color: var(--grey-7) !important;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .tabs {
     margin-left: 55px;
   }

--- a/app/components/views/HomePage/HomePage.module.css
+++ b/app/components/views/HomePage/HomePage.module.css
@@ -126,7 +126,7 @@
   grid-template-columns: repeat(2, max-content);
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .overviewTransactionsTicket {
     padding: 30px 20px;
   }

--- a/app/components/views/PrivacyPage/Privacy/Privacy.module.css
+++ b/app/components/views/PrivacyPage/Privacy/Privacy.module.css
@@ -153,7 +153,7 @@
   width: 17rem;
   text-align: center;
 }
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .privacyContent {
     width: 634px;
   }

--- a/app/components/views/PrivacyPage/Privacy/SendOutputRow/SendOutputRow.module.css
+++ b/app/components/views/PrivacyPage/Privacy/SendOutputRow/SendOutputRow.module.css
@@ -115,7 +115,7 @@
 .tooltipSendToSelf {
   width: 18rem;
 }
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .sendOutputContainer {
     grid-template-columns: max-content 240px minmax(max-content, 1fr) 240px;
     padding: 7px 0 26px 0;

--- a/app/components/views/ProposalDetailsPage/ProposalDetails.module.css
+++ b/app/components/views/ProposalDetailsPage/ProposalDetails.module.css
@@ -79,7 +79,7 @@
   font-weight: var(--font-weight-semi-bold) !important;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .detailsText {
     width: 665px;
   }

--- a/app/components/views/ProposalDetailsPage/helpers/ProposalCard/ProposalCard.module.css
+++ b/app/components/views/ProposalDetailsPage/helpers/ProposalCard/ProposalCard.module.css
@@ -109,7 +109,7 @@
   color: var(--tab-text-active-color) !important;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .overview {
     width: 626px;
   }

--- a/app/components/views/ProposalDetailsPage/helpers/VotePreferenceWrapper/VotePreference/VotePreference.module.css
+++ b/app/components/views/ProposalDetailsPage/helpers/VotePreferenceWrapper/VotePreference/VotePreference.module.css
@@ -45,7 +45,7 @@
   top: 0.4rem !important;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .votePreference {
     flex-basis: initial;
   }

--- a/app/components/views/ProposalDetailsPage/helpers/VoteSection/VoteSection.module.css
+++ b/app/components/views/ProposalDetailsPage/helpers/VoteSection/VoteSection.module.css
@@ -13,7 +13,7 @@
   font-weight: 600;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .voteSection {
     width: 665px;
   }

--- a/app/components/views/SettingsPage/LinksTab/LinksTab.module.css
+++ b/app/components/views/SettingsPage/LinksTab/LinksTab.module.css
@@ -6,7 +6,7 @@
   max-width: 740px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .list {
     margin-left: 0;
   }

--- a/app/components/views/SettingsPage/SettingsTab/MiscSettings.jsx
+++ b/app/components/views/SettingsPage/SettingsTab/MiscSettings.jsx
@@ -2,6 +2,7 @@ import { FormattedMessage as T } from "react-intl";
 import { SettingsInput, NumericInput } from "inputs";
 import { InfoDocFieldModalButton } from "buttons";
 import styles from "./Settings.module.css";
+import { classNames } from "pi-ui";
 
 const propTypes = {
   tempSettings: PropTypes.object.isRequired,
@@ -41,16 +42,16 @@ const MiscSettings = ({
 
       {walletReady && (
         <div className={styles.row}>
-          <div className={styles.label}>
+          <div className={classNames(styles.label, styles.gapLimitLabel)}>
             <label id="gap-limit-input" className={styles.label}>
               <T id="settings.gapLimit.label" m="Gap Limit" />
-              <InfoDocFieldModalButton
-                document="GapLimitInfo"
-                modalClassName={styles.hasWarning}
-                double
-                draggable
-              />
             </label>
+            <InfoDocFieldModalButton
+              document="GapLimitInfo"
+              modalClassName={styles.hasWarning}
+              double
+              draggable
+            />
           </div>
           <div className={styles.input}>
             <NumericInput

--- a/app/components/views/SettingsPage/SettingsTab/MiscSettings.jsx
+++ b/app/components/views/SettingsPage/SettingsTab/MiscSettings.jsx
@@ -42,14 +42,14 @@ const MiscSettings = ({
       {walletReady && (
         <div className={styles.row}>
           <div className={styles.label}>
-            <InfoDocFieldModalButton
-              document="GapLimitInfo"
-              modalClassName={styles.hasWarning}
-              double
-              draggable
-            />
             <label id="gap-limit-input" className={styles.label}>
               <T id="settings.gapLimit.label" m="Gap Limit" />
+              <InfoDocFieldModalButton
+                document="GapLimitInfo"
+                modalClassName={styles.hasWarning}
+                double
+                draggable
+              />
             </label>
           </div>
           <div className={styles.input}>

--- a/app/components/views/SettingsPage/SettingsTab/NetworkSettings.jsx
+++ b/app/components/views/SettingsPage/SettingsTab/NetworkSettings.jsx
@@ -94,6 +94,7 @@ const NetworkSettings = ({ tempSettings, onChangeTempSettings }) => (
           content={<AlreadySetMessage />}
           disabled={!tempSettings.spvConnectFromCli}>
           <SettingsTextInput
+            className={styles.settingsTextInput}
             id="spvConnectInput"
             value={tempSettings.spvConnect}
             disabled={tempSettings.spvConnectFromCli}

--- a/app/components/views/SettingsPage/SettingsTab/ProxySettings.jsx
+++ b/app/components/views/SettingsPage/SettingsTab/ProxySettings.jsx
@@ -26,7 +26,6 @@ const ProxySettings = ({ tempSettings, onChangeTempSettings }) => (
         <label id="proxy-type-input" className={styles.label}>
           <T id="settings.proxy.type" m="Proxy Type" />
         </label>
-        <div className={styles.label}></div>
         <SettingsInput
           className={styles.input}
           value={tempSettings.proxyType}
@@ -45,6 +44,7 @@ const ProxySettings = ({ tempSettings, onChangeTempSettings }) => (
           <T id="settings.proxy.location" m="Proxy Location" />
         </label>
         <SettingsTextInput
+          className={styles.settingsTextInput}
           id="proxyLocationInput"
           value={tempSettings.proxyLocation}
           ariaLabelledBy="proxy-location"

--- a/app/components/views/SettingsPage/SettingsTab/Settings.module.css
+++ b/app/components/views/SettingsPage/SettingsTab/Settings.module.css
@@ -354,7 +354,7 @@
   }
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .group {
     width: 649px;
   }

--- a/app/components/views/SettingsPage/SettingsTab/Settings.module.css
+++ b/app/components/views/SettingsPage/SettingsTab/Settings.module.css
@@ -40,6 +40,7 @@
 .rowChecklist {
   flex-wrap: wrap;
   justify-content: flex-start;
+  flex-direction: column;
 }
 
 .rowChecklist .label {
@@ -165,6 +166,10 @@
   padding: 0px 4px 1px 10px;
 }
 
+.settingsTextInput {
+  width: 150px !important;
+}
+
 .inputError {
   width: 290px;
   float: right;
@@ -227,7 +232,7 @@
   background-color: var(--input-color);
 }
 
-@media screen and (min-width: 1680px) and (max-width: 1919px) {
+@media screen and (min-width: 1680px) and (max-width: 1920px) {
   .wrapper {
     width: 1240px;
   }
@@ -267,7 +272,7 @@
     width: 1240px;
   }
 }
-@media screen and (min-width: 1440px) and (max-width: 1679px) {
+@media screen and (min-width: 1400px) and (max-width: 1680px) {
   .wrapper {
     flex-direction: column;
   }
@@ -294,8 +299,8 @@
     order: 2;
   }
 
-  .group .wrapper .column {
-    width: 419px;
+  .columnWrapper .column {
+    width: 420px;
   }
 
   .group .wrapper .column.timezone .columnContent .row {
@@ -313,7 +318,7 @@
   }
 }
 
-@media screen and (max-width: 1539px) {
+@media screen and (max-width: 1400px) {
   .wrapper {
     flex-direction: column;
   }
@@ -417,6 +422,8 @@
     padding-right: 35px;
   }
 
+  .wrapper .group .columnWrapper .column:nth-of-type(1),
+  .wrapper .group .columnWrapper .column:nth-of-type(3),
   .wrapper .group .columnWrapper .column {
     width: 100%;
   }
@@ -441,10 +448,3 @@
   }
 }
 
-@media screen and (max-width: 676px) {
-  .app-modal.about-modal,
-  .app-modal-reduced-bar.about-modal,
-  .app-modal-standalone.about-modal {
-    margin-left: 9px;
-  }
-}

--- a/app/components/views/SettingsPage/SettingsTab/Settings.module.css
+++ b/app/components/views/SettingsPage/SettingsTab/Settings.module.css
@@ -105,6 +105,20 @@
   width: 116px;
 }
 
+.wrapper .label button {
+  margin-right: 0;
+}
+.wrapper .label.gapLimitLabel {
+  display: flex;
+  justify-content: flex-end;
+}
+.wrapper .label.gapLimitLabel label {
+  margin-right: 0;
+}
+.wrapper .label.gapLimitLabel button {
+  width: 24px;
+}
+
 .wrapper .label .infoLabel,
 .wrapper .label .infoFieldModalButton {
   display: inline;

--- a/app/components/views/SettingsPage/SettingsTab/Settings.module.css
+++ b/app/components/views/SettingsPage/SettingsTab/Settings.module.css
@@ -447,4 +447,3 @@
     text-align: center;
   }
 }
-

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_AddForm/AddForm.module.css
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_AddForm/AddForm.module.css
@@ -91,7 +91,7 @@
   margin-left: 5px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .addTitle {
     width: 634px;
   }

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_PurchaseTickets/PurchaseTicketsAdvanced/PurchaseTicketsAdvanced.module.css
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_PurchaseTickets/PurchaseTicketsAdvanced/PurchaseTicketsAdvanced.module.css
@@ -93,7 +93,7 @@ label.infoLabel.expiry {
   padding: 0;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .infoGrid {
     grid-template-columns: repeat(4, max-content);
   }

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_PurchaseTickets/PurchaseTicketsQuickBar/PurchaseTicketsQuickBar.module.css
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_PurchaseTickets/PurchaseTicketsQuickBar/PurchaseTicketsQuickBar.module.css
@@ -68,7 +68,7 @@
   align-self: flex-end;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .quickBar {
     grid-template-columns: repeat(4, 1fr);
     grid-column-gap: 9px;

--- a/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_Tickets/Tickets.module.css
+++ b/app/components/views/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_Tickets/Tickets.module.css
@@ -28,7 +28,7 @@
   align-self: flex-end;
   margin-right: 10px;
 }
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .purchaseTicketArea {
     width: 667px;
   }

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTab.module.css
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTab.module.css
@@ -46,7 +46,7 @@
   justify-content: space-between;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .purchaseTicketArea {
     width: 667px;
   }

--- a/app/components/views/TicketsPage/StatisticsTab/Statistics.module.css
+++ b/app/components/views/TicketsPage/StatisticsTab/Statistics.module.css
@@ -125,7 +125,7 @@
   width: max-content;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .charts {
     width: 667px;
   }

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.module.css
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.module.css
@@ -196,36 +196,9 @@
   .abandonBtnContainer {
     width: 770px;
   }
-}
-
-@media screen and (max-width: 1106px) {
-  .rebroadcastBtnContainer,
   .abandonBtnContainer {
     width: 670px;
   }
-
-  .abandonBtnContainer {
-    width: 670px;
-  }
-}
-
-@media screen and (max-width: 768px) {
-  .rebroadcastBtnContainer,
-  .abandonBtnContainer {
-    width: 375px;
-    text-align: center;
-    display: block;
-    margin-top: -22px;
-
-    .rebroadcastBtn,
-    .abandonBtn {
-      float: none;
-      padding: 12px 30px 14px 48px;
-      margin-top: 0;
-    }
-  }
-}
-@media screen and (max-width: 1106px) {
   .overview {
     width: 633px;
   }
@@ -238,7 +211,31 @@
     width: 511px;
   }
 }
+
 @media screen and (max-width: 768px) {
+  .buttonContainer {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+  .rebroadcastBtnContainer,
+  .abandonBtnContainer {
+    width: 375px;
+    text-align: center;
+    display: block;
+    margin-top: -22px;
+  }
+  .rebroadcastBtn,
+  .abandonBtn {
+    float: none;
+    margin-top: 0;
+  }
+  .abandonBtn {
+    margin: 0;
+  }
+
+  .abandonBtnContainer {
+    height: 72px;
+  }
   .overview {
     flex-direction: column;
     padding-left: 42px;

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.module.css
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.module.css
@@ -191,7 +191,7 @@
   margin-right: 20px;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .rebroadcastBtnContainer,
   .abandonBtnContainer {
     width: 770px;

--- a/app/components/views/TransactionsPage/HistoryTab/HistoryPage/HistoryPage.module.css
+++ b/app/components/views/TransactionsPage/HistoryTab/HistoryPage/HistoryPage.module.css
@@ -26,7 +26,7 @@
   width: 10.5rem;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .historyPageContent {
     width: 667px;
   }

--- a/app/components/views/TransactionsPage/SendTab/SendForm.module.css
+++ b/app/components/views/TransactionsPage/SendTab/SendForm.module.css
@@ -42,24 +42,21 @@
   font-size: 16px;
 }
 .passphraseModal {
-  width: 415px;
+    display: grid;
+    grid-template-columns: max-content auto;
 }
 .passphraseModalLabel {
-  float: left;
-  width: 65%;
   margin-top: 5px;
 }
 .passphraseModalAddress {
   margin-left: 20px;
   margin-top: 5px;
   font-weight: 600;
-  float: right;
 }
 .passphraseModalBalance {
   margin-left: 20px;
   font-weight: 600;
   margin-top: 5px;
-  float: right;
 }
 .error {
   color: var(--error-text-color);

--- a/app/components/views/TransactionsPage/SendTab/SendForm.module.css
+++ b/app/components/views/TransactionsPage/SendTab/SendForm.module.css
@@ -42,8 +42,8 @@
   font-size: 16px;
 }
 .passphraseModal {
-    display: grid;
-    grid-template-columns: max-content auto;
+  display: grid;
+  grid-template-columns: max-content auto;
 }
 .passphraseModalLabel {
   margin-top: 5px;

--- a/app/components/views/TransactionsPage/SendTab/SendForm.module.css
+++ b/app/components/views/TransactionsPage/SendTab/SendForm.module.css
@@ -77,7 +77,7 @@
   color: var(--input-color-default);
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .sendArea {
     width: 667px;
   }

--- a/app/components/views/TransactionsPage/SendTab/SendOutputRow/SendOutputRow.module.css
+++ b/app/components/views/TransactionsPage/SendTab/SendOutputRow/SendOutputRow.module.css
@@ -189,7 +189,7 @@
   opacity: 0.85;
 }
 
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 1180px) {
   .amountContainer .sendInputWrapper {
     width: 185px;
   }

--- a/app/components/views/TutorialsPage/PagedTutorial/PagedTutorial.module.css
+++ b/app/components/views/TutorialsPage/PagedTutorial/PagedTutorial.module.css
@@ -4,8 +4,10 @@
   background-repeat: no-repeat;
   background-size: 12px;
   background-image: var(--x-grey);
-  float: right;
   padding: 0;
+  position: absolute;
+  top: 60px;
+  right: 60px;
 }
 
 .title {
@@ -25,9 +27,10 @@
   color: var(--new-wallet-label);
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 768px) {
   .closeButton {
-    margin-right: 20px;
+    top: 30px;
+    right: 30px;
   }
 
   .title,

--- a/app/components/views/TutorialsPage/StandardPage/StandardPage.module.css
+++ b/app/components/views/TutorialsPage/StandardPage/StandardPage.module.css
@@ -60,7 +60,7 @@
   color: var(--wallet-tutorial-link);
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 768px) {
   .standardPage {
     flex-direction: column;
   }

--- a/app/components/views/TutorialsPage/TutorialsPage.module.css
+++ b/app/components/views/TutorialsPage/TutorialsPage.module.css
@@ -4,8 +4,8 @@
   color: var(--title-text-and-button-background);
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 768px) {
   .walletTutorial {
-    padding: 30px 0;
+    padding: 30px 20px 30px 0;
   }
 }


### PR DESCRIPTION
In this diff, the layout breakpoints simplified to:
- 560px
- 768px
- 1000px
- 1180px (decrediton specific breakpoint) 

Additional wide screen breakpoints introduced by #2412:
- 1400px (although in the design 1440px is defined, 1400px is more compatibe with pigui)
- 1680px
- 1920px

Fixed a couple of layout problems also:
- testnet logo on small screens
- transaction confirmation modal 
- privacy options on small screens
- next button height on the tutorial  page

Closes #3309