### PR TITLE
[trezor] keep the trezor word modal alive during the restore device process

### DIFF
--- a/app/actions/TrezorActions.js
+++ b/app/actions/TrezorActions.js
@@ -267,6 +267,9 @@ function setDeviceListeners(dispatch, getState) {
       case UI.REQUEST_WORD: {
         console.log("word requested, waiting two seconds to respond");
         await new Promise((r) => setTimeout(r, 2000));
+        const {
+          trezor: { performingRecoverDevice }
+        } = getState();
         const wordCallBack = (canceled, word) => {
           if (canceled) {
             session.cancel();
@@ -277,7 +280,12 @@ function setDeviceListeners(dispatch, getState) {
             });
           }
         };
-        dispatch({ wordCallBack, type: TRZ_WORD_REQUESTED });
+        // During sleep, the restore process may have been canceled.
+        if (performingRecoverDevice) {
+          dispatch({ wordCallBack, type: TRZ_WORD_REQUESTED });
+        } else {
+          session?.cancel();
+        }
         break;
       }
 

--- a/app/components/modals/TrezorModals/TrezorWordModal.jsx
+++ b/app/components/modals/TrezorModals/TrezorWordModal.jsx
@@ -19,7 +19,12 @@ const getSeedWords = (input, callback) => {
   });
 };
 
-const TrezorWordModal = ({ isGetStarted, onCancelModal, onSubmitWord }) => {
+const TrezorWordModal = ({
+  isGetStarted,
+  onCancelModal,
+  onSubmitWord,
+  waitingForWord
+}) => {
   const [word, setWord] = useState("");
   const [value, setValue] = useState(null);
 
@@ -88,11 +93,16 @@ const TrezorWordModal = ({ isGetStarted, onCancelModal, onSubmitWord }) => {
             />
           }
           onInputKeyDown={onSelectKeyDown}
+          disabled={!waitingForWord}
         />
       </div>
 
       <ButtonsToolbar
-        {...{ onCancelModal: onCancelWordModal, onSubmit }}
+        {...{
+          onCancelModal: onCancelWordModal,
+          onSubmit,
+          loading: !waitingForWord
+        }}
         className={styles.buttons}
       />
     </Modal>

--- a/app/components/shared/ButtonsToolbar.jsx
+++ b/app/components/shared/ButtonsToolbar.jsx
@@ -7,7 +7,8 @@ const ButtonsToolbar = ({
   onCancelModal,
   submitLabel,
   isValid,
-  className
+  className,
+  loading
 }) => (
   <div className={className}>
     <InvisibleButton
@@ -16,9 +17,10 @@ const ButtonsToolbar = ({
       <T id="passphraseModal.btnCancel" m="Cancel" />
     </InvisibleButton>
     <KeyBlueButton
+      loading={loading}
       disabled={
         // if isValid is not passed as props, we never validate it.
-        isValid === undefined ? false : !isValid
+        (isValid === undefined ? false : !isValid) || loading
       }
       onClick={onSubmit}>
       {submitLabel ? (

--- a/app/components/views/TrezorPage/TrezorPageContent.jsx
+++ b/app/components/views/TrezorPage/TrezorPageContent.jsx
@@ -30,6 +30,7 @@ const TrezorPageContent = () => {
     performingOperation,
     device,
     connect,
+    performingRecoverDevice,
     togglePinProtection,
     togglePassPhraseProtection,
     togglePassphraseOnDevice,
@@ -42,6 +43,8 @@ const TrezorPageContent = () => {
     updateFirmware
   } = useTrezorPage();
 
+  const loading = performingOperation || performingRecoverDevice;
+
   return !device ? (
     <NoDevicePage onConnect={connect} />
   ) : (
@@ -52,21 +55,25 @@ const TrezorPageContent = () => {
           togglePassPhraseProtection,
           togglePassphraseOnDevice,
           changeToDecredHomeScreen,
-          performingOperation
+          performingOperation: loading
         }}
       />
-      <ChangeLabel {...{ changeLabel, performingOperation }} />
+      <ChangeLabel {...{ changeLabel, performingOperation: loading }} />
       <RecoveryButtons
         {...{
           wipeDevice,
           recoverDevice,
           initDevice,
           backupDevice,
-          performingOperation
+          performingOperation: loading
         }}
       />
       <FirmwareUpdate
-        {...{ updateFirmware, performingOperation, isPerformingUpdate }}
+        {...{
+          updateFirmware,
+          performingOperation: loading,
+          isPerformingUpdate
+        }}
       />
     </>
   );

--- a/app/components/views/TrezorPage/hooks.js
+++ b/app/components/views/TrezorPage/hooks.js
@@ -7,6 +7,9 @@ export function useTrezorPage() {
   const isPerformingUpdate = useSelector(sel.isPerformingTrezorUpdate);
   const device = useSelector(sel.trezorDevice);
   const performingOperation = useSelector(sel.trezorPerformingOperation);
+  const performingRecoverDevice = useSelector(
+    sel.trezorPerformingRecoverDevice
+  );
 
   const dispatch = useDispatch();
 
@@ -50,6 +53,7 @@ export function useTrezorPage() {
   return {
     isPerformingUpdate,
     performingOperation,
+    performingRecoverDevice,
     device,
     connect,
     togglePinProtection,

--- a/app/hooks/useTrezor.js
+++ b/app/hooks/useTrezor.js
@@ -21,6 +21,9 @@ const useTrezor = () => {
   const walletCreationMasterPubkeyAttempt = useSelector(
     sel.trezorWalletCreationMasterPubkeyAttempt
   );
+  const performingRecoverDevice = useSelector(
+    sel.trezorPerformingRecoverDevice
+  );
 
   const dispatch = useDispatch();
 
@@ -93,6 +96,7 @@ const useTrezor = () => {
     enablePassphraseProtection,
     confirmingTogglePassphrase,
     togglePassphraseConfirmCallback,
+    performingRecoverDevice,
     onConnect,
     onCancelCurrentOperation,
     onSubmitPin,

--- a/app/index.js
+++ b/app/index.js
@@ -408,6 +408,7 @@ const initialState = {
     waitingForPin: false,
     waitingForPassPhrase: false,
     waitingForWord: false,
+    performingRecoverDevice: false,
     confirmingTogglePassphrase: false,
     enablePassphraseProtection: false,
     pinCallBack: null,

--- a/app/reducers/trezor.js
+++ b/app/reducers/trezor.js
@@ -172,6 +172,7 @@ export default function trezor(state = {}, action) {
     case TRZ_CANCELOPERATION_SUCCESS:
       return {
         ...state,
+        performingRecoverDevice: false,
         waitingForPin: false,
         pinCallBack: null,
         pinMessage: null,
@@ -194,9 +195,14 @@ export default function trezor(state = {}, action) {
     case TRZ_CHANGEHOMESCREEN_ATTEMPT:
     case TRZ_CHANGELABEL_ATTEMPT:
     case TRZ_WIPEDEVICE_ATTEMPT:
-    case TRZ_RECOVERDEVICE_ATTEMPT:
     case TRZ_INITDEVICE_ATTEMPT:
       return { ...state, performingOperation: true };
+    case TRZ_RECOVERDEVICE_ATTEMPT:
+      return {
+        ...state,
+        performingOperation: true,
+        performingRecoverDevice: true
+      };
     case TRZ_UPDATEFIRMWARE_ATTEMPT:
       return {
         ...state,
@@ -240,13 +246,18 @@ export default function trezor(state = {}, action) {
     case TRZ_CHANGELABEL_FAILED:
     case TRZ_WIPEDEVICE_FAILED:
     case TRZ_WIPEDEVICE_SUCCESS:
-    case TRZ_RECOVERDEVICE_FAILED:
-    case TRZ_RECOVERDEVICE_SUCCESS:
     case TRZ_INITDEVICE_FAILED:
     case TRZ_INITDEVICE_SUCCESS:
     case TRZ_BACKUPDEVICE_FAILED:
     case TRZ_BACKUPDEVICE_SUCCESS:
       return { ...state, performingOperation: false };
+    case TRZ_RECOVERDEVICE_FAILED:
+    case TRZ_RECOVERDEVICE_SUCCESS:
+      return {
+        ...state,
+        performingOperation: false,
+        performingRecoverDevice: false
+      };
     case TRZ_UPDATEFIRMWARE_FAILED:
     case TRZ_UPDATEFIRMWARE_SUCCESS:
       return {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1791,6 +1791,10 @@ export const trezorWaitingForPassPhrase = get([
   "waitingForPassPhrase"
 ]);
 export const trezorWaitingForWord = get(["trezor", "waitingForWord"]);
+export const trezorPerformingRecoverDevice = get([
+  "trezor",
+  "performingRecoverDevice"
+]);
 export const trezorConfirmingTogglePassphrase = get([
   "trezor",
   "confirmingTogglePassphrase"


### PR DESCRIPTION
This keeps the trezor word modal alive during the restore device process and display loading state between the individual word request.

closes #3427