### PR TITLE
[Multi] Watch-only wallet fixes

### DIFF
--- a/app/components/Snackbar/Snackbar.module.css
+++ b/app/components/Snackbar/Snackbar.module.css
@@ -25,6 +25,7 @@
 }
 
 .snackbar.snackbarWarning,
+.snackbar.snackbarSimpleMessage,
 .snackbar.snackbarError {
   background-image: var(--notification-error-icon);
 }

--- a/app/components/Snackbar/index.js
+++ b/app/components/Snackbar/index.js
@@ -14,6 +14,7 @@ import {
 } from "constants/decrediton";
 import { classNames } from "pi-ui";
 import style from "./Snackbar.module.css";
+import { SNACKBAR_SIMPLE_MESSAGE } from "actions/SnackbarActions";
 
 const snackbarClasses = ({ type }) =>
   ({
@@ -49,7 +50,11 @@ const snackbarClasses = ({ type }) =>
     ),
     Warning: classNames(style.snackbar, style.snackbarWarning),
     Error: classNames(style.snackbar, style.snackbarError),
-    Success: classNames(style.snackbar, style.snackbarSuccess)
+    Success: classNames(style.snackbar, style.snackbarSuccess),
+    [SNACKBAR_SIMPLE_MESSAGE]: classNames(
+      style.snackbar,
+      style.snackbarSimpleMessage
+    )
   }[type] || "snackbar");
 
 const Snackbar = () => {

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.jsx
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.jsx
@@ -142,6 +142,7 @@ const CreateWalletForm = ({
                       id="createwallet.walletmasterpubkey.label"
                       m="Master Pub Key"
                     />
+                    :
                     <div className={styles.daemonLongInput}>
                       <TextInput
                         id="masterPubKeyInput"

--- a/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.module.css
+++ b/app/components/views/GetStartedPage/PreCreateWallet/CreateWalletForm/CreateWalletForm.module.css
@@ -44,11 +44,11 @@
   margin: 15px 23px 30px;
   display: flex;
   flex-flow: row wrap;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .daemonLongInput {
-  padding-left: 20px;
+  padding-left: 10px;
   width: 350px;
 }
 

--- a/app/components/views/PrivacyPage/PrivacyTab/ConfigMixer/CreateDefaultAccounts/CreateDefaultAccounts.jsx
+++ b/app/components/views/PrivacyPage/PrivacyTab/ConfigMixer/CreateDefaultAccounts/CreateDefaultAccounts.jsx
@@ -43,7 +43,7 @@ const CreateDefaultAccounts = ({
             isValid
           }}
           loading={createMixerAccountAttempt}
-          disabled={isCreateAccountDisabled || createMixerAccountAttempt}
+          isDisabled={isCreateAccountDisabled || createMixerAccountAttempt}
           modalTitle={
             <T
               id="accounts.defaultAccountConfirmations"

--- a/app/components/views/PrivacyPage/PrivacyTab/ConfigMixer/CreateNeededAccounts/CreateNeededAccounts.jsx
+++ b/app/components/views/PrivacyPage/PrivacyTab/ConfigMixer/CreateNeededAccounts/CreateNeededAccounts.jsx
@@ -46,7 +46,7 @@ const CreateNeededAccounts = ({
           parentIsValid: isValid
         }}
         loading={createMixerAccountAttempt}
-        disabled={isCreateAccountDisabled || createMixerAccountAttempt}
+        isDisabled={isCreateAccountDisabled || createMixerAccountAttempt}
         modalTitle={
           <T id="accounts.createNeededAcc" m="Create Needed Accounts" />
         }

--- a/test/unit/components/views/PrivacyPage/PrivacyTab.spec.js
+++ b/test/unit/components/views/PrivacyPage/PrivacyTab.spec.js
@@ -9,11 +9,13 @@ import * as sel from "selectors";
 import * as act from "actions/AccountMixerActions";
 import * as wl from "wallet";
 import * as ca from "actions/ControlActions";
+import * as sa from "actions/SnackbarActions";
 
 const selectors = sel;
 const wallet = wl;
 const controlActions = ca;
 const accountMixerActions = act;
+const snackbarActions = sa;
 
 const mockDefaultAccount = {
   hidden: false,
@@ -76,6 +78,7 @@ let mockStopAccountMixer;
 let mockToggleAllowSendFromUnmixed;
 let mockConstructTransactionAttempt;
 let mockGetPrivacyLogs;
+let mockDispatchSingleMessage;
 
 beforeEach(() => {
   selectors.currencyDisplay = jest.fn(() => DCR);
@@ -128,6 +131,9 @@ beforeEach(() => {
   );
   controlActions.getNextAddressAttempt = jest.fn(() => () => {});
   mockConstructTransactionAttempt = controlActions.constructTransactionAttempt = jest.fn(
+    () => () => {}
+  );
+  mockDispatchSingleMessage = snackbarActions.dispatchSingleMessage = jest.fn(
     () => () => {}
   );
 });
@@ -373,4 +379,23 @@ test("check logs", async () => {
   await wait(() =>
     expect(screen.queryByText(mockLogLine)).not.toBeInTheDocument()
   );
+});
+
+test("privacy configuration have to be disabled in watching only (already have mixed or unmixed account)", () => {
+  selectors.getMixedAccount = jest.fn(() => null);
+  selectors.getChangeAccount = jest.fn(() => null);
+  selectors.isWatchingOnly = jest.fn(() => true);
+  render(<PrivacyTab />);
+  user.click(getCreateNeededAccountsButton());
+  expect(mockDispatchSingleMessage).toHaveBeenCalledTimes(1);
+});
+
+test("privacy configuration have to be disabled in watching only ", () => {
+  selectors.getMixedAccount = jest.fn(() => null);
+  selectors.getChangeAccount = jest.fn(() => null);
+  selectors.isWatchingOnly = jest.fn(() => true);
+  selectors.balances = jest.fn(() => []);
+  render(<PrivacyTab />);
+  user.click(getCreateDefaultAccountsButton());
+  expect(mockDispatchSingleMessage).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
Found and fixed:
- style of watch-only warning snack bar was broken. Before/after: 
<img width="313" alt="image" src="https://user-images.githubusercontent.com/52497040/143917880-5bdf05d0-2a2c-477f-aa2d-8c420b5638a4.png">

- label of `Master Pub Key` was misaligned. Before/after: <img width="469" alt="image" src="https://user-images.githubusercontent.com/52497040/143918068-13c9c782-fefa-4ec8-83d9-e54b789083f5.png">
- on `Privacy Configuration` view the `Create Default Accounts` button was simply disabled for watch-only wallets and the watch-only warning snack bar never showed.
