### PR TITLE
[vsp] Alert user for any un-upgraded used vsp that has > 0 unspent tickets

### DIFF
--- a/app/components/views/GovernancePage/Blockchain/Blockchain.jsx
+++ b/app/components/views/GovernancePage/Blockchain/Blockchain.jsx
@@ -5,7 +5,7 @@ import { ExternalLink, ExternalButton } from "shared";
 import { FormattedMessage as T, defineMessages } from "react-intl";
 import PageHeader from "../PageHeader";
 import styles from "./Blockchain.module.css";
-import { Tooltip } from "pi-ui";
+import { Tooltip, Message } from "pi-ui";
 import { TextInput } from "inputs";
 import { EyeFilterMenu } from "buttons";
 import { useIntl } from "react-intl";
@@ -32,7 +32,12 @@ const sortOptions = [
 ];
 
 const Blockchain = () => {
-  const { allAgendas, voteChoices, viewAgendaDetailsHandler } = useBlockchain();
+  const {
+    allAgendas,
+    voteChoices,
+    viewAgendaDetailsHandler,
+    outdatedUsedVsps
+  } = useBlockchain();
   const [filterByName, setFilterByName] = useState("");
   const [sortBy, setSortBy] = useState(sortOptions[0]);
   const [agendas, setAgendas] = useState(allAgendas);
@@ -93,6 +98,49 @@ const Blockchain = () => {
           }
         />
       </div>
+      {outdatedUsedVsps?.length > 0 && (
+        <div className={styles.outdatedUsedVspsAlert}>
+          <Message kind="warning">
+            <T
+              id="votingPreferences.outdatedUsedVsps.alert.header"
+              m="You have unspent tickets at {vspCount, plural, one {a VSP} other {VSPs}} that has not upgraded to the
+                          minimum version. While your confirmed/paid for tickets will be
+                          voted, your vote preferences will not be used."
+              values={{
+                vspCount: outdatedUsedVsps.length
+              }}
+            />
+            <div>
+              <T
+                id="votingPreferences.outdatedUsedVsps.alert"
+                m="Please contact {host} to ask them to upgrade."
+                values={{
+                  host:
+                    outdatedUsedVsps?.length === 1 ? (
+                      <ExternalLink
+                        className={styles.proposalsLink}
+                        href={outdatedUsedVsps[0].host}>
+                        {outdatedUsedVsps[0].host}
+                      </ExternalLink>
+                    ) : (
+                      <ul className="margin-left-l">
+                        {outdatedUsedVsps.map((vsp) => (
+                          <li key={vsp.host}>
+                            <ExternalLink
+                              className={styles.proposalsLink}
+                              href={vsp.host}>
+                              {vsp.host}
+                            </ExternalLink>
+                          </li>
+                        ))}
+                      </ul>
+                    )
+                }}
+              />
+            </div>
+          </Message>
+        </div>
+      )}
       <div className={styles.filters}>
         <div className={styles.searchByNameInput}>
           <TextInput

--- a/app/components/views/GovernancePage/Blockchain/Blockchain.module.css
+++ b/app/components/views/GovernancePage/Blockchain/Blockchain.module.css
@@ -56,6 +56,11 @@
   width: max-content;
 }
 
+.outdatedUsedVspsAlert {
+  margin: 2rem 6rem;
+  width: 76.4rem;
+}
+
 @media screen and (max-width: 1180px) {
   .agendaWrapper {
     margin-left: 35px;

--- a/app/components/views/GovernancePage/Blockchain/hooks.js
+++ b/app/components/views/GovernancePage/Blockchain/hooks.js
@@ -1,18 +1,40 @@
+import { useMemo } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import * as sel from "selectors";
 import * as gov from "actions/GovernanceActions";
+import * as vspa from "actions/VSPActions";
+import { useMountEffect } from "hooks";
 
 export function useBlockchain() {
   const allAgendas = useSelector(sel.allAgendas);
   const voteChoices = useSelector(sel.voteChoices);
+  const unspentUnexpiredVspTickets = useSelector(
+    sel.unspentUnexpiredVspTickets
+  );
+  const availableVSPs = useSelector(sel.getAvailableVSPs);
+  const outdatedUsedVsps = useMemo(
+    () =>
+      unspentUnexpiredVspTickets?.filter(
+        (v) =>
+          v.tickets.length > 0 &&
+          availableVSPs?.find((av) => `https://${av.host}` === v.host)?.outdated
+      ),
+    [unspentUnexpiredVspTickets, availableVSPs]
+  );
+
   const dispatch = useDispatch();
   const viewAgendaDetailsHandler = (agendaId) => {
     return dispatch(gov.viewAgendaDetails(agendaId));
   };
 
+  useMountEffect(() => {
+    dispatch(vspa.getUnspentUnexpiredVspTickets());
+  });
+
   return {
     allAgendas,
     viewAgendaDetailsHandler,
-    voteChoices
+    voteChoices,
+    outdatedUsedVsps
   };
 }

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -24,7 +24,10 @@ import {
   SET_CANDISABLEPROCESSMANAGED,
   GETVSP_ATTEMPT,
   GETVSP_FAILED,
-  GETVSP_SUCCESS
+  GETVSP_SUCCESS,
+  GETUNSPENTUNEXPIREDVSPTICKETS_ATTEMPT,
+  GETUNSPENTUNEXPIREDVSPTICKETS_SUCCESS,
+  GETUNSPENTUNEXPIREDVSPTICKETS_FAILED
 } from "actions/VSPActions";
 import {
   STARTTICKETBUYERV3_ATTEMPT,
@@ -202,6 +205,20 @@ export default function vsp(state = {}, action) {
       return {
         ...state,
         getVSPAttempt: false
+      };
+    case GETUNSPENTUNEXPIREDVSPTICKETS_ATTEMPT:
+      return { ...state, getUnspentUnexpiredVspTicketsAttempt: true };
+    case GETUNSPENTUNEXPIREDVSPTICKETS_SUCCESS:
+      return {
+        ...state,
+        getUnspentUnexpiredVspTicketsAttempt: false,
+        unspentUnexpiredVspTickets: action.vsps
+      };
+    case GETUNSPENTUNEXPIREDVSPTICKETS_FAILED:
+      return {
+        ...state,
+        getUnspentUnexpiredVspTicketsError: String(action.error),
+        getUnspentUnexpiredVspTicketsAttempt: false
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -938,6 +938,10 @@ export const getRememberedVspHost = get(["vsp", "rememberedVspHost"]);
 
 const getVSPTicketsHashes = get(["vsp", "vspTickets"]);
 export const isGetVSPAttempt = get(["vsp", "getVSPAttempt"]);
+export const unspentUnexpiredVspTickets = get([
+  "vsp",
+  "unspentUnexpiredVspTickets"
+]);
 
 // getVSPTickets is a selector for getting an object with feeStatus as keys
 // and an array of tickets which have this feeStatus.

--- a/test/unit/actions/vspMocks.js
+++ b/test/unit/actions/vspMocks.js
@@ -1,0 +1,183 @@
+import {
+  LIVE,
+  UNMINED,
+  IMMATURE,
+  VOTED,
+  MISSED,
+  EXPIRED,
+  REVOKED
+} from "constants";
+
+export const mockVspInfo = {
+  data: {
+    pubkey: "test-pubkey"
+  }
+};
+
+export const defaultMockAvailableMainnetVsps = [
+  {
+    host: "test-stakepool1.eu",
+    label: "test-stakepool1.eu",
+    outdated: false,
+    vspData: {
+      feepercentage: 2,
+      network: "mainnet",
+      vspdversion: "1.1.0"
+    }
+  },
+  {
+    host: "test-stakepool2.eu",
+    label: "test-stakepool2.eu",
+    outdated: false,
+    vspData: {
+      feepercentage: 3,
+      network: "mainnet",
+      vspdversion: "1.1.0"
+    }
+  },
+  {
+    host: "test-stakepool3.eu",
+    label: "test-stakepool3.eu",
+    outdated: false,
+    vspData: {
+      feepercentage: 4,
+      network: "mainnet",
+      vspdversion: "1.1.0"
+    }
+  },
+  {
+    host: "test-stakepool4.eu",
+    label: "test-stakepool4.eu",
+    outdated: false,
+    vspData: {
+      network: "mainnet",
+      vspdversion: "1.1.0"
+    }
+  },
+  {
+    host: "test-stakepool5.eu",
+    label: "test-stakepool5.eu",
+    outdated: false,
+    vspData: {
+      network: "mainnet",
+      vspdversion: "1.1.0"
+    }
+  },
+  {
+    host: "test-stakepool6.eu",
+    label: "test-stakepool6.eu",
+    outdated: true,
+    vspData: {
+      feepercentage: 1, // this vsp is outdated, so it's not going to be
+      // chosen in randomVSP despite the low fee percentage
+      network: "mainnet",
+      vspdversion: "1.0.0"
+    }
+  }
+];
+
+export const defaultMockAvailableTestnetVsps = [
+  {
+    host: "test-stakepool6.eu",
+    label: "test-stakepool6.eu",
+    outdated: false,
+    vspData: {
+      feepercentage: 4,
+      network: "testnet",
+      vspdversion: "1.1.0"
+    }
+  },
+  {
+    host: "test-stakepool7.eu",
+    label: "test-stakepool7.eu",
+    outdated: false,
+    vspData: {
+      feepercentage: 5,
+      network: "testnet",
+      vspdversion: "1.1.0"
+    }
+  }
+];
+
+export const defaultMockAvailableInvalidVsps = [
+  {
+    host: "test-stakepool8.eu",
+    label: "test-stakepool8.eu"
+  }
+];
+
+export const mockTickets = [
+  {
+    status: LIVE,
+    ticket: {
+      txHash: "tx-hash-1",
+      vspHost: `https://${defaultMockAvailableMainnetVsps[0].host}`
+    }
+  },
+  {
+    status: IMMATURE,
+    ticket: {
+      txHash: "tx-hash-2",
+      vspHost: `https://${defaultMockAvailableMainnetVsps[1].host}`
+    }
+  },
+  {
+    status: UNMINED,
+    ticket: {
+      txHash: "tx-hash-3",
+      vspHost: `https://${defaultMockAvailableMainnetVsps[1].host}`
+    }
+  },
+  // vspHost is outdated
+  {
+    status: LIVE,
+    ticket: {
+      txHash: "tx-hash-4",
+      vspHost: `https://${defaultMockAvailableMainnetVsps[5].host}`
+    }
+  },
+  // vspHost is ""
+  {
+    status: LIVE,
+    ticket: {
+      txHash: "tx-hash-5",
+      vspHost: ""
+    }
+  },
+  // missing vspHost
+  {
+    status: LIVE,
+    ticket: {
+      txHash: "tx-hash-6"
+    }
+  },
+  // spent/expired tickets
+  {
+    status: VOTED,
+    ticket: {
+      txHash: "tx-hash-7",
+      vspHost: `https://${defaultMockAvailableMainnetVsps[0].host}`
+    }
+  },
+  {
+    status: MISSED,
+    ticket: {
+      txHash: "tx-hash-7",
+      vspHost: `https://${defaultMockAvailableMainnetVsps[0].host}`
+    }
+  },
+  {
+    status: EXPIRED,
+    ticket: {
+      txHash: "tx-hash-8",
+      vspHost: `https://${defaultMockAvailableMainnetVsps[0].host}`
+    }
+  },
+  {
+    status: REVOKED,
+    ticket: {
+      txHash: "tx-hash-9",
+      vspHost: `https://${defaultMockAvailableMainnetVsps[0].host}`
+    }
+  }
+];


### PR DESCRIPTION
This diff alerts the user for any un-upgraded used vsp that has > 0 unspent tickets on the governance page.

Requires https://github.com/decred/dcrwallet/pull/2146
Requires #3732
Part of #3723

Screenshots:

<img width="688" alt="2022-04-01_15-01" src="https://user-images.githubusercontent.com/52497040/161277893-42fd449c-11d6-4e1f-a8f0-9d9cb778c65f.png">
<img width="688" alt="2022-04-01_15-02" src="https://user-images.githubusercontent.com/52497040/161277901-49fc8f8a-84dd-4141-b9d2-f46c9f30ff43.png">




