### PR TITLE
[transactions] Limit number of non wallet outputs

### DIFF
--- a/app/actions/TransactionActions.js
+++ b/app/actions/TransactionActions.js
@@ -25,6 +25,7 @@ import {
   REVOKED
 } from "constants";
 import { getNextAddressAttempt } from "./ControlActions";
+import { MaxNonWalletOutputs } from "constants";
 
 const { TransactionDetails } = api;
 
@@ -511,9 +512,8 @@ const getNonWalletOutputs = (walletService, chainParams, tx) =>
       // etc cause crashes in decrediton due to this repeated request for
       // validate address.  Since this is merely for display purposes we will
       //  we limit the amount of outputs to 10.
-      const nonWalletLimit = 10;
       let updatedOutputs = [];
-      if (decodedTx.outputs.length > nonWalletLimit) {
+      if (decodedTx.outputs.length > MaxNonWalletOutputs) {
         updatedOutputs = decodedTx.outputs.map((o) => {
           const address = o.decodedScript.address;
           return {

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -11,6 +11,7 @@ import {
 } from "constants/decrediton";
 import styles from "./TransactionContent.module.css";
 import { classNames } from "pi-ui";
+import { MaxNonWalletOutputs } from "constants";
 
 const { DecodedTransaction } = api;
 
@@ -129,9 +130,16 @@ const TransactionContent = ({
               {txOutputs.map(({ address }, i) => (
                 <div key={i}>{addSpacingAroundText(address)}</div>
               ))}
-              {nonWalletOutputs.map(({ address }, i) => (
-                <div key={i}>{addSpacingAroundText(address)}</div>
-              ))}
+              {nonWalletOutputs.length > MaxNonWalletOutputs ? (
+                <T
+                  id="txDetails.tooManyNonWalletOutputsAddresses"
+                  m="Please use the txid link above to see all non-wallet addresses on dcrdata."
+                />
+              ) : (
+                nonWalletOutputs.map(({ address }, i) => (
+                  <div key={i}>{addSpacingAroundText(address)}</div>
+                ))
+              )}
             </div>
           </div>
         )}
@@ -275,14 +283,24 @@ const TransactionContent = ({
                 }>
                 <T id="txDetails.nonWalletOutputs" m="Non Wallet Outputs" />
               </div>
-              {nonWalletOutputs.map(({ address, amount }, idx) => (
-                <div key={idx} className={styles.row}>
-                  <div className={classNames(styles.address, styles.nonWallet)}>
-                    {addSpacingAroundText(address)}
-                  </div>
-                  <div className={styles.amount}>{amount}</div>
+              {nonWalletOutputs.length > MaxNonWalletOutputs ? (
+                <div className={styles.row}>
+                  <T
+                    id="txDetails.tooManyNonWalletOutputs"
+                    m="Please use the txid link above to see all non-wallet outputs on dcrdata."
+                  />
                 </div>
-              ))}
+              ) : (
+                nonWalletOutputs.map(({ address, amount }, idx) => (
+                  <div key={idx} className={styles.row}>
+                    <div
+                      className={classNames(styles.address, styles.nonWallet)}>
+                      {addSpacingAroundText(address)}
+                    </div>
+                    <div className={styles.amount}>{amount}</div>
+                  </div>
+                ))
+              )}
             </div>
           </div>
         </div>

--- a/app/constants/decred.js
+++ b/app/constants/decred.js
@@ -131,3 +131,8 @@ export const ripemd160Size = 20;
 // for an SStx tx.
 // 20 bytes P2SH/P2PKH + 8 byte amount + 4 byte fee range limits
 export const SStxPKHMinOutSize = 32;
+
+// Due processing issues we only validate addresses for transactions that have
+// less than 10 non wallet outputs.  We also limit listing addresses on
+// the transaction details when over this amount.
+export const MaxNonWalletOutputs = 10;


### PR DESCRIPTION
We were able to determine various crashes in 1.6.3 were caused by the processing of transactions that contained very large amounts of outputs.  So avoid this we will limit the number of outputs to check to 10.  Also this is just for display purposes in transaction details so it shouldn't effect any functionality.