### PR TITLE
i18n: translator fixes

### DIFF
--- a/app/i18n/translator.html
+++ b/app/i18n/translator.html
@@ -128,7 +128,7 @@
 
       function prepareTranslatedFile() {
         const translated = state.translated;
-        let data = Object.keys(translated).sort().map(k => `    "${k}": ${JSON.stringify(translated[k])}`).join(",\n");
+        let data = Object.keys(translated).sort().map(k => `  "${k}": ${JSON.stringify(translated[k])}`).join(",\n");
         let json = `{\n${data}\n}\n`;
         const file = new Blob([json], {type: "application/octet-stream"});
         const url = URL.createObjectURL(file);

--- a/app/i18n/translator.html
+++ b/app/i18n/translator.html
@@ -196,7 +196,10 @@
         const filterVal = document.querySelector('input[name="filter"]:checked').value;
         for (let i = 0; i < keys.length; i++) {
           const k = keys[i];
-          if (filterVal === "untranslated" && state.translated[k] != "") {
+          // When on Untranslated view, skip to next key considered
+          // "untranslated", i.e. undefined (new key) or "" (existing key with
+          // empty translation).
+          if (filterVal === "untranslated" && state.translated[k]) {
             continue;
           }
 

--- a/app/i18n/translator.html
+++ b/app/i18n/translator.html
@@ -20,6 +20,8 @@
         margin: 10px;
         padding-right: 0.5em;
         padding-top: 1em;
+        overflow: hidden scroll;
+        height: 34em;
       }
 
       #string_list li {

--- a/app/i18n/translator.html
+++ b/app/i18n/translator.html
@@ -203,6 +203,11 @@
             continue;
           }
 
+          // When on Changed view, skip to next key considered "changed".
+          if (filterVal === "changed" && state.changedEntries.indexOf(k) == -1) {
+            continue;
+          }
+
           if (gotPrev) {
             changeToKey(k);
             return;


### PR DESCRIPTION
This fixes several bugs in the new `translator.html` tool:

- Indent generated JSON with 2 spaces to reduce diffs with all existing
  translation `.json` files.

- Limit the height of the left-hand panel to fix excessive scrolling
  between an item selected down the list and input fields at the top of
  the view.

- Fix going to next item on Untranslated list.

- Fix going to next item on Changed list.

Closes #3575.