### PR TITLE
[launcher] Allow completing unfinished wallet setup

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -336,14 +336,18 @@ export const createWallet = (selectedWallet) => (dispatch, getState) =>
           type: WALLETCREATED
         });
         dispatch(setSelectedWallet(selectedWallet));
+        const walletCfg = wallet.getWalletCfg(
+          network == TESTNET,
+          selectedWallet.value.wallet
+        );
+        walletCfg.set(
+          cfgConstants.WALLET_CREATED_AS_NEW,
+          !!selectedWallet.value.isNew
+        );
         if (
           selectedWallet.value.gapLimit &&
           selectedWallet.value.gapLimit > 0
         ) {
-          const walletCfg = wallet.getWalletCfg(
-            network == TESTNET,
-            selectedWallet.value.wallet
-          );
           walletCfg.set(cfgConstants.GAP_LIMIT, selectedWallet.value.gapLimit);
         }
         resolve(selectedWallet);
@@ -531,7 +535,7 @@ export const startWallet = (selectedWallet, hasPassPhrase) => (
       });
       selectedWallet.value.isTrezor && dispatch(enableTrezor());
       await dispatch(getVersionServiceAttempt());
-      await dispatch(openWalletAttempt("", false));
+      await dispatch(openWalletAttempt("", false, selectedWallet));
       return discoverAccountsComplete;
     };
 

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -139,6 +139,7 @@ export const createWalletRequest = (pubPass, privPass, seed, isNew) => (
         } = getState();
         const config = wallet.getWalletCfg(isTestNet(getState()), walletName);
         config.delete(cfgConstants.DISCOVER_ACCOUNTS);
+        config.delete(cfgConstants.WALLET_CREATED_AS_NEW);
         config.set(cfgConstants.DISCOVER_ACCOUNTS, isNew);
         dispatch({ complete: isNew, type: UPDATEDISCOVERACCOUNTS });
         dispatch({ type: CREATEWALLET_SUCCESS });
@@ -193,7 +194,7 @@ export const OPENWALLET_ATTEMPT = "OPENWALLET_ATTEMPT";
 export const OPENWALLET_FAILED = "OPENWALLET_FAILED";
 export const OPENWALLET_SUCCESS = "OPENWALLET_SUCCESS";
 
-export const openWalletAttempt = (pubPass, retryAttempt) => (
+export const openWalletAttempt = (pubPass, retryAttempt, selectedWallet) => (
   dispatch,
   getState
 ) =>
@@ -236,6 +237,15 @@ export const openWalletAttempt = (pubPass, retryAttempt) => (
           return reject(OPENWALLET_INPUT);
         }
 
+        if (!selectedWallet.finished) {
+          const walletCfg = wallet.getWalletCfg(
+            isTestNet(getState()),
+            selectedWallet.value.wallet
+          );
+          error.walletCreatedAsNew = !!walletCfg.get(
+            cfgConstants.WALLET_CREATED_AS_NEW
+          );
+        }
         dispatch({ error, type: OPENWALLET_FAILED });
         reject(error);
       });
@@ -693,14 +703,4 @@ export const setLastPoliteiaAccessTime = () => (dispatch, getState) => {
     currentBlockHeight,
     timestamp
   });
-};
-
-export const STOP_UNFINISHED_WALLET_FAILED = "STOP_UNFINISHED_WALLET_FAILED";
-export const stopUnfinishedWallet = () => async (dispatch) => {
-  try {
-    await wallet.stopWallet();
-    dispatch(setSelectedWallet(null));
-  } catch (err) {
-    dispatch({ error: err, type: STOP_UNFINISHED_WALLET_FAILED });
-  }
 };

--- a/app/components/views/GetStartedPage/hooks.js
+++ b/app/components/views/GetStartedPage/hooks.js
@@ -53,8 +53,7 @@ export const useGetStarted = () => {
     appVersion,
     syncAttemptRequest,
     onGetDcrdLogs,
-    daemonWarning,
-    stopUnfinishedWallet
+    daemonWarning
   } = useDaemonStartup();
   const [PageComponent, setPageComponent] = useState(null);
   const [showNavLinks, setShowNavLinks] = useState(true);
@@ -133,7 +132,7 @@ export const useGetStarted = () => {
           );
       },
       isAtChoosingWallet: (ctx, event) => {
-        const { selectedWallet } = event;
+        const selectedWallet = event?.selectedWallet || ctx?.selectedWallet;
         const { availableWalletsError } = ctx;
         if (selectedWallet) {
           return submitChosenWallet(selectedWallet);
@@ -176,7 +175,7 @@ export const useGetStarted = () => {
               !selectedWallet.finished &&
               error.message.includes("missing database file")
             ) {
-              stopUnfinishedWallet().then(() => send({ type: "ERROR", error }));
+              return onShowCreateWallet({ isNew: error.walletCreatedAsNew });
             }
 
             // If the error is OPENWALLET_INPUTPRIVPASS, the wallet needs the

--- a/app/constants/config.js
+++ b/app/constants/config.js
@@ -90,6 +90,7 @@ export const NEEDS_VSPD_PROCESS_TICKETS = "needs_vspd_process_tickets";
 export const DEX_BTC_SPV = "dex_use_btc_spv";
 export const ASK_DEX_BTC_SPV = "ask_dex_use_btc_spv";
 export const CONFIRM_DEX_SEED = "confirm_dex_seed";
+export const WALLET_CREATED_AS_NEW = "wallet_created_as_new";
 
 export const WALLET_INITIAL_VALUE = {
   [ENABLE_TICKET_BUYER]: false,
@@ -137,7 +138,8 @@ export const WALLET_INITIAL_VALUE = {
 
   // Force as true to ensure wallets with tickets prior to when this config was
   // introduced trigger a view of the "process managed tickets" page.
-  [NEEDS_VSPD_PROCESS_TICKETS]: true
+  [NEEDS_VSPD_PROCESS_TICKETS]: true,
+  [WALLET_CREATED_AS_NEW]: null
 };
 
 export const INITIAL_VALUES = {

--- a/app/hooks/useDaemonStartup.js
+++ b/app/hooks/useDaemonStartup.js
@@ -233,11 +233,6 @@ const useDaemonStartup = () => {
     [dispatch]
   );
 
-  const stopUnfinishedWallet = useCallback(
-    () => dispatch(wla.stopUnfinishedWallet()),
-    [dispatch]
-  );
-
   return {
     onShowTutorial,
     validateMasterPubKey,
@@ -316,7 +311,6 @@ const useDaemonStartup = () => {
     isProcessingManaged,
     isProcessingUnmanaged,
     needsProcessManagedTickets,
-    stopUnfinishedWallet,
     isSettingAccountsPassphrase
   };
 };

--- a/app/stateMachines/GetStartedStateMachine.js
+++ b/app/stateMachines/GetStartedStateMachine.js
@@ -322,7 +322,13 @@ export const getStartedMachine = Machine({
         }
       },
       on: {
-        BACK: "startMachine.choosingWallet",
+        BACK: {
+          target: "startMachine.choosingWallet",
+          actions: assign({
+            selectedWallet: () => null,
+            passPhrase: () => null
+          })
+        },
         WALLET_CREATED: {
           target: "startMachine.preStart",
           actions: assign({
@@ -333,7 +339,9 @@ export const getStartedMachine = Machine({
         ERROR: {
           target: "startMachine.choosingWallet",
           actions: assign({
-            error: (_, event) => event.error && event.error
+            error: (_, event) => event.error && event.error,
+            selectedWallet: () => null,
+            passPhrase: () => null
           })
         }
       }


### PR DESCRIPTION
This diff adds a way to the unfinished wallets could be continued. 
To find out the unfinished wallet wheater new or restored a new wallet config parameter is introduced: `WALLET_CREATED_AS_NEW`. It is deleted after the creation process.

Closes  #2920
