### PR TITLE
[governance] Fix the background color of <code> tag in dark mode

### DIFF
--- a/app/style/themes/darkTheme.js
+++ b/app/style/themes/darkTheme.js
@@ -121,7 +121,7 @@ const darkTheme = {
   "seedword-select-border-default-hover-text-color": "#7DA7D9",
   "txdetails-top-bg": "#1F325F",
   "trezor-line-color": "#608ACE",
-  "proposal-text-markdown": "#f6f8fa",
+  "proposal-text-markdown": "var(--background-container)",
   "background-address-copy-color": "#2F4D8C",
   "icons-shadow": "#09144036",
   "no-more-tickets-indicator-bg": "#2F4D8C",


### PR DESCRIPTION
Closes #2509

<img width="606" alt="dark-mode" src="https://user-images.githubusercontent.com/52497040/138945909-079b9ae6-28b9-4333-aa9e-89edec16666e.png">