### PR TITLE
[Startup] Fix account pwd for watching only

### DIFF
--- a/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/PreCreateWallet.jsx
@@ -125,7 +125,7 @@ const PreCreateWallet = ({
     // creatingWallet state.
     onSendContinue();
     if (isTrezor) {
-      walletSelected.watchingOnly = true;
+      walletSelected.isWatchingOnly = true;
       return trezorGetWalletCreationMasterPubKey().then((walletMasterPubKey) =>
         onCreateWallet(walletSelected).then(() =>
           onShowCreateWallet({

--- a/app/components/views/GetStartedPage/SetupWallet/SetAccountsPassphrase/SetAccountsPassphrase.js
+++ b/app/components/views/GetStartedPage/SetupWallet/SetAccountsPassphrase/SetAccountsPassphrase.js
@@ -2,14 +2,16 @@ import { Subtitle } from "shared";
 import { FormattedMessage as T } from "react-intl";
 import { PassphraseModalButton } from "buttons";
 import styles from "./SettingAccountsPassphrase.module.css";
+import { useDaemonStartup } from "hooks";
 
 const SetAccountsPassphrase = ({
   onSubmitAccountsPassphrase,
   title,
   description,
-  error,
-  isProcessingManaged
+  error
 }) => {
+  const { isSettingAccountsPassphrase } = useDaemonStartup();
+
   return (
     <div className={styles.content}>
       <Subtitle className={styles.subtitle} title={title} />
@@ -22,8 +24,8 @@ const SetAccountsPassphrase = ({
           modalClassName={styles.passphraseModal}
           onSubmit={onSubmitAccountsPassphrase}
           buttonLabel={<T id="process.settingPassAccts.button" m="Continue" />}
-          disabled={isProcessingManaged}
-          loading={isProcessingManaged}
+          disabled={isSettingAccountsPassphrase}
+          loading={isSettingAccountsPassphrase}
         />
       </div>
     </div>

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -41,6 +41,9 @@ const useDaemonStartup = () => {
   const isTrezor = useSelector(sel.isTrezor);
   const syncAttemptRequest = useSelector(sel.getSyncAttemptRequest);
   const daemonWarning = useSelector(sel.daemonWarning);
+  const isSettingAccountsPassphrase = useSelector(
+    sel.isSettingAccountsPassphrase
+  );
   // end of daemon selectors
 
   // vsp selectors
@@ -313,7 +316,8 @@ const useDaemonStartup = () => {
     isProcessingManaged,
     isProcessingUnmanaged,
     needsProcessManagedTickets,
-    stopUnfinishedWallet
+    stopUnfinishedWallet,
+    isSettingAccountsPassphrase
   };
 };
 

--- a/app/index.js
+++ b/app/index.js
@@ -373,7 +373,8 @@ const initialState = {
     cantCloseModalVisible: false,
     changeScriptByAccount: {},
     monitorLockableAccountsTimer: null,
-    confirmationDialogModalVisible: false
+    confirmationDialogModalVisible: false,
+    settingAccountsPassphrase: false
   },
   snackbar: {
     messages: Array()

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -55,7 +55,7 @@ export const getAvailableWallets = (network) => {
 
     const cfg = getWalletCfg(isTestNet, wallet);
     const lastAccess = cfg.get(cfgConstants.LAST_ACCESS);
-    const watchingOnly = cfg.get(cfgConstants.IS_WATCH_ONLY);
+    const isWatchingOnly = cfg.get(cfgConstants.IS_WATCH_ONLY);
     const isTrezor = cfg.get(cfgConstants.TREZOR);
     const isPrivacy = cfg.get(cfgConstants.MIXED_ACCOUNT_CFG);
     const walletDbFilePath = getWalletDb(isTestNet, wallet);
@@ -65,7 +65,7 @@ export const getAvailableWallets = (network) => {
       wallet,
       finished,
       lastAccess,
-      watchingOnly,
+      isWatchingOnly,
       isTrezor,
       isPrivacy
     });

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -89,7 +89,10 @@ import {
   CONFIRMATIONDIALOG_HIDDEN,
   DISCOVERUSAGE_SUCCESS,
   DISCOVERUSAGE_ATTEMPT,
-  DISCOVERUSAGE_FAILED
+  DISCOVERUSAGE_FAILED,
+  SETACCOUNTSPASSPHRASE_ATTEMPT,
+  SETACCOUNTSPASSPHRASE_SUCCESS,
+  SETACCOUNTSPASSPHRASE_FAILED
 } from "../actions/ControlActions";
 import { WALLET_AUTOBUYER_SETTINGS } from "actions/DaemonActions";
 import { CLOSEWALLET_SUCCESS } from "actions/WalletLoaderActions";
@@ -654,6 +657,21 @@ export default function control(state = {}, action) {
       return {
         ...state,
         discoverUsageAttempt: false
+      };
+    case SETACCOUNTSPASSPHRASE_ATTEMPT:
+      return {
+        ...state,
+        settingAccountsPassphrase: true
+      };
+    case SETACCOUNTSPASSPHRASE_SUCCESS:
+      return {
+        ...state,
+        settingAccountsPassphrase: false
+      };
+    case SETACCOUNTSPASSPHRASE_FAILED:
+      return {
+        ...state,
+        settingAccountsPassphrase: false
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -181,7 +181,7 @@ const availableWalletsSelect = createSelector([availableWallets], (wallets) =>
       value: wallet,
       network: wallet.network,
       finished: wallet.finished,
-      isWatchingOnly: wallet.watchingOnly,
+      isWatchingOnly: wallet.isWatchingOnly,
       lastAccess: wallet.lastAccess ? new Date(wallet.lastAccess) : null
     }),
     wallets
@@ -978,6 +978,10 @@ export const isProcessingManaged = get(["vsp", "processManagedTicketsAttempt"]);
 export const isProcessingUnmanaged = get([
   "vsp",
   "processUnmanagedTicketsAttempt"
+]);
+export const isSettingAccountsPassphrase = get([
+  "control",
+  "settingAccountsPassphrase"
 ]);
 
 export const getAvailableVSPsPubkeys = get(["vsp", "availableVSPsPubkeys"]);

--- a/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
+++ b/test/unit/components/views/GetStaredPage/PreCreateWallet.spec.js
@@ -316,7 +316,7 @@ test("trezor device is connected", async () => {
   const testRestoreSelectedWallet = {
     ...testSelectedWallet,
     value: { ...testSelectedWallet.value, isNew: false, isTrezor: true },
-    watchingOnly: true
+    isWatchingOnly: true
   };
 
   mockCreateWatchOnlyWalletRequest = wlActions.createWatchOnlyWalletRequest = jest.fn(


### PR DESCRIPTION
This fixes the migrate to per account passphrase stage of wallet startup to
ignore watching only wallets.

It also adds an indicator to the same stage, to prevent double execution of
the process.