### PR TITLE
Reduce borders on Dex icon.

### DIFF
--- a/app/style/icons/dex.svg
+++ b/app/style/icons/dex.svg
@@ -1,1 +1,66 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 423 423"><defs><style>.a{fill:#fff;opacity:0;}.b{fill:#151640;}</style></defs><title>symbol - positive - bw</title><rect class="a" width="423" height="423"/><path class="b" d="M329,94v47H305.5c-30.7,0-56.12,19.62-65.8,47H183.3c-9.68-27.38-35.1-47-65.8-47H94V94h23.5a117.33,117.33,0,0,1,94,47,117.33,117.33,0,0,1,94-47Z"/><path class="b" d="M305.5,282H329v47H305.5a117.33,117.33,0,0,1-94-47,117.33,117.33,0,0,1-94,47H94V282h23.5c30.7,0,56.12-19.62,65.8-47h56.4C249.38,262.38,274.8,282,305.5,282Z"/><rect class="b" x="239.7" y="188" width="89.3" height="47"/><rect class="b" x="94" y="188" width="89.3" height="47"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 245 245.00006"
+   version="1.1"
+   id="svg18"
+   width="245"
+   height="245.00006">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>symbol - positive - bw</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4">
+    <style
+       id="style2">.a{fill:#fff;opacity:0;}.b{fill:#151640;}</style>
+  </defs>
+  <title
+     id="title6">symbol - positive - bw</title>
+  <rect
+     class="a"
+     width="423"
+     height="423"
+     id="rect8"
+     x="-89"
+     y="-88.999969"
+     style="opacity:0;fill:#ffffff" />
+  <path
+     class="b"
+     d="M 240,5.0000308 V 52.000031 h -23.5 c -30.7,0 -56.12,19.62 -65.8,47 H 94.3 c -9.68,-27.38 -35.1,-47 -65.8,-47 H 5 V 5.0000308 h 23.5 a 117.33,117.33 0 0 1 94,47.0000002 117.33,117.33 0 0 1 94,-47.0000002 z"
+     id="path10"
+     style="fill:#151640" />
+  <path
+     class="b"
+     d="M 216.5,193.00003 H 240 v 47 h -23.5 a 117.33,117.33 0 0 1 -94,-47 117.33,117.33 0 0 1 -94,47 H 5 v -47 h 23.5 c 30.7,0 56.12,-19.62 65.8,-47 h 56.4 c 9.68,27.38 35.1,47 65.8,47 z"
+     id="path12"
+     style="fill:#151640" />
+  <rect
+     class="b"
+     x="150.7"
+     y="99.000031"
+     width="89.300003"
+     height="47"
+     id="rect14"
+     style="fill:#151640" />
+  <rect
+     class="b"
+     x="5"
+     y="99.000031"
+     width="89.300003"
+     height="47"
+     id="rect16"
+     style="fill:#151640" />
+</svg>

--- a/app/style/icons/dexDark.svg
+++ b/app/style/icons/dexDark.svg
@@ -1,1 +1,66 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 423 423"><defs><style>.a{fill:#fff;opacity:0;}.b{fill:#99c1e3;}</style></defs><title>symbol - positive - bw</title><rect class="a" width="423" height="423"/><path class="b" d="M329,94v47H305.5c-30.7,0-56.12,19.62-65.8,47H183.3c-9.68-27.38-35.1-47-65.8-47H94V94h23.5a117.33,117.33,0,0,1,94,47,117.33,117.33,0,0,1,94-47Z"/><path class="b" d="M305.5,282H329v47H305.5a117.33,117.33,0,0,1-94-47,117.33,117.33,0,0,1-94,47H94V282h23.5c30.7,0,56.12-19.62,65.8-47h56.4C249.38,262.38,274.8,282,305.5,282Z"/><rect class="b" x="239.7" y="188" width="89.3" height="47"/><rect class="b" x="94" y="188" width="89.3" height="47"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 245 245.00006"
+   version="1.1"
+   id="svg18"
+   width="245"
+   height="245.00006">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>symbol - positive - bw</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4">
+    <style
+       id="style2">.a{fill:#fff;opacity:0;}.b{fill:#99c1e3;}</style>
+  </defs>
+  <title
+     id="title6">symbol - positive - bw</title>
+  <rect
+     class="a"
+     width="423"
+     height="423"
+     id="rect8"
+     x="-89"
+     y="-88.999969"
+     style="opacity:0;fill:#ffffff" />
+  <path
+     class="b"
+     d="M 240,5.0000308 V 52.000031 h -23.5 c -30.7,0 -56.12,19.62 -65.8,47 H 94.3 c -9.68,-27.38 -35.1,-47 -65.8,-47 H 5 V 5.0000308 h 23.5 a 117.33,117.33 0 0 1 94,47.0000002 117.33,117.33 0 0 1 94,-47.0000002 z"
+     id="path10"
+     style="fill:#99c1e3" />
+  <path
+     class="b"
+     d="M 216.5,193.00003 H 240 v 47 h -23.5 a 117.33,117.33 0 0 1 -94,-47 117.33,117.33 0 0 1 -94,47 H 5 v -47 h 23.5 c 30.7,0 56.12,-19.62 65.8,-47 h 56.4 c 9.68,27.38 35.1,47 65.8,47 z"
+     id="path12"
+     style="fill:#99c1e3" />
+  <rect
+     class="b"
+     x="150.7"
+     y="99.000031"
+     width="89.300003"
+     height="47"
+     id="rect14"
+     style="fill:#99c1e3" />
+  <rect
+     class="b"
+     x="5"
+     y="99.000031"
+     width="89.300003"
+     height="47"
+     id="rect16"
+     style="fill:#99c1e3" />
+</svg>


### PR DESCRIPTION
This ensures the Dex icon appears more similar in size to other icons in the navigation menu. Previously it was undersized.

### Before

![Screenshot from 2021-12-30 12-39-49](https://user-images.githubusercontent.com/6762864/147754289-55ef2ccf-89e5-4b55-8135-aba0708d5a9b.png)

### After

![Screenshot from 2021-12-30 13-04-17](https://user-images.githubusercontent.com/6762864/147754538-1ac97558-1d73-497e-8295-c9229b869275.png)
