### PR TITLE
Fix Peer Count display

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -1063,11 +1063,7 @@ export const getPeerInfo = () => (dispatch, getState) => {
   return wallet
     .getPeerInfo(getState().grpc.walletService)
     .then((resp) => {
-      // if resp wrappers is null, no peers were found.
-      if (!resp.wrappers_) {
-        return dispatch({ type: GETPEERINFO_SUCCESS, peersCount: 0 });
-      }
-      const peersCount = resp.wrappers_[1].length;
+      const peersCount = resp.peerInfoList.length;
       dispatch({ type: GETPEERINFO_SUCCESS, peersCount });
     })
     .catch((error) => dispatch({ type: GETPEERINFO_FAILED, error }));


### PR DESCRIPTION
Currently peer count is broken and always shows 0.  I'm not sure the reason for checking resp.wrappers_ in the past, but doesn't seem necessary anymore.