### PR TITLE
Treasury Spending: Fix undefined `treasuryPolicies`.

### DIFF
--- a/app/components/views/GovernancePage/TreasurySpendingTab/helpers/VoteSection/VoteSection.jsx
+++ b/app/components/views/GovernancePage/TreasurySpendingTab/helpers/VoteSection/VoteSection.jsx
@@ -12,7 +12,9 @@ const VoteSection = ({
   isLoading
 }) => {
   const [selected, setSelected] = useState(
-    () => treasuryPolicies.find((tp) => tp.key === piKey)?.policy ?? "abstain"
+    () =>
+      treasuryPolicies &&
+      (treasuryPolicies.find((tp) => tp.key === piKey)?.policy ?? "abstain")
   );
   const updatePreferences = (passphrase) =>
     setTreasuryPolicy(piKey, selected, passphrase);


### PR DESCRIPTION
Before this commit `Treasury Spending` page crashed with undefined `treasuryPolicies`.