### PR TITLE
[launcher] Fix bug for old rpc backup

### DIFF
--- a/app/helpers/files.js
+++ b/app/helpers/files.js
@@ -52,11 +52,7 @@ export function makeFileBackup(file, directory) {
     fs.mkdirSync(directory);
   }
   // copy it to directory specified
-  try {
-    fs.copyFileSync(file, `${directory}/${fileName}`);
-  } catch (err) {
-    throw err;
-  }
+  fs.copyFileSync(file, `${directory}/${fileName}`);
 
   return true;
 }

--- a/app/helpers/files.js
+++ b/app/helpers/files.js
@@ -52,11 +52,11 @@ export function makeFileBackup(file, directory) {
     fs.mkdirSync(directory);
   }
   // copy it to directory specified
-  fs.copyFileSync(file, `${directory}/${fileName}`, (err) => {
-    if (err) {
-      throw err;
-    }
-  });
+  try {
+    fs.copyFileSync(file, `${directory}/${fileName}`);
+  } catch (err) {
+    throw err;
+  }
 
   return true;
 }


### PR DESCRIPTION
This fixes a bug that was relatively common among users in support.

Some older wallets would require upgrades for dcrd cert/keys.  "is_electron8": false would hit these.  