### PR TITLE
[ui] Improve transaction history view

### DIFF
--- a/app/components/Snackbar/Notification/Transaction.jsx
+++ b/app/components/Snackbar/Notification/Transaction.jsx
@@ -89,7 +89,7 @@ const Transaction = ({
         <Tooltip content={`${message.txHash}`}>
           <Link
             onClick={onDismissMessage}
-            to={`/transaction/history/${message.txHash}`}>
+            to={`/transactions/history/${message.txHash}`}>
             {message.txHash}
           </Link>
         </Tooltip>

--- a/app/components/layout/TabbedPage/TabbedPage.jsx
+++ b/app/components/layout/TabbedPage/TabbedPage.jsx
@@ -73,7 +73,11 @@ const TabbedPage = ({
                     h(content, { ...props }, null);
                 return (
                   <Tab label={label} key={key ?? path}>
-                    <div key={`${key ?? path}-key`}>{element}</div>
+                    <div
+                      key={`${key ?? path}-key`}
+                      className={styles.tabContentContainer}>
+                      {element}
+                    </div>
                   </Tab>
                 );
               })}

--- a/app/components/layout/TabbedPage/TabbedPage.module.css
+++ b/app/components/layout/TabbedPage/TabbedPage.module.css
@@ -32,7 +32,10 @@
   bottom: 0;
   left: 0;
   right: 0;
-  height: calc(100% - 66px);
+}
+
+.tabContentContainer {
+  height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 30px 80px 30px 60px;
@@ -42,7 +45,7 @@
   .tabbedPageHeader {
     padding-left: 20px;
   }
-  .tabContent {
+  .tabContentContainer {
     padding: 30px 20px 30px 20px;
   }
   .tabs {
@@ -56,7 +59,7 @@
     padding-top: 30px;
   }
 
-  .tabContent {
+  .tabContentContainer {
     padding: 15px 10px 80px 10px;
     top: 45px;
   }

--- a/app/components/shared/TxHistory/TxHistory.jsx
+++ b/app/components/shared/TxHistory/TxHistory.jsx
@@ -78,7 +78,7 @@ const TxHistory = ({ transactions = [], limit, overview, tsDate, history }) => {
               txLeaveTs: tx.leaveTimestamp && tsDate(tx.leaveTimestamp),
               overview,
               pending: tx.isPending,
-              onClick: () => history.push(`/transaction/history/${tx.txHash}`),
+              onClick: () => history.push(`/transactions/history/${tx.txHash}`),
               timeMessage: (txTimestamp) =>
                 shortDatetimeFormatter.format(txTimestamp)
             }}

--- a/app/components/shared/TxHistory/index.js
+++ b/app/components/shared/TxHistory/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TxHistory";

--- a/app/components/shared/index.js
+++ b/app/components/shared/index.js
@@ -14,7 +14,7 @@ export { default as Subtitle } from "./Subtitle/Subtitle";
 export { default as FormattedRelative } from "./FormattedRelative";
 export { default as CreatePassPhrase } from "./CreatePassPhrase/CreatePassPhrase";
 export { default as UnsignedTx } from "./UnsignedTx";
-export { default as TxHistory } from "./TxHistory/TxHistory";
+export { default as TxHistory } from "./TxHistory";
 export { default as LoadingError } from "./LoadingError";
 export { default as ButtonsToolbar } from "./ButtonsToolbar";
 export { default as TabsHeader } from "./TabsHeader/TabsHeader";

--- a/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfoDisplay.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/StakeInfo/StakeInfoDisplay.jsx
@@ -90,7 +90,7 @@ const StakeInfoDisplay = ({
             foot={
               lastVotedTicket && (
                 <Link
-                  to={`/transaction/history/${lastVotedTicket.txHash}`}
+                  to={`/transactions/history/${lastVotedTicket.txHash}`}
                   className={styles.foot}>
                   <span className={styles.purchaseTicketFoot}>
                     <T

--- a/app/components/views/TransactionsPage/HistoryTab/HistoryPage/HistoryPage.module.css
+++ b/app/components/views/TransactionsPage/HistoryTab/HistoryPage/HistoryPage.module.css
@@ -9,6 +9,7 @@
 
 .historySearchTx {
   display: inline-block;
+  width: 15rem;
 }
 
 .historyPageContent {

--- a/app/containers/Wallet/Wallet.jsx
+++ b/app/containers/Wallet/Wallet.jsx
@@ -62,7 +62,7 @@ const Wallet = ({ setInterval }) => {
           <Route path="/dex" component={DexPage} />
         </StaticSwitch>
         <Route
-          path="/transaction/history/:txHash"
+          path="/transactions/history/:txHash"
           component={TransactionPage}
         />
         <Route


### PR DESCRIPTION
This diff improves the transaction history view in multiple ways:
- Fix infinite scroll. Before this, when the user arrived at the history page, the app loaded immediately all data chunks independently from the scroll state. In a wallet with long tx history, this could have caused a slow, unresponsive state.
- Now history tab remembers its scroll position after coming back from the tx details page.
- Fix search tx input width