### PR TITLE
[css] Fix snackbar layout

### DIFF
--- a/app/components/Snackbar/Snackbar.module.css
+++ b/app/components/Snackbar/Snackbar.module.css
@@ -40,7 +40,7 @@
 }
 
 .snackbarMessage {
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
before and after:

<img width="425" alt="image" src="https://user-images.githubusercontent.com/52497040/160425626-67c78c5a-204b-4b89-8544-b19c932c562f.png">
<img width="278" alt="image" src="https://user-images.githubusercontent.com/52497040/160425854-5801ee66-3063-4be6-889a-7b995316574f.png">
