### PR TITLE
[dex] Add BTC SPV question and remove Register

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -399,6 +399,8 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
 
       const enableDex = walletCfg.get(cfgConstants.ENABLE_DEX);
       const dexAccount = walletCfg.get(cfgConstants.DEX_ACCOUNT);
+      const askDexBtcSpv = walletCfg.get(cfgConstants.ASK_DEX_BTC_SPV);
+      const dexBtcSpv = walletCfg.get(cfgConstants.DEX_BTC_SPV);
       const btcWalletName = walletCfg.get(cfgConstants.BTCWALLET_NAME);
       let rpcCreds = {};
       if (enableDex) {
@@ -513,7 +515,9 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
         dexAccount,
         rpcCreds,
         btcWalletName,
-        needsVSPdProcessManaged
+        needsVSPdProcessManaged,
+        askDexBtcSpv,
+        dexBtcSpv
       });
       selectedWallet.value.isTrezor && dispatch(enableTrezor());
       await dispatch(getVersionServiceAttempt());

--- a/app/actions/DexActions.js
+++ b/app/actions/DexActions.js
@@ -142,6 +142,32 @@ export const DEX_LOGOUT_FAILED = "DEX_LOGOUT_FAILED";
 
 export const logoutDex = () => dex.logout();
 
+export const DEX_USE_SPV_BTC_ATTEMPT = "DEX_USE_SPV_BTC_ATTEMPT";
+export const DEX_USE_SPV_BTC_SUCCESS = "DEX_USE_SPV_BTC_SUCCESS";
+export const DEX_USE_SPV_BTC_FAILED = "DEX_USE_SPV_BTC_FAILED";
+
+export const useBtcSpvDex = (useSPV) => (dispatch, getState) => {
+  const {
+    daemon: { walletName }
+  } = getState();
+  try {
+    dispatch({ type: DEX_USE_SPV_BTC_ATTEMPT });
+    const walletConfig = wallet.getWalletCfg(
+      sel.isTestNet(getState()),
+      walletName
+    );
+    dispatch({
+      type: DEX_USE_SPV_BTC_SUCCESS,
+      dexBtcSpv: useSPV,
+      askDexBtcSpv: true
+    });
+    walletConfig.set(configConstants.DEX_BTC_SPV, useSPV);
+    walletConfig.set(configConstants.ASK_DEX_BTC_SPV, true);
+  } catch (error) {
+    dispatch({ type: DEX_USE_SPV_BTC_FAILED, error });
+  }
+};
+
 export const DEX_CREATEWALLET_ATTEMPT = "DEX_CREATEWALLET_ATTEMPT";
 export const DEX_CREATEWALLET_SUCCESS = "DEX_CREATEWALLET_SUCCESS";
 export const DEX_CREATEWALLET_FAILED = "DEX_CREATEWALLET_FAILED";

--- a/app/components/views/DexPage/CreateWalletsPage/CreateWalletsPage.jsx
+++ b/app/components/views/DexPage/CreateWalletsPage/CreateWalletsPage.jsx
@@ -22,7 +22,11 @@ const CreateWalletsPage = () => {
     onCheckBTCConfig,
     btcConfigUpdateNeeded,
     btcInstallNeeded,
-    btcWalletName
+    btcWalletName,
+    onUseBtcSpv,
+    onDoNotUseBtcSPV,
+    dexBtcSpv,
+    askDexBtcSpv
   } = useDex();
 
   const {
@@ -46,144 +50,164 @@ const CreateWalletsPage = () => {
   });
   return (
     <div className="flex-column align-start">
-      {!dexBTCWalletRunning ? (
-        btcConfig ? (
-          <>
+      {!askDexBtcSpv ? (
+        <div>
+          <KeyBlueButton className="margin-top-m" onClick={onUseBtcSpv}>
+            <T id="dex.useBTCSPV" m="Use DEX Native BTC" />
+          </KeyBlueButton>
+          <KeyBlueButton className="margin-top-m" onClick={onDoNotUseBtcSPV}>
+            <T id="dex.doNotUseBTCSPV" m="Use Bitcoind Wallet" />
+          </KeyBlueButton>
+        </div>
+      ) : !dexBtcSpv ? (
+        !dexBTCWalletRunning ? (
+          btcConfig ? (
+            <>
+              <div>
+                <T
+                  id="dex.connectBTCWallet"
+                  m="Please enter the name of your BTC Wallet then attempt to connect to the wallet."
+                />
+              </div>
+              <div className="margin-top-s">
+                <T
+                  id="dex.connectBTCWalletNote"
+                  m="Note: we have found a bitcoin.conf at the default location which will be used to communicate with your BTC Wallet."
+                />
+              </div>
+              <div className="margin-top-s">
+                <T
+                  id="dex.connectBTCWalletNote2"
+                  m="Make sure you BTC Wallet is currently running before attempting to connect."
+                />
+              </div>
+              <TextInput
+                id="walletNameInput"
+                className={classNames("margin-top-m", styles.walletNameInput)}
+                required
+                value={walletName}
+                onChange={(e) => setWalletName(e.target.value)}
+                placeholder="BTC Wallet Name (leave empty if unnamed default wallet)"
+              />
+              <AppPassAndPassphraseModalButton
+                className="margin-top-m"
+                passphraseLabel={
+                  <T
+                    id="dex.createBTCWalletPassphrase"
+                    m="BTC Passphrase (if set)"
+                  />
+                }
+                modalTitle={
+                  <T id="dex.createBTCWallet" m="Connect BTC Wallet" />
+                }
+                loading={btcCreateWalletDexAttempt}
+                onSubmit={onBTCCreateWallet}
+                buttonLabel={
+                  <T
+                    id="dex.createWalletBTCPassphraseButton"
+                    m="Connect BTC Wallet"
+                  />
+                }
+                passphraseNotRequired
+              />
+            </>
+          ) : (
             <div>
-              <T
-                id="dex.connectBTCWallet"
-                m="Please enter the name of your BTC Wallet then attempt to connect to the wallet."
-              />
+              {!btcConfigUpdateNeeded && !btcInstallNeeded && (
+                <div
+                  className={classNames(
+                    "margin-top-s",
+                    styles.btcConfigNeededArea
+                  )}>
+                  <Checkbox
+                    label={
+                      <T
+                        id="dex.btcWalletLocation.label"
+                        m="You have a non-default bitcoin directory"
+                      />
+                    }
+                    id="hasDexSeed"
+                    description={
+                      <T
+                        id="dex.btcWalletLocation.description"
+                        m="If you have a non-default bitcoin location, please check the box and indentify the location."
+                      />
+                    }
+                    checked={hasNonDefault}
+                    onChange={toggleHasNonDefault}
+                  />
+                  {hasNonDefault && (
+                    <Input className="margin-top-m">
+                      <PathBrowseInput
+                        id="btcDirectory"
+                        required
+                        type="directory"
+                        value={bitcoinDirectory}
+                        onChange={(value) => setBitcoinDirectory(value)}
+                        placeholder="Bitcoin Directory"
+                      />
+                    </Input>
+                  )}
+                  <KeyBlueButton
+                    className="margin-top-m"
+                    onClick={onCheckBTCConfigDex}>
+                    <T id="dex.findBTCConfigButton" m="Find bitcoin conf" />
+                  </KeyBlueButton>
+                </div>
+              )}
+              {btcConfigUpdateNeeded && (
+                <div className="margin-top-m">
+                  <T
+                    id="dex.updateBTCConfig"
+                    m="You must update your bitcoin.conf to properly communicate with the DEX."
+                  />
+                  <T
+                    id="dex.neededFieldsInConfig"
+                    m="The following fields are required in the bitcoin.conf rpcuser, rpcpassword, rpcbind, rpcport. You must also set 'server=1' to start the wallet listening for connections.  If you have any trouble with these instructions, please go to the support channel on chat.decred.org for further assistance."
+                  />
+                  <KeyBlueButton
+                    className="margin-top-m"
+                    onClick={onCheckBTCConfigDex}>
+                    <T id="dex.checkBTCConfigButtonTryAgain" m="Try again" />
+                  </KeyBlueButton>
+                </div>
+              )}
+              {btcInstallNeeded && (
+                <div>
+                  <div className="margin-top-s">
+                    <T
+                      id="dex.checkBTCConfig"
+                      m="You must confirm your bitcoin.conf is properly set up for connecting to DEX. If you have not yet installed a bitcoin wallet, please go to bitcoin.org for further instructions."
+                    />
+                  </div>
+                  <div className="margin-top-s">
+                    <T
+                      id="dex.checkBTCConfigInstalled"
+                      m="If you have already installed bitcoin.conf, but have not created a bitcoin.conf file, we can create one for you with the button below."
+                    />
+                  </div>
+                  <KeyBlueButton
+                    className="margin-top-m"
+                    onClick={onNewBTCConfigDex}>
+                    <T id="dex.updateBTCConfigButton" m="Create BTC Config" />
+                  </KeyBlueButton>
+                </div>
+              )}
             </div>
-            <div className="margin-top-s">
-              <T
-                id="dex.connectBTCWalletNote"
-                m="Note: we have found a bitcoin.conf at the default location which will be used to communicate with your BTC Wallet."
-              />
-            </div>
-            <div className="margin-top-s">
-              <T
-                id="dex.connectBTCWalletNote2"
-                m="Make sure you BTC Wallet is currently running before attempting to connect."
-              />
-            </div>
-            <TextInput
-              id="walletNameInput"
-              className={classNames("margin-top-m", styles.walletNameInput)}
-              required
-              value={walletName}
-              onChange={(e) => setWalletName(e.target.value)}
-              placeholder="BTC Wallet Name (leave empty if unnamed default wallet)"
-            />
-            <AppPassAndPassphraseModalButton
-              className="margin-top-m"
-              passphraseLabel={
-                <T
-                  id="dex.createBTCWalletPassphrase"
-                  m="BTC Passphrase (if set)"
-                />
-              }
-              modalTitle={<T id="dex.createBTCWallet" m="Connect BTC Wallet" />}
-              loading={btcCreateWalletDexAttempt}
-              onSubmit={onBTCCreateWallet}
-              buttonLabel={
-                <T
-                  id="dex.createWalletBTCPassphraseButton"
-                  m="Connect BTC Wallet"
-                />
-              }
-              passphraseNotRequired
-            />
-          </>
+          )
         ) : (
           <div>
-            {!btcConfigUpdateNeeded && !btcInstallNeeded && (
-              <div
-                className={classNames(
-                  "margin-top-s",
-                  styles.btcConfigNeededArea
-                )}>
-                <Checkbox
-                  label={
-                    <T
-                      id="dex.btcWalletLocation.label"
-                      m="You have a non-default bitcoin directory"
-                    />
-                  }
-                  id="hasDexSeed"
-                  description={
-                    <T
-                      id="dex.btcWalletLocation.description"
-                      m="If you have a non-default bitcoin location, please check the box and indentify the location."
-                    />
-                  }
-                  checked={hasNonDefault}
-                  onChange={toggleHasNonDefault}
-                />
-                {hasNonDefault && (
-                  <Input className="margin-top-m">
-                    <PathBrowseInput
-                      id="btcDirectory"
-                      required
-                      type="directory"
-                      value={bitcoinDirectory}
-                      onChange={(value) => setBitcoinDirectory(value)}
-                      placeholder="Bitcoin Directory"
-                    />
-                  </Input>
-                )}
-                <KeyBlueButton
-                  className="margin-top-m"
-                  onClick={onCheckBTCConfigDex}>
-                  <T id="dex.findBTCConfigButton" m="Find bitcoin conf" />
-                </KeyBlueButton>
-              </div>
-            )}
-            {btcConfigUpdateNeeded && (
-              <div className="margin-top-m">
-                <T
-                  id="dex.updateBTCConfig"
-                  m="You must update your bitcoin.conf to properly communicate with the DEX."
-                />
-                <T
-                  id="dex.neededFieldsInConfig"
-                  m="The following fields are required in the bitcoin.conf rpcuser, rpcpassword, rpcbind, rpcport. You must also set 'server=1' to start the wallet listening for connections.  If you have any trouble with these instructions, please go to the support channel on chat.decred.org for further assistance."
-                />
-                <KeyBlueButton
-                  className="margin-top-m"
-                  onClick={onCheckBTCConfigDex}>
-                  <T id="dex.checkBTCConfigButtonTryAgain" m="Try again" />
-                </KeyBlueButton>
-              </div>
-            )}
-            {btcInstallNeeded && (
-              <div>
-                <div className="margin-top-s">
-                  <T
-                    id="dex.checkBTCConfig"
-                    m="You must confirm your bitcoin.conf is properly set up for connecting to DEX. If you have not yet installed a bitcoin wallet, please go to bitcoin.org for further instructions."
-                  />
-                </div>
-                <div className="margin-top-s">
-                  <T
-                    id="dex.checkBTCConfigInstalled"
-                    m="If you have already installed bitcoin.conf, but have not created a bitcoin.conf file, we can create one for you with the button below."
-                  />
-                </div>
-                <KeyBlueButton
-                  className="margin-top-m"
-                  onClick={onNewBTCConfigDex}>
-                  <T id="dex.updateBTCConfigButton" m="Create BTC Config" />
-                </KeyBlueButton>
-              </div>
-            )}
+            <T
+              id="dex.btcWalletConnected"
+              m="BTC Wallet has been successfully connected!"
+            />
           </div>
         )
       ) : (
         <div>
           <T
-            id="dex.btcWalletConnected"
-            m="BTC Wallet has been successfully connected!"
+            id="dex.usingBtcSpv"
+            m="You have chosen to use the integrated BTC Wallet."
           />
         </div>
       )}

--- a/app/components/views/DexPage/hooks.js
+++ b/app/components/views/DexPage/hooks.js
@@ -137,7 +137,6 @@ export const useDex = () => {
   ]);
 
   const { Page, Header } = useMemo(() => {
-    console.log(dexBTCWalletRunning || dexBtcSpv, dexDCRWalletRunning);
     let page, header;
     if (!dexEnabled) {
       page = <EnablePage />;

--- a/app/components/views/DexPage/hooks.js
+++ b/app/components/views/DexPage/hooks.js
@@ -4,7 +4,6 @@ import { FormattedMessage as T } from "react-intl";
 import * as sel from "selectors";
 import * as da from "actions/DexActions";
 import * as dm from "actions/DaemonActions";
-import { RegisterPage, RegisterPageHeader } from "./RegisterPage";
 import { DexView, DexViewHeader } from "./DexView";
 import {
   CreateWalletsPage,
@@ -33,7 +32,6 @@ export const useDex = () => {
   const loggedIn = useSelector(sel.loggedInDex);
   const dexAddr = useSelector(sel.dexAddr);
   const dexConfig = useSelector(sel.dexConfig);
-  const dexRegistered = useSelector(sel.dexRegistered);
   const dexConnected = useSelector(sel.dexConnected);
   const dexDCRWalletRunning = useSelector(sel.dexDCRWalletRunning);
   const dexBTCWalletRunning = useSelector(sel.dexBTCWalletRunning);
@@ -59,7 +57,8 @@ export const useDex = () => {
   const mixedAccount = useSelector(sel.getMixedAccount);
   const intl = useIntl();
   const restoredFromSeed = useSelector(sel.restoredFromSeed);
-  const alreadyPaid = useSelector(sel.alreadyPaid);
+  const dexBtcSpv = useSelector(sel.dexBtcSpv);
+  const askDexBtcSpv = useSelector(sel.askDexBtcSpv);
 
   const onGetDexLogs = () => dispatch(dm.getDexLogs());
   const onLaunchDexWindow = useCallback(() => dispatch(da.launchDexWindow()), [
@@ -129,7 +128,16 @@ export const useDex = () => {
     [dispatch]
   );
 
+  const onUseBtcSpv = useCallback(() => dispatch(da.useBtcSpvDex(true)), [
+    dispatch
+  ]);
+
+  const onDoNotUseBtcSPV = useCallback(() => dispatch(da.useBtcSpvDex(false)), [
+    dispatch
+  ]);
+
   const { Page, Header } = useMemo(() => {
+    console.log(dexBTCWalletRunning || dexBtcSpv, dexDCRWalletRunning);
     let page, header;
     if (!dexEnabled) {
       page = <EnablePage />;
@@ -139,19 +147,12 @@ export const useDex = () => {
         if (!loggedIn) {
           page = <LoginPage />;
           header = <LoginPageHeader />;
-        } else if (
-          (dexRegistered || alreadyPaid) &&
-          dexDCRWalletRunning &&
-          dexBTCWalletRunning
-        ) {
+        } else if (dexDCRWalletRunning && (dexBTCWalletRunning || dexBtcSpv)) {
           page = <DexView />;
           header = <DexViewHeader />;
         } else if (!dexAccount) {
           page = <CreateDexAcctPage />;
           header = <CreateDexAcctPageHeader />;
-        } else if (dexDCRWalletRunning && dexBTCWalletRunning) {
-          page = <RegisterPage />;
-          header = <RegisterPageHeader />;
         } else if (!dexDCRWalletRunning || !dexBTCWalletRunning) {
           page = <CreateWalletsPage />;
           header = <CreateWalletsPageHeader />;
@@ -177,11 +178,10 @@ export const useDex = () => {
     dexActive,
     dexInit,
     loggedIn,
-    dexRegistered,
     dexDCRWalletRunning,
     dexBTCWalletRunning,
     dexAccount,
-    alreadyPaid
+    dexBtcSpv
   ]);
   return {
     dexEnabled,
@@ -202,7 +202,6 @@ export const useDex = () => {
     loggedIn,
     dexAddr,
     dexConfig,
-    dexRegistered,
     dexConnected,
     dexDCRWalletRunning,
     dexBTCWalletRunning,
@@ -238,6 +237,9 @@ export const useDex = () => {
     mixedAccount,
     intl,
     restoredFromSeed,
-    alreadyPaid
+    onUseBtcSpv,
+    onDoNotUseBtcSPV,
+    dexBtcSpv,
+    askDexBtcSpv
   };
 };

--- a/app/constants/config.js
+++ b/app/constants/config.js
@@ -87,6 +87,8 @@ export const DEXWALLET_RPCPASSWORD = "dexwallet_rpcpass";
 export const DEXWALLET_HOSTPORT = "dexwallet_host";
 export const BTCWALLET_NAME = "btcwallet_name";
 export const NEEDS_VSPD_PROCESS_TICKETS = "needs_vspd_process_tickets";
+export const DEX_BTC_SPV = "dex_use_btc_spv";
+export const ASK_DEX_BTC_SPV = "ask_dex_use_btc_spv";
 
 export const WALLET_INITIAL_VALUE = {
   [ENABLE_TICKET_BUYER]: false,
@@ -124,6 +126,8 @@ export const WALLET_INITIAL_VALUE = {
   [DEXWALLET_RPCPASSWORD]: "",
   [DEXWALLET_HOSTPORT]: "",
   [DEX_ACCOUNT]: null,
+  [DEX_BTC_SPV]: false,
+  [ASK_DEX_BTC_SPV]: false,
   [AUTOBUYER_SETTINGS]: null,
   // STAKEPOOLS is a legacy code which can be deleted after stopping giving
   // support for old vsp versions.

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -36,7 +36,8 @@ import {
 import { WALLETCREATED } from "actions/DaemonActions";
 import {
   CREATEDEXACCOUNT_SUCCESS,
-  SELECT_DEXACCOUNT_SUCCESS
+  SELECT_DEXACCOUNT_SUCCESS,
+  DEX_USE_SPV_BTC_SUCCESS
 } from "actions/DexActions";
 import {
   CREATEMIXERACCOUNTS_SUCCESS,
@@ -118,7 +119,9 @@ export default function walletLoader(state = {}, action) {
         dexEnabled: action.enableDex,
         dexAccount: action.dexAccount,
         dexRpcSettings: action.rpcCreds,
-        btcWalletName: action.btcWalletName
+        btcWalletName: action.btcWalletName,
+        askDexBtcSpv: action.askDexBtcSpv,
+        dexBtcSpv: action.dexBtcSpv
       };
     case GETWALLETSEEDSVC_ATTEMPT:
       return { ...state, seedService: null };
@@ -244,6 +247,12 @@ export default function walletLoader(state = {}, action) {
       return {
         ...state,
         dexAccount: action.dexAccount
+      };
+    case DEX_USE_SPV_BTC_SUCCESS:
+      return {
+        ...state,
+        dexBtcSpv: action.dexBtcSpv,
+        askDexBtcSpv: action.askDexBtcSpv
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1957,6 +1957,8 @@ export const dexAddr = get(["dex", "addr"]);
 export const dexConfig = get(["dex", "config"]);
 export const alreadyPaid = get(["dex", "alreadyPaid"]);
 export const getConfigAttempt = get(["dex", "getConfigAttempt"]);
+export const askDexBtcSpv = get(["walletLoader", "askDexBtcSpv"]);
+export const dexBtcSpv = get(["walletLoader", "dexBtcSpv"]);
 export const dexAccount = get(["walletLoader", "dexAccount"]);
 export const dexAccountNumber = createSelector(
   [dexAccount, balances],


### PR DESCRIPTION
This adds the ability to chose whether or not you'd like to use the new native (spv/neutrino) btc wallet that is included within dexc.

We have also decided to bypass the Register page and actions since the funnel within dexc is much more flushed out and allows for payment from a variety of assets instead of just DCR.  I have left the RegisterPage and Actions in for now and when we have finalized the functionality we can remove all that is unused.