### PR TITLE
Fix missing insufficient unmixed account balance error msg on privacy view

### DIFF
--- a/app/actions/AccountMixerActions.js
+++ b/app/actions/AccountMixerActions.js
@@ -1,3 +1,4 @@
+import { FormattedMessage as T } from "react-intl";
 import * as sel from "selectors";
 import { wallet } from "wallet-preload-shim";
 import {
@@ -75,7 +76,12 @@ export const checkUnmixedAccountBalance = (changeAccount) => async (
   const spendableBal = await dispatch(getAcctSpendableBalance(changeAccount));
   if (spendableBal < MIN_RELAY_FEE_ATOMS + MIN_MIX_DENOMINATION_ATOMS) {
     dispatch({
-      error: "Insufficient unmixed account balance",
+      error: (
+        <T
+          id="accountMixer.insufficientUnmixedAccountBalance"
+          m="Insufficient unmixed account balance"
+        />
+      ),
       type: RUNACCOUNTMIXER_NOBALANCE
     });
   } else {

--- a/app/constants/decred.js
+++ b/app/constants/decred.js
@@ -1,6 +1,7 @@
 export const MAX_POSSIBLE_FEE_INPUT = 0.1;
 
 export const MIN_RELAY_FEE = 0.0001;
+export const MIN_RELAY_FEE_ATOMS = 10000;
 
 export const MIN_MIX_DENOMINATION = 1 << 18; // 000.00262144
 export const MIN_MIX_DENOMINATION_ATOMS = 262144;


### PR DESCRIPTION
Also closes  #2959 

before:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/52497040/138932904-d9f9af3b-f518-43ad-bfff-eed388fb99b6.png">

after:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/52497040/138932587-599985bc-dd20-4710-9ee3-59f73f6d4a98.png">


