### PR TITLE
settings: Update account passphrases on private passphrase change

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -215,7 +215,7 @@ export const changePassphraseAttempt = (oldPass, newPass, priv) => (
         await Promise.all(
           oldAccounts.map(async (acct) => {
             // just skip if imported account.
-            if (acct.accountNumber === Math.pow(2, 31) - 1) {
+            if (acct.accountNumber >= Math.pow(2, 31) - 1) {
               return acct;
             }
             // we set the account passphrase as the wallet passphrase to avoid the user


### PR DESCRIPTION
Previously we were just updating the private passphrase, but after the forced upgrade for account locking we need to update all accounts to the new private passphrase as well.