### PR TITLE
Fix missing navigation links

### DIFF
--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -146,6 +146,8 @@ export const useGetStarted = () => {
         onGetAvailableWallets()
           .then((w) => send({ type: "CHOOSE_WALLET", payload: { w } }))
           .catch((error) => send({ type: "AVAILABLE_WALLET_ERROR", error }));
+
+        setShowNavLinks(true);
       },
       isAtStartWallet: (context) => {
         const { selectedWallet } = context;


### PR DESCRIPTION
@JoeGruffins reported an issue on the matrix: "If I go to restore from seed, and reject there, Settings are missing from the top right until I go to create/restore and go back"

This diff fixes it.