### PR TITLE
[dex] Fix error occurring when creating an account for dex

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -162,6 +162,7 @@ export const getNextAccountAttempt = (passphrase, accountName) => async (
     return dispatch({ getNextAccountResponse, type: GETNEXTACCOUNT_SUCCESS });
   } catch (error) {
     dispatch({ error, type: GETNEXTACCOUNT_FAILED });
+    throw error;
   }
 };
 

--- a/app/components/inputs/AccountsSelect/hooks.js
+++ b/app/components/inputs/AccountsSelect/hooks.js
@@ -61,7 +61,7 @@ export const useAccountsSelect = ({
   useEffect(() => {
     const newAccounts = getAccountsToShow();
     if (!isEqual(newAccounts, accounts)) {
-      if (!newAccounts.find((a) => isEqual(a.value, account.value))) {
+      if (!newAccounts.find((a) => isEqual(a.value, account?.value))) {
         setAccount(newAccounts[0]);
         onChange(newAccounts[0]);
       }


### PR DESCRIPTION
Closes #3697

Also, I noticed if some error happened during the account creation, the error only dispatched into redux, and the dex registration progress silently moved on. It maybe causes an error like reported in #3694. Now the error is thrown toward, and it can be handled in `DexActions/CreateDexAccount`