### PR TITLE
Remove 15.x node version from CI build matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node version v15 is not supported anymore: (https://nodejs.org/en/about/releases/) and there is no point in building on it. 
Later, we can add 16.x, when we update electron to v16.