### PR TITLE
[dex] Bump to dcrdex v0.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/decrediton
 go 1.16
 
 require (
-	decred.org/dcrdex v0.4.2
+	decred.org/dcrdex v0.4.3
 	github.com/decred/dcrd/certgen v1.1.2-0.20210914212651-723d86274b0d // indirect
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.4-0.20210914212651-723d86274b0d // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1-0.20210914212651-723d86274b0d // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 decred.org/cspp/v2 v2.0.0-20211122173608-ee00e4952d5f/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
-decred.org/dcrdex v0.4.2 h1:6GTdsliXhj9DPyyWVKw08fovkjyZhujxBDw1MzUt3+4=
-decred.org/dcrdex v0.4.2/go.mod h1:DW/f9bgvXcdJ4dg5e2slvHCc0TfkFvoDbqrWqB8l82s=
+decred.org/dcrdex v0.4.3 h1:B30jh79IH13UcALbBO9uY6V7rd3RyRA5sm0h9JldxTI=
+decred.org/dcrdex v0.4.3/go.mod h1:DW/f9bgvXcdJ4dg5e2slvHCc0TfkFvoDbqrWqB8l82s=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb h1:vio6o+nzszBrdj2Yi3/gifDa5ocfy49A9SqYPlbUjXo=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb/go.mod h1:rbFJaCuXCfDhYoI5ZdeZr8TmF4A4Sb1zE7jQAwtaFMo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/modules/dex/libdexc/adapter.go
+++ b/modules/dex/libdexc/adapter.go
@@ -118,9 +118,13 @@ func (c *CoreAdapter) startCore(raw json.RawMessage) error {
 
 	c.ctx, c.kill = context.WithCancel(context.Background())
 	ccore, err := core.New(&core.Config{
-		DBPath:   form.DBPath,
-		Net:      form.Net,
-		Logger:   logger,
+		DBPath: form.DBPath,
+		Net:    form.Net,
+		Logger: logger,
+		// Onion applies ONLY to .onion addresses, unlike TorProxy, which is
+		// used for connections to all servers regardless of hostname. TODO:
+		// expose an option for the user to set this and TorProxy.
+		Onion:    "127.0.0.1:9050",
 		Language: form.Language,
 	})
 	if err != nil {

--- a/modules/dex/libdexc/adapter.go
+++ b/modules/dex/libdexc/adapter.go
@@ -19,8 +19,10 @@ import (
 	"decred.org/dcrdex/dex"
 	"github.com/decred/slog"
 
-	_ "decred.org/dcrdex/client/asset/btc" // register btc asset
-	_ "decred.org/dcrdex/client/asset/dcr" // register dcr asset
+	_ "decred.org/dcrdex/client/asset/btc"  // register btc asset
+	_ "decred.org/dcrdex/client/asset/dcr"  // register dcr asset
+	_ "decred.org/dcrdex/client/asset/doge" // register doge asset
+	_ "decred.org/dcrdex/client/asset/ltc"  // register ltc asset
 )
 
 type callHandler func(json.RawMessage) (string, error)

--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "bufferutil": "^4.0.3",
     "connected-react-router": "^6.8.0",
     "copy-webpack-plugin": "^8.1.0",
-    "dcrdex-assets": "https://github.com/decred/dcrdex-assets#v0.4.2",
+    "dcrdex-assets": "https://github.com/decred/dcrdex-assets#v0.4.3",
     "dex": "./modules/dex",
     "dom-helpers": "^3.4.0",
     "electron-devtools-installer": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4536,9 +4536,9 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-"dcrdex-assets@https://github.com/decred/dcrdex-assets#v0.4.2":
+"dcrdex-assets@https://github.com/decred/dcrdex-assets#v0.4.3":
   version "0.0.0"
-  resolved "https://github.com/decred/dcrdex-assets#c15fce6e40784ae25a4a8f007a72bc41a593ee11"
+  resolved "https://github.com/decred/dcrdex-assets#df683f161bd24fc32e8e9d1216a0101e7e5282aa"
 
 debounce-fn@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This updates to dcrdex v0.4.3 with some important bug fixes and new features.
https://github.com/decred/dcrdex/milestone/19?closed=1

```sh
$  nvm use v14
Now using node v14.17.6 (npm v6.14.15)
$  yarn
yarn install v1.22.18
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
...
Done in 8.46s.
$  yarn upgrade dcrdex-assets@https://github.com/decred/dcrdex-assets#v0.4.3
yarn upgrade v1.22.18
...
[5/5] Rebuilding all packages...
success Saved lockfile.
success Saved 1 new dependency.
info Direct dependencies
└─ dcrdex-assets@0.0.0
info All dependencies
└─ dcrdex-assets@0.0.0
Done in 8.64s.
$  go get -d decred.org/dcrdex@v0.4.3
go: downloading decred.org/dcrdex v0.4.3
go: upgraded decred.org/dcrdex v0.4.2 => v0.4.3
$  go mod tidy
```

yarn.lock correctly shows https://github.com/decred/dcrdex-assets/commit/df683f161bd24fc32e8e9d1216a0101e7e5282aa
