### PR TITLE
Fix error flows in create wallet

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -319,7 +319,15 @@ export const createWallet = (selectedWallet) => (dispatch, getState) =>
           selectedWallet.value.wallet,
           network == TESTNET
         );
-        await dispatch(startWallet(selectedWallet));
+        try {
+          await dispatch(startWallet(selectedWallet));
+        } catch (error) {
+          // This error message happens if we start creating a wallet. As its
+          // wallet.db file still not created.
+          if (!error.message.includes("missing database file")) {
+            throw error;
+          }
+        }
         dispatch({
           isWatchingOnly: selectedWallet.value.isWatchingOnly,
           createNewWallet: selectedWallet.value.isNew,

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -219,11 +219,6 @@ export const openWalletAttempt = (pubPass, retryAttempt) => (
         resolve(true);
       })
       .catch(async (error) => {
-        // This error message happens if we start creating a wallet. As its
-        // wallet.db file still not created.
-        if (error.message.includes("missing database file")) {
-          resolve();
-        }
         // This error message happens after creating a new wallet as we already
         // started it on creation. So we just ignore it.
         if (error.message.includes("wallet already")) {
@@ -698,4 +693,14 @@ export const setLastPoliteiaAccessTime = () => (dispatch, getState) => {
     currentBlockHeight,
     timestamp
   });
+};
+
+export const STOP_UNFINISHED_WALLET_FAILED = "STOP_UNFINISHED_WALLET_FAILED";
+export const stopUnfinishedWallet = () => async (dispatch) => {
+  try {
+    await wallet.stopWallet();
+    dispatch(setSelectedWallet(null));
+  } catch (err) {
+    dispatch({ error: err, type: STOP_UNFINISHED_WALLET_FAILED });
+  }
 };

--- a/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
+++ b/app/components/views/GetStartedPage/CreateWalletPage/CreateWalletPage.jsx
@@ -86,7 +86,10 @@ const CreateWalletPage = ({ createWalletRef, onSendBack }) => {
     if (!(seed && passPhrase)) return;
     createWalletRequest(pubpass, passPhrase, seed, newWallet)
       .then(() => sendEvent({ type: "WALLET_CREATED" }))
-      .catch((error) => sendEvent({ type: "ERROR", error }));
+      .catch(async (error) => {
+        await cancelCreateWallet();
+        sendEvent({ type: "ERROR", payload: { error } });
+      });
     // we send a continue so we go to loading state
     sendContinue();
   }, [
@@ -94,7 +97,8 @@ const CreateWalletPage = ({ createWalletRef, onSendBack }) => {
     current.context,
     newWallet,
     sendContinue,
-    sendEvent
+    sendEvent,
+    cancelCreateWallet
   ]);
 
   const onCreateWatchOnly = useCallback(() => {

--- a/app/components/views/GetStartedPage/GetStartedMachinePage/GetStartedMachinePage.jsx
+++ b/app/components/views/GetStartedPage/GetStartedMachinePage/GetStartedMachinePage.jsx
@@ -7,6 +7,7 @@ export default ({
   StateComponent,
   getDaemonSynced,
   error,
+  availableWalletsError,
   text,
   getCurrentBlockCount,
   animationType,
@@ -44,6 +45,11 @@ export default ({
     {error && (
       <div className={classNames(styles.error, styles.launchError)}>
         {error}
+      </div>
+    )}
+    {availableWalletsError && (
+      <div className={classNames(styles.error, styles.launchError)}>
+        {availableWalletsError}
       </div>
     )}
     {daemonWarning && (

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -230,6 +230,11 @@ const useDaemonStartup = () => {
     [dispatch]
   );
 
+  const stopUnfinishedWallet = useCallback(
+    () => dispatch(wla.stopUnfinishedWallet()),
+    [dispatch]
+  );
+
   return {
     onShowTutorial,
     validateMasterPubKey,
@@ -307,7 +312,8 @@ const useDaemonStartup = () => {
     rememberedVspHost,
     isProcessingManaged,
     isProcessingUnmanaged,
-    needsProcessManagedTickets
+    needsProcessManagedTickets,
+    stopUnfinishedWallet
   };
 };
 

--- a/app/stateMachines/CreateWalletStateMachine.js
+++ b/app/stateMachines/CreateWalletStateMachine.js
@@ -132,12 +132,14 @@ export const CreateWalletMachine = Machine({
     loading: {
       on: {
         ERROR: {
-          target: "walletCreated",
+          target: "finished",
           actions: [
-            assign({ completed: true }),
-            sendParent((ctx, event) => ({
-              type: event.type,
-              passPhrase: ctx.passPhrase
+            assign({
+              completed: true
+            }),
+            sendParent((_, { type, payload: { error } }) => ({
+              type: type,
+              error: error
             }))
           ]
         },

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -15,6 +15,7 @@ export const getStartedMachine = Machine({
     selectedWallet: null,
     appdata: null,
     error: null,
+    availableWalletsError: null,
     isCreateNewWallet: null,
     isSPV: null,
     isAdvancedDaemon: null
@@ -64,6 +65,22 @@ export const getStartedMachine = Machine({
             },
             CHOOSE_WALLET: {
               target: "choosingWallet",
+              actions: assign({
+                isAdvancedDaemon: (context, event) =>
+                  event.isAdvancedDaemon
+                    ? !!event.isAdvancedDaemon
+                    : context.isAdvancedDaemon,
+                isSPV: (context, event) =>
+                  event.isSPV ? !!event.isSPV : context.isSPV,
+                selectedWallet: (context, event) =>
+                  event.selectedWallet
+                    ? event.selectedWallet
+                    : context.selectedWallet,
+                error: (context, event) => event.error
+              })
+            },
+            SUBMIT_CHOOSE_WALLET: {
+              target: "startingWallet",
               actions: assign({
                 isAdvancedDaemon: (context, event) =>
                   event.isAdvancedDaemon
@@ -190,6 +207,7 @@ export const getStartedMachine = Machine({
             CREATE_WALLET: {
               target: "preCreateWallet",
               actions: assign({
+                error: () => "",
                 isCreateNewWallet: (context, event) =>
                   !isUndefined(event.isNew)
                     ? event.isNew
@@ -199,7 +217,15 @@ export const getStartedMachine = Machine({
             ERROR: {
               target: "choosingWallet",
               actions: assign({
-                error: (_, event) => event.error
+                error: (_, event) => event.error && event.error,
+                availableWalletsError: () => ""
+              })
+            },
+            AVAILABLE_WALLET_ERROR: {
+              target: "choosingWallet",
+              actions: assign({
+                error: () => "",
+                availableWalletsError: (_, event) => event.error && event.error
               })
             }
           }
@@ -300,13 +326,14 @@ export const getStartedMachine = Machine({
         WALLET_CREATED: {
           target: "startMachine.preStart",
           actions: assign({
+            error: () => "",
             passPhrase: (context, event) => event.passPhrase
           })
         },
         ERROR: {
-          target: "startMachine.preCreateWallet",
+          target: "startMachine.choosingWallet",
           actions: assign({
-            error: (context, event) => event.error && event.error
+            error: (_, event) => event.error && event.error
           })
         }
       }

--- a/test/unit/components/views/GetStaredPage/CreateWallet.spec.js
+++ b/test/unit/components/views/GetStaredPage/CreateWallet.spec.js
@@ -319,7 +319,10 @@ test("pasting invalid seed words on existing seed view", async () => {
   await wait(() => screen.getByText(/Error: seed is not valid./i));
 });
 
-test("pasting valid seed words on existing seed view and receive decode error and create wallet request error", async () => {
+test("pasting valid seed words on existing seed view and receive create wallet request error", async () => {
+  mockCreateWalletRequest = wlActions.createWalletRequest = jest.fn(() => () =>
+    Promise.reject(testCreateWalletRequestErrorMsg)
+  );
   mockDecodeSeed = wlActions.decodeSeed = jest.fn(() => () =>
     Promise.resolve({
       decodedSeed: testSeedArray
@@ -339,8 +342,10 @@ test("pasting valid seed words on existing seed view and receive decode error an
   expect(mockCreateWallet).toHaveBeenCalled();
   expect(mockCreateWalletRequest).toHaveBeenCalled();
 
-  // A check needs to be added here after
-  // https://github.com/decred/decrediton/issues/3524 is fixed.
+  // expect to jump back to the wallet choose view, and display
+  // the error msg received from createWalletRequest
+  await wait(() => screen.getByText(testCreateWalletRequestErrorMsg));
+  screen.getByText(/choose a wallet to open/i);
 });
 
 test("pasting valid seed words on existing seed view and successfully create wallet", async () => {

--- a/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
+++ b/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
@@ -320,7 +320,9 @@ test("trezor device is connected", async () => {
   };
 
   mockCreateWatchOnlyWalletRequest = wlActions.createWatchOnlyWalletRequest = jest.fn(
-    () => () => Promise.resolve(true)
+    () => () => {
+      return new Promise((resolve) => setTimeout(() => resolve(), 1));
+    }
   );
   mockCreateWallet = daemonActions.createWallet = jest.fn(() => () => {
     return Promise.resolve(testRestoreSelectedWallet);
@@ -354,16 +356,14 @@ test("trezor device is connected", async () => {
   expect(mockEnableTrezor).toHaveBeenCalled();
 
   user.click(continueButton);
+  await wait(() => expect(screen.getByTestId("decred-loading")));
   expect(mockGetWalletCreationMasterPubKey).toHaveBeenCalled();
   await wait(() =>
-    expect(mockCreateWallet).toHaveBeenCalledWith(testRestoreSelectedWallet)
+    expect(mockCreateWatchOnlyWalletRequest).toHaveBeenCalledWith(
+      testWalletCreationMasterPubKey,
+      ""
+    )
   );
-  expect(mockAlertNoConnectedDevice).not.toHaveBeenCalled();
-
-  // This is wrong: after creating the wallet the wallet selection screen
-  // shouldn't be flashing. This needs to be fixed when addressing
-  // https://github.com/decred/decrediton/issues/3524
-  expect(screen.getByText("Launch Wallet")).toBeInTheDocument();
 });
 
 test("trezor has to auto-disable when step back from restore view", async () => {


### PR DESCRIPTION
Closes #3524

Found and fixed these errors in create wallet flow:
1. rejecting the final confirmation dialog (or receiving an error from the wallet create request) at the final stage of creation/restore wallet jumps back to the create/restore view (`PreCreateWallet`) and displays an error: `loader.OpenExistingWallet: item does not exist:: wallet.OpenDB: missing database file`. The wallet is partially created and started but until the restart of the app, it can not be stopped or start any other wallet. 
2. when an app refresh breaks the creation/restore process, a similar thing happens. The partially created/restored wallet is running in the background and it can not be stopped or start any other wallet. 
3. the flashing wallet selection screen after creating a wallet is also fixed. It is mentioned here: https://github.com/decred/decrediton/blob/c46d2f8e0fe40cebf16cecab1adb3b6056775bca/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js#L363/L365