### PR TITLE
[css] Fix css bug on LN channel details view

### DIFF
--- a/app/components/layout/StandalonePageBody/StandalonePageBody.module.css
+++ b/app/components/layout/StandalonePageBody/StandalonePageBody.module.css
@@ -3,6 +3,7 @@
   overflow-y: scroll;
   padding: 30px 60px 30px 60px;
   background-color: var(--background-container);
+  height: 100%;
 }
 
 @media screen and (max-width: 1180px) {


### PR DESCRIPTION
The LN channel details view is too small and the channel list is visible underneath. This diff fixes it.

<img width="646" alt="image" src="https://user-images.githubusercontent.com/52497040/148287229-61930b5a-e76e-4a55-90a2-8289724069fd.png">
