### PR TITLE
dcrdex v0.4.0-rc2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/decrediton
 go 1.16
 
 require (
-	decred.org/dcrdex v0.4.0-rc1
+	decred.org/dcrdex v0.4.0-rc2
 	github.com/decred/dcrd/certgen v1.1.2-0.20210914212651-723d86274b0d // indirect
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.4-0.20210914212651-723d86274b0d // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1-0.20210914212651-723d86274b0d // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 decred.org/cspp/v2 v2.0.0-20211122173608-ee00e4952d5f/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
-decred.org/dcrdex v0.4.0-rc1 h1:WE2dSSS+G6lchWC1T1A7wCZSr8fOS6DSwr8fod8bZk0=
-decred.org/dcrdex v0.4.0-rc1/go.mod h1:8tXM3igbHUkEu4YJd1q7Czwmfh9xf0oA3dSdrUi/Bqs=
+decred.org/dcrdex v0.4.0-rc2 h1:bWXd+OOVtLR9w6fbQNZMV1u6VeMX6Eh3a1LBxNRXjjE=
+decred.org/dcrdex v0.4.0-rc2/go.mod h1:8tXM3igbHUkEu4YJd1q7Czwmfh9xf0oA3dSdrUi/Bqs=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb h1:vio6o+nzszBrdj2Yi3/gifDa5ocfy49A9SqYPlbUjXo=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb/go.mod h1:rbFJaCuXCfDhYoI5ZdeZr8TmF4A4Sb1zE7jQAwtaFMo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "bufferutil": "^4.0.3",
     "connected-react-router": "^6.8.0",
     "copy-webpack-plugin": "^8.1.0",
-    "dcrdex-assets": "https://github.com/decred/dcrdex-assets#v0.4.0-rc1",
+    "dcrdex-assets": "https://github.com/decred/dcrdex-assets#v0.4.0-rc2",
     "dex": "./modules/dex",
     "dom-helpers": "^3.4.0",
     "electron-devtools-installer": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4530,9 +4530,9 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-"dcrdex-assets@https://github.com/decred/dcrdex-assets#v0.4.0-rc1":
+"dcrdex-assets@https://github.com/decred/dcrdex-assets#v0.4.0-rc2":
   version "0.0.0"
-  resolved "https://github.com/decred/dcrdex-assets#690b74c7f5c0b11e7363f93335568f7f37201ce1"
+  resolved "https://github.com/decred/dcrdex-assets#707a0de1c181698f5679f91158d2ee6fca524f8f"
 
 debounce-fn@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This updates to dcrdex v0.4.0-rc2.

For libdexc this brings:
- A bug fix with BTC funding UTXO selection when there are p2sh outputs ([dda8654](https://github.com/decred/dcrdex/commit/dda86540ad9b585b3165bf0eb06c733576596a9d))
- slightly quieter logging with "spot price" notifications silent ([61e9138](https://github.com/decred/dcrdex/commit/61e913882708a2cfc059c1c47b4c48e48462d99c))
- Removes a hard coded 100 sat/vB fee rate used with BTC `Withdraw` in SPV mode, instead using a server's fee suggestion ([deab1c9](https://github.com/decred/dcrdex/commit/deab1c9deeab70876059d5246c60f023fa6a3e28))

For dcrdex-assets (frontend), just fix a zero price in the depth chart legend ([94eedbd](https://github.com/decred/dcrdex/commit/94eedbd56241e10c40859ed2206f354688ce8c5e)).