### PR TITLE
[ui] Improve performance of the tx history tab 

### DIFF
--- a/app/components/shared/TxHistory/RegularTxRow.jsx
+++ b/app/components/shared/TxHistory/RegularTxRow.jsx
@@ -72,9 +72,10 @@ const RegularTxRow = ({
   txAccountNameDebited,
   timeMessage,
   className,
+  active,
   ...props
 }) => (
-  <Row {...{ ...props, txAccountName, pending, overview }}>
+  <Row {...{ ...props, txAccountName, pending, overview, active }}>
     <div className={classNames(styles.info, overview && styles.overviewInfo)}>
       <div className={styles.iconContainer}>
         <Tooltip content={iconTooltipByType(className)} placement="right">

--- a/app/components/shared/TxHistory/Row.jsx
+++ b/app/components/shared/TxHistory/Row.jsx
@@ -2,13 +2,22 @@ import { FormattedMessage as T } from "react-intl";
 import { classNames, Tooltip } from "pi-ui";
 import styles from "./TxHistory.module.css";
 
-const Row = ({ pending, onClick, className, children, overview, eligible }) => (
+const Row = ({
+  pending,
+  onClick,
+  className,
+  children,
+  overview,
+  eligible,
+  active
+}) => (
   <div
     className={classNames(
       overview && pending && classNames("flex-row", styles.overviewPending),
       overview && styles.overviewRow,
       !overview && classNames("flex-row", styles.historyRow),
-      eligible && styles.eligibleRow
+      eligible && styles.eligibleRow,
+      active && styles.activeRow
     )}>
     <div className={classNames(styles.txInfo, className)} onClick={onClick}>
       <div className={styles.txRowWrapper}>{children}</div>

--- a/app/components/shared/TxHistory/TxHistory.jsx
+++ b/app/components/shared/TxHistory/TxHistory.jsx
@@ -1,14 +1,22 @@
+import { useState } from "react";
 import { withRouter } from "react-router-dom";
 import TxRow from "./TxRow";
 
 // TxHistory is responsible for calling the right component row according to
 // the Tx row type.
-const TxHistory = ({ transactions = [], limit, overview, tsDate, history }) =>
-  transactions.map((tx, index) => {
+const TxHistory = ({ transactions = [], limit, overview, tsDate, history }) => {
+  const [activeRow, setActiveRow] = useState(null);
+  return transactions.map((tx, index) => {
     if (limit && index >= limit) return;
     if (!tx) return;
     const key = `${tx.spenderHash}-${tx.txHash}`;
-    return <TxRow key={key} {...{ tx, tsDate, overview, history }} />;
+    return (
+      <TxRow
+        key={key}
+        {...{ tx, tsDate, overview, history, activeRow, setActiveRow }}
+      />
+    );
   });
+};
 
 export default withRouter(TxHistory);

--- a/app/components/shared/TxHistory/TxHistory.jsx
+++ b/app/components/shared/TxHistory/TxHistory.jsx
@@ -1,92 +1,14 @@
 import { withRouter } from "react-router-dom";
-import RegularTxRow from "./RegularTxRow";
-import StakeTxRow from "./StakeTxRow";
-import LiveStakeTxRow from "./LiveStakeTxRow";
-import * as txTypes from "constants/decrediton";
-import { shortDatetimeFormatter } from "helpers";
-
-const TxRowByType = {
-  // LiveStakeTxRow is used for tickets which can still be voted.
-  [txTypes.UNMINED]: LiveStakeTxRow,
-  [txTypes.IMMATURE]: LiveStakeTxRow,
-  [txTypes.LIVE]: LiveStakeTxRow,
-  // Otherwise we use stakeTxRow
-  [txTypes.TICKET]: StakeTxRow,
-  [txTypes.VOTE]: StakeTxRow,
-  [txTypes.REVOCATION]: StakeTxRow,
-  [txTypes.UNKNOWN]: StakeTxRow,
-  [txTypes.VOTED]: StakeTxRow,
-  [txTypes.MISSED]: StakeTxRow,
-  [txTypes.EXPIRED]: StakeTxRow,
-  [txTypes.REVOKED]: StakeTxRow,
-  [txTypes.TRANSACTION_DIR_SENT]: RegularTxRow,
-  [txTypes.TRANSACTION_DIR_RECEIVED]: RegularTxRow,
-  [txTypes.TICKET_FEE]: RegularTxRow,
-  [txTypes.SELFTRANSFER]: RegularTxRow,
-  [txTypes.MIXED]: RegularTxRow,
-  [txTypes.COINBASE]: RegularTxRow
-};
+import TxRow from "./TxRow";
 
 // TxHistory is responsible for calling the right component row according to
 // the Tx row type.
-const TxHistory = ({ transactions = [], limit, overview, tsDate, history }) => {
-  return (
-    <>
-      {transactions.map((tx, index) => {
-        if (limit && index >= limit) return;
-        if (!tx) return;
-        const txTimestamp = tx.enterTimestamp || tx.timestamp;
-        // we define the transaction icon by its rowType, so we pass it as a
-        // className props
-        let rowType = tx.status || tx.txType;
-        rowType = rowType.toLowerCase();
-        // If it is a regular tx we use its direction to show a proper icon.
-        if (rowType === txTypes.REGULAR) {
-          rowType = tx.txDirection;
-        } else {
-          rowType = [
-            txTypes.MISSED,
-            txTypes.UNMINED,
-            txTypes.IMMATURE,
-            txTypes.LIVE
-          ].includes(tx.status)
-            ? tx.status
-            : tx.txType;
-        }
-        if (tx.mixedTx) rowType = txTypes.MIXED;
-        if (tx.selfTx) rowType = txTypes.SELFTRANSFER;
-
-        // gets the proper component to show, based on it rowType
-        const Component = TxRowByType[rowType];
-        const key = `${tx.spenderHash}-${tx.txHash}`;
-
-        const txOutputAddresses =
-          tx.outputs &&
-          tx.outputs
-            .filter((o) => !o.isChange)
-            .map((o) => o.address)
-            .join(" ");
-
-        return (
-          <Component
-            key={key}
-            {...{
-              ...tx,
-              txOutputAddresses,
-              className: rowType,
-              txTs: txTimestamp && tsDate(txTimestamp),
-              txLeaveTs: tx.leaveTimestamp && tsDate(tx.leaveTimestamp),
-              overview,
-              pending: tx.isPending,
-              onClick: () => history.push(`/transactions/history/${tx.txHash}`),
-              timeMessage: (txTimestamp) =>
-                shortDatetimeFormatter.format(txTimestamp)
-            }}
-          />
-        );
-      })}
-    </>
-  );
-};
+const TxHistory = ({ transactions = [], limit, overview, tsDate, history }) =>
+  transactions.map((tx, index) => {
+    if (limit && index >= limit) return;
+    if (!tx) return;
+    const key = `${tx.spenderHash}-${tx.txHash}`;
+    return <TxRow key={key} {...{ tx, tsDate, overview, history }} />;
+  });
 
 export default withRouter(TxHistory);

--- a/app/components/shared/TxHistory/TxHistory.module.css
+++ b/app/components/shared/TxHistory/TxHistory.module.css
@@ -353,6 +353,11 @@
   height: 54px;
 }
 
+.historyRow.activeRow {
+  border-left: 0.4rem solid var(--accent-color);
+  filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.16));
+}
+
 .historyRow:hover {
   background-image: var(--arrow-right-blue-icon);
   background-color: var(--tx-history-background-hover);
@@ -375,6 +380,10 @@
 .historyRow.eligibleRow .txInfo .txRowWrapper {
   padding: 16px 20px 16px 20px;
   width: 100%;
+}
+
+.historyRow.activeRow .txInfo .txRowWrapper {
+  padding-left: 1.6rem;
 }
 
 .overviewRow .txInfo .myTickets .timeDateSpacer {

--- a/app/components/shared/TxHistory/TxRow.jsx
+++ b/app/components/shared/TxHistory/TxRow.jsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useCallback } from "react";
 import RegularTxRow from "./RegularTxRow";
 import StakeTxRow from "./StakeTxRow";
 import LiveStakeTxRow from "./LiveStakeTxRow";
@@ -28,7 +28,8 @@ const TxRowByType = {
   [txTypes.COINBASE]: RegularTxRow
 };
 
-const TxRow = ({ tx, tsDate, overview, history }) => {
+const TxRow = ({ tx, tsDate, overview, history, activeRow, setActiveRow }) => {
+  const txHash = tx.txHash;
   const txTimestamp = tx.enterTimestamp || tx.timestamp; // we define the transaction icon by its rowType, so we pass it as a
   // className props
   let rowType = tx.status || tx.txType;
@@ -59,17 +60,23 @@ const TxRow = ({ tx, tsDate, overview, history }) => {
       .map((o) => o.address)
       .join(" ");
 
+  const onClick = useCallback(() => {
+    setActiveRow(txHash);
+    history.push(`/transactions/history/${txHash}`);
+  }, [txHash, setActiveRow, history]);
+
   return (
     <Component
       {...{
         ...tx,
+        active: activeRow === txHash,
         txOutputAddresses,
         className: rowType,
         txTs: txTimestamp && tsDate(txTimestamp),
         txLeaveTs: tx.leaveTimestamp && tsDate(tx.leaveTimestamp),
         overview,
         pending: tx.isPending,
-        onClick: () => history.push(`/transactions/history/${tx.txHash}`),
+        onClick,
         timeMessage: (txTimestamp) => shortDatetimeFormatter.format(txTimestamp)
       }}
     />

--- a/app/components/shared/TxHistory/TxRow.jsx
+++ b/app/components/shared/TxHistory/TxRow.jsx
@@ -1,0 +1,81 @@
+import { memo } from "react";
+import RegularTxRow from "./RegularTxRow";
+import StakeTxRow from "./StakeTxRow";
+import LiveStakeTxRow from "./LiveStakeTxRow";
+import * as txTypes from "constants/decrediton";
+import { shortDatetimeFormatter } from "helpers";
+import { isEqual } from "lodash/fp";
+
+const TxRowByType = {
+  // LiveStakeTxRow is used for tickets which can still be voted.
+  [txTypes.UNMINED]: LiveStakeTxRow,
+  [txTypes.IMMATURE]: LiveStakeTxRow,
+  [txTypes.LIVE]: LiveStakeTxRow,
+  // Otherwise we use stakeTxRow
+  [txTypes.TICKET]: StakeTxRow,
+  [txTypes.VOTE]: StakeTxRow,
+  [txTypes.REVOCATION]: StakeTxRow,
+  [txTypes.UNKNOWN]: StakeTxRow,
+  [txTypes.VOTED]: StakeTxRow,
+  [txTypes.MISSED]: StakeTxRow,
+  [txTypes.EXPIRED]: StakeTxRow,
+  [txTypes.REVOKED]: StakeTxRow,
+  [txTypes.TRANSACTION_DIR_SENT]: RegularTxRow,
+  [txTypes.TRANSACTION_DIR_RECEIVED]: RegularTxRow,
+  [txTypes.TICKET_FEE]: RegularTxRow,
+  [txTypes.SELFTRANSFER]: RegularTxRow,
+  [txTypes.MIXED]: RegularTxRow,
+  [txTypes.COINBASE]: RegularTxRow
+};
+
+const TxRow = ({ tx, tsDate, overview, history }) => {
+  const txTimestamp = tx.enterTimestamp || tx.timestamp; // we define the transaction icon by its rowType, so we pass it as a
+  // className props
+  let rowType = tx.status || tx.txType;
+  rowType = rowType.toLowerCase();
+  // If it is a regular tx we use its direction to show a proper icon.
+  if (rowType === txTypes.REGULAR) {
+    rowType = tx.txDirection;
+  } else {
+    rowType = [
+      txTypes.MISSED,
+      txTypes.UNMINED,
+      txTypes.IMMATURE,
+      txTypes.LIVE
+    ].includes(tx.status)
+      ? tx.status
+      : tx.txType;
+  }
+  if (tx.mixedTx) rowType = txTypes.MIXED;
+  if (tx.selfTx) rowType = txTypes.SELFTRANSFER;
+
+  // gets the proper component to show, based on it rowType
+  const Component = TxRowByType[rowType];
+
+  const txOutputAddresses =
+    tx.outputs &&
+    tx.outputs
+      .filter((o) => !o.isChange)
+      .map((o) => o.address)
+      .join(" ");
+
+  return (
+    <Component
+      {...{
+        ...tx,
+        txOutputAddresses,
+        className: rowType,
+        txTs: txTimestamp && tsDate(txTimestamp),
+        txLeaveTs: tx.leaveTimestamp && tsDate(tx.leaveTimestamp),
+        overview,
+        pending: tx.isPending,
+        onClick: () => history.push(`/transactions/history/${tx.txHash}`),
+        timeMessage: (txTimestamp) => shortDatetimeFormatter.format(txTimestamp)
+      }}
+    />
+  );
+};
+
+export default memo(TxRow, (prevProps, nextProps) => {
+  return isEqual(prevProps, nextProps);
+});

--- a/app/components/views/TransactionsPage/HistoryTab/HistoryTab.jsx
+++ b/app/components/views/TransactionsPage/HistoryTab/HistoryTab.jsx
@@ -44,14 +44,14 @@ const HistoryTab = () => {
   const [index, setIndex] = useState(() =>
     Math.min(BATCH_TX_COUNT, transactions.length)
   );
-  const [noMoreTransactionsReally, setNoMoreTransactionsReally] = useState(
+  const [noMoreTransactionsToShow, setNoMoreTransactionsToShow] = useState(
     false
   );
   const { search, listDirection } = transactionsFilter;
 
   useEffect(() => {
     setIndex(BATCH_TX_COUNT);
-    setNoMoreTransactionsReally(false);
+    setNoMoreTransactionsToShow(false);
   }, [transactionsFilter]);
 
   const selTxTypeKeys = selectedTxTypesFromFilter(transactionsFilter);
@@ -87,7 +87,7 @@ const HistoryTab = () => {
     } else if (!noMoreTransactions) {
       onGetTransactions(false);
     } else {
-      setNoMoreTransactionsReally(true);
+      setNoMoreTransactionsToShow(true);
     }
   };
 
@@ -159,7 +159,7 @@ const HistoryTab = () => {
         loadMoreThreshold,
         transactions: visibleTransactions,
         transactionsFilter,
-        noMoreTransactions: noMoreTransactionsReally,
+        noMoreTransactions: noMoreTransactionsToShow,
         selectedSortOrderKey,
         selectedTxTypeKeys,
         searchText,

--- a/app/components/views/TransactionsPage/HistoryTab/HistoryTab.jsx
+++ b/app/components/views/TransactionsPage/HistoryTab/HistoryTab.jsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useState, useEffect, useMemo } from "react";
 import ErrorScreen from "ErrorScreen";
 import HistoryPage from "./HistoryPage";
 import { FormattedMessage as T } from "react-intl";
 import { DescriptionHeader } from "layout";
 import { BalanceDisplay } from "shared";
-import { DCR } from "constants";
+import { DCR, BATCH_TX_COUNT } from "constants";
 import { useService } from "hooks";
 import { useHistoryTab } from "./hooks";
 import { selectedTxTypesFromFilter, getSortTypes, getTxTypes } from "./helpers";
@@ -41,7 +41,17 @@ const HistoryTab = () => {
     transactionsRequestAttempt
   } = useHistoryTab();
 
+  const [index, setIndex] = useState(transactions.length);
+  const [noMoreTransactionsReally, setNoMoreTransactionsReally] = useState(
+    false
+  );
   const { search, listDirection } = transactionsFilter;
+
+  useEffect(() => {
+    setIndex(BATCH_TX_COUNT);
+    setNoMoreTransactionsReally(false);
+  }, [transactionsFilter]);
+
   const selTxTypeKeys = selectedTxTypesFromFilter(transactionsFilter);
 
   const [searchText, setSearchText] = useState(search);
@@ -69,7 +79,15 @@ const HistoryTab = () => {
     setSearchText(searchText);
   };
 
-  const onLoadMoreTransactions = () => onGetTransactions(false);
+  const onLoadMoreTransactions = () => {
+    if (index < transactions.length) {
+      setIndex(Math.min(index + BATCH_TX_COUNT, transactions.length));
+    } else if (!noMoreTransactions) {
+      onGetTransactions(false);
+    } else {
+      setNoMoreTransactionsReally(true);
+    }
+  };
 
   const onChangeSliderValue = (value, minOrMax) => {
     // convert from atoms
@@ -125,6 +143,11 @@ const HistoryTab = () => {
     });
   };
 
+  const visibleTransactions = useMemo(() => transactions.slice(0, index), [
+    index,
+    transactions
+  ]);
+
   return !walletService ? (
     <ErrorScreen />
   ) : (
@@ -132,9 +155,9 @@ const HistoryTab = () => {
       {...{
         tsDate,
         loadMoreThreshold,
-        transactions,
+        transactions: visibleTransactions,
         transactionsFilter,
-        noMoreTransactions,
+        noMoreTransactions: noMoreTransactionsReally,
         selectedSortOrderKey,
         selectedTxTypeKeys,
         searchText,

--- a/app/components/views/TransactionsPage/HistoryTab/HistoryTab.jsx
+++ b/app/components/views/TransactionsPage/HistoryTab/HistoryTab.jsx
@@ -41,7 +41,9 @@ const HistoryTab = () => {
     transactionsRequestAttempt
   } = useHistoryTab();
 
-  const [index, setIndex] = useState(transactions.length);
+  const [index, setIndex] = useState(() =>
+    Math.min(BATCH_TX_COUNT, transactions.length)
+  );
   const [noMoreTransactionsReally, setNoMoreTransactionsReally] = useState(
     false
   );

--- a/app/components/views/TransactionsPage/HistoryTab/hooks.js
+++ b/app/components/views/TransactionsPage/HistoryTab/hooks.js
@@ -1,15 +1,62 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import * as sel from "selectors";
 import * as ta from "actions/TransactionActions";
+import { MIXED } from "constants";
 
 export function useHistoryTab() {
   const window = useSelector(sel.mainWindow);
   const tsDate = useSelector(sel.tsDate);
   const currencyDisplay = useSelector(sel.currencyDisplay);
   const unitDivisor = useSelector(sel.unitDivisor);
-  const transactions = useSelector(sel.filteredRegularTxs);
-  const transactionsFilter = useSelector(sel.transactionsFilter);
+  const transactions = useSelector(sel.regularTransactions);
+  const txFilter = useSelector(sel.transactionsFilter);
+
+  // filteredTransactions filters a list of transactions given a filtering object.
+  //
+  // Currently supported filters in the txFilter object:
+  // - type (array): Array of types a transaction must belong to, to be accepted.
+  //   Currently, just the MIXED type is supported
+  // - directions (array): Array of allowed directions for regular
+  //   transactions (sent/received/transferred/ticketfee)
+  //
+  // If empty, all transactions are accepted.
+  const filteredTransactions = useMemo(
+    () =>
+      Object.keys(transactions)
+        .map((hash) => transactions[hash])
+        .filter(
+          (v) =>
+            txFilter.directions.length == 0 || // All directions
+            txFilter.directions.includes(v.txDirection)
+        )
+        .filter((v) =>
+          txFilter.search
+            ? v.creditAddresses.find(
+                (address) =>
+                  address.length > 1 &&
+                  address
+                    .toLowerCase()
+                    .indexOf(txFilter.search.toLowerCase()) !== -1
+              ) != undefined ||
+              v.txHash.toLowerCase().includes(txFilter.search.toLowerCase())
+            : true
+        )
+        .filter((v) =>
+          txFilter.minAmount ? Math.abs(v.txAmount) >= txFilter.minAmount : true
+        )
+        .filter((v) =>
+          txFilter.maxAmount ? Math.abs(v.txAmount) <= txFilter.maxAmount : true
+        )
+        .filter(
+          (v) =>
+            (txFilter.directions.length == 0 && txFilter.types.length == 0) || // All directions
+            v.mixedTx == txFilter.types.includes(MIXED)
+        ),
+
+    [transactions, txFilter]
+  );
+
   const noMoreTransactions = useSelector(sel.noMoreRegularTxs);
   const totalBalance = useSelector(sel.totalBalance);
   const transactionsRequestAttempt = useSelector(
@@ -30,8 +77,8 @@ export function useHistoryTab() {
     tsDate,
     currencyDisplay,
     unitDivisor,
-    transactions,
-    transactionsFilter,
+    transactions: filteredTransactions,
+    transactionsFilter: txFilter,
     totalBalance,
     noMoreTransactions,
     onGetTransactions,

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -44,7 +44,6 @@ import {
   TRANSACTION_DIR_SENT,
   TRANSACTION_DIR_RECEIVED,
   TICKET_FEE,
-  MIXED,
   VOTED,
   LIVE,
   UNMINED,
@@ -809,52 +808,6 @@ export const getStakeTransactionsCancel = get([
   "grpc",
   "stakeTransactionsCancel"
 ]);
-
-// filterTransactions filters a list of transactions given a filtering object.
-//
-// Currently supported filters in the filter object:
-// - type (array): Array of types a transaction must belong to, to be accepted.
-//   Currently, just the MIXED type is supported
-// - directions (array): Array of allowed directions for regular
-//   transactions (sent/received/transferred/ticketfee)
-//
-// If empty, all transactions are accepted.
-export const filteredRegularTxs = createSelector(
-  [regularTransactions, transactionsFilter],
-  (transactions, filter) => {
-    const filteredTxs = Object.keys(transactions)
-      .map((hash) => transactions[hash])
-      .filter(
-        (v) =>
-          filter.directions.length == 0 || // All directions
-          filter.directions.includes(v.txDirection)
-      )
-      .filter((v) =>
-        filter.search
-          ? v.creditAddresses.find(
-              (address) =>
-                address.length > 1 &&
-                address.toLowerCase().indexOf(filter.search.toLowerCase()) !==
-                  -1
-            ) != undefined ||
-            v.txHash.toLowerCase().includes(filter.search.toLowerCase())
-          : true
-      )
-      .filter((v) =>
-        filter.minAmount ? Math.abs(v.txAmount) >= filter.minAmount : true
-      )
-      .filter((v) =>
-        filter.maxAmount ? Math.abs(v.txAmount) <= filter.maxAmount : true
-      )
-      .filter(
-        (v) =>
-          (filter.directions.length == 0 && filter.types.length == 0) || // All directions
-          v.mixedTx == filter.types.includes(MIXED)
-      );
-
-    return filteredTxs;
-  }
-);
 
 export const filteredStakeTxs = createSelector(
   [stakeTransactions, ticketsFilter],


### PR DESCRIPTION
Requires #3743

The tx history tab tends to become a bit sluggish if the tx history is large. After I investigated the bottlenecks, added these performance improvements:
-  Loads the rows gradually using the infinite scroll's functionality, even if the data is already fetched from the dcrwallet. Before this PR, if the user scrolls down deep to the older transactions first and leaves the tab, then comes back, the application renders all the previously loaded items at once, which could be quite time-consuming.
- Moved the `filteredRegularTxs` from the selectors to the `HistoryTab` custom hooks to be able to memoize it.
- Memoize each row item and render it only if there was a data change
- tests are updated

Also, I noticed that after clicking on one of the transaction items to reach the details page and closing it, it's easy to get lost. I've added an indicator to the last clicked tx row: 

<img width="694" alt="image" src="https://user-images.githubusercontent.com/52497040/165145725-f3302123-ad4c-4ea7-9240-31183c2a3db5.png">