### PR TITLE
Improve VSPSelect usability and responsivity 

### DIFF
--- a/app/components/inputs/VSPSelect/VSPSelect.jsx
+++ b/app/components/inputs/VSPSelect/VSPSelect.jsx
@@ -116,7 +116,7 @@ function VSPSelect({ onChange, options, intl, value, isDisabled, setVspFee }) {
     return (
       <Creatable
         options={vspList}
-        clearable={false}
+        clearable={!!newOption}
         placeholder={intl.formatMessage(messages.placeholder)}
         onChange={(option) => handleOnChange(option, isRetry)}
         value={selectedOption}

--- a/app/components/inputs/VSPSelect/VSPSelect.jsx
+++ b/app/components/inputs/VSPSelect/VSPSelect.jsx
@@ -60,7 +60,7 @@ function VSPSelect({ onChange, options, intl, value, isDisabled, setVspFee }) {
               />
             </div>
           }>
-          {vsp.host}
+          <div className={styles.optionWrapper}>{vsp.host}</div>
         </Tooltip>
       ),
       value: vsp

--- a/app/components/inputs/VSPSelect/VSPSelect.jsx
+++ b/app/components/inputs/VSPSelect/VSPSelect.jsx
@@ -116,6 +116,7 @@ function VSPSelect({ onChange, options, intl, value, isDisabled, setVspFee }) {
     return (
       <Creatable
         options={vspList}
+        clearable={false}
         placeholder={intl.formatMessage(messages.placeholder)}
         onChange={(option) => handleOnChange(option, isRetry)}
         value={selectedOption}

--- a/app/components/inputs/VSPSelect/VSPSelect.modules.css
+++ b/app/components/inputs/VSPSelect/VSPSelect.modules.css
@@ -3,7 +3,7 @@
 }
 
 .tooltip {
-  width: 180px;
+  width: 100%;
   line-height: 30px;
   padding: 0 0 0 10px;
   margin: -10px;

--- a/app/components/inputs/VSPSelect/VSPSelect.modules.css
+++ b/app/components/inputs/VSPSelect/VSPSelect.modules.css
@@ -7,6 +7,10 @@
   line-height: 30px;
   padding: 0 0 0 10px;
   margin: -10px;
+  display: inline-flex !important;
+}
+
+.optionWrapper {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/app/components/inputs/VSPSelect/VSPSelect.modules.css
+++ b/app/components/inputs/VSPSelect/VSPSelect.modules.css
@@ -7,6 +7,9 @@
   line-height: 30px;
   padding: 0 0 0 10px;
   margin: -10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .error {

--- a/app/components/inputs/VSPSelect/VSPSelect.modules.css
+++ b/app/components/inputs/VSPSelect/VSPSelect.modules.css
@@ -3,7 +3,7 @@
 }
 
 .tooltip {
-  width: 100%;
+  width: calc(100% + 20px);
   line-height: 30px;
   padding: 0 0 0 10px;
   margin: -10px;
@@ -18,11 +18,4 @@
   line-height: 20px;
   width: 95px;
   transition: 0.1s all ease;
-}
-
-@media screen and (max-width: 768px) {
-  .tooltip {
-    width: 150px;
-    padding: 0 10px 0 0;
-  }
 }

--- a/app/components/modals/AutoBuyerSettingsModal/AutoBuyerSettingsModal.module.css
+++ b/app/components/modals/AutoBuyerSettingsModal/AutoBuyerSettingsModal.module.css
@@ -43,11 +43,11 @@
   color: var(--stroke-color-hovered);
 }
 .accountSelectInput {
-  width: 332px;
+  width: 100%;
   margin-bottom: 25px;
 }
 .balanceToMaintainInput {
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 }
 .balanceToMaintainInput input {
   font-size: 16px;


### PR DESCRIPTION
This PR improves the responsivity of the ``VSPSelect`` and ``AutoBuyerSettingsModal`` components by:

- Stretching the account select to adjust the modal width.
- Enabling clicks on the right corner of a VSP option (currently, there's a padding inserted by ``react-select``).
- Inserting ellipsis on long VSP host names.

Also, the small "close" icon should clear the current input only when typing, since it's useless for clearing the selected VSP.  