### PR TITLE
[vsp] Show fee tx hash and fee status on tx details view

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -881,6 +881,7 @@ export const signMessageAttempt = (address, message, passphrase) => async (
       getSignMessageSignature: sig,
       type: SIGNMESSAGE_SUCCESS
     });
+    return sig;
   } catch (error) {
     dispatch({ error, type: SIGNMESSAGE_FAILED });
   }

--- a/app/components/views/TicketsPage/PurchaseTab/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/hooks.js
@@ -63,11 +63,6 @@ export const usePurchaseTab = () => {
     () => dispatch(ca.ticketBuyerCancel()),
     [dispatch]
   );
-  const getTicketStatus = useCallback(
-    (host, tickethash, passphrase) =>
-      dispatch(vspa.getVSPTicketStatus(host, tickethash, passphrase)),
-    [dispatch]
-  );
 
   const getVSPTicketsByFeeStatus = (feeStatus) => {
     dispatch(vspa.getVSPTicketsByFeeStatus(feeStatus));
@@ -114,7 +109,6 @@ export const usePurchaseTab = () => {
     availableVSPs: isVSPListingEnabled ? availableVSPs : [],
     availableVSPsError,
     onDisableTicketAutoBuyer,
-    getTicketStatus,
     ticketAutoBuyerRunning,
     getVSPTicketsByFeeStatus,
     isLegacy,

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -2,7 +2,8 @@ import { Balance, ExternalLink } from "shared";
 import {
   KeyBlueButton,
   RevokeModalButton,
-  CopyToClipboardButton
+  CopyToClipboardButton,
+  PassphraseModalButton
 } from "buttons";
 import { addSpacingAroundText } from "helpers";
 import { FormattedMessage as T } from "react-intl";
@@ -50,7 +51,10 @@ const TransactionContent = ({
   currentBlockHeight,
   isSPV,
   agendas,
-  getAgendaSelectedChoice
+  getAgendaSelectedChoice,
+  getVSPTicketStatus,
+  getVSPTicketStatusAttempt,
+  VSPTicketStatus
 }) => {
   const {
     txHash,
@@ -260,12 +264,61 @@ const TransactionContent = ({
           </div>
         )}
         {(txType == TICKET || txType == VOTE) && ticketTx.vspHost && (
-          <div className={styles.topRow}>
-            <div className={styles.name}>
-              <T id="txDetails.vspHost" m="VSP host" />:
+          <>
+            <div className={styles.topRow}>
+              <div className={styles.name}>
+                <T id="txDetails.vspHost" m="VSP host" />:
+              </div>
+              <div className={styles.value}>{ticketTx.vspHost}</div>
             </div>
-            <div className={styles.value}>{ticketTx.vspHost}</div>
-          </div>
+            {VSPTicketStatus ? (
+              <>
+                <div className={styles.topRow}>
+                  <div className={styles.name}>
+                    <T id="txDetails.feeTxHashLabel" m="Fee tx hash" />:
+                  </div>
+                  <div className={styles.value}>
+                    <ExternalLink
+                      className={styles.value}
+                      href={VSPTicketStatus.feetxUrl}>
+                      {VSPTicketStatus.feetxhash}
+                    </ExternalLink>
+                  </div>
+                </div>
+                <div className={styles.topRow}>
+                  <div className={styles.name}>
+                    <T id="txDetails.feeStatusLabel" m="Fee status" />:
+                  </div>
+                  <div className={styles.value}>
+                    {VSPTicketStatus.feetxstatus}
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className={styles.topRow}>
+                <div className={styles.name}></div>
+                <div className={styles.value}>
+                  <PassphraseModalButton
+                    modalTitle={
+                      <T
+                        id="txDetails.signMessageModal"
+                        m="Fetch VSP Ticket Status"
+                      />
+                    }
+                    buttonLabel={
+                      <T
+                        id="txDetails.signMessageBtn"
+                        m="Fetch VSP Ticket Status"
+                      />
+                    }
+                    loading={getVSPTicketStatusAttempt}
+                    disabled={getVSPTicketStatusAttempt}
+                    onSubmit={getVSPTicketStatus}
+                  />
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
       {isPending ? (

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -271,53 +271,54 @@ const TransactionContent = ({
               </div>
               <div className={styles.value}>{ticketTx.vspHost}</div>
             </div>
-            {VSPTicketStatus ? (
-              <>
+            {txType == TICKET &&
+              (VSPTicketStatus ? (
+                <>
+                  <div className={styles.topRow}>
+                    <div className={styles.name}>
+                      <T id="txDetails.feeTxHashLabel" m="Fee tx hash" />:
+                    </div>
+                    <div className={styles.value}>
+                      <ExternalLink
+                        className={styles.value}
+                        href={VSPTicketStatus.feetxUrl}>
+                        {VSPTicketStatus.feetxhash}
+                      </ExternalLink>
+                    </div>
+                  </div>
+                  <div className={styles.topRow}>
+                    <div className={styles.name}>
+                      <T id="txDetails.feeTxStatusLabel" m="Fee tx status" />:
+                    </div>
+                    <div className={styles.value}>
+                      {VSPTicketStatus.feetxstatus}
+                    </div>
+                  </div>
+                </>
+              ) : (
                 <div className={styles.topRow}>
-                  <div className={styles.name}>
-                    <T id="txDetails.feeTxHashLabel" m="Fee tx hash" />:
-                  </div>
+                  <div className={styles.name}></div>
                   <div className={styles.value}>
-                    <ExternalLink
-                      className={styles.value}
-                      href={VSPTicketStatus.feetxUrl}>
-                      {VSPTicketStatus.feetxhash}
-                    </ExternalLink>
+                    <PassphraseModalButton
+                      modalTitle={
+                        <T
+                          id="txDetails.signMessageModal"
+                          m="Fetch VSP Ticket Status"
+                        />
+                      }
+                      buttonLabel={
+                        <T
+                          id="txDetails.signMessageBtn"
+                          m="Fetch VSP Ticket Status"
+                        />
+                      }
+                      loading={getVSPTicketStatusAttempt}
+                      disabled={getVSPTicketStatusAttempt}
+                      onSubmit={getVSPTicketStatus}
+                    />
                   </div>
                 </div>
-                <div className={styles.topRow}>
-                  <div className={styles.name}>
-                    <T id="txDetails.feeStatusLabel" m="Fee status" />:
-                  </div>
-                  <div className={styles.value}>
-                    {VSPTicketStatus.feetxstatus}
-                  </div>
-                </div>
-              </>
-            ) : (
-              <div className={styles.topRow}>
-                <div className={styles.name}></div>
-                <div className={styles.value}>
-                  <PassphraseModalButton
-                    modalTitle={
-                      <T
-                        id="txDetails.signMessageModal"
-                        m="Fetch VSP Ticket Status"
-                      />
-                    }
-                    buttonLabel={
-                      <T
-                        id="txDetails.signMessageBtn"
-                        m="Fetch VSP Ticket Status"
-                      />
-                    }
-                    loading={getVSPTicketStatusAttempt}
-                    disabled={getVSPTicketStatusAttempt}
-                    onSubmit={getVSPTicketStatus}
-                  />
-                </div>
-              </div>
-            )}
+              ))}
           </>
         )}
       </div>

--- a/app/components/views/TransactionPage/TransactionPage.jsx
+++ b/app/components/views/TransactionPage/TransactionPage.jsx
@@ -18,7 +18,10 @@ const Transaction = () => {
     decodedTx,
     isSPV,
     agendas,
-    getAgendaSelectedChoice
+    getAgendaSelectedChoice,
+    getVSPTicketStatus,
+    getVSPTicketStatusAttempt,
+    VSPTicketStatus
   } = useTransactionPage(txHash);
 
   if (!viewedTransaction) return null;
@@ -48,7 +51,10 @@ const Transaction = () => {
               currentBlockHeight,
               isSPV,
               agendas,
-              getAgendaSelectedChoice
+              getAgendaSelectedChoice,
+              getVSPTicketStatus,
+              getVSPTicketStatusAttempt,
+              VSPTicketStatus
             }}
           />
         </StandalonePage>

--- a/app/components/views/TransactionPage/hooks.js
+++ b/app/components/views/TransactionPage/hooks.js
@@ -6,6 +6,7 @@ import * as sel from "selectors";
 import * as ca from "actions/ControlActions";
 import * as ta from "actions/TransactionActions";
 import * as clia from "actions/ClientActions";
+import * as vspa from "actions/VSPActions";
 import { find, compose, eq, get } from "fp";
 
 export function useTransactionPage(txHash) {
@@ -15,6 +16,7 @@ export function useTransactionPage(txHash) {
   const decodedTransactions = useSelector(sel.decodedTransactions);
   const agendas = useSelector(sel.allAgendas);
   const voteChoices = useSelector(sel.voteChoices);
+  const getVSPTicketStatusAttempt = useSelector(sel.getVSPTicketStatusAttempt);
   const getAgendaSelectedChoice = useCallback(
     (agendaId) =>
       get(
@@ -52,6 +54,24 @@ export function useTransactionPage(txHash) {
     () => dispatch(ca.publishUnminedTransactionsAttempt()),
     [dispatch]
   );
+
+  const [VSPTicketStatus, setVSPTicketStatus] = useState(null);
+
+  const getVSPTicketStatus = useCallback(
+    async (passphrase) => {
+      try {
+        const res = await dispatch(
+          vspa.getVSPTicketStatus(passphrase, viewedTransaction, decodedTx)
+        );
+        setVSPTicketStatus(res);
+      } catch (error) {
+        // TODO
+        console.error({ error });
+      }
+    },
+    [dispatch, viewedTransaction, decodedTx]
+  );
+
   const [state, send] = useMachine(fetchMachine, {
     actions: {
       initial: () => {
@@ -102,6 +122,9 @@ export function useTransactionPage(txHash) {
     decodedTx,
     isSPV,
     agendas,
-    getAgendaSelectedChoice
+    getAgendaSelectedChoice,
+    getVSPTicketStatus,
+    getVSPTicketStatusAttempt,
+    VSPTicketStatus
   };
 }

--- a/app/components/views/TransactionPage/hooks.js
+++ b/app/components/views/TransactionPage/hooks.js
@@ -58,16 +58,10 @@ export function useTransactionPage(txHash) {
   const [VSPTicketStatus, setVSPTicketStatus] = useState(null);
 
   const getVSPTicketStatus = useCallback(
-    async (passphrase) => {
-      try {
-        const res = await dispatch(
-          vspa.getVSPTicketStatus(passphrase, viewedTransaction, decodedTx)
-        );
-        setVSPTicketStatus(res);
-      } catch (error) {
-        // TODO
-        console.error({ error });
-      }
+    (passphrase) => {
+      dispatch(
+        vspa.getVSPTicketStatus(passphrase, viewedTransaction, decodedTx)
+      ).then((res) => setVSPTicketStatus(res));
     },
     [dispatch, viewedTransaction, decodedTx]
   );

--- a/app/main_dev/externalRequests.js
+++ b/app/main_dev/externalRequests.js
@@ -143,8 +143,15 @@ export const installSessionHandlers = (mainLogger) => {
         statusLine = "OK";
         newHeaders["Access-Control-Allow-Headers"] = "Content-Type";
       }
-    }
 
+      const globalCfg = getGlobalCfg();
+      const cfgAllowedVSPs = globalCfg.get(cfgConstants.ALLOWED_VSP_HOSTS, []);
+      if (cfgAllowedVSPs.some((url) => details.url.includes(url))) {
+        statusLine = "OK";
+        newHeaders["Access-Control-Allow-Headers"] =
+          "Content-Type, VSP-Client-Signature";
+      }
+    }
     callback({ responseHeaders: newHeaders, statusLine });
   });
 };
@@ -208,7 +215,7 @@ export const allowVSPRequests = (stakePoolHost) => {
   if (allowedExternalRequests[reqType]) return;
 
   addAllowedURL(stakePoolHost + "/api/v3/vspinfo");
-  addAllowedURL(stakePoolHost + "/api/ticketstatus");
+  addAllowedURL(stakePoolHost + "/api/v3/ticketstatus");
 };
 
 export const reloadAllowedExternalRequests = () => {

--- a/app/middleware/vspapi.js
+++ b/app/middleware/vspapi.js
@@ -33,11 +33,13 @@ const LEGACY_POST = (path, apiToken, json) => {
 };
 
 const POST = (path, vspClientSig, json) => {
-  const config = {
-    headers: {
-      "VSP-CLIENT-SIGNATURE": vspClientSig
-    }
-  };
+  const config = vspClientSig
+    ? {
+        headers: {
+          "VSP-Client-Signature": vspClientSig
+        }
+      }
+    : {};
   // This json request is strigfied at the call which is making it.
   return postJSON(path, json, config);
 };
@@ -174,8 +176,8 @@ export function getVSPInfo(host, cb) {
     .catch((error) => cb(null, error, host));
 }
 
-export function getTicketStatus({ host, vspClientSig, request }, cb) {
-  POST(host + "/api/ticketstatus", vspClientSig, request)
+export function getVSPTicketStatus({ host, sig, json }, cb) {
+  POST(host + "/api/v3/ticketstatus", sig, json)
     .then((resp) => cb(resp, null, host))
     .catch((error) => cb(null, error, host));
 }

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -66,7 +66,8 @@ import {
   SYNCVSPTICKETS_SUCCESS,
   SYNCVSPTICKETS_FAILED,
   PROCESSMANAGEDTICKETS_FAILED,
-  SETVSPDVOTECHOICE_FAILED
+  SETVSPDVOTECHOICE_FAILED,
+  GETVSP_TICKET_STATUS_FAILED
 } from "actions/VSPActions";
 import {
   ABANDONTRANSACTION_SUCCESS,
@@ -654,6 +655,10 @@ const messages = defineMessages({
     id: "set.vspdvote.failed",
     defaultMessage: "Set vspd vote choices failed: {originalError}"
   },
+  GETVSP_TICKET_STATUS_FAILED: {
+    id: "set.getvspticketstatus.failed",
+    defaultMessage: "Fetch vsp ticket status failed: {originalError}"
+  },
   DEX_STARTUP_FAILED: {
     id: "dex.startup.failed",
     defaultMessage: "DEX Client Failed to Start: {originalError}"
@@ -973,6 +978,7 @@ export default function snackbar(state = {}, action) {
     case PROCESSMANAGEDTICKETS_FAILED:
     case SETVOTECHOICES_FAILED:
     case SETVSPDVOTECHOICE_FAILED:
+    case GETVSP_TICKET_STATUS_FAILED:
     case DEX_STARTUP_FAILED:
     case DEX_LOGIN_FAILED:
     case DEX_ENABLE_FAILED:

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -40,7 +40,6 @@ import {
 } from "actions/ControlActions";
 import { CLOSEWALLET_SUCCESS } from "actions/WalletLoaderActions";
 import { WALLET_LOADER_SETTINGS } from "actions/DaemonActions";
-import { GETVSPTICKETSTATUS_FAILED } from "actions/VSPActions";
 
 export default function vsp(state = {}, action) {
   switch (action.type) {

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -27,7 +27,10 @@ import {
   GETVSP_SUCCESS,
   GETUNSPENTUNEXPIREDVSPTICKETS_ATTEMPT,
   GETUNSPENTUNEXPIREDVSPTICKETS_SUCCESS,
-  GETUNSPENTUNEXPIREDVSPTICKETS_FAILED
+  GETUNSPENTUNEXPIREDVSPTICKETS_FAILED,
+  GETVSP_TICKET_STATUS_ATTEMPT,
+  GETVSP_TICKET_STATUS_SUCCESS,
+  GETVSP_TICKET_STATUS_FAILED
 } from "actions/VSPActions";
 import {
   STARTTICKETBUYERV3_ATTEMPT,
@@ -37,6 +40,7 @@ import {
 } from "actions/ControlActions";
 import { CLOSEWALLET_SUCCESS } from "actions/WalletLoaderActions";
 import { WALLET_LOADER_SETTINGS } from "actions/DaemonActions";
+import { GETVSPTICKETSTATUS_FAILED } from "actions/VSPActions";
 
 export default function vsp(state = {}, action) {
   switch (action.type) {
@@ -219,6 +223,19 @@ export default function vsp(state = {}, action) {
         ...state,
         getUnspentUnexpiredVspTicketsError: String(action.error),
         getUnspentUnexpiredVspTicketsAttempt: false
+      };
+    case GETVSP_TICKET_STATUS_ATTEMPT:
+      return { ...state, getVSPTicketStatusAttempt: true };
+    case GETVSP_TICKET_STATUS_SUCCESS:
+      return {
+        ...state,
+        getVSPTicketStatusAttempt: false
+      };
+    case GETVSP_TICKET_STATUS_FAILED:
+      return {
+        ...state,
+        getVSPTicketStatusError: String(action.error),
+        getVSPTicketStatusAttempt: false
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -1763,6 +1763,10 @@ export const setVspdVoteChoicesAttempt = get([
   "vsp",
   "setVspdVoteChoicesRequestAttempt"
 ]);
+export const getVSPTicketStatusAttempt = get([
+  "vsp",
+  "getVSPTicketStatusAttempt"
+]);
 export const voteChoices = get(["grpc", "getVoteChoicesResponse"]);
 export const newNotYetVotedAgendasCount = createSelector(
   [allAgendas, voteChoices],

--- a/app/wallet/vsp.js
+++ b/app/wallet/vsp.js
@@ -50,8 +50,8 @@ export const getStakePoolInfo = promisifyReqLogNoData(
 );
 export const getVSPInfo = promisifyReqLogNoData("getVSPInfo", api.getVSPInfo);
 export const getVSPTicketStatus = promisifyReqLogNoData(
-  "getVSPTicketStatusInfo",
-  api.getTicketStatus
+  "getVSPTicketStatus",
+  api.getVSPTicketStatus
 );
 
 // addAllowedVSPsInCfg modifies the config file to allow the given VSP hosts

--- a/test/unit/actions/VSPActions.spec.js
+++ b/test/unit/actions/VSPActions.spec.js
@@ -647,10 +647,7 @@ test("test getVSPTicketStatus (signMessage error)", async () => {
   expect(res).toStrictEqual(undefined);
   expect(mockSignMessageAttempt).toHaveBeenCalled();
   expect(mockGetVSPTicketStatus).not.toHaveBeenCalled();
-  // the error message is shown by snackbar
-  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(
-    "Error: Invalid signature"
-  );
+  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(undefined);
 });
 
 test("test getVSPTicketStatus (signMessage error)", async () => {
@@ -667,8 +664,5 @@ test("test getVSPTicketStatus (signMessage error)", async () => {
   expect(res).toStrictEqual(undefined);
   expect(mockSignMessageAttempt).toHaveBeenCalled();
   expect(mockGetVSPTicketStatus).not.toHaveBeenCalled();
-  // the error message is shown by snackbar
-  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(
-    "Error: Invalid signature"
-  );
+  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(undefined);
 });

--- a/test/unit/actions/VSPActions.spec.js
+++ b/test/unit/actions/VSPActions.spec.js
@@ -1,6 +1,7 @@
 import * as sel from "selectors";
 import * as wal from "wallet";
 import * as vspa from "actions/VSPActions";
+import * as ca from "actions/ControlActions";
 import { createStore } from "test-utils.js";
 import * as arrs from "../../../app/helpers/arrays";
 import { cloneDeep } from "fp";
@@ -11,6 +12,7 @@ import {
   defaultMockAvailableInvalidVsps,
   mockTickets
 } from "./vspMocks.js";
+import { mockStakeTransactions } from "../components/views/TransactionPage/mocks.js";
 
 let mockAvailableMainnetVsps = cloneDeep(defaultMockAvailableMainnetVsps);
 
@@ -18,6 +20,30 @@ const selectors = sel;
 const vspActions = vspa;
 const wallet = wal;
 const arrays = arrs;
+const controlActions = ca;
+
+let mockSignMessageAttempt;
+let mockGetVSPTicketStatus;
+
+const mockSig = "test-sig";
+const mockVSPTicketInfoResponse = {
+  data: {
+    timestamp: 1651855899,
+    ticketconfirmed: true,
+    feetxstatus: "confirmed",
+    feetxhash: "test-feetxhash",
+    altsignaddress: "",
+    votechoices: {
+      autorevocations: "abstain",
+      changesubsidysplit: "abstain",
+      explicitverupgrades: "abstain",
+      reverttreasurypolicy: "abstain"
+    },
+    tspendpolicy: {},
+    treasurypolicy: {},
+    request: "test-request"
+  }
+};
 
 beforeEach(() => {
   selectors.getVSPInfoTimeoutTime = jest.fn(() => 100);
@@ -31,6 +57,12 @@ beforeEach(() => {
     ...cloneDeep(defaultMockAvailableInvalidVsps)
   ]);
   wallet.getTickets = jest.fn(() => Promise.resolve(mockTickets));
+  mockSignMessageAttempt = controlActions.signMessageAttempt = jest.fn(
+    () => () => mockSig
+  );
+  mockGetVSPTicketStatus = wallet.getVSPTicketStatus = jest.fn(() =>
+    Promise.resolve(mockVSPTicketInfoResponse)
+  );
 });
 
 const testRandomVSP = async (
@@ -309,5 +341,254 @@ test("test getUnspentUnexpiredVspTickets", async () => {
   expect(store.getState().vsp.unspentUnexpiredVspTickets).toBe(undefined);
   expect(store.getState().vsp.getUnspentUnexpiredVspTicketsError).toBe(
     testError
+  );
+});
+
+const mockPassphrase = "test-passphrase";
+const mockTx =
+  mockStakeTransactions[
+    "7d6d36b1ee3edc40941aadfab51a8b179d166a0612300742c0e39e60fac16873"
+  ];
+const mockVspHost = "mock-vsp-host";
+const mockCommitmentAddress = "test-commitment-address";
+const mockDecodedTx = {
+  outputs: [
+    {},
+    {
+      decodedScript: {
+        address: mockCommitmentAddress
+      }
+    }
+  ]
+};
+
+test("test getVSPTicketStatus", async () => {
+  const mockTxCopy = cloneDeep(mockTx);
+  mockTxCopy.ticketTx = { vspHost: mockVspHost };
+  const store = createStore({});
+  const res = await store.dispatch(
+    vspActions.getVSPTicketStatus(mockPassphrase, mockTxCopy, mockDecodedTx)
+  );
+
+  expect(res).toStrictEqual(mockVSPTicketInfoResponse.data);
+  expect(res).toHaveProperty(
+    "feetxUrl",
+    `https://dcrdata.decred.org/tx/${mockVSPTicketInfoResponse.data.feetxhash}`
+  );
+
+  expect(mockSignMessageAttempt).toHaveBeenCalledWith(
+    mockCommitmentAddress,
+    `{"tickethash":"${mockTx["txHash"]}"}`,
+    mockPassphrase
+  );
+
+  expect(mockGetVSPTicketStatus).toHaveBeenCalledWith({
+    host: mockVspHost,
+    json: { tickethash: mockTx["txHash"] },
+    sig: mockSig
+  });
+
+  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(undefined);
+});
+
+test("test getVSPTicketStatus (in testnet mode the fee tx hash url should point to testnet)", async () => {
+  const mockTxCopy = cloneDeep(mockTx);
+  mockTxCopy.ticketTx = { vspHost: mockVspHost };
+  const store = createStore({
+    settings: { currentSettings: { network: "testnet" } }
+  });
+  const res = await store.dispatch(
+    vspActions.getVSPTicketStatus(mockPassphrase, mockTxCopy, mockDecodedTx)
+  );
+
+  expect(res).toStrictEqual(mockVSPTicketInfoResponse.data);
+  expect(res).toHaveProperty(
+    "feetxUrl",
+    `https://testnet.decred.org/tx/${mockVSPTicketInfoResponse.data.feetxhash}`
+  );
+});
+
+const testGetVSPTicketStatusFailing = async (
+  _,
+  errorMsg,
+  getInvalidMockTx,
+  mockInvalidDecodedTx
+) => {
+  const mockTxCopy = getInvalidMockTx();
+  const store = createStore({});
+  const res = await store.dispatch(
+    vspActions.getVSPTicketStatus(
+      mockPassphrase,
+      mockTxCopy,
+      mockInvalidDecodedTx
+    )
+  );
+
+  expect(res).toStrictEqual(undefined);
+  expect(mockSignMessageAttempt).not.toHaveBeenCalled();
+  expect(mockGetVSPTicketStatus).not.toHaveBeenCalled();
+  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(errorMsg);
+};
+
+const mockValidMockTxCopy = cloneDeep(mockTx);
+mockValidMockTxCopy.ticketTx = { vspHost: mockVspHost };
+
+test.each([
+  [
+    "invalid tx parameter",
+    "Error: Invalid tx parameter",
+    () => null,
+    cloneDeep(mockDecodedTx)
+  ],
+  [
+    "invalid tx.ticketTx parameter",
+    "Error: Invalid tx parameter",
+    () => {
+      const res = cloneDeep(mockValidMockTxCopy);
+      res.ticketTx = null;
+      return res;
+    },
+    cloneDeep(mockDecodedTx)
+  ],
+  [
+    "invalid tx.ticketTx.vspHost parameter",
+    "Error: Invalid tx parameter",
+    () => cloneDeep(mockTx),
+    cloneDeep(mockDecodedTx)
+  ],
+  [
+    "invalid tx.txHash",
+    "Error: Invalid tx parameter",
+    () => {
+      const res = cloneDeep(mockValidMockTxCopy);
+      res.txHash = null;
+      return res;
+    },
+    cloneDeep(mockDecodedTx)
+  ],
+  [
+    "invalid decodedTx",
+    "Error: Invalid decodedTx parameter",
+    () => cloneDeep(mockValidMockTxCopy),
+    null
+  ],
+  [
+    "empy decodedTx",
+    "Error: Invalid decodedTx parameter",
+    () => cloneDeep(mockValidMockTxCopy),
+    {}
+  ],
+  [
+    "decodedTx.output empty",
+    "Error: Invalid decodedTx parameter",
+    () => cloneDeep(mockValidMockTxCopy),
+    {
+      output: []
+    }
+  ],
+  [
+    "decodedTx.output has only one element",
+    "Error: Invalid decodedTx parameter",
+    () => cloneDeep(mockValidMockTxCopy),
+    {
+      output: [{}]
+    }
+  ],
+  [
+    "decodedTx.output first odd output has not decodedScript prop",
+    "Error: Invalid decodedTx parameter",
+    () => cloneDeep(mockValidMockTxCopy),
+    {
+      output: [{}, {}]
+    }
+  ],
+  [
+    "decodedTx.output.decodedScript has no address prop",
+    "Error: Invalid decodedTx parameter",
+    () => cloneDeep(mockValidMockTxCopy),
+    {
+      output: [{}, { decodedScript: {} }]
+    }
+  ]
+])("test failing getVSPTicketStatus (%s)", testGetVSPTicketStatusFailing);
+
+test("test getVSPTicketStatus (getVSPTicketStatus error)", async () => {
+  const mockErrorMessage = "mockErrorMessage";
+  mockGetVSPTicketStatus = wallet.getVSPTicketStatus = jest.fn(() =>
+    Promise.reject(mockErrorMessage)
+  );
+  const mockTxCopy = cloneDeep(mockTx);
+  mockTxCopy.ticketTx = { vspHost: mockVspHost };
+  const store = createStore({});
+  const res = await store.dispatch(
+    vspActions.getVSPTicketStatus(mockPassphrase, mockTxCopy, mockDecodedTx)
+  );
+
+  expect(res).toStrictEqual(undefined);
+  expect(mockSignMessageAttempt).toHaveBeenCalled();
+  expect(mockGetVSPTicketStatus).toHaveBeenCalled();
+  // the error message is shown by snackbar
+  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(
+    mockErrorMessage
+  );
+});
+
+test("test getVSPTicketStatus (getVSPTicketStatus invalid response)", async () => {
+  mockGetVSPTicketStatus = wallet.getVSPTicketStatus = jest.fn(() =>
+    Promise.resolve({})
+  );
+  const mockTxCopy = cloneDeep(mockTx);
+  mockTxCopy.ticketTx = { vspHost: mockVspHost };
+  const store = createStore({});
+  const res = await store.dispatch(
+    vspActions.getVSPTicketStatus(mockPassphrase, mockTxCopy, mockDecodedTx)
+  );
+
+  expect(res).toStrictEqual(undefined);
+  expect(mockSignMessageAttempt).toHaveBeenCalled();
+  expect(mockGetVSPTicketStatus).toHaveBeenCalled();
+  // the error message is shown by snackbar
+  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(
+    "Error: Invalid response from the VSP"
+  );
+});
+
+test("test getVSPTicketStatus (getVSPTicketStatus response error)", async () => {
+  mockGetVSPTicketStatus = wallet.getVSPTicketStatus = jest.fn(() =>
+    Promise.resolve({ data: { code: 10, message: "test-message" } })
+  );
+  const mockTxCopy = cloneDeep(mockTx);
+  mockTxCopy.ticketTx = { vspHost: mockVspHost };
+  const store = createStore({});
+  const res = await store.dispatch(
+    vspActions.getVSPTicketStatus(mockPassphrase, mockTxCopy, mockDecodedTx)
+  );
+
+  expect(res).toStrictEqual(undefined);
+  expect(mockSignMessageAttempt).toHaveBeenCalled();
+  expect(mockGetVSPTicketStatus).toHaveBeenCalled();
+  // the error message is shown by snackbar
+  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(
+    "Error: test-message (code: 10)"
+  );
+});
+
+test("test getVSPTicketStatus (signMessage error)", async () => {
+  mockSignMessageAttempt = controlActions.signMessageAttempt = jest.fn(
+    () => () => null
+  );
+  const mockTxCopy = cloneDeep(mockTx);
+  mockTxCopy.ticketTx = { vspHost: mockVspHost };
+  const store = createStore({});
+  const res = await store.dispatch(
+    vspActions.getVSPTicketStatus(mockPassphrase, mockTxCopy, mockDecodedTx)
+  );
+
+  expect(res).toStrictEqual(undefined);
+  expect(mockSignMessageAttempt).toHaveBeenCalled();
+  expect(mockGetVSPTicketStatus).not.toHaveBeenCalled();
+  // the error message is shown by snackbar
+  expect(store.getState().vsp.getVSPTicketStatusError).toEqual(
+    "Error: Invalid signature"
   );
 });

--- a/test/unit/components/views/TransactionPage/TransactionPage.spec.js
+++ b/test/unit/components/views/TransactionPage/TransactionPage.spec.js
@@ -30,7 +30,7 @@ let mockSignMessageAttempt;
 
 const mockVSPTicketInfoResponse = {
   data: {
-    feetxstatus: "confirmed",
+    feetxstatus: "broadcasted",
     feetxhash: "test-feetxhash"
   }
 };

--- a/test/unit/components/views/TransactionPage/TransactionPage.spec.js
+++ b/test/unit/components/views/TransactionPage/TransactionPage.spec.js
@@ -7,12 +7,19 @@ import * as sel from "selectors";
 import * as clia from "actions/ClientActions";
 import * as ca from "actions/ControlActions";
 import * as wl from "wallet";
+import { cloneDeep } from "fp";
 import {
   mockRegularTransactions,
   mockStakeTransactions,
   mockOldTxs,
   mockAgendas
 } from "./mocks.js";
+import {
+  mockMixedAccountValue,
+  mockChangeAccountValue,
+  mockMixedAccount
+} from "../../TicketsPage/PurchaseTab/mocks";
+import { defaultMockAvailableMainnetVsps } from "../../../actions/vspMocks";
 
 const selectors = sel;
 const clientActions = clia;
@@ -35,6 +42,9 @@ const mockVSPTicketInfoResponse = {
   }
 };
 const mockSig = "mock-sig";
+const mockAvailableMainnetVspsPubkeys = cloneDeep(
+  defaultMockAvailableMainnetVsps
+).map((v) => ({ ...v, pubkey: `${v.host}-pubkey` }));
 
 beforeEach(() => {
   selectors.isTestNet = jest.fn(() => true);
@@ -42,6 +52,14 @@ beforeEach(() => {
   selectors.currencyDisplay = jest.fn(() => DCR);
   selectors.allAgendas = jest.fn(() => mockAgendas);
   selectors.voteChoices = jest.fn(() => {});
+  selectors.spendingAccounts = jest.fn(() => [mockMixedAccount]);
+  selectors.visibleAccounts = jest.fn(() => [mockMixedAccount]);
+  selectors.getMixedAccount = jest.fn(() => mockMixedAccountValue);
+  selectors.getChangeAccount = jest.fn(() => mockChangeAccountValue);
+  selectors.defaultSpendingAccount = jest.fn(() => mockMixedAccount);
+  selectors.getAvailableVSPsPubkeys = jest.fn(
+    () => mockAvailableMainnetVspsPubkeys
+  );
   mockAbandonTransactionAttempt = clientActions.abandonTransactionAttempt = jest.fn(
     () => () => {}
   );
@@ -61,9 +79,13 @@ beforeEach(() => {
   mockGetVSPTicketStatus = wallet.getVSPTicketStatus = jest.fn(() =>
     Promise.resolve(mockVSPTicketInfoResponse)
   );
-
   mockSignMessageAttempt = controlActions.signMessageAttempt = jest.fn(
     () => () => mockSig
+  );
+
+  wallet.processManagedTickets = jest.fn(() => () => {});
+  wallet.getVSPTicketsByFeeStatus = jest.fn(() =>
+    Promise.resolve({ ticketHashes: [] })
   );
 });
 jest.mock("react-router-dom", () => ({


### PR DESCRIPTION
Closes #2859
Closes #3083
One step further to #3010
Requires https://github.com/decred/dcrwallet/pull/2146 (has been merged)

This diff displays a button on the tx details page if the vsp host info is present. Clicking on it, it asks for the private passphrase and signs the message for the vsp communication. After fetching the vsp info, displays the clickable tx hash and the fee status. 

Also, if the received fee tx is in confirmed status for an unspent ticket but the dcrwallet thinks it's not yet confirmed, the app processes and updates the status in the background.

<img width="680" alt="2022-05-06_16-36" src="https://user-images.githubusercontent.com/52497040/167472949-e7c18d65-1794-43b9-a4d7-0342c34977a8.png">
<img width="680" alt="2022-05-06_16-37" src="https://user-images.githubusercontent.com/52497040/167472976-36ce94d0-d6a4-4942-8b14-8ece52477427.png">
<img width="680" alt="2022-05-06_16-37_1" src="https://user-images.githubusercontent.com/52497040/167473048-bd0a07e6-08e6-4141-98de-7ef76c7be780.png">

