### PR TITLE
[tx/ui] Trim leading/trailing space from tx address 

### DIFF
--- a/app/components/inputs/AddressInput.jsx
+++ b/app/components/inputs/AddressInput.jsx
@@ -1,7 +1,18 @@
 import Input from "./Input";
 
 // AddressInput is an input that restricts values to a decred address
-// doesn't do validation yet, but may in the future
-const AddressInput = ({ ...props }) => <Input {...{ ...props }} />;
+const AddressInput = ({ ...props }) => {
+  let value = props.value;
+
+  const onChange = (e) => {
+    const newValue = e.target.value.trim();
+    if (value !== newValue) {
+      value = newValue;
+      e.target.value = newValue;
+      props.onChange && props.onChange(e);
+    }
+  };
+  return <Input {...props} onChange={onChange} value={value} />;
+};
 
 export default AddressInput;

--- a/app/components/views/TransactionsPage/SendTab/SendOutputRow/SendOutputRow.jsx
+++ b/app/components/views/TransactionsPage/SendTab/SendOutputRow/SendOutputRow.jsx
@@ -331,7 +331,7 @@ const SendOutputRow = ({
                   onClick={(e) => {
                     e.preventDefault();
                     onValidateAddress({
-                      address: wallet.readFromClipboard(),
+                      address: wallet.readFromClipboard().trim(),
                       index
                     });
                   }}>

--- a/test/unit/components/views/TransactionsPage/SendTab/SendTab.spec.js
+++ b/test/unit/components/views/TransactionsPage/SendTab/SendTab.spec.js
@@ -569,3 +569,26 @@ test("watching only trezor should show send button", () => {
   render(<SendTab />);
   expect(getSendButton()).toBeInTheDocument();
 });
+
+test("address input have to allow leading/trailing spaces", async () => {
+  render(<SendTab />);
+  const index = 0;
+  const sendToInput = getAllSendToInput()[index];
+  // test pasting address with trailing and leading spaces with paste putton
+  const pasteButton = getPasteButton();
+  const mockPastedAddress = "mockPastedAddress";
+  wallet.readFromClipboard.mockImplementation(
+    () => `          ${mockPastedAddress}              `
+  );
+
+  user.click(pasteButton);
+  await wait(() => expect(sendToInput.value).toBe(mockPastedAddress));
+
+  // type address with trailing and leading spaces
+  user.clear(sendToInput);
+  screen.debug();
+  fireEvent.change(sendToInput, {
+    target: { value: `   ${mockOutputs[index].address}     ` }
+  });
+  await wait(() => expect(sendToInput.value).toBe(mockOutputs[index].address));
+});


### PR DESCRIPTION
This diff trims leading/trailing space from the typed and pasted address on Send Tx form.

Maybe this is a solution for  #3644.