### PR TITLE
Hide the legacy purchase option

### DIFF
--- a/app/components/shared/PurchaseTicketsForm/PurchaseTicketsForm.jsx
+++ b/app/components/shared/PurchaseTicketsForm/PurchaseTicketsForm.jsx
@@ -29,23 +29,6 @@ const messages = defineMessages({
   }
 });
 
-export const LegacyVSPWarning = () => (
-  <T
-    id="purchase.isLegacyDescription"
-    m="Use a VSP which has not updated to vspd. Not recommended, legacy VSP support will soon be removed."
-  />
-);
-
-const LegacyCheckbox = ({ isLegacy, toggleIsLegacy }) => (
-  <Checkbox
-    label={<T id="purchase.isLegacy" m="Use Legacy VSP" />}
-    className={styles.useLegacyLabel}
-    id="box"
-    checked={isLegacy}
-    onChange={() => toggleIsLegacy(!isLegacy)}
-  />
-);
-
 const PurchaseTicketsForm = ({
   spvMode,
   isValid,
@@ -70,7 +53,6 @@ const PurchaseTicketsForm = ({
   toggleRememberVspHostCheckBox,
   notMixedAccounts,
   getRunningIndicator,
-  toggleIsLegacy,
   isLegacy,
   dismissBackupRedeemScript,
   onDismissBackupRedeemScript,
@@ -126,17 +108,6 @@ const PurchaseTicketsForm = ({
             </label>
           )}
           <div className={styles.checkboxWrapper}>
-            <div>
-              {!isLegacy ? (
-                <Tooltip
-                  contentClassName={styles.useLegacyTooltip}
-                  content={<LegacyVSPWarning />}>
-                  <LegacyCheckbox {...{ isLegacy, toggleIsLegacy }} />
-                </Tooltip>
-              ) : (
-                <LegacyCheckbox {...{ isLegacy, toggleIsLegacy }} />
-              )}
-            </div>
             {vsp && !isLegacy && (
               <Checkbox
                 className={styles.rememberVspCheckBox}

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -930,7 +930,7 @@ export const legacyBuyerBalanceToMaintain = get([
 ]);
 export const legacyBuyerAccount = get(["control", "legacyAccount"]);
 export const getHasVSPTicketsError = get(["vsp", "hasVSPTicketsError"]);
-export const getIsLegacy = get(["vsp", "isLegacy"]);
+export const getIsLegacy = () => false; // hide legacy purchase
 export const getRememberedVspHost = get(["vsp", "rememberedVspHost"]);
 
 const getVSPTicketsHashes = get(["vsp", "vspTickets"]);

--- a/test/unit/components/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_PurchasePage.spec.js
+++ b/test/unit/components/TicketsPage/PurchaseTab/LEGACY_PurchasePage/LEGACY_PurchasePage.spec.js
@@ -148,7 +148,6 @@ let mockIsTicketAutoBuyerEnabled;
 let mockTicketBuyerV2Cancel;
 let mockGetRunningIndicator;
 let mockAddCustomStakePool;
-let mockToggleIsLegacy;
 
 beforeEach(() => {
   selectors.getIsLegacy = jest.fn(() => true);
@@ -195,18 +194,16 @@ beforeEach(() => {
   mockGetRunningIndicator = selectors.getRunningIndicator = jest.fn(
     () => false
   );
-  mockToggleIsLegacy = spActions.toggleIsLegacy = jest.fn(() => () => {});
 });
 
 test("render LEGACY_PurchasePage", () => {
   render(<Purchase />, initialState);
 
-  // check Use Legacy VSP checkbox
+  // check if Use Legacy VSP checkbox is hidden
   expect(
     screen.queryByText(/use a VSP which has not updated to vspd/i)
   ).not.toBeInTheDocument(); // tooltip
-  user.click(screen.getByLabelText("Use Legacy VSP"));
-  expect(mockToggleIsLegacy).toHaveBeenCalledWith(false);
+  expect(screen.queryByLabelText("Use Legacy VSP")).not.toBeInTheDocument();
 
   expect(
     screen.getByText("Current VSP").nextElementSibling.textContent

--- a/test/unit/components/TicketsPage/PurchaseTab/PurchasePage.spec.js
+++ b/test/unit/components/TicketsPage/PurchaseTab/PurchasePage.spec.js
@@ -92,7 +92,6 @@ let mockStartTicketBuyerV3Attempt;
 let mockGetTicketAutoBuyerRunning;
 let mockTicketBuyerCancel;
 let mockGetRunningIndicator;
-let mockToggleIsLegacy;
 let mockSetRememberedVspHost;
 let mockAddAllowedExternalRequest;
 
@@ -143,7 +142,6 @@ beforeEach(() => {
   wallet.getVSPInfo = jest.fn(() => {
     return Promise.resolve(mockVspInfo);
   });
-  mockToggleIsLegacy = vspActions.toggleIsLegacy = jest.fn(() => () => {});
   mockSetRememberedVspHost = vspActions.setRememberedVspHost = jest.fn(
     () => () => {}
   );
@@ -159,12 +157,11 @@ test("render PurchasePage", async () => {
     screen.getByText(/Purchasing mixed tickets can take some time/i)
   ).toBeInTheDocument();
 
-  // check Use Legacy VSP checkbox
+  // check if Use Legacy VSP checkbox is hidden
   expect(
-    screen.getByText(/use a VSP which has not updated to vspd/i)
-  ).toBeInTheDocument(); //tooltip
-  user.click(screen.getByLabelText("Use Legacy VSP"));
-  expect(mockToggleIsLegacy).toHaveBeenCalledWith(true);
+    screen.queryByText(/use a VSP which has not updated to vspd/i)
+  ).not.toBeInTheDocument(); // tooltip
+  expect(screen.queryByLabelText("Use Legacy VSP")).not.toBeInTheDocument();
 
   // set stakepool
   user.click(screen.getByText("Select VSP..."));


### PR DESCRIPTION
This diff is a preliminary step toward #3586 and hides the legacy purchase option for now without nuking the code.