### PR TITLE
[LN] Show startup progress and log line

### DIFF
--- a/app/components/views/LNPage/ConnectPage/ConnectPage.jsx
+++ b/app/components/views/LNPage/ConnectPage/ConnectPage.jsx
@@ -15,6 +15,7 @@ import { LN_ICON } from "constants";
 import { useConnectPage } from "./hooks";
 import { CreateLNWallet, CreateLNWalletHeader } from "./CreateLNWallet";
 import { AutopilotSwitch } from "./AutopilotSwitch";
+import { LinearProgressSmall } from "indicators";
 
 const stageMsgs = {
   [LNWALLET_STARTUPSTAGE_STARTDCRLND]: (
@@ -76,6 +77,10 @@ const ConnectPage = () => {
     onAccountOptionClick,
     onAcceptCreationWarning,
     runningIndicator,
+    lastLogLine,
+    routerPruneTarget,
+    routerPruneHeight,
+    routerPruneStart,
     intl
   } = useConnectPage();
 
@@ -154,6 +159,15 @@ const ConnectPage = () => {
             )}
           </div>
           {stageMsgs[startupStage] && <div>{stageMsgs[startupStage]}</div>}
+          {routerPruneTarget != routerPruneHeight && (
+            <LinearProgressSmall
+              className={styles.linearProgress}
+              value={routerPruneHeight}
+              max={routerPruneTarget}
+              min={routerPruneStart}
+            />
+          )}
+          <div className={styles.logLine}>{lastLogLine}</div>
         </div>
       )}
     </StandalonePage>

--- a/app/components/views/LNPage/ConnectPage/ConnectPage.module.css
+++ b/app/components/views/LNPage/ConnectPage/ConnectPage.module.css
@@ -22,6 +22,15 @@
   text-align: center;
 }
 
+.logLine {
+  font-family: var(--font-family-mono);
+  margin-top: 2em;
+}
+
+.linearProgress {
+  margin-top: 1em;
+}
+
 @media screen and (max-width: 1180px) {
   .buttonContrainer,
   .connectOpts {

--- a/app/components/views/LNPage/ConnectPage/hooks.js
+++ b/app/components/views/LNPage/ConnectPage/hooks.js
@@ -13,7 +13,11 @@ export function useConnectPage() {
     startDcrlnd,
     startAttempt,
     startupStage,
-    runningIndicator
+    runningIndicator,
+    lastLogLine,
+    routerPruneTarget,
+    routerPruneHeight,
+    routerPruneStart
   } = useLNPage();
 
   const [autopilotEnabled, setAutopilotEnabled] = useState(false);
@@ -71,6 +75,10 @@ export function useConnectPage() {
     onAccountOptionClick,
     onAcceptCreationWarning,
     runningIndicator,
+    lastLogLine,
+    routerPruneTarget,
+    routerPruneHeight,
+    routerPruneStart,
     intl
   };
 }

--- a/app/components/views/LNPage/hooks.js
+++ b/app/components/views/LNPage/hooks.js
@@ -27,6 +27,10 @@ export function useLNPage() {
   const runningIndicator = useSelector(sel.getRunningIndicator);
   const describeGraph = useSelector(sel.lnDescribeGraph);
   const transactions = useSelector(sel.lnTransactions);
+  const lastLogLine = useSelector(sel.lnLastLogLine);
+  const routerPruneTarget = useSelector(sel.lnRouterPruneTarget);
+  const routerPruneHeight = useSelector(sel.lnRouterPruneHeight);
+  const routerPruneStart = useSelector(sel.lnRouterPruneStart);
 
   const recentNodes = useMemo(
     () =>
@@ -136,6 +140,10 @@ export function useLNPage() {
     runningIndicator,
     describeGraph,
     transactions,
-    cancelInvoice
+    cancelInvoice,
+    lastLogLine,
+    routerPruneTarget,
+    routerPruneHeight,
+    routerPruneStart
   };
 }

--- a/app/index.js
+++ b/app/index.js
@@ -485,7 +485,11 @@ const initialState = {
     getAutopilotStatusAttempt: false,
     autopilotEnabled: false,
     getTransactionsAttempt: false,
-    transactions: Array()
+    transactions: Array(),
+    lastDcrlndLogLine: "",
+    routerPruneTarget: 0,
+    routerPruneHeight: 0,
+    routerPruneStart: 0
   },
   dex: {
     dexOrdersOpen: false,

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -500,6 +500,10 @@ ipcMain.on("get-last-log-line-dcrwallet", (event) => {
   event.returnValue = lastLogLine(GetDcrwalletLogs());
 });
 
+ipcMain.on("get-last-log-line-dcrlnd", (event) => {
+  event.returnValue = lastLogLine(GetDcrlndLogs());
+});
+
 ipcMain.on("get-privacy-logs", (event) => {
   event.returnValue = getPrivacyLogs();
 });

--- a/app/middleware/ln/rpc.proto
+++ b/app/middleware/ln/rpc.proto
@@ -1537,6 +1537,16 @@ message GetInfoResponse {
     used.
     **/
     bool server_active = 901 [json_name = "server_active"];
+
+    /*
+    Target height of the channel router startup graph pruning process.
+    */
+    uint32 router_prune_target = 902;
+
+    /*
+    Last checked height of the channel router startup graph pruning process.
+    */
+    uint32 router_prune_height = 903;
 }
 
 message GetRecoveryInfoRequest {

--- a/app/middleware/ln/rpc_pb.js
+++ b/app/middleware/ln/rpc_pb.js
@@ -15088,7 +15088,9 @@ proto.lnrpc.GetInfoResponse.toObject = function(includeInstance, msg) {
     proto.lnrpc.Chain.toObject, includeInstance),
     urisList: (f = jspb.Message.getRepeatedField(msg, 12)) == null ? undefined : f,
     featuresMap: (f = msg.getFeaturesMap()) ? f.toObject(includeInstance, proto.lnrpc.Feature.toObject) : [],
-    serverActive: jspb.Message.getBooleanFieldWithDefault(msg, 901, false)
+    serverActive: jspb.Message.getBooleanFieldWithDefault(msg, 901, false),
+    routerPruneTarget: jspb.Message.getFieldWithDefault(msg, 902, 0),
+    routerPruneHeight: jspb.Message.getFieldWithDefault(msg, 903, 0)
   };
 
   if (includeInstance) {
@@ -15203,6 +15205,14 @@ proto.lnrpc.GetInfoResponse.deserializeBinaryFromReader = function(msg, reader) 
     case 901:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setServerActive(value);
+      break;
+    case 902:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setRouterPruneTarget(value);
+      break;
+    case 903:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setRouterPruneHeight(value);
       break;
     default:
       reader.skipField();
@@ -15361,6 +15371,20 @@ proto.lnrpc.GetInfoResponse.serializeBinaryToWriter = function(message, writer) 
   if (f) {
     writer.writeBool(
       901,
+      f
+    );
+  }
+  f = message.getRouterPruneTarget();
+  if (f !== 0) {
+    writer.writeUint32(
+      902,
+      f
+    );
+  }
+  f = message.getRouterPruneHeight();
+  if (f !== 0) {
+    writer.writeUint32(
+      903,
       f
     );
   }
@@ -15749,6 +15773,42 @@ proto.lnrpc.GetInfoResponse.prototype.getServerActive = function() {
  */
 proto.lnrpc.GetInfoResponse.prototype.setServerActive = function(value) {
   return jspb.Message.setProto3BooleanField(this, 901, value);
+};
+
+
+/**
+ * optional uint32 router_prune_target = 902;
+ * @return {number}
+ */
+proto.lnrpc.GetInfoResponse.prototype.getRouterPruneTarget = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 902, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.lnrpc.GetInfoResponse} returns this
+ */
+proto.lnrpc.GetInfoResponse.prototype.setRouterPruneTarget = function(value) {
+  return jspb.Message.setProto3IntField(this, 902, value);
+};
+
+
+/**
+ * optional uint32 router_prune_height = 903;
+ * @return {number}
+ */
+proto.lnrpc.GetInfoResponse.prototype.getRouterPruneHeight = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 903, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.lnrpc.GetInfoResponse} returns this
+ */
+proto.lnrpc.GetInfoResponse.prototype.setRouterPruneHeight = function(value) {
+  return jspb.Message.setProto3IntField(this, 903, value);
 };
 
 

--- a/app/reducers/ln.js
+++ b/app/reducers/ln.js
@@ -50,7 +50,8 @@ import {
   LNWALLET_GET_AUTOPILOT_STATUS_FAILED,
   LNWALLET_GETTRANSACTIONS_ATTEMPT,
   LNWALLET_GETTRANSACTIONS_SUCCESS,
-  LNWALLET_GETTRANSACTIONS_FAILED
+  LNWALLET_GETTRANSACTIONS_FAILED,
+  LNWALLET_WAITSYNC_PROGRESS
 } from "actions/LNActions";
 
 function addOutstandingPayment(oldOut, rhashHex, payData) {
@@ -257,6 +258,9 @@ export default function ln(state = {}, action) {
           maxInboundAmount: 0,
           maxOutboundAmount: 0
         },
+        lastDcrlndLogLine: "",
+        routerPruneTarget: 0,
+        routerPruneHeight: 0,
         towersList: [],
         recentlyOpenedChannel: null
       };
@@ -394,6 +398,14 @@ export default function ln(state = {}, action) {
       return {
         ...state,
         getTransactionsAttempt: false
+      };
+    case LNWALLET_WAITSYNC_PROGRESS:
+      return {
+        ...state,
+        lastDcrlndLogLine: action.lastDcrlndLogLine,
+        routerPruneTarget: action.routerPruneTarget,
+        routerPruneHeight: action.routerPruneHeight,
+        routerPruneStart: action.firstRouterPruneHeight
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1903,6 +1903,10 @@ export const lnRecentlyOpenedChannel = get(["ln", "recentlyOpenedChannel"]);
 export const lnDescribeGraph = get(["ln", "describeGraph"]);
 export const lnAutopilotEnabled = get(["ln", "autopilotEnabled"]);
 export const lnTransactions = get(["ln", "transactions"]);
+export const lnLastLogLine = get(["ln", "lastDcrlndLogLine"]);
+export const lnRouterPruneTarget = get(["ln", "routerPruneTarget"]);
+export const lnRouterPruneHeight = get(["ln", "routerPruneHeight"]);
+export const lnRouterPruneStart = get(["ln", "routerPruneStart"]);
 
 // end of ln selectors
 

--- a/app/wallet/daemon.js
+++ b/app/wallet/daemon.js
@@ -194,6 +194,9 @@ export const getDcrdLastLogLine = () =>
 export const getDcrwalletLastLogLine = () =>
   Promise.resolve(ipcRenderer.sendSync("get-last-log-line-dcrwallet"));
 
+export const getDcrlndLastLogLine = () =>
+  Promise.resolve(ipcRenderer.sendSync("get-last-log-line-dcrlnd"));
+
 export const getPrivacyLogs = () =>
   Promise.resolve(ipcRenderer.sendSync("get-privacy-logs"));
 


### PR DESCRIPTION
This adds a linear progress component during the router pruning stage of the
LN wallet startup. It also adds the last log line of the dcrlnd process to the
startup UI and removes the 60 second limit of the startup sync time.

These help mitigate issues when opening an LN wallet that has been offline for
a long time.

~Depends on https://github.com/decred/dcrlnd/pull/153~ (merged)
Closes #3636