### PR TITLE
[electron] Remove winston as a dependency

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -811,9 +811,14 @@ app.on("ready", async () => {
   setMenuLocale(locale);
 });
 
-app.on("before-quit", (event) => {
+app.on("before-quit", async (event) => {
   logger.log("info", "Caught before-quit. Set decrediton as was closed");
   event.preventDefault();
   cleanShutdown(mainWindow, app, GetDcrdPID(), GetDcrwPID());
+  try {
+    await logger.close();
+  } catch (error) {
+    console.error("Error closing log file:", error);
+  }
   app.exit(0);
 });

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -19,7 +19,8 @@ import {
   GetDcrwalletLogs,
   GetDcrlndLogs,
   getPrivacyLogs,
-  cleanPrivacyLogs
+  cleanPrivacyLogs,
+  getLogFileName
 } from "./main_dev/logging";
 import {
   getWalletsDirectoryPath,
@@ -465,11 +466,7 @@ ipcMain.on("get-dcrlnd-logs", (event) => {
 });
 
 ipcMain.on("get-decrediton-logs", (event) => {
-  const logTransport = logger.transports.find((transport) => {
-    return transport.filename === "decrediton.log";
-  });
-  const logFileName = logTransport.dirname + "/" + logTransport.filename;
-  readFileBackward(logFileName, MAX_LOG_LENGTH, (err, data) => {
+  readFileBackward(getLogFileName(), MAX_LOG_LENGTH, (err, data) => {
     if (err) {
       logger.log("error", "Error reading log: " + err);
       return (event.returnValue = null);

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -262,7 +262,7 @@ logger.log(
 );
 
 process.on("uncaughtException", (err) => {
-  logger.log("error", "UNCAUGHT EXCEPTION: " + err);
+  logger.log("error", `UNCAUGHT EXCEPTION: ${err}`);
   throw err;
 });
 

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -256,14 +256,13 @@ checkAndInitWalletCfg(false);
 logger.log("info", "Using config/data from:" + app.getPath("userData"));
 logger.log(
   "info",
-  "Versions: Decrediton: %s, Electron: %s, Chrome: %s",
-  app.getVersion(),
-  process.versions.electron,
-  process.versions.chrome
+  `Versions: Decrediton: ${app.getVersion()}, ` +
+    `Electron: ${process.versions.electron}, ` +
+    `Chrome: ${process.versions.chrome}`
 );
 
 process.on("uncaughtException", (err) => {
-  logger.log("error", "UNCAUGHT EXCEPTION", err);
+  logger.log("error", "UNCAUGHT EXCEPTION: " + err);
   throw err;
 });
 

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -700,7 +700,7 @@ export const launchDCRWallet = async (
           e &&
           e.code &&
           e.code != "EOF" &&
-          logger.log("error", "tx stream error: " + e)
+          logger.log("error", `tx stream error: ${e}`)
       );
       dcrwTxStream.on("close", () =>
         logger.log("info", "dcrwallet tx stream closed")
@@ -872,7 +872,7 @@ export const launchDCRLnd = (
       if (!lastDcrdErr || lastDcrdErr === "") {
         lastDcrdErr = lastPanicLine(GetDcrdLogs());
       }
-      logger.log("error", "dcrd closed due to an error: " + lastDcrdErr);
+      logger.log("error", `dcrd closed due to an error: ${lastDcrdErr}`);
       return reject(lastDcrdErr);
     }
     */

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -418,7 +418,7 @@ export const launchDCRD = (reactIPC, testnet, appdata) =>
         if (!lastDcrdErr || lastDcrdErr === "") {
           lastDcrdErr = lastPanicLine(GetDcrdLogs());
         }
-        logger.log("error", "dcrd closed due to an error: ", lastDcrdErr);
+        logger.log("error", "dcrd closed due to an error: " + lastDcrdErr);
         reactIPC.send("error-received", true, lastDcrdErr);
         reject(lastDcrdErr);
       }
@@ -654,7 +654,7 @@ export const launchDCRWallet = async (
 
   const notifyGrpcPort = (port) => {
     dcrwPort = port;
-    logger.log("info", "wallet grpc running on port %d", port);
+    logger.log("info", `wallet grpc running on port ${port}`);
     portResolve(dcrwPort);
   };
 
@@ -700,7 +700,7 @@ export const launchDCRWallet = async (
           e &&
           e.code &&
           e.code != "EOF" &&
-          logger.log("error", "tx stream error", e)
+          logger.log("error", "tx stream error: " + e)
       );
       dcrwTxStream.on("close", () =>
         logger.log("info", "dcrwallet tx stream closed")
@@ -765,8 +765,7 @@ export const launchDCRWallet = async (
       }
       logger.log(
         "error",
-        "dcrwallet closed due to an error: ",
-        lastDcrwalletErr
+        "dcrwallet closed due to an error: " + lastDcrwalletErr
       );
       reactIPC.send("error-received", false, lastDcrwalletErr);
     } else {
@@ -873,7 +872,7 @@ export const launchDCRLnd = (
       if (!lastDcrdErr || lastDcrdErr === "") {
         lastDcrdErr = lastPanicLine(GetDcrdLogs());
       }
-      logger.log("error", "dcrd closed due to an error: ", lastDcrdErr);
+      logger.log("error", "dcrd closed due to an error: " + lastDcrdErr);
       return reject(lastDcrdErr);
     }
     */

--- a/app/main_dev/logging.js
+++ b/app/main_dev/logging.js
@@ -1,9 +1,8 @@
-import winston from "winston";
 import path from "path";
 import { MAX_LOG_LENGTH } from "constants";
 import { getAppDataDirectory } from "./paths";
 import os from "os";
-import logform from "logform";
+import fs from "fs";
 
 let dcrdLogs = Buffer.from("");
 let dcrwalletLogs = Buffer.from("");
@@ -45,47 +44,92 @@ const logLevelsPrintable = {
   silly: "TRC"
 };
 
-const logFormatter = (opts) => {
-  const lvl = logLevelsPrintable[opts.level] || "UNK";
-  const time = opts.timestamp;
-  const msg = opts.message;
-  const subsys = "DCTN";
-  return `${time} [${lvl}] ${subsys}: ${msg}`;
-};
+class Logger {
+  constructor(debug) {
+    this.debug = debug;
+    this.logLevels = {
+      error: 0,
+      warn: 1,
+      info: 2,
+      verbose: 3,
+      debug: 3,
+      silly: 3
+    };
+    this.colorCodes = {
+      [-1]: "\u001b[39m",
+      0: "\u001b[91m",
+      1: "\u001b[35m",
+      2: "\u001b[32m",
+      3: "\u001b[34m"
+    };
+    this.drained = true;
+    this.buffer = [];
+    this.logFile = fs.createWriteStream(
+      path.join(getAppDataDirectory(), "decrediton.log")
+    );
+    this.logFile.on("drain", this.dequeue);
+  }
+
+  dequeue() {
+    if (this.buffer.length === 0) {
+      this.drained = true;
+      return;
+    }
+
+    // Keep writing data to the file until we either write all available data or
+    // the file becomes busy for writes (in which case this function will be
+    // called again once the file can be written to again).
+    let drained = true;
+    while (this.buffer.length() > 0 && drained) {
+      const data = this.buffer.shift();
+      this.drained = this.logFile.write(data);
+      drained = this.drained;
+    }
+  }
+
+  queue(data) {
+    if (this.drained) {
+      // Fast path: file is not busy, so write directly.
+      this.drained = this.logFile.write(data);
+    } else {
+      // Slow path: file is busy, so enqueue data to be written as possible.
+      this.buffer.push(data);
+    }
+  }
+
+  log(level, msg) {
+    const levelLower = level.toLowerCase();
+    const logLevel = this.logLevels[levelLower] || 3;
+
+    const subsys = "DCTN";
+    const lvl = logLevelsPrintable[levelLower] || "UNK";
+    const data = `${logTimestamp()} [${lvl}] ${subsys}: ${msg}`;
+
+    // Log to file only if msg is of level INFO or lower.
+    if (logLevel <= 2) {
+      this.queue(data + "\n");
+    }
+
+    // Log to console if debug is set and level is DEBUG or lower.
+    if (this.debug && logLevel <= 3) {
+      console.log(this.colorCodes[logLevel] + data + this.colorCodes[-1]);
+    }
+  }
+
+  close() {
+    return new Promise((ok) => {
+      this.logFile.once("finish", ok);
+      this.logFile.end();
+    });
+  }
+}
 
 // createLogger creates the main app logger. This stores all logs into the
 // decrediton app data dir and sends to the console when debug == true.
 // This is meant to be called from the ipcMain thread.
 export function createLogger(debug) {
-  if (logger) return logger;
-
-  const { combine, timestamp, printf, colorize, splat } = logform.format;
-
-  logger = new winston.createLogger({
-    transports: [
-      new winston.transports.File({
-        filename: path.join(getAppDataDirectory(), "decrediton.log"),
-        format: combine(
-          timestamp({ format: logTimestamp }),
-          splat(),
-          printf(logFormatter)
-        )
-      })
-    ]
-  });
-
-  if (debug) {
-    logger.add(
-      new winston.transports.Console({
-        level: "debug",
-        format: combine(
-          timestamp({ format: logTimestamp }),
-          splat(),
-          printf(logFormatter),
-          colorize({ all: true })
-        )
-      })
-    );
+  if (!logger) {
+    logger = new Logger(debug);
   }
 
   return logger;

--- a/app/main_dev/logging.js
+++ b/app/main_dev/logging.js
@@ -44,6 +44,9 @@ const logLevelsPrintable = {
   silly: "TRC"
 };
 
+export const getLogFileName = () =>
+  path.join(getAppDataDirectory(), "decrediton.log");
+
 class Logger {
   constructor(debug) {
     this.debug = debug;
@@ -64,9 +67,7 @@ class Logger {
     };
     this.drained = true;
     this.buffer = [];
-    this.logFile = fs.createWriteStream(
-      path.join(getAppDataDirectory(), "decrediton.log")
-    );
+    this.logFile = fs.createWriteStream(getLogFileName());
     this.logFile.on("drain", this.dequeue);
   }
 

--- a/app/wallet/app.js
+++ b/app/wallet/app.js
@@ -78,7 +78,8 @@ const formatLogArgs = (msg, args) => {
   };
 
   const logArgs = args.map(formatArg);
-  const logMsg = msg + " " + logArgs.join(" ");
+  const argsStr = logArgs.join(" ");
+  const logMsg = `${msg} ${argsStr}`;
 
   return { logMsg };
 };

--- a/package.json
+++ b/package.json
@@ -315,7 +315,6 @@
     "stylelint-config-recommended": "^4.0.0",
     "timezone-mock": "^1.1.3",
     "utf-8-validate": "^5.0.5",
-    "winston": "^3.3.3",
     "worker-loader": "^3.0.8",
     "xstate": "^4.17.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,15 +1071,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@dabh/diagnostics@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
-  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
-  dependencies:
-    colorspace "1.1.x"
-    enabled "2.0.x"
-    kuler "^2.0.0"
-
 "@develar/schema-utils@~2.6.5":
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/@develar/schema-utils/-/schema-utils-2.6.5.tgz#3ece22c5838402419a6e0425f85742b961d9b6c6"
@@ -2738,11 +2729,6 @@ async@0.9.x:
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
-async@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -3811,7 +3797,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -3830,26 +3816,10 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-color-string@^1.5.2:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
-  integrity sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
-  dependencies:
-    color-name "^1.0.0"
-    simple-swizzle "^0.2.2"
-
-color@3.0.x:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
-  integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
-  dependencies:
-    color-convert "^1.9.1"
-    color-string "^1.5.2"
 
 colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
@@ -3861,18 +3831,10 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.2.1, colors@^1.3.3:
+colors@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
-colorspace@1.1.x:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
-  integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
-  dependencies:
-    color "3.0.x"
-    text-hex "1.0.x"
 
 colour@latest:
   version "0.7.1"
@@ -5135,11 +5097,6 @@ emotion@^9.1.2:
     babel-plugin-emotion "^9.2.11"
     create-emotion "^9.2.12"
 
-enabled@2.0.x:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
-  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
-
 encodeurl@^1.0.2, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -5779,11 +5736,6 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.0.4:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
-  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
-
 fast-text-encoding@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
@@ -5827,11 +5779,6 @@ fd-slicer@~1.0.1:
   integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
   dependencies:
     pend "~1.2.0"
-
-fecha@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.0.tgz#3ffb6395453e3f3efff850404f0a59b6747f5f41"
-  integrity sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -5969,11 +5916,6 @@ flatten@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
-
-fn.name@1.x.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
-  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -7013,11 +6955,6 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
-
-is-arrayish@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
-  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.1"
@@ -8136,11 +8073,6 @@ known-css-properties@^0.21.0:
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.21.0.tgz#15fbd0bbb83447f3ce09d8af247ed47c68ede80d"
   integrity sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==
 
-kuler@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
-  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
-
 latest-version@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
@@ -8266,17 +8198,6 @@ log-symbols@^4.0.0, log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
-
-logform@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/logform/-/logform-2.2.0.tgz#40f036d19161fc76b68ab50fdc7fe495544492f2"
-  integrity sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==
-  dependencies:
-    colors "^1.2.1"
-    fast-safe-stringify "^2.0.4"
-    fecha "^4.2.0"
-    ms "^2.1.1"
-    triple-beam "^1.3.0"
 
 long@^4.0.0:
   version "4.0.0"
@@ -9345,13 +9266,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
-
-one-time@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
-  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
-  dependencies:
-    fn.name "1.x.x"
 
 onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
@@ -10624,7 +10538,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.5, readable-stream@^2.3.7, readable-stream@~2.3.6:
+readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -11478,13 +11392,6 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
-simple-swizzle@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
-  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
-  dependencies:
-    is-arrayish "^0.3.1"
-
 sisteransi@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.4.tgz#386713f1ef688c7c0304dc4c0632898941cad2e3"
@@ -11688,11 +11595,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
-
-stack-trace@0.0.x:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stack-utils@^2.0.2:
   version "2.0.3"
@@ -12192,11 +12094,6 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-text-hex@1.0.x:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
-  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -12347,11 +12244,6 @@ trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
-
-triple-beam@^1.2.0, triple-beam@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
-  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 trough@^1.0.0:
   version "1.0.5"
@@ -13105,29 +12997,6 @@ win32ipc@./modules/win32ipc:
   version "0.1.0"
   dependencies:
     bindings "~1.2.1"
-
-winston-transport@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
-  integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
-  dependencies:
-    readable-stream "^2.3.7"
-    triple-beam "^1.2.0"
-
-winston@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"
-  integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
-  dependencies:
-    "@dabh/diagnostics" "^2.0.2"
-    async "^3.1.0"
-    is-stream "^2.0.0"
-    logform "^2.2.0"
-    one-time "^1.0.0"
-    readable-stream "^3.4.0"
-    stack-trace "0.0.x"
-    triple-beam "^1.3.0"
-    winston-transport "^4.4.0"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
This removes the winston log library as a dependency from the project. This helps reduce the number of dependencies on the main electron layer.

This is done by implementing a very basic logger that replicates the features we were using from winston: writing both to a log file and to the terminal when `debug` is set.

Dependencies of the main electron layer before winston is removed:

![electron-deps-winston](https://user-images.githubusercontent.com/1752493/126382618-153804ff-54e9-43d9-9d41-f10fdd96dabe.png)

After removing winston:
![electron-deps-no-winston](https://user-images.githubusercontent.com/1752493/126382606-d72fcfc3-0b2b-4410-8d9c-2438f7a96923.png)

