### PR TITLE
[pi-ui] Revert the URL of `pi-ui` library

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
     "minimist": "^1.2.3",
     "mv": "^2.1.1",
     "node-polyfill-webpack-plugin": "^1.1.0",
-    "pi-ui": "https://github.com/bgptr/pi-ui#statusbar-balance",
+    "pi-ui": "https://github.com/decred/pi-ui",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",
     "qrcode": "^1.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9590,9 +9590,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/bgptr/pi-ui#statusbar-balance":
+"pi-ui@https://github.com/decred/pi-ui":
   version "1.0.0"
-  resolved "https://github.com/bgptr/pi-ui#a3315fc05a7e568fbe0fbabfc669daf08fd931ed"
+  resolved "https://github.com/decred/pi-ui#276278d968443f5552252dc7caaa8889e4b312cf"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"


### PR DESCRIPTION
This diff is a post-cleanup PR after #3543. 
Now since my https://github.com/decred/pi-ui/pull/354 has been merged, I could write back the pi-ui URL.