### PR TITLE
[vsp] Show differently and disable out of date vsps

### DIFF
--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -19,6 +19,8 @@ import * as cfgConstants from "constants/config";
 import { shuffle } from "helpers";
 import { mapArray } from "fp";
 import { isArray } from "lodash";
+import semver from "semver";
+import { MIN_VSP_VERSION } from "constants";
 
 export const GETVSP_ATTEMPT = "GETVSP_ATTEMPT";
 export const GETVSP_FAILED = "GETVSP_FAILED";
@@ -491,7 +493,8 @@ export const discoverAvailableVSPs = () => async (dispatch, getState) => {
       .map((vsp) => ({
         ...vsp,
         label: vsp.host,
-        value: vsp.host
+        value: vsp.host,
+        outdated: isVSPOutdated(vsp.vspData?.vspdversion, MIN_VSP_VERSION)
       }))
       .filter(({ vspData }) => {
         if (!vspData) return false;
@@ -510,6 +513,12 @@ export const discoverAvailableVSPs = () => async (dispatch, getState) => {
       error
     });
   }
+};
+
+// returns true if version < minVersion or version is not
+// defined, so VSP is out of date
+export const isVSPOutdated = (version, minVersion) => {
+  return !version || semver.lt(version, minVersion);
 };
 
 export const CHANGESELECTEDSTAKEPOOL = "CHANGESELECTEDSTAKEPOOL";
@@ -921,7 +930,8 @@ export const getRandomVSP = (maxFeePercentage) => async (
     throw new Error("The available VSPs list is empty.");
   }
   const filteredVSPs = availableVSPs.filter(
-    (vsp) => vsp.vspData.feepercentage <= parseFloat(maxFeePercentage)
+    (vsp) =>
+      vsp.vspData.feepercentage <= parseFloat(maxFeePercentage) && !vsp.outdated
   );
   if (filteredVSPs.length == 0) {
     throw new Error("Max fee is too low.");

--- a/app/components/inputs/VSPSelect/VSPSelect.jsx
+++ b/app/components/inputs/VSPSelect/VSPSelect.jsx
@@ -2,7 +2,7 @@ import { injectIntl, defineMessages } from "react-intl";
 import { useEffect, useState, useMemo } from "react";
 import { useVSPSelect } from "./hooks";
 import { FormattedMessage as T } from "react-intl";
-import { Tooltip } from "pi-ui";
+import { Tooltip, classNames } from "pi-ui";
 import styles from "./VSPSelect.modules.css";
 import { Select } from "inputs";
 
@@ -59,19 +59,32 @@ function VSPSelect({
           contentClassName={styles.tooltipContent}
           content={
             <div>
-              <T
-                id="vsp.feeTooltip"
-                m="Fee: {feePercentage} %"
-                values={{
-                  feePercentage: vsp.vspData.feepercentage
-                }}
-              />
+              {vsp.outdated ? (
+                <div>
+                  <T id="vsp.outdated" m="Out of date" />
+                </div>
+              ) : (
+                <T
+                  id="vsp.feeTooltip"
+                  m="Fee: {feePercentage} %"
+                  values={{
+                    feePercentage: vsp.vspData.feepercentage
+                  }}
+                />
+              )}
             </div>
           }>
-          <div className={styles.optionWrapper}>{vsp.host}</div>
+          <div
+            className={classNames(
+              styles.optionWrapper,
+              vsp.outdated && styles.outdated
+            )}>
+            {vsp.host}
+          </div>
         </Tooltip>
       ),
-      value: vsp
+      value: vsp,
+      isDisabled: vsp.outdated
     }));
     opts = [
       {

--- a/app/components/inputs/VSPSelect/VSPSelect.modules.css
+++ b/app/components/inputs/VSPSelect/VSPSelect.modules.css
@@ -16,6 +16,11 @@
   text-overflow: ellipsis;
 }
 
+.optionWrapper.outdated {
+  color: var(--grey-5);
+  cursor: default;
+}
+
 .error {
   color: var(--error-text-color);
 }
@@ -23,6 +28,6 @@
 .tooltipContent {
   text-align: center;
   line-height: 20px;
-  width: 95px;
+  width: max-content;
   transition: 0.1s all ease;
 }

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
@@ -39,9 +39,23 @@ const Tickets = ({ toggleIsLegacy }) => {
   }, [visibleAccounts, account]);
 
   // todo use this vsp to buy solo tickets.
-  const [vsp, setVSP] = useState(
-    rememberedVspHost ? { host: rememberedVspHost.host } : null
-  );
+  const [vsp, setVSP] = useState(() => {
+    if (rememberedVspHost) {
+      // reset rememberedVspHost if it's outdated
+      if (
+        availableVSPs?.find(
+          (availableVSP) => availableVSP.host === rememberedVspHost.host
+        )?.outdated === true
+      ) {
+        setRememberedVspHost(null);
+        return null;
+      } else {
+        return { host: rememberedVspHost.host };
+      }
+    } else {
+      return null;
+    }
+  });
   const [numTicketsToBuy, setNumTicketsToBuy] = useState(1);
   const [isValid, setIsValid] = useState(false);
 

--- a/app/constants/decred.js
+++ b/app/constants/decred.js
@@ -144,3 +144,5 @@ export const PiKeys = [
   "03f6e7041f1cf51ee10e0a01cd2b0385ce3cd9debaabb2296f7e9dee9329da946c"
   // "0319a37405cb4d1691971847d7719cfce70857c0f6e97d7c9174a3998cf0ab86dd",
 ];
+
+export const MIN_VSP_VERSION = "1.1.0";

--- a/test/unit/actions/VSPActions.spec.js
+++ b/test/unit/actions/VSPActions.spec.js
@@ -20,39 +20,60 @@ const defaultMockAvailableMainnetVsps = [
   {
     host: "test-stakepool1.eu",
     label: "test-stakepool1.eu",
+    outdated: false,
     vspData: {
       feepercentage: 2,
-      network: "mainnet"
+      network: "mainnet",
+      vspdversion: "1.1.0"
     }
   },
   {
     host: "test-stakepool2.eu",
     label: "test-stakepool2.eu",
+    outdated: false,
     vspData: {
       feepercentage: 3,
-      network: "mainnet"
+      network: "mainnet",
+      vspdversion: "1.1.0"
     }
   },
   {
     host: "test-stakepool3.eu",
     label: "test-stakepool3.eu",
+    outdated: false,
     vspData: {
       feepercentage: 4,
-      network: "mainnet"
+      network: "mainnet",
+      vspdversion: "1.1.0"
     }
   },
   {
     host: "test-stakepool4.eu",
     label: "test-stakepool4.eu",
+    outdated: false,
     vspData: {
-      network: "mainnet"
+      network: "mainnet",
+      vspdversion: "1.1.0"
     }
   },
   {
     host: "test-stakepool5.eu",
     label: "test-stakepool5.eu",
+    outdated: false,
     vspData: {
-      network: "mainnet"
+      network: "mainnet",
+      vspdversion: "1.1.0"
+    }
+  },
+  {
+    host: "test-stakepool6.eu",
+    label: "test-stakepool6.eu",
+    outdated: true,
+    vspData: {
+      feepercentage: 1, // this vsp is outdated, so it's not going to be
+      // chosen in randomVSP despite the low fee percentage
+      network: "mainnet",
+      vspdversion: "1.0.0"
     }
   }
 ];
@@ -60,17 +81,21 @@ const defaultMockAvailableTestnetVsps = [
   {
     host: "test-stakepool6.eu",
     label: "test-stakepool6.eu",
+    outdated: false,
     vspData: {
       feepercentage: 4,
-      network: "testnet"
+      network: "testnet",
+      vspdversion: "1.1.0"
     }
   },
   {
     host: "test-stakepool7.eu",
     label: "test-stakepool7.eu",
+    outdated: false,
     vspData: {
       feepercentage: 5,
-      network: "testnet"
+      network: "testnet",
+      vspdversion: "1.1.0"
     }
   }
 ];
@@ -232,7 +257,8 @@ test("test getVSPsPubkeys", async () => {
     [`https://${mockAvailableMainnetVsps[1].host}`]: null, // will be rejected
     [`https://${mockAvailableMainnetVsps[2].host}`]: "invalid",
     [`https://${mockAvailableMainnetVsps[3].host}`]: "test-pubkey3",
-    [`https://${mockAvailableMainnetVsps[4].host}`]: "test-pubkey4"
+    [`https://${mockAvailableMainnetVsps[4].host}`]: "test-pubkey4",
+    [`https://${mockAvailableMainnetVsps[5].host}`]: "test-pubkey5"
   };
 
   const fetchTimes = {
@@ -240,7 +266,8 @@ test("test getVSPsPubkeys", async () => {
     [`https://${mockAvailableMainnetVsps[1].host}`]: 10,
     [`https://${mockAvailableMainnetVsps[2].host}`]: 5,
     [`https://${mockAvailableMainnetVsps[3].host}`]: 0,
-    [`https://${mockAvailableMainnetVsps[4].host}`]: 1000 // will timeout
+    [`https://${mockAvailableMainnetVsps[4].host}`]: 1000, // will timeout
+    [`https://${mockAvailableMainnetVsps[5].host}`]: 0
   };
 
   wallet.getVSPInfo = jest.fn((host) => {
@@ -267,20 +294,36 @@ test("test getVSPsPubkeys", async () => {
       Object {
         "host": "test-stakepool1.eu",
         "label": "test-stakepool1.eu",
+        "outdated": false,
         "pubkey": "test-pubkey1",
         "value": "test-stakepool1.eu",
         "vspData": Object {
           "feepercentage": 2,
           "network": "mainnet",
+          "vspdversion": "1.1.0",
         },
       },
       Object {
         "host": "test-stakepool4.eu",
         "label": "test-stakepool4.eu",
+        "outdated": false,
         "pubkey": "test-pubkey3",
         "value": "test-stakepool4.eu",
         "vspData": Object {
           "network": "mainnet",
+          "vspdversion": "1.1.0",
+        },
+      },
+      Object {
+        "host": "test-stakepool6.eu",
+        "label": "test-stakepool6.eu",
+        "outdated": true,
+        "pubkey": "test-pubkey5",
+        "value": "test-stakepool6.eu",
+        "vspData": Object {
+          "feepercentage": 1,
+          "network": "mainnet",
+          "vspdversion": "1.0.0",
         },
       },
     ]
@@ -298,4 +341,24 @@ test("test getVSPsPubkeys (error)", async () => {
   expect(store.getState().vsp.availableVSPsPubkeysError).toEqual(
     "Error: INVALID_VSPS"
   );
+});
+
+test("test isVSPOutdated function", () => {
+  const minVersion = "1.1.0";
+  expect(vspActions.isVSPOutdated("1.1.0", minVersion)).toBeFalsy();
+  expect(vspActions.isVSPOutdated("2.2.0", minVersion)).toBeFalsy();
+  expect(vspActions.isVSPOutdated("1.2.0", minVersion)).toBeFalsy();
+  expect(vspActions.isVSPOutdated("1.1.1", minVersion)).toBeFalsy();
+  expect(vspActions.isVSPOutdated("1.2.1", minVersion)).toBeFalsy();
+  expect(vspActions.isVSPOutdated("1.2.1-pre", minVersion)).toBeFalsy();
+  expect(vspActions.isVSPOutdated("1.2.1-alpha", minVersion)).toBeFalsy();
+  expect(vspActions.isVSPOutdated("1.2.1-beta", minVersion)).toBeFalsy();
+
+  expect(vspActions.isVSPOutdated("1.0.0", minVersion)).toBeTruthy();
+  expect(vspActions.isVSPOutdated("1.0.0-pre", minVersion)).toBeTruthy();
+  expect(vspActions.isVSPOutdated("1.1.0-pre", minVersion)).toBeTruthy();
+  expect(vspActions.isVSPOutdated("1.1.0-alpha", minVersion)).toBeTruthy();
+  expect(vspActions.isVSPOutdated("1.1.0-beta", minVersion)).toBeTruthy();
+  expect(vspActions.isVSPOutdated(null, minVersion)).toBeTruthy();
+  expect(vspActions.isVSPOutdated(undefined, minVersion)).toBeTruthy();
 });


### PR DESCRIPTION
Closes #3720

Changes:
- consider vsps below `1.1.0` as out of date
- minimum vsp version could be set by `MIN_VSP_VERSION` in `app/constants/decred.js`
- indicate and disable out of date vsps in the dropdowns
- clear remembered vsp from the config if earlier an outdated vsp has remembered (clicking on the "Always use this VSP" checkbox)
- automatic ticket buyer now does not choose an outdated vsp
- add and update tests