### PR TITLE
[governance] Choice getId error fix 

### DIFF
--- a/app/components/views/AgendaDetailsPage/hooks.js
+++ b/app/components/views/AgendaDetailsPage/hooks.js
@@ -18,9 +18,9 @@ export const useAgendaDetails = () => {
 
   const agendaChoices = agenda.choices;
   const choices = useMemo(
-    () =>
+    () => 
       agendaChoices.map((choice) => ({
-        choiceId: choice.getId()
+        choiceId: choice.id
       })),
     [agendaChoices]
   );

--- a/app/components/views/AgendaDetailsPage/hooks.js
+++ b/app/components/views/AgendaDetailsPage/hooks.js
@@ -18,7 +18,7 @@ export const useAgendaDetails = () => {
 
   const agendaChoices = agenda.choices;
   const choices = useMemo(
-    () => 
+    () =>
       agendaChoices.map((choice) => ({
         choiceId: choice.id
       })),


### PR DESCRIPTION
Previously, when the treasury agenda is clicked it would throw a choice.getId() is not a function.