### PR TITLE
dex: Add dex seed and pre-registration check

### DIFF
--- a/app/actions/DexActions.js
+++ b/app/actions/DexActions.js
@@ -106,7 +106,6 @@ export const initDex = (passphrase, seed) => async (dispatch, getState) => {
   }
   try {
     await dex.init(passphrase, seed);
-    console.log(seed);
     dispatch({ type: DEX_INIT_SUCCESS, fromSeed: seed });
     // Request current user information
     dispatch(userDex());

--- a/app/actions/DexActions.js
+++ b/app/actions/DexActions.js
@@ -98,15 +98,16 @@ export const DEX_INIT_ATTEMPT = "DEX_INIT_ATTEMPT";
 export const DEX_INIT_SUCCESS = "DEX_INIT_SUCCESS";
 export const DEX_INIT_FAILED = "DEX_INIT_FAILED";
 
-export const initDex = (passphrase) => async (dispatch, getState) => {
+export const initDex = (passphrase, seed) => async (dispatch, getState) => {
   dispatch({ type: DEX_INIT_ATTEMPT });
   if (!sel.dexActive(getState())) {
     dispatch({ type: DEX_INIT_FAILED, error: "Dex isn't active" });
     return;
   }
   try {
-    await dex.init(passphrase);
-    dispatch({ type: DEX_INIT_SUCCESS });
+    await dex.init(passphrase, seed);
+    console.log(seed);
+    dispatch({ type: DEX_INIT_SUCCESS, fromSeed: seed });
     // Request current user information
     dispatch(userDex());
   } catch (error) {
@@ -256,6 +257,31 @@ export const userDex = () => async (dispatch, getState) => {
     dispatch({ type: DEX_USER_SUCCESS, user });
   } catch (error) {
     dispatch({ type: DEX_USER_FAILED, error });
+    return;
+  }
+};
+
+export const DEX_PREREGISTER_ATTEMPT = "DEX_PREREGISTER_ATTEMPT";
+export const DEX_PREREGISTER_SUCCESS = "DEX_PREREGISTER_SUCCESS";
+export const DEX_PREREGISTER_FAILED = "DEX_PREREGISTER_FAILED";
+
+export const preRegisterDex = (appPass, addr) => async (dispatch, getState) => {
+  dispatch({ type: DEX_PREREGISTER_ATTEMPT });
+  if (!sel.dexActive(getState())) {
+    dispatch({ type: DEX_PREREGISTER_FAILED, error: "Dex isn't active" });
+    return;
+  }
+  try {
+    const alreadyPaid = await dex.preRegister(appPass, addr);
+    // If it's not already paid it returns the config that is used to pay the
+    // required fee.
+    if (typeof alreadyPaid == "boolean") {
+      dispatch({ type: DEX_PREREGISTER_SUCCESS, alreadyPaid, addr });
+    } else {
+      dispatch({ type: DEX_GETCONFIG_SUCCESS, config: alreadyPaid, addr });
+    }
+  } catch (error) {
+    dispatch({ type: DEX_PREREGISTER_FAILED, error });
     return;
   }
 };

--- a/app/components/views/DexPage/InitPage/InitPage.jsx
+++ b/app/components/views/DexPage/InitPage/InitPage.jsx
@@ -1,9 +1,17 @@
 import { FormattedMessage as T } from "react-intl";
 import { useDex } from "../hooks";
+import { classNames, Checkbox } from "pi-ui";
+import { useInitPage } from "./hooks";
 import { SetNewPassphraseModalButton } from "buttons";
+import { TextInput } from "inputs";
+import styles from "./InitPage.module.css";
 
 const InitPage = () => {
-  const { onInitDex, initDexAttempt } = useDex();
+  const { onInitDex, onInitDexWithSeed, initDexAttempt } = useDex();
+  const { hasSeed, toggleHasSeed, seed, setSeed, onInitDexCall } = useInitPage({
+    onInitDex,
+    onInitDexWithSeed
+  });
 
   return (
     <>
@@ -19,12 +27,39 @@ const InitPage = () => {
           m="Note: If you lose the DEX passphrase, you will be forced to create a new DEX account and pay your exchange fees again."
         />
       </div>
+      <Checkbox
+        label={
+          <T
+            id="dex.hasDexSeed.label"
+            m="I already have a DEX Seed to recover."
+          />
+        }
+        id="hasDexSeed"
+        description={
+          <T
+            id="dex.hasDexSeed.description"
+            m="DEX has a seed that allows you to recover your account at a paticular server."
+          />
+        }
+        checked={hasSeed}
+        onChange={toggleHasSeed}
+      />
+      {hasSeed && (
+        <TextInput
+          id="dexSeed"
+          className={classNames("margin-top-m", styles.seedInput)}
+          required
+          value={seed}
+          onChange={(e) => setSeed(e.target.value)}
+          placeholder="DEX Seed"
+        />
+      )}
       <SetNewPassphraseModalButton
         className="margin-top-m"
         disabled={initDexAttempt}
         modalTitle={<T id="dex.initPassphrase" m="Set Dex Passphrase" />}
         loading={initDexAttempt}
-        onSubmit={onInitDex}
+        onSubmit={onInitDexCall}
         buttonLabel={<T id="dex.initPassphraseButton" m="Set Dex Passphrase" />}
       />
     </>

--- a/app/components/views/DexPage/InitPage/InitPage.module.css
+++ b/app/components/views/DexPage/InitPage/InitPage.module.css
@@ -1,0 +1,4 @@
+.seedInput {
+  width: 90% !important;
+  max-width: 650px;
+}

--- a/app/components/views/DexPage/InitPage/hooks.js
+++ b/app/components/views/DexPage/InitPage/hooks.js
@@ -1,0 +1,44 @@
+import { useMountEffect } from "hooks";
+import { useState, useCallback } from "react";
+
+export const useInitPage = ({ onInitDex, onInitDexWithSeed }) => {
+  const [hasSeed, setHasSeed] = useState(false);
+
+  const [seed, setSeed] = useState("");
+
+  const [seedError, setSeedError] = useState(null);
+
+  const resetState = () => {
+    setSeed("");
+    setSeedError(null);
+  };
+
+  useMountEffect(() => {
+    resetState();
+  });
+
+  const onInitDexCall = (passphrase) => {
+    if (hasSeed) {
+      if (seed == "") {
+        setSeedError("You must enter a seed.");
+      } else {
+        onInitDexWithSeed(passphrase, seed);
+      }
+    } else {
+      onInitDex(passphrase);
+    }
+  };
+
+  const toggleHasSeed = useCallback(() => {
+    setHasSeed(!hasSeed);
+  }, [hasSeed]);
+
+  return {
+    hasSeed,
+    toggleHasSeed,
+    seed,
+    setSeed,
+    seedError,
+    onInitDexCall
+  };
+};

--- a/app/components/views/DexPage/RegisterPage/RegisterPage.jsx
+++ b/app/components/views/DexPage/RegisterPage/RegisterPage.jsx
@@ -14,23 +14,28 @@ const RegisterPage = () => {
     onRegisterDex,
     registerDexAttempt,
     onGetConfig,
+    onPreregister,
     dexConfig,
     dexAddr,
     defaultServerAddress,
-    dexRegisterError
+    dexRegisterError,
+    restoredFromSeed
   } = useDex();
 
   const {
     isValid,
     error,
     onGetConfigDex,
+    onPreRegisterDex,
     addr,
     setAddress,
     dexAccountNumber,
     defaultSpendingAccount,
-    dexAccountSpendable
+    dexAccountSpendable,
+    getConfigAttempt
   } = useDexRegisterPage({
     onGetConfig,
+    onPreregister,
     defaultServerAddress
   });
 
@@ -121,6 +126,42 @@ const RegisterPage = () => {
         )}
       </>
     );
+  } else if (restoredFromSeed) {
+    return (
+      <div>
+        <label className={styles.dexAddressLabel} htmlFor="dexServer">
+          <T id="dex.dexServer" m="DEX Server" />
+        </label>
+        <TextInput
+          id="dexServer"
+          className={styles.dexAddress}
+          required
+          value={addr}
+          onChange={(e) => setAddress(e.target.value)}
+          placeholder="DEX Server"
+        />
+        {error && <div className="error">{error}</div>}
+        <PassphraseModalButton
+          className="margin-top-m"
+          disabled={!isValid || getConfigAttempt}
+          modalTitle={
+            <T id="dex.preRegisterModalTitle" m="Confirm Registration Check" />
+          }
+          modalDescription={
+            <T
+              id="dex.preRegisterModalDescription"
+              m="Since you have restored your DEX account from seed, we can now check to see if you have already paid your fee at the provided DEX server."
+            />
+          }
+          passphraseLabel={
+            <T id="dex.payDexFeeAppPassphrase" m="DEX Passphrase" />
+          }
+          loading={getConfigAttempt}
+          onSubmit={onPreRegisterDex}
+          buttonLabel={<T id="dex.preRegisterButton" m="Check Registration" />}
+        />
+      </div>
+    );
   } else {
     return (
       <div>
@@ -138,8 +179,8 @@ const RegisterPage = () => {
         {error && <div className="error">{error}</div>}
         <KeyBlueButton
           className="margin-top-m"
-          disabled={!isValid || registerDexAttempt}
-          loading={registerDexAttempt}
+          disabled={!isValid || getConfigAttempt}
+          loading={getConfigAttempt}
           onClick={onGetConfigDex}>
           <T id="dex.getFeeButton" m="Get Fee to Pay" />
         </KeyBlueButton>

--- a/app/components/views/DexPage/RegisterPage/hooks.js
+++ b/app/components/views/DexPage/RegisterPage/hooks.js
@@ -2,12 +2,18 @@ import { useEffect, useState, useCallback } from "react";
 import { useSelector, shallowEqual } from "react-redux";
 import * as sel from "selectors";
 
-export const useDexRegisterPage = ({ defaultServerAddress, onGetConfig }) => {
+export const useDexRegisterPage = ({
+  defaultServerAddress,
+  onPreregister,
+  onGetConfig
+}) => {
   const [isValid, setIsValid] = useState(false);
   const [addr, setAddress] = useState(defaultServerAddress);
   const [error, setIsError] = useState("");
 
+  const getConfigAttempt = useSelector(sel.getConfigAttempt);
   const dexAccountNumber = useSelector(sel.dexAccountNumber);
+  const alreadyPaid = useSelector(sel.alreadyPaid);
   const defaultSpendingAccount = useSelector(
     sel.defaultSpendingAccount,
     shallowEqual
@@ -18,6 +24,10 @@ export const useDexRegisterPage = ({ defaultServerAddress, onGetConfig }) => {
     setAddress(null);
   }, []);
 
+  const onPreRegisterDex = (passphrase) => {
+    onPreregister(passphrase, addr);
+    resetState();
+  };
   const onGetConfigDex = () => {
     onGetConfig(addr);
     resetState();
@@ -46,12 +56,15 @@ export const useDexRegisterPage = ({ defaultServerAddress, onGetConfig }) => {
 
   return {
     onGetConfigDex,
+    onPreRegisterDex,
     error,
     isValid,
     addr,
     setAddress,
     dexAccountNumber,
     defaultSpendingAccount,
-    dexAccountSpendable
+    dexAccountSpendable,
+    getConfigAttempt,
+    alreadyPaid
   };
 };

--- a/app/components/views/DexPage/hooks.js
+++ b/app/components/views/DexPage/hooks.js
@@ -57,6 +57,8 @@ export const useDex = () => {
   const btcWalletName = useSelector(sel.btcWalletName);
   const mixedAccount = useSelector(sel.getMixedAccount);
   const intl = useIntl();
+  const restoredFromSeed = useSelector(sel.restoredFromSeed);
+  const alreadyPaid = useSelector(sel.alreadyPaid);
 
   const onGetDexLogs = () => dispatch(dm.getDexLogs());
   const onLaunchDexWindow = useCallback(() => dispatch(da.launchDexWindow()), [
@@ -65,6 +67,11 @@ export const useDex = () => {
 
   const onInitDex = useCallback(
     (passphrase) => dispatch(da.initDex(passphrase)),
+    [dispatch]
+  );
+
+  const onInitDexWithSeed = useCallback(
+    (passphrase, seed) => dispatch(da.initDex(passphrase, seed)),
     [dispatch]
   );
 
@@ -101,6 +108,11 @@ export const useDex = () => {
 
   const onEnableDex = useCallback(() => dispatch(da.enableDex()), [dispatch]);
 
+  const onPreregister = useCallback(
+    (passphrase, address) => dispatch(da.preRegisterDex(passphrase, address)),
+    [dispatch]
+  );
+
   const onGetConfig = useCallback(
     (address) => dispatch(da.getConfigDex(address)),
     [dispatch]
@@ -125,7 +137,7 @@ export const useDex = () => {
           page = <LoginPage />;
           header = <LoginPageHeader />;
         } else if (
-          dexRegistered &&
+          (dexRegistered || alreadyPaid) &&
           dexDCRWalletRunning &&
           dexBTCWalletRunning
         ) {
@@ -165,7 +177,8 @@ export const useDex = () => {
     dexRegistered,
     dexDCRWalletRunning,
     dexBTCWalletRunning,
-    dexAccount
+    dexAccount,
+    alreadyPaid
   ]);
 
   return {
@@ -173,6 +186,7 @@ export const useDex = () => {
     dexActive,
     dexInit,
     onInitDex,
+    onInitDexWithSeed,
     initDexAttempt,
     onRegisterDex,
     onGetDexLogs,
@@ -191,6 +205,7 @@ export const useDex = () => {
     onEnableDex,
     enableDexAttempt,
     onGetConfig,
+    onPreregister,
     user,
     onLaunchDexWindow,
     onBTCCreateWalletDex,
@@ -218,6 +233,8 @@ export const useDex = () => {
     Page,
     Header,
     mixedAccount,
-    intl
+    intl,
+    restoredFromSeed,
+    alreadyPaid
   };
 };

--- a/app/index.js
+++ b/app/index.js
@@ -479,7 +479,8 @@ const initialState = {
   },
   dex: {
     dexOrdersOpen: false,
-    loggedIn: false
+    loggedIn: false,
+    alreadyPaid: false
   },
   locales: locales
 };

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -78,6 +78,7 @@ import {
   loginDex,
   logoutDex,
   getConfigDex,
+  preRegister,
   registerDex
 } from "./main_dev/ipc";
 import {
@@ -400,6 +401,8 @@ handle("logout-dex", logoutDex);
 handle("create-wallet-dex", createWalletDex);
 
 handle("get-config-dex", getConfigDex);
+
+handle("preregister-dex", preRegister);
 
 handle("register-dex", registerDex);
 

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -23,6 +23,7 @@ import {
   initDexCall,
   createWalletDexCall,
   getDexConfigCall,
+  preRegisterCall,
   registerDexCall,
   userDexCall,
   loginDexCall,
@@ -276,14 +277,14 @@ export const checkInitDex = async () => {
   }
 };
 
-export const initDex = async (passphrase) => {
+export const initDex = async (passphrase, seed) => {
   if (!GetDexPID()) {
     logger.log("info", "Skipping init since dex is not runnning");
     return false;
   }
 
   try {
-    const init = await initDexCall(passphrase);
+    const init = await initDexCall(passphrase, seed);
     return init;
   } catch (e) {
     logger.log("error", `error init dex: ${e}`);
@@ -365,6 +366,22 @@ export const getConfigDex = async (addr) => {
     return getDexConfig;
   } catch (e) {
     logger.log("error", `error get config dex: ${e}`);
+    return e;
+  }
+};
+
+export const preRegister = async (appPass, addr) => {
+  if (!GetDexPID()) {
+    logger.log("info", "Skipping preregister since dex is not runnning");
+    return false;
+  }
+
+  try {
+    const registered = await preRegisterCall(appPass, addr);
+    console.log("registered already?", registered);
+    return registered;
+  } catch (e) {
+    logger.log("error", `error preregister dex: ${e}`);
     return e;
   }
 };

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -938,8 +938,8 @@ export const launchDex = (walletPath, testnet, locale) => {
 
 export const initCheckDex = () => (!dex ? null : callDEX("IsInitialized", {}));
 
-export const initDexCall = (passphrase) =>
-  !dex ? null : callDEX("Init", { pass: passphrase });
+export const initDexCall = (passphrase, seed) =>
+  !dex ? null : callDEX("Init", { pass: passphrase, seed: seed });
 
 export const loginDexCall = (passphrase) =>
   !dex ? null : callDEX("Login", { pass: passphrase });
@@ -1007,6 +1007,9 @@ export const createWalletDexCall = (
 
 export const getDexConfigCall = (addr) =>
   !dex ? null : callDEX("DexConfig", { addr });
+
+export const preRegisterCall = (appPass, addr) =>
+  !dex ? null : callDEX("PreRegister", { appPass, addr });
 
 export const registerDexCall = (appPass, addr, fee) =>
   !dex

--- a/app/reducers/dex.js
+++ b/app/reducers/dex.js
@@ -29,6 +29,9 @@ import {
   DEX_GETCONFIG_ATTEMPT,
   DEX_GETCONFIG_FAILED,
   DEX_GETCONFIG_SUCCESS,
+  DEX_PREREGISTER_ATTEMPT,
+  DEX_PREREGISTER_FAILED,
+  DEX_PREREGISTER_SUCCESS,
   CREATEDEXACCOUNT_ATTEMPT,
   CREATEDEXACCOUNT_FAILED,
   CREATEDEXACCOUNT_SUCCESS,
@@ -189,7 +192,8 @@ export default function ln(state = {}, action) {
         initAttempt: false,
         dexInit: true,
         loggedIn: true,
-        registerError: null
+        registerError: null,
+        restoredFromSeed: action.fromSeed
       };
     case DEX_LAUNCH_WINDOW_ATTEMPT:
       return {
@@ -253,6 +257,27 @@ export default function ln(state = {}, action) {
         config: action.config,
         addr: action.addr,
         getConfigError: null
+      };
+    case DEX_PREREGISTER_ATTEMPT:
+      return {
+        ...state,
+        getConfigAttempt: true,
+        addr: null,
+        getConfigError: null
+      };
+    case DEX_PREREGISTER_FAILED:
+      return {
+        ...state,
+        getConfigAttempt: false,
+        getConfigError: action.error
+      };
+    case DEX_PREREGISTER_SUCCESS:
+      return {
+        ...state,
+        getConfigAttempt: false,
+        addr: action.addr,
+        getConfigError: null,
+        alreadyPaid: action.alreadyPaid
       };
     case CREATEDEXACCOUNT_ATTEMPT:
       return {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1845,6 +1845,7 @@ export const getHasTicketFeeError = createSelector(
       : false;
   }
 );
+export const restoredFromSeed = get(["dex", "restoredFromSeed"]);
 export const dexOrdersOpen = get(["dex", "openOrder"]);
 export const loggedInDex = bool(get(["dex", "loggedIn"]));
 
@@ -1934,6 +1935,8 @@ export const dexBTCWalletRunning = compose(
 
 export const dexAddr = get(["dex", "addr"]);
 export const dexConfig = get(["dex", "config"]);
+export const alreadyPaid = get(["dex", "alreadyPaid"]);
+export const getConfigAttempt = get(["dex", "getConfigAttempt"]);
 export const dexAccount = get(["walletLoader", "dexAccount"]);
 export const dexAccountNumber = createSelector(
   [dexAccount, balances],

--- a/app/wallet/dex/index.js
+++ b/app/wallet/dex/index.js
@@ -9,6 +9,7 @@ export const logout = invocable("logout-dex");
 export const createWallet = invocable("create-wallet-dex");
 export const user = invocable("user-dex");
 export const getConfig = invocable("get-config-dex");
+export const preRegister = invocable("preregister-dex");
 export const register = invocable("register-dex");
 export const launchWindow = invocable("launch-dex-window");
 export const checkBTCConfig = invocable("check-btc-config");

--- a/modules/dex/libdexc/adapter.go
+++ b/modules/dex/libdexc/adapter.go
@@ -288,7 +288,7 @@ func (c *CoreAdapter) register(raw json.RawMessage) (string, error) {
 
 // When restoring from seed with init/InitializeClient, it may be desirable to
 // first attempt DEX account discovery without commiting to a fee payment. This
-// check with the given DEX server if our account (a public key) is already
+// checks with the given DEX server if our account (a public key) is already
 // registered. If it is, this creates the account in Core, returns true, and the
 // caller should NOT call register. If it returns false, the user should be
 // prompted to pay the registration fee as normal using the register method.

--- a/modules/dex/libdexc/adapter.go
+++ b/modules/dex/libdexc/adapter.go
@@ -6,6 +6,7 @@ package main
 import "C"
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -72,6 +73,7 @@ func NewCoreAdapter() *CoreAdapter {
 		"CreateWallet": c.createWallet,
 		"UpdateWallet": c.updateWallet,
 		"User":         c.user,
+		"PreRegister":  c.discoverAcct,
 		"Register":     c.register,
 		"Login":        c.login,
 		"Logout":       c.logout,
@@ -208,13 +210,20 @@ func (c *CoreAdapter) run(callData *CallData) (string, error) {
 func (c *CoreAdapter) init(raw json.RawMessage) (string, error) {
 	form := new(struct {
 		Pass string `json:"pass"`
-		// Seed string `json:"seed"` (TODO)
+		Seed string `json:"seed"`
 	})
 	if err := json.Unmarshal(raw, form); err != nil {
 		return "", err
 	}
-
+	if form.Seed != "" {
+		seed, err := hex.DecodeString(form.Seed)
+		if err != nil {
+			return "", err
+		}
+		return "", c.core.InitializeClient([]byte(form.Pass), seed)
+	}
 	return "", c.core.InitializeClient([]byte(form.Pass), nil)
+
 }
 
 func (c *CoreAdapter) isInitialized(json.RawMessage) (string, error) {
@@ -292,9 +301,13 @@ func (c *CoreAdapter) discoverAcct(raw json.RawMessage) (string, error) {
 	if err := json.Unmarshal(raw, form); err != nil {
 		return "", err
 	}
-	_, alreadyRegistered, err := c.core.DiscoverAccount(form.Addr, []byte(form.AppPW), []byte(form.Cert))
+	config, alreadyRegistered, err := c.core.DiscoverAccount(form.Addr, []byte(form.AppPW), []byte(form.Cert))
 	// If alreadyRegistered == true, skip register. It's ready to go.
-	return replyWithErrorCheck(alreadyRegistered, err)
+	if alreadyRegistered {
+		return replyWithErrorCheck(alreadyRegistered, err)
+	} else {
+		return replyWithErrorCheck(config, err)
+	}
 }
 
 func (c *CoreAdapter) login(raw json.RawMessage) (string, error) {


### PR DESCRIPTION
Require #3549 

This adds the ability to restore a DEX account from seed.  Along with that functionality, when a user restores from seed we check to see if they have already paid the server's registration fee.  If they have they can skip the step that asks for payment.