### PR TITLE
[dex]: dcr spv no longer experimental

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -108,10 +108,7 @@ const startWalletServicesTrigger = () => (dispatch, getState) =>
       await dispatch(getTreasuryPolicies());
 
       // Start Dex if dexEnabled and NOT SPV mode
-      if (
-        dexEnabled &&
-        (!sel.isSPV(getState()) || sel.useDexSpvExperimental(getState()))
-      ) {
+      if (dexEnabled) {
         await dispatch(startDex());
       }
     };

--- a/app/components/SideBar/MenuLinks/hooks.js
+++ b/app/components/SideBar/MenuLinks/hooks.js
@@ -3,7 +3,6 @@ import { useSelector } from "react-redux";
 import * as sel from "selectors";
 import { linkList, TREZOR_KEY, LN_KEY, DEX_KEY } from "./Links";
 import { useHistory } from "react-router-dom";
-import { FormattedMessage as T } from "react-intl";
 import { cloneDeep } from "fp";
 
 export function useMenuLinks() {
@@ -12,14 +11,12 @@ export function useMenuLinks() {
   const expandSideBar = useSelector(sel.expandSideBar);
   const isTrezor = useSelector(sel.isTrezor);
   const lnEnabled = useSelector(sel.lnEnabled);
-  const isSPV = useSelector(sel.isSPV);
 
   const newActiveVoteProposalsCount = useSelector(
     sel.newActiveVoteProposalsCount
   );
   const newPreVoteProposalsCount = useSelector(sel.newPreVoteProposalsCount);
   const newProposalsStartedVoting = useSelector(sel.newProposalsStartedVoting);
-  const useDexSpvExperimental = useSelector(sel.useDexSpvExperimental);
   const newNotYetVotedAgendasCount = useSelector(
     sel.newNotYetVotedAgendasCount
   );
@@ -55,20 +52,6 @@ export function useMenuLinks() {
     if (isTrezor) {
       links = links.filter((l) => l.key !== DEX_KEY);
     }
-    if (isSPV) {
-      links = links.map((l) => {
-        if (l.key === DEX_KEY && !useDexSpvExperimental) {
-          l.disabled = true;
-          l.tooltip = (
-            <T
-              id="sidebar.link.disabledDexTooltip"
-              m="DEX not available while using SPV. Please go to settings and disable SPV to access the DEX."
-            />
-          );
-        }
-        return l;
-      });
-    }
     return links.map((link) => ({
       ...link,
       notifProp: link.notifProp?.reduce(
@@ -76,7 +59,7 @@ export function useMenuLinks() {
         0
       )
     }));
-  }, [notifProps, isTrezor, lnEnabled, isSPV, useDexSpvExperimental]);
+  }, [notifProps, isTrezor, lnEnabled]);
 
   const [activeTabIndex, setActiveTabIndex] = useState(-1);
   const history = useHistory();

--- a/app/constants/config.js
+++ b/app/constants/config.js
@@ -25,7 +25,6 @@ export const DISABLE_HARDWARE_ACCEL = "disable_hardware_accel";
 export const LN_ENABLED = "ln_enabled";
 export const TREZOR_DEBUG = "trezor_debug";
 export const UPGD_ELECTRON8 = "is_electron8";
-export const DEX_SPV_EXPERIMENTAL = "dex_spv_experimental";
 
 // advanced daemon configs
 export const RPCUSER = "rpc_user";
@@ -169,6 +168,5 @@ export const INITIAL_VALUES = {
   [TREZOR_DEBUG]: false,
   [DISABLE_HARDWARE_ACCEL]: false,
   [LN_ENABLED]: false,
-  [UPGD_ELECTRON8]: false,
-  [DEX_SPV_EXPERIMENTAL]: false
+  [UPGD_ELECTRON8]: false
 };

--- a/app/index.js
+++ b/app/index.js
@@ -76,8 +76,7 @@ const currentSettings = {
   network: hasCliOption("network") || globalCfg.get(NETWORK),
   networkFromCli: !!hasCliOption("network"),
   theme: globalCfg.get(THEME),
-  uiAnimations: globalCfg.get(cfgConstants.UI_ANIMATIONS),
-  useDexSpvExperimental: globalCfg.get(cfgConstants.DEX_SPV_EXPERIMENTAL)
+  uiAnimations: globalCfg.get(cfgConstants.UI_ANIMATIONS)
 };
 const initialState = {
   settings: {

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -75,11 +75,6 @@ export const getSyncAttemptRequest = get([
 ]);
 
 // general startup selector
-export const useDexSpvExperimental = get([
-  "settings",
-  "currentSettings",
-  "useDexSpvExperimental"
-]);
 export const pageBodyScrollHandler = get(["control", "pageBodyScrollHandler"]);
 export const pageBodyTopRef = get(["control", "pageBodyTopRef"]);
 export const setLanguage = get(["daemon", "setLanguage"]);


### PR DESCRIPTION
This will go with a v0.4.3 shortly.  We should try to release a 1.7 patch with said dex patch.

Working for me, not blocking DEX in SPV mode, but this is a fairly naive purge of the option based on the commit that added it, so I may have missed something.