### PR TITLE
[selectors] Move isMix determination to higher level

### DIFF
--- a/app/selectors.js
+++ b/app/selectors.js
@@ -16,13 +16,7 @@ import {
 } from "./fp";
 import { isNull } from "lodash";
 import { appLocaleFromElectronLocale } from "./i18n/locales";
-import {
-  decodeVoteScript,
-  reverseHash,
-  isMixTx,
-  dateToLocal,
-  dateToUTC
-} from "helpers";
+import { decodeVoteScript, reverseHash, dateToLocal, dateToUTC } from "helpers";
 import {
   EXTERNALREQUEST_STAKEPOOL_LISTING,
   EXTERNALREQUEST_POLITEIA,
@@ -645,6 +639,7 @@ export const transactionNormalizer = createSelector(
         timestamp,
         txHash,
         rawTx,
+        isMix,
         outputs,
         creditAddresses,
         direction,
@@ -735,13 +730,6 @@ export const transactionNormalizer = createSelector(
               txDirection: TRANSACTION_DIR_RECEIVED,
               txAccountName: creditedAccountName
             };
-
-      const { isMix } = isMixTx(
-        wallet.decodeRawTransaction(
-          Buffer.from(origTx.rawTx, "hex"),
-          chainParams
-        )
-      );
 
       return {
         txUrl,

--- a/app/wallet/service.js
+++ b/app/wallet/service.js
@@ -22,6 +22,7 @@ import {
   selializeNoWitnessEncode,
   decodeRawTransaction as decodeHelper
 } from "../helpers/msgTx";
+import { isMixTx } from "../helpers/transactions";
 import { extractPkScriptAddrs } from "../helpers/scripts";
 import { addrFromSStxPkScrCommitment } from "../helpers/tickets";
 import {
@@ -155,9 +156,15 @@ export function formatTransaction(block, transaction, index) {
   const txHash = transaction.getHash()
     ? rawHashToHex(transaction.getHash())
     : null;
-  const rawTx = transaction.getTransaction()
-    ? rawToHex(transaction.getTransaction())
-    : null;
+  let rawTx = null,
+    isMix = false;
+  if (transaction.getTransaction()) {
+    const buffTx = Buffer.from(transaction.getTransaction());
+    rawTx = buffTx.toString("hex");
+    const decoded = decodeHelper(buffTx);
+    isMix = isMixTx(decoded).isMix;
+  }
+
   const timestamp = block.getTimestamp()
     ? block.getTimestamp()
     : transaction.getTimestamp();
@@ -182,7 +189,8 @@ export function formatTransaction(block, transaction, index) {
     credits: transaction.getCreditsList().map((v) => v.toObject()),
     debits: transaction.getDebitsList().map((v) => v.toObject()),
     rawTx,
-    direction
+    direction,
+    isMix
   };
 }
 

--- a/test/unit/components/views/TransactionPage/mocks.js
+++ b/test/unit/components/views/TransactionPage/mocks.js
@@ -178,6 +178,7 @@ const mockRegularTransactionList = [
     type: 0,
     amount: -3610,
     fee: 0,
+    isMix: true,
     debitAccounts: [4],
     creditAddresses: [
       "TshTsuJmLsbpFCPgFYkeR4nmbRqiAAjGvAR",


### PR DESCRIPTION
This moves the determination of whether a transaction is a mix transaction
from the selectors to the formatTransaction function that runs after fetching
transactions from the wallets.

This avoids having to decode and recalculate whether a tx is a mix transaction
every time the selectors are updated, which was causing slowdown on wallets
that participated in mixed transactions.