### PR TITLE
[dex] Add ExportSeed and ConfirmSeed page

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -401,6 +401,7 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
       const enableDex = walletCfg.get(cfgConstants.ENABLE_DEX);
       const dexAccount = walletCfg.get(cfgConstants.DEX_ACCOUNT);
       const askDexBtcSpv = walletCfg.get(cfgConstants.ASK_DEX_BTC_SPV);
+      const confirmDexSeed = walletCfg.get(cfgConstants.CONFIRM_DEX_SEED);
       const dexBtcSpv = walletCfg.get(cfgConstants.DEX_BTC_SPV);
       const btcWalletName = walletCfg.get(cfgConstants.BTCWALLET_NAME);
       let rpcCreds = {};
@@ -525,7 +526,8 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
         btcWalletName,
         needsVSPdProcessManaged,
         askDexBtcSpv,
-        dexBtcSpv
+        dexBtcSpv,
+        confirmDexSeed
       });
       selectedWallet.value.isTrezor && dispatch(enableTrezor());
       await dispatch(getVersionServiceAttempt());

--- a/app/actions/DexActions.js
+++ b/app/actions/DexActions.js
@@ -165,7 +165,7 @@ export const DEX_CONFIRM_SEED_ATTEMPT = "DEX_CONFIRM_SEED_ATTEMPT";
 export const DEX_CONFIRM_SEED_SUCCESS = "DEX_CONFIRM_SEED_SUCCESS";
 export const DEX_CONFIRM_SEED_FAILED = "DEX_CONFIRM_SEED_FAILED";
 
-export const confirmDexSeed = () => async (dispatch, getState) => {
+export const confirmDexSeed = () => (dispatch, getState) => {
   const {
     daemon: { walletName }
   } = getState();
@@ -178,7 +178,7 @@ export const confirmDexSeed = () => async (dispatch, getState) => {
     walletConfig.set(configConstants.CONFIRM_DEX_SEED, true);
     dispatch({ type: DEX_CONFIRM_SEED_SUCCESS });
   } catch (error) {
-    dispatch({ type: DEX_CONFIRM_SEED_ERROR, error });
+    dispatch({ type: DEX_CONFIRM_SEED_FAILED, error });
   }
 };
 

--- a/app/actions/DexActions.js
+++ b/app/actions/DexActions.js
@@ -121,11 +121,17 @@ export const DEX_LOGIN_FAILED = "DEX_LOGIN_FAILED";
 
 export const loginDex = (passphrase) => async (dispatch, getState) => {
   dispatch({ type: DEX_LOGIN_ATTEMPT });
+  const {
+    walletLoader: { confirmDexSeed }
+  } = getState();
   if (!sel.dexActive(getState())) {
     dispatch({ type: DEX_LOGIN_FAILED, error: "Dex isn't active" });
     return;
   }
   try {
+    if (!confirmDexSeed) {
+      dispatch(exportSeedDex(passphrase));
+    }
     await dex.login(passphrase);
     dispatch({ type: DEX_LOGIN_SUCCESS });
     // Request current user information
@@ -159,7 +165,7 @@ export const DEX_CONFIRM_SEED_ATTEMPT = "DEX_CONFIRM_SEED_ATTEMPT";
 export const DEX_CONFIRM_SEED_SUCCESS = "DEX_CONFIRM_SEED_SUCCESS";
 export const DEX_CONFIRM_SEED_FAILED = "DEX_CONFIRM_SEED_FAILED";
 
-export const cofirmDexSeed = () => async (dispatch, getState) => {
+export const confirmDexSeed = () => async (dispatch, getState) => {
   const {
     daemon: { walletName }
   } = getState();

--- a/app/actions/DexActions.js
+++ b/app/actions/DexActions.js
@@ -99,6 +99,9 @@ export const DEX_INIT_SUCCESS = "DEX_INIT_SUCCESS";
 export const DEX_INIT_FAILED = "DEX_INIT_FAILED";
 
 export const initDex = (passphrase, seed) => async (dispatch, getState) => {
+  const {
+    walletLoader: { confirmDexSeed }
+  } = getState();
   dispatch({ type: DEX_INIT_ATTEMPT });
   if (!sel.dexActive(getState())) {
     dispatch({ type: DEX_INIT_FAILED, error: "Dex isn't active" });
@@ -108,6 +111,9 @@ export const initDex = (passphrase, seed) => async (dispatch, getState) => {
     await dex.init(passphrase, seed);
     dispatch({ type: DEX_INIT_SUCCESS, fromSeed: seed });
     // Request current user information
+    if (!confirmDexSeed) {
+      dispatch(exportSeedDex(passphrase));
+    }
     dispatch(userDex());
   } catch (error) {
     dispatch({ type: DEX_INIT_FAILED, error });

--- a/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.jsx
+++ b/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.jsx
@@ -26,9 +26,9 @@ const ConfirmDexSeed = () => {
           m="You should carefully write down your application
       seed and save a copy. Should you lose access to this machine or the
       critical application files, the seed can be used to restore your DEX accounts
-       and native wallets. Some older accounts cannot be restored from seed,
-       and whether old or new, it's good practice to backup the account keys
-       separately from the seed."
+       and native wallets. DEX accounts created in prior versions are not
+       recoverable with this seed, so be sure to export any such accounts
+       from the DEX Settings page."
         />
       </div>
       <div className={classNames(styles.actions, styles.isRow)}>

--- a/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.jsx
+++ b/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.jsx
@@ -1,0 +1,20 @@
+import { useDex } from "../hooks";
+import { KeyBlueButton } from "buttons";
+import { FormattedMessage as T } from "react-intl";
+
+const ConfirmDexSeed = () => {
+  const { onConfirmDexSeed, dexSeed } = useDex();
+
+  return (
+    <div>
+      <div>{dexSeed}</div>
+      <KeyBlueButton
+        onClick={() => onConfirmDexSeed()}
+      >
+        {<T id="dex.confirmDexSeedButton" m="Confirm DEX Seed" />}
+      </KeyBlueButton>
+    </div>
+  );
+};
+
+export default ConfirmDexSeed;

--- a/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.jsx
+++ b/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.jsx
@@ -1,17 +1,70 @@
 import { useDex } from "../hooks";
-import { KeyBlueButton } from "buttons";
+import { useState } from "react";
+import { Tooltip, classNames } from "pi-ui";
+import { KeyBlueButton, CopyToClipboardButton } from "buttons";
 import { FormattedMessage as T } from "react-intl";
+import styles from "./ConfirmDexSeed.module.css";
 
 const ConfirmDexSeed = () => {
   const { onConfirmDexSeed, dexSeed } = useDex();
+  const [showSeed, setShowSeed] = useState(false);
+
+  const onToggleSeed = () => {
+    setShowSeed(!showSeed);
+  };
 
   return (
     <div>
-      <div>{dexSeed}</div>
-      <KeyBlueButton
-        onClick={() => onConfirmDexSeed()}
-      >
-        {<T id="dex.confirmDexSeedButton" m="Confirm DEX Seed" />}
+      <div
+        className={classNames(
+          styles.actions,
+          styles.isRow,
+          styles.seedInstructions
+        )}>
+        <T
+          id="dex.instructions.seed"
+          m="You should carefully write down your application
+      seed and save a copy. Should you lose access to this machine or the
+      critical application files, the seed can be used to restore your DEX accounts
+       and native wallets. Some older accounts cannot be restored from seed,
+       and whether old or new, it's good practice to backup the account keys
+       separately from the seed."
+        />
+      </div>
+      <div className={classNames(styles.actions, styles.isRow)}>
+        <div className={styles.seed}>
+          <div className={styles.seedLabel}>
+            <T id="dex.seed" m="DEX Account Seed" />
+          </div>
+          {showSeed ? (
+            <>
+              <Tooltip
+                content={
+                  <T id="dex.hide.seed" m="Click to Hide DEX Account Seed" />
+                }>
+                <div className={styles.seedArea} onClick={onToggleSeed}>
+                  {dexSeed}
+                </div>
+              </Tooltip>
+              <CopyToClipboardButton
+                textToCopy={dexSeed}
+                className={styles.seedClipboard}
+              />
+            </>
+          ) : (
+            <div className={styles.seedAreaHidden} onClick={onToggleSeed}>
+              <T id="dex.seed.Hidden" m="Click to reveal DEX Account Seed" />
+            </div>
+          )}
+        </div>
+      </div>
+      <KeyBlueButton onClick={() => onConfirmDexSeed()}>
+        {
+          <T
+            id="dex.confirmDexSeedButton"
+            m="I have copied the DEX Account Seed"
+          />
+        }
       </KeyBlueButton>
     </div>
   );

--- a/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.module.css
+++ b/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.module.css
@@ -1,0 +1,113 @@
+.isRow {
+  display: flex;
+  flex-direction: row;
+}
+
+.columns {
+  width: 100%;
+  color: var(--account-text);
+  margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.columnLeft,
+.columnRight {
+  margin-top: 15px;
+}
+
+.title {
+  font-size: 19px;
+  text-align: right;
+  padding-right: 200px;
+  margin-bottom: 10px;
+}
+
+.actions {
+  width: 93%;
+  margin-left: 20px;
+  height: 100px;
+}
+.seedInstructions {
+  font-size: 20px;
+}
+
+.seed {
+  display: flex;
+  flex-direction: row;
+  margin-left: 30px;
+  margin-top: 18px;
+  width: 88%;
+}
+
+.seedLabel {
+  font-size: 13px;
+  line-height: 17px;
+  margin-top: 2px;
+  margin-right: 14px;
+}
+
+.seedButton {
+  height: 25px;
+  width: 75px;
+  color: var(--input-color-default);
+  font-size: 13px;
+  line-height: 17px;
+  font-weight: 400;
+  background-color: var(--disabled-color);
+  padding: 2px 20px 3px 20px;
+  box-shadow: none;
+  transition: all 131ms var(--ease-in-out-quart);
+  cursor: auto;
+}
+
+.seedArea {
+  color: var(--input-color);
+  text-align: center;
+  font-size: 13px;
+  line-height: 17px;
+  font-weight: 600;
+  padding: 2px 20px 3px 20px;
+  border-radius: 3px;
+  background-color: var(--background-copy-color);
+  height: 55px;
+  width: 390px;
+  word-break: break-all;
+  transition: all 131ms var(--ease-in-out-quart);
+  cursor: auto;
+}
+
+.seedAreaHidden {
+  color: var(--input-color-default);
+  text-align: center;
+  font-size: 13px;
+  line-height: 17px;
+  font-weight: 600;
+  padding: 15px 20px 3px 20px;
+  border-radius: 3px;
+  background-color: var(--disabled-color);
+  height: 55px;
+  width: 390px;
+  word-break: break-all;
+  transition: all 131ms var(--ease-in-out-quart);
+  cursor: auto;
+}
+.seedAreaHidden:hover {
+  opacity: 0.7;
+}
+
+.seedClipboard {
+  margin-left: 10px;
+}
+
+@media screen and (max-width: 768px) {
+  .actions.isRow {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .buttons {
+    margin: 0 auto;
+  }
+}

--- a/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeedHeader.jsx
+++ b/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeedHeader.jsx
@@ -4,9 +4,12 @@ import { StandaloneHeader } from "layout";
 
 const ConfirmDexSeedHeader = () => (
   <StandaloneHeader
-    title={<T id="dex.confirmDexSeed.title" m="Confirm DEX App Seed" />}
+    title={<T id="dex.confirmDexSeed.title" m="Confirm DEX Account Seed" />}
     description={
-      <T id="dex.confirmDexSeed.description" m="Please confirm your DEX app seed before proceeding." />
+      <T
+        id="dex.confirmDexSeed.description"
+        m="Please confirm your DEX account seed before proceeding."
+      />
     }
     iconType={DEX_ICON}
   />

--- a/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeedHeader.jsx
+++ b/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeedHeader.jsx
@@ -1,0 +1,15 @@
+import { FormattedMessage as T } from "react-intl";
+import { DEX_ICON } from "constants";
+import { StandaloneHeader } from "layout";
+
+const ConfirmDexSeedHeader = () => (
+  <StandaloneHeader
+    title={<T id="dex.confirmDexSeed.title" m="Confirm DEX App Seed" />}
+    description={
+      <T id="dex.confirmDexSeed.description" m="Please confirm your DEX app seed before proceeding." />
+    }
+    iconType={DEX_ICON}
+  />
+);
+
+export default ConfirmDexSeedHeader;

--- a/app/components/views/DexPage/ConfirmDexSeed/index.js
+++ b/app/components/views/DexPage/ConfirmDexSeed/index.js
@@ -1,0 +1,2 @@
+export { default as ConfirmDexSeed } from "./ConfirmDexSeed";
+export { default as ConfirmDexSeedHeader } from "./ConfirmDexSeedHeader";

--- a/app/components/views/DexPage/hooks.js
+++ b/app/components/views/DexPage/hooks.js
@@ -12,6 +12,7 @@ import {
 import { EnablePage, EnablePageHeader } from "./EnablePage";
 import { InitPage, InitPageHeader } from "./InitPage";
 import { LoginPage, LoginPageHeader } from "./LoginPage";
+import { ConfirmDexSeed, ConfirmDexSeedHeader } from "./ConfirmDexSeed";
 import {
   CreateDexAcctPage,
   CreateDexAcctPageHeader
@@ -59,6 +60,9 @@ export const useDex = () => {
   const restoredFromSeed = useSelector(sel.restoredFromSeed);
   const dexBtcSpv = useSelector(sel.dexBtcSpv);
   const askDexBtcSpv = useSelector(sel.askDexBtcSpv);
+  const confirmDexSeed = useSelector(sel.confirmDexSeed);
+  const dexSeed = useSelector(sel.dexSeed);
+
 
   const onGetDexLogs = () => dispatch(dm.getDexLogs());
   const onLaunchDexWindow = useCallback(() => dispatch(da.launchDexWindow()), [
@@ -94,6 +98,11 @@ export const useDex = () => {
 
   const onLoginDex = useCallback(
     (passphrase) => dispatch(da.loginDex(passphrase)),
+    [dispatch]
+  );
+
+  const onConfirmDexSeed = useCallback(
+    () => dispatch(da.confirmDexSeed()),
     [dispatch]
   );
 
@@ -146,6 +155,9 @@ export const useDex = () => {
         if (!loggedIn) {
           page = <LoginPage />;
           header = <LoginPageHeader />;
+        } else if (!confirmDexSeed) {
+          page = <ConfirmDexSeed />;
+          header = <ConfirmDexSeedHeader />;
         } else if (dexDCRWalletRunning && (dexBTCWalletRunning || dexBtcSpv)) {
           page = <DexView />;
           header = <DexViewHeader />;
@@ -180,7 +192,8 @@ export const useDex = () => {
     dexDCRWalletRunning,
     dexBTCWalletRunning,
     dexAccount,
-    dexBtcSpv
+    dexBtcSpv,
+    confirmDexSeed
   ]);
   return {
     dexEnabled,
@@ -239,6 +252,9 @@ export const useDex = () => {
     onUseBtcSpv,
     onDoNotUseBtcSPV,
     dexBtcSpv,
-    askDexBtcSpv
+    askDexBtcSpv,
+    confirmDexSeed,
+    onConfirmDexSeed,
+    dexSeed
   };
 };

--- a/app/components/views/DexPage/hooks.js
+++ b/app/components/views/DexPage/hooks.js
@@ -63,7 +63,6 @@ export const useDex = () => {
   const confirmDexSeed = useSelector(sel.confirmDexSeed);
   const dexSeed = useSelector(sel.dexSeed);
 
-
   const onGetDexLogs = () => dispatch(dm.getDexLogs());
   const onLaunchDexWindow = useCallback(() => dispatch(da.launchDexWindow()), [
     dispatch
@@ -101,10 +100,9 @@ export const useDex = () => {
     [dispatch]
   );
 
-  const onConfirmDexSeed = useCallback(
-    () => dispatch(da.confirmDexSeed()),
-    [dispatch]
-  );
+  const onConfirmDexSeed = useCallback(() => dispatch(da.confirmDexSeed()), [
+    dispatch
+  ]);
 
   const onCreateDexAccount = useCallback(
     (passphrase, name) => dispatch(da.createDexAccount(passphrase, name)),

--- a/app/constants/config.js
+++ b/app/constants/config.js
@@ -89,6 +89,7 @@ export const BTCWALLET_NAME = "btcwallet_name";
 export const NEEDS_VSPD_PROCESS_TICKETS = "needs_vspd_process_tickets";
 export const DEX_BTC_SPV = "dex_use_btc_spv";
 export const ASK_DEX_BTC_SPV = "ask_dex_use_btc_spv";
+export const CONFIRM_DEX_SEED = "confirm_dex_seed";
 
 export const WALLET_INITIAL_VALUE = {
   [ENABLE_TICKET_BUYER]: false,
@@ -128,6 +129,7 @@ export const WALLET_INITIAL_VALUE = {
   [DEX_ACCOUNT]: null,
   [DEX_BTC_SPV]: false,
   [ASK_DEX_BTC_SPV]: false,
+  [CONFIRM_DEX_SEED]: false,
   [AUTOBUYER_SETTINGS]: null,
   // STAKEPOOLS is a legacy code which can be deleted after stopping giving
   // support for old vsp versions.

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -77,6 +77,7 @@ import {
   userDex,
   loginDex,
   logoutDex,
+  exportSeed,
   getConfigDex,
   preRegister,
   registerDex
@@ -400,6 +401,8 @@ handle("check-init-dex", checkInitDex);
 handle("init-dex", initDex);
 
 handle("login-dex", loginDex);
+
+handle("export-seed-dex", exportSeed);
 
 handle("logout-dex", logoutDex);
 

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -28,6 +28,7 @@ import {
   userDexCall,
   loginDexCall,
   logoutDexCall,
+  exportSeedDexCall,
   GetDexPID,
   closeDcrlnd,
   closeDex,
@@ -303,6 +304,21 @@ export const loginDex = async (passphrase) => {
     return login;
   } catch (e) {
     logger.log("error", `error login dex: ${e}`);
+    return e;
+  }
+};
+
+export const exportSeed = async (passphrase) => {
+  if (!GetDexPID()) {
+    logger.log("info", "Skipping export seed since dex is not runnning");
+    return false;
+  }
+
+  try {
+    const login = await exportSeedDexCall(passphrase);
+    return login;
+  } catch (e) {
+    logger.log("error", `error export seed dex: ${e}`);
     return e;
   }
 };

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -946,6 +946,9 @@ export const loginDexCall = (passphrase) =>
 
 export const logoutDexCall = () => (!dex ? null : callDEX("Logout", {}));
 
+export const exportSeedDexCall = (passphrase) =>
+  !dex ? null : callDEX("ExportSeed", { pass: passphrase });
+
 export const createWalletDexCall = (
   assetID,
   walletType,

--- a/app/reducers/dex.js
+++ b/app/reducers/dex.js
@@ -51,7 +51,13 @@ import {
   NEW_BTC_CONFIG_FAILED,
   BTC_CREATEWALLET_FAILED,
   BTC_CREATEWALLET_ATTEMPT,
-  BTC_CREATEWALLET_SUCCESS
+  BTC_CREATEWALLET_SUCCESS,
+  DEX_EXPORT_SEED_ATTEMPT,
+  DEX_EXPORT_SEED_SUCCESS,
+  DEX_EXPORT_SEED_FAILED,
+  DEX_CONFIRM_SEED_ATTEMPT,
+  DEX_CONFIRM_SEED_SUCCESS,
+  DEX_CONFIRM_SEED_FAILED
 } from "../actions/DexActions";
 import { CLOSEWALLET_SUCCESS } from "actions/WalletLoaderActions";
 
@@ -416,6 +422,44 @@ export default function ln(state = {}, action) {
         btcInstallNeeded: false,
         btcConfigUpdateNeeded: false,
         btcConfig: action.btcConfig
+      };
+    case DEX_EXPORT_SEED_ATTEMPT:
+      return {
+        ...state,
+        exportSeedAttempt: true,
+        exportSeedError: null,
+        dexSeed: null
+      };
+    case DEX_EXPORT_SEED_SUCCESS:
+      return {
+        ...state,
+        exportSeedAttempt: false,
+        exportSeedError: null,
+        dexSeed: action.dexSeed
+      };
+    case DEX_EXPORT_SEED_FAILED:
+      return {
+        ...state,
+        exportSeedAttempt: false,
+        exportSeedError: action.error,
+        dexSeed: null
+      };
+    case DEX_CONFIRM_SEED_ATTEMPT:
+      return {
+        ...state,
+        confirmSeedError: null
+      };
+    case DEX_CONFIRM_SEED_SUCCESS:
+      return {
+        ...state,
+        confirmSeedError: null,
+        dexSeed: null
+      };
+    case DEX_CONFIRM_SEED_FAILED:
+      return {
+        ...state,
+        confirmSeedError: action.error,
+        dexSeed: null
       };
     case CLOSEWALLET_SUCCESS:
       return {

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -17,7 +17,8 @@ import {
   DEX_LOGOUT_FAILED,
   DEX_USER_FAILED,
   NEW_BTC_CONFIG_FAILED,
-  NEW_BTC_CONFIG_SUCCESS
+  NEW_BTC_CONFIG_SUCCESS,
+  DEX_EXPORT_SEED_FAILED
 } from "actions/DexActions";
 import {
   PUBLISHTX_FAILED,
@@ -724,6 +725,10 @@ const messages = defineMessages({
     id: "newBTCConfig.success",
     defaultMessage:
       "You have successfully created a default bitcoin config.  Please restart your Bitcoin Core wallet for this config to be used as expected."
+  },
+  DEX_EXPORT_SEED_FAILED: {
+    id: "dex.export.seed.failed",
+    defaultMessage: "{originalError}"
   }
 });
 
@@ -967,6 +972,7 @@ export default function snackbar(state = {}, action) {
     case SETACCOUNTSPASSPHRASE_FAILED:
     case DISCOVERUSAGE_FAILED:
     case NEW_BTC_CONFIG_FAILED:
+    case DEX_EXPORT_SEED_FAILED:
       type = "Error";
       if (
         action.error &&

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -37,7 +37,8 @@ import { WALLETCREATED } from "actions/DaemonActions";
 import {
   CREATEDEXACCOUNT_SUCCESS,
   SELECT_DEXACCOUNT_SUCCESS,
-  DEX_USE_SPV_BTC_SUCCESS
+  DEX_USE_SPV_BTC_SUCCESS,
+  DEX_CONFIRM_SEED_SUCCESS
 } from "actions/DexActions";
 import {
   CREATEMIXERACCOUNTS_SUCCESS,
@@ -121,7 +122,8 @@ export default function walletLoader(state = {}, action) {
         dexRpcSettings: action.rpcCreds,
         btcWalletName: action.btcWalletName,
         askDexBtcSpv: action.askDexBtcSpv,
-        dexBtcSpv: action.dexBtcSpv
+        dexBtcSpv: action.dexBtcSpv,
+        confirmDexSeed: action.confirmDexSeed
       };
     case GETWALLETSEEDSVC_ATTEMPT:
       return { ...state, seedService: null };
@@ -253,6 +255,11 @@ export default function walletLoader(state = {}, action) {
         ...state,
         dexBtcSpv: action.dexBtcSpv,
         askDexBtcSpv: action.askDexBtcSpv
+      };
+    case DEX_CONFIRM_SEED_SUCCESS:
+      return {
+        ...state,
+        confirmDexSeed: true
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1959,6 +1959,8 @@ export const alreadyPaid = get(["dex", "alreadyPaid"]);
 export const getConfigAttempt = get(["dex", "getConfigAttempt"]);
 export const askDexBtcSpv = get(["walletLoader", "askDexBtcSpv"]);
 export const dexBtcSpv = get(["walletLoader", "dexBtcSpv"]);
+export const dexSeed = get(["dex", "dexSeed"]);
+export const confirmDexSeed = get(["walletLoader", "confirmDexSeed"]);
 export const dexAccount = get(["walletLoader", "dexAccount"]);
 export const dexAccountNumber = createSelector(
   [dexAccount, balances],

--- a/app/wallet/dex/index.js
+++ b/app/wallet/dex/index.js
@@ -6,6 +6,7 @@ export const checkInit = invocable("check-init-dex");
 export const init = invocable("init-dex");
 export const login = invocable("login-dex");
 export const logout = invocable("logout-dex");
+export const exportSeed = invocable("export-seed-dex");
 export const createWallet = invocable("create-wallet-dex");
 export const user = invocable("user-dex");
 export const getConfig = invocable("get-config-dex");

--- a/modules/dex/libdexc/adapter.go
+++ b/modules/dex/libdexc/adapter.go
@@ -70,6 +70,7 @@ func NewCoreAdapter() *CoreAdapter {
 		"shutdown":    c.shutdown,
 		// Pass-throughs to Core
 		"Init":         c.init,
+		"ExportSeed":   c.exportSeed,
 		"CreateWallet": c.createWallet,
 		"UpdateWallet": c.updateWallet,
 		"User":         c.user,
@@ -223,6 +224,17 @@ func (c *CoreAdapter) init(raw json.RawMessage) (string, error) {
 		return "", c.core.InitializeClient([]byte(form.Pass), seed)
 	}
 	return "", c.core.InitializeClient([]byte(form.Pass), nil)
+
+}
+
+func (c *CoreAdapter) exportSeed(raw json.RawMessage) (string, error) {
+	form := new(struct {
+		Pass string `json:"pass"`
+	})
+	if err := json.Unmarshal(raw, form); err != nil {
+		return "", err
+	}
+	return replyWithErrorCheck(c.core.ExportSeed([]byte(form.Pass)))
 
 }
 


### PR DESCRIPTION
Close #3646 
This now allows all users to copy down their DEX account seed.  

When a user completes their initial passphrase setting or logs in they will be shown this information until they have clicked the button on the confirm seed page.

