### PR TITLE
[dex] Bump to dcrdex v0.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/decrediton
 go 1.16
 
 require (
-	decred.org/dcrdex v0.4.1
+	decred.org/dcrdex v0.4.2
 	github.com/decred/dcrd/certgen v1.1.2-0.20210914212651-723d86274b0d // indirect
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.4-0.20210914212651-723d86274b0d // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1-0.20210914212651-723d86274b0d // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 decred.org/cspp/v2 v2.0.0-20211122173608-ee00e4952d5f/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
-decred.org/dcrdex v0.4.1 h1:QcmDa7FcFfdRNWSHvhwcBbbYEl+U1Ay9Stez5eDEXXI=
-decred.org/dcrdex v0.4.1/go.mod h1:C9PstuxJQIQWmFWJj2L1gWi+YSH9/WYZb0UgCGJ7cCE=
+decred.org/dcrdex v0.4.2 h1:6GTdsliXhj9DPyyWVKw08fovkjyZhujxBDw1MzUt3+4=
+decred.org/dcrdex v0.4.2/go.mod h1:DW/f9bgvXcdJ4dg5e2slvHCc0TfkFvoDbqrWqB8l82s=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb h1:vio6o+nzszBrdj2Yi3/gifDa5ocfy49A9SqYPlbUjXo=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb/go.mod h1:rbFJaCuXCfDhYoI5ZdeZr8TmF4A4Sb1zE7jQAwtaFMo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -526,8 +526,9 @@ github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6Ut
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zquestz/grab v0.0.0-20190224022517-abcee96e61b1/go.mod h1:bslhAiUxakrA6z6CHmVyvkfpnxx18RJBwVyx2TluJWw=
 go.etcd.io/bbolt v1.3.5-0.20200615073812-232d8fc87f50/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
-go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
+go.etcd.io/bbolt v1.3.7-0.20220130032806-d5db64bdbfde h1:jqAsjG/dU6OSvhzkskltTptEQ+xeolIxgK2jh5qKqGo=
+go.etcd.io/bbolt v1.3.7-0.20220130032806-d5db64bdbfde/go.mod h1:sh/Yp01MYDakY7RVfzKZn+T1WOMTTFJrWjl7+M73RXA=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -660,6 +661,7 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "bufferutil": "^4.0.3",
     "connected-react-router": "^6.8.0",
     "copy-webpack-plugin": "^8.1.0",
-    "dcrdex-assets": "https://github.com/decred/dcrdex-assets#v0.4.1",
+    "dcrdex-assets": "https://github.com/decred/dcrdex-assets#v0.4.2",
     "dex": "./modules/dex",
     "dom-helpers": "^3.4.0",
     "electron-devtools-installer": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4536,9 +4536,9 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-"dcrdex-assets@https://github.com/decred/dcrdex-assets#v0.4.1":
+"dcrdex-assets@https://github.com/decred/dcrdex-assets#v0.4.2":
   version "0.0.0"
-  resolved "https://github.com/decred/dcrdex-assets#f07835a796a15097d898ece9d401ae0923f710a8"
+  resolved "https://github.com/decred/dcrdex-assets#c15fce6e40784ae25a4a8f007a72bc41a593ee11"
 
 debounce-fn@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Update to dcrdex v0.4.2. **NOT YET TESTED.**

https://github.com/decred/dcrdex/compare/v0.4.1...release-v0.4

A couple critical bug fixes, automatic db compaction on shutdown, some minor frontend fixes, and first steps on fixing a comms signature bug.