### PR TITLE
[privacy] allow buying tickets from unmixed accounts when privacy is enabled

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -347,12 +347,20 @@ export const purchaseTicketsAttempt =
               type: PURCHASETICKETS_ATTEMPT
             });
             const dontSignTx = sel.isWatchingOnly(getState());
+            const isAccountMixed =
+              account.value == sel.getMixedAccount(getState());
             const csppReq = {
-              mixedAccount: sel.getMixedAccount(getState()),
-              changeAccount: sel.getChangeAccount(getState()),
-              csppServer: sel.getCsppServer(getState()),
-              csppPort: sel.getCsppPort(getState()),
-              mixedAcctBranch: sel.getMixedAccountBranch(getState())
+              mixedAccount: isAccountMixed
+                ? sel.getMixedAccount(getState())
+                : "",
+              changeAccount: isAccountMixed
+                ? sel.getChangeAccount(getState())
+                : "",
+              csppServer: isAccountMixed ? sel.getCsppServer(getState()) : "",
+              csppPort: isAccountMixed ? sel.getCsppPort(getState()) : "",
+              mixedAcctBranch: isAccountMixed
+                ? sel.getMixedAccountBranch(getState())
+                : ""
             };
             // Since we're about to purchase a ticket, ensure on next startup we'll
             // process managed tickets.

--- a/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/TicketAutoBuyer/hooks.js
@@ -21,7 +21,7 @@ export const useTicketAutoBuyer = () => {
     buyerMaxFeePercentage
   );
 
-  const notMixedAccounts = useSelector(sel.getNotMixedAccounts);
+  const notMixedAccounts = useSelector(sel.getNotMixedAcctIfAllowed);
   // isValid check if we can show the modal to start the auto buyer.
   const [isValid, setIsValid] = useState(null);
   const [errorMsg, setErrorMsg] = useState(null);

--- a/app/components/views/TicketsPage/PurchaseTab/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/hooks.js
@@ -20,7 +20,7 @@ export const usePurchaseTab = () => {
   const availableVSPsError = useSelector(sel.getDiscoverAvailableVSPError);
   const ticketAutoBuyerRunning = useSelector(sel.getTicketAutoBuyerRunning);
   const isLoading = useSelector(sel.purchaseTicketsRequestAttempt);
-  const notMixedAccounts = useSelector(sel.getNotMixedAccounts);
+  const notMixedAccounts = useSelector(sel.getNotMixedAcctIfAllowed);
 
   const rememberedVspHost = useSelector(sel.getRememberedVspHost);
   const visibleAccounts = useSelector(sel.visibleAccounts);


### PR DESCRIPTION
This diff allows buying tickets from unmixed accounts when privacy is enabled, and the "Allow sending from unmixed accounts" control is checked on the privacy page. 
Allowed this on autobuyer modal too.

Closes  #3004