### PR TITLE
[dex] Improve the style of the Connect Wallets to Dex view

### DIFF
--- a/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.jsx
+++ b/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.jsx
@@ -1,6 +1,6 @@
 import { useDex } from "../hooks";
 import { useState } from "react";
-import { Tooltip, classNames } from "pi-ui";
+import { Tooltip, classNames, Message } from "pi-ui";
 import { KeyBlueButton, CopyToClipboardButton } from "buttons";
 import { FormattedMessage as T } from "react-intl";
 import styles from "./ConfirmDexSeed.module.css";
@@ -14,13 +14,10 @@ const ConfirmDexSeed = () => {
   };
 
   return (
-    <div>
-      <div
-        className={classNames(
-          styles.actions,
-          styles.isRow,
-          styles.seedInstructions
-        )}>
+    <div className={styles.container}>
+      <Message
+        kind="warning"
+        className={classNames(styles.isRow, styles.seedInstructions)}>
         <T
           id="dex.instructions.seed"
           m="You should carefully write down your application
@@ -30,15 +27,16 @@ const ConfirmDexSeed = () => {
        recoverable with this seed, so be sure to export any such accounts
        from the DEX Settings page."
         />
-      </div>
-      <div className={classNames(styles.actions, styles.isRow)}>
+      </Message>
+      <div className={styles.isRow}>
         <div className={styles.seed}>
           <div className={styles.seedLabel}>
-            <T id="dex.seed" m="DEX Account Seed" />
+            <T id="dex.seed" m="DEX Account Seed" />:
           </div>
           {showSeed ? (
             <>
               <Tooltip
+                contentClassName={styles.seedTooltip}
                 content={
                   <T id="dex.hide.seed" m="Click to Hide DEX Account Seed" />
                 }>

--- a/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.module.css
+++ b/app/components/views/DexPage/ConfirmDexSeed/ConfirmDexSeed.module.css
@@ -1,3 +1,8 @@
+.container {
+  width: 60rem;
+  color: var(--main-dark-blue);
+}
+
 .isRow {
   display: flex;
   flex-direction: row;
@@ -36,9 +41,12 @@
 .seed {
   display: flex;
   flex-direction: row;
-  margin-left: 30px;
-  margin-top: 18px;
-  width: 88%;
+  align-items: center;
+  margin: 3rem;
+}
+
+.seedTooltip {
+  width: max-content;
 }
 
 .seedLabel {
@@ -84,7 +92,7 @@
   font-size: 13px;
   line-height: 17px;
   font-weight: 600;
-  padding: 15px 20px 3px 20px;
+  padding: 2rem;
   border-radius: 3px;
   background-color: var(--disabled-color);
   height: 55px;

--- a/app/components/views/DexPage/CreateDexAcctPage/CreateDexAcctPage.module.css
+++ b/app/components/views/DexPage/CreateDexAcctPage/CreateDexAcctPage.module.css
@@ -1,6 +1,8 @@
 .dexContent {
   width: 740px;
   min-height: 300px;
+  font-size: 1.6rem;
+  line-height: 2rem;
 }
 
 .accountSelect {

--- a/app/components/views/DexPage/CreateWalletsPage/CreateWalletsPage.jsx
+++ b/app/components/views/DexPage/CreateWalletsPage/CreateWalletsPage.jsx
@@ -1,5 +1,5 @@
 import { FormattedMessage as T } from "react-intl";
-import { classNames, Checkbox } from "pi-ui";
+import { classNames, Checkbox, Message } from "pi-ui";
 import { useDex } from "../hooks";
 import { PathBrowseInput } from "inputs";
 import { Input } from "../../GetStartedPage/helpers";
@@ -50,19 +50,35 @@ const CreateWalletsPage = () => {
   });
   return (
     <div className="flex-column align-start">
+      <div className={styles.subtitle}>
+        <T id="dex.subtitle.btcWallet" m="BTC wallet" />
+      </div>
       {!askDexBtcSpv ? (
-        <div>
-          <KeyBlueButton className="margin-top-m" onClick={onUseBtcSpv}>
-            <T id="dex.useBTCSPV" m="Use DEX Native BTC" />
-          </KeyBlueButton>
-          <KeyBlueButton className="margin-top-m" onClick={onDoNotUseBtcSPV}>
-            <T id="dex.doNotUseBTCSPV" m="Use Bitcoind Wallet" />
-          </KeyBlueButton>
+        <div className={classNames("flex-row", "align-center", styles.box)}>
+          <div className={classNames("flex-column", "align-center")}>
+            <strong>
+              <T id="dex.doNotUseBTCSPV.simpleSetup" m="Simple Setup" />
+            </strong>
+            <KeyBlueButton className="margin-top-s" onClick={onUseBtcSpv}>
+              <T id="dex.useBTCSPV" m="Use DEX Native BTC" />
+            </KeyBlueButton>
+          </div>
+          <div className={classNames("margin-left-s", "margin-right-s")}>
+            <T id="dex.doNotUseBTCSPV.or" m="or" />
+          </div>
+          <div className={classNames("flex-column", "align-center")}>
+            <strong>
+              <T id="dex.doNotUseBTCSPV.advancedSetup" m="Advanced Setup" />
+            </strong>
+            <KeyBlueButton className="margin-top-s" onClick={onDoNotUseBtcSPV}>
+              <T id="dex.doNotUseBTCSPV" m="Use Bitcoind Wallet" />
+            </KeyBlueButton>
+          </div>
         </div>
       ) : !dexBtcSpv ? (
         !dexBTCWalletRunning ? (
           btcConfig ? (
-            <>
+            <div className={styles.box}>
               <div>
                 <T
                   id="dex.connectBTCWallet"
@@ -89,35 +105,42 @@ const CreateWalletsPage = () => {
                 onChange={(e) => setWalletName(e.target.value)}
                 placeholder="BTC Wallet Name (leave empty if unnamed default wallet)"
               />
-              <AppPassAndPassphraseModalButton
-                className="margin-top-m"
-                passphraseLabel={
-                  <T
-                    id="dex.createBTCWalletPassphrase"
-                    m="BTC Passphrase (if set)"
-                  />
-                }
-                modalTitle={
-                  <T id="dex.createBTCWallet" m="Connect BTC Wallet" />
-                }
-                loading={btcCreateWalletDexAttempt}
-                onSubmit={onBTCCreateWallet}
-                buttonLabel={
-                  <T
-                    id="dex.createWalletBTCPassphraseButton"
-                    m="Connect BTC Wallet"
-                  />
-                }
-                passphraseNotRequired
-              />
-            </>
+              <div
+                className={classNames(
+                  "margin-top-m",
+                  "align-center",
+                  "flex-column"
+                )}>
+                <AppPassAndPassphraseModalButton
+                  passphraseLabel={
+                    <T
+                      id="dex.createBTCWalletPassphrase"
+                      m="BTC Passphrase (if set)"
+                    />
+                  }
+                  modalTitle={
+                    <T id="dex.createBTCWallet" m="Connect BTC Wallet" />
+                  }
+                  loading={btcCreateWalletDexAttempt}
+                  onSubmit={onBTCCreateWallet}
+                  buttonLabel={
+                    <T
+                      id="dex.createWalletBTCPassphraseButton"
+                      m="Connect BTC Wallet"
+                    />
+                  }
+                  passphraseNotRequired
+                />
+              </div>
+            </div>
           ) : (
-            <div>
+            <div className={styles.box}>
               {!btcConfigUpdateNeeded && !btcInstallNeeded && (
                 <div
                   className={classNames(
                     "margin-top-s",
-                    styles.btcConfigNeededArea
+                    styles.btcConfigNeededArea,
+                    "flex-column"
                   )}>
                   <Checkbox
                     label={
@@ -148,23 +171,35 @@ const CreateWalletsPage = () => {
                       />
                     </Input>
                   )}
-                  <KeyBlueButton
-                    className="margin-top-m"
-                    onClick={onCheckBTCConfigDex}>
-                    <T id="dex.findBTCConfigButton" m="Find bitcoin conf" />
-                  </KeyBlueButton>
+                  <div
+                    className={classNames(
+                      "margin-top-m",
+                      "align-center",
+                      "flex-column"
+                    )}>
+                    <KeyBlueButton onClick={onCheckBTCConfigDex}>
+                      <T id="dex.findBTCConfigButton" m="Find bitcoin conf" />
+                    </KeyBlueButton>
+                  </div>
                 </div>
               )}
               {btcConfigUpdateNeeded && (
-                <div className="margin-top-m">
-                  <T
-                    id="dex.updateBTCConfig"
-                    m="You must update your bitcoin.conf to properly communicate with the DEX."
-                  />
-                  <T
-                    id="dex.neededFieldsInConfig"
-                    m="The following fields are required in the bitcoin.conf rpcuser, rpcpassword, rpcbind, rpcport. You must also set 'server=1' to start the wallet listening for connections.  If you have any trouble with these instructions, please go to the support channel on chat.decred.org for further assistance."
-                  />
+                <div
+                  className={classNames(
+                    "margin-top-m",
+                    "align-center",
+                    "flex-column"
+                  )}>
+                  <div>
+                    <T
+                      id="dex.updateBTCConfig"
+                      m="You must update your bitcoin.conf to properly communicate with the DEX."
+                    />
+                    <T
+                      id="dex.neededFieldsInConfig"
+                      m="The following fields are required in the bitcoin.conf rpcuser, rpcpassword, rpcbind, rpcport. You must also set 'server=1' to start the wallet listening for connections.  If you have any trouble with these instructions, please go to the support channel on chat.decred.org for further assistance."
+                    />
+                  </div>
                   <KeyBlueButton
                     className="margin-top-m"
                     onClick={onCheckBTCConfigDex}>
@@ -173,8 +208,13 @@ const CreateWalletsPage = () => {
                 </div>
               )}
               {btcInstallNeeded && (
-                <div>
-                  <div className="margin-top-s">
+                <div
+                  className={classNames(
+                    "margin-top-m",
+                    "align-center",
+                    "flex-column"
+                  )}>
+                  <div>
                     <T
                       id="dex.checkBTCConfig"
                       m="You must confirm your bitcoin.conf is properly set up for connecting to DEX. If you have not yet installed a bitcoin wallet, please go to bitcoin.org for further instructions."
@@ -196,41 +236,51 @@ const CreateWalletsPage = () => {
             </div>
           )
         ) : (
-          <div>
-            <T
-              id="dex.btcWalletConnected"
-              m="BTC Wallet has been successfully connected!"
-            />
+          <div className={styles.box}>
+            <Message kind="success">
+              <T
+                id="dex.btcWalletConnected"
+                m="BTC Wallet has been successfully connected!"
+              />
+            </Message>
           </div>
         )
       ) : (
-        <div>
-          <T
-            id="dex.usingBtcSpv"
-            m="You have chosen to use the integrated BTC Wallet."
-          />
+        <div className={styles.box}>
+          <Message kind="success">
+            <T
+              id="dex.usingBtcSpv"
+              m="You have chosen to use the integrated BTC Wallet."
+            />
+          </Message>
         </div>
       )}
+      <div className={classNames(styles.subtitle, "margin-top-m")}>
+        <T id="dex.subtitle.dcrWallet" m="DCR wallet" />
+      </div>
       {!dexDCRWalletRunning ? (
-        <AppPassAndPassphraseModalButton
-          className="margin-top-m"
-          disabled={createWalletDexAttempt}
-          modalTitle={<T id="dex.createDCRWallet" m="Connect DCR Wallet" />}
-          loading={createWalletDexAttempt}
-          onSubmit={onCreateWallet}
-          buttonLabel={
-            <T
-              id="dex.createWalletDCRPassphraseButton"
-              m="Connect DCR Wallet"
-            />
-          }
-        />
-      ) : (
-        <div>
-          <T
-            id="dex.dcrWalletConnected"
-            m="DCR Wallet has been successfully connected!"
+        <div className={classNames(styles.box, "justify-center")}>
+          <AppPassAndPassphraseModalButton
+            disabled={createWalletDexAttempt}
+            modalTitle={<T id="dex.createDCRWallet" m="Connect DCR Wallet" />}
+            loading={createWalletDexAttempt}
+            onSubmit={onCreateWallet}
+            buttonLabel={
+              <T
+                id="dex.createWalletDCRPassphraseButton"
+                m="Connect DCR Wallet"
+              />
+            }
           />
+        </div>
+      ) : (
+        <div className={styles.box}>
+          <Message kind="success">
+            <T
+              id="dex.dcrWalletConnected"
+              m="DCR Wallet has been successfully connected!"
+            />
+          </Message>
         </div>
       )}
     </div>

--- a/app/components/views/DexPage/CreateWalletsPage/CreateWalletsPage.module.css
+++ b/app/components/views/DexPage/CreateWalletsPage/CreateWalletsPage.module.css
@@ -2,3 +2,23 @@
   width: 90% !important;
   max-width: 650px;
 }
+
+.box {
+  background-color: var(--background-back-color);
+  padding: 3rem 4rem;
+  width: 50rem;
+  justify-content: space-around;
+}
+
+.subtitle {
+  color: var(--grey-6);
+  font-size: 2.4rem;
+  line-height: 2.5rem;
+  margin-bottom: 1.5rem;
+}
+
+@media screen and (max-width: 768px) {
+  .box {
+    width: 355px;
+  }
+}

--- a/app/components/views/DexPage/EnablePage/EnablePage.jsx
+++ b/app/components/views/DexPage/EnablePage/EnablePage.jsx
@@ -1,12 +1,13 @@
 import { FormattedMessage as T } from "react-intl";
 import { useDex } from "../hooks";
 import { ResetNetworkButton } from "buttons";
+import styles from "./EnablePage.module.css";
 
 const EnablePage = () => {
   const { onEnableDex, enableDexAttempt } = useDex();
 
   return (
-    <>
+    <div className={styles.container}>
       <div>
         <T
           id="dex.enableInformation"
@@ -31,7 +32,7 @@ const EnablePage = () => {
         block={false}
         onSubmit={onEnableDex}
       />
-    </>
+    </div>
   );
 };
 

--- a/app/components/views/DexPage/EnablePage/EnablePage.module.css
+++ b/app/components/views/DexPage/EnablePage/EnablePage.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 60rem;
+}

--- a/app/components/views/DexPage/InitPage/InitPage.jsx
+++ b/app/components/views/DexPage/InitPage/InitPage.jsx
@@ -14,7 +14,7 @@ const InitPage = () => {
   });
 
   return (
-    <>
+    <div className={styles.container}>
       <div>
         <T
           id="dex.newPassphrase"
@@ -43,6 +43,7 @@ const InitPage = () => {
         }
         checked={hasSeed}
         onChange={toggleHasSeed}
+        className="margin-top-s"
       />
       {hasSeed && (
         <TextInput
@@ -62,7 +63,7 @@ const InitPage = () => {
         onSubmit={onInitDexCall}
         buttonLabel={<T id="dex.initPassphraseButton" m="Set Dex Passphrase" />}
       />
-    </>
+    </div>
   );
 };
 

--- a/app/components/views/DexPage/InitPage/InitPage.module.css
+++ b/app/components/views/DexPage/InitPage/InitPage.module.css
@@ -1,4 +1,8 @@
+.container {
+  width: 60rem;
+  color: var(--main-dark-blue);
+}
+
 .seedInput {
-  width: 90% !important;
   max-width: 650px;
 }


### PR DESCRIPTION
Closes #3662

This diff improves the style of the `Connect Wallets to Dex` view. 
Also, enhanced the style of pages shown before this view a little bit. 

Screenshots:
<img width="500" alt="2022-01-13_22-11" src="https://user-images.githubusercontent.com/52497040/149420042-0e115788-4869-4606-b26c-e7cae0f0e149.png">
<img width="500" alt="2022-01-13_22-18" src="https://user-images.githubusercontent.com/52497040/149420045-8e47f609-50aa-4442-a63a-35e65e6fc716.png">
<img width="500" alt="2022-01-13_22-19" src="https://user-images.githubusercontent.com/52497040/149420048-3f7e5abc-e5e4-4b8c-a478-07facb188842.png">
<img width="500" alt="2022-01-13_22-20" src="https://user-images.githubusercontent.com/52497040/149420049-5f46ec13-0504-4a2e-95db-b28d4c0d683d.png">
<img width="500" alt="2022-01-13_22-12" src="https://user-images.githubusercontent.com/52497040/149420044-bddfb8d6-1749-497a-aab5-1e24e17f3a15.png">
<img width="500" alt="2022-01-13_22-42" src="https://user-images.githubusercontent.com/52497040/149420050-8db27a44-46ec-4fba-83eb-1efd0f715ff0.png">
<img width="500" alt="2022-01-13_22-43" src="https://user-images.githubusercontent.com/52497040/149420052-692ebad2-25aa-4ccc-acf2-a9e12d16f557.png">
<img width="500" alt="2022-01-13_22-44" src="https://user-images.githubusercontent.com/52497040/149420055-f2a99446-5de9-4bf8-a64f-2663c9a29680.png">

