### PR TITLE
Log signing parameters on testnet if the produced tx rejected

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -296,6 +296,18 @@ export const signTransactionAttempt = (passphrase, rawTx, acctNumber) => async (
     });
     dispatch(publishTransactionAttempt(signTransactionResponse.transaction));
   } catch (error) {
+    if (sel.isTestNet(getState()) === true) {
+      wallet.log(
+        "warn",
+        "Sign Transaction Failed: " +
+          JSON.stringify({
+            error: error.message,
+            passphrase,
+            rawTx,
+            acctNumber
+          })
+      );
+    }
     dispatch({ error, type: SIGNTX_FAILED });
   }
 };


### PR DESCRIPTION
Probably there is a race around signing the transaction. 
As @davecgh suggested on matrix, this adds some logging for debugging purposes when the wallet is on the testnet. 