### PR TITLE
[settings] Update Tickets tutorial, hide the rest

### DIFF
--- a/app/components/views/SettingsPage/SettingsPage.jsx
+++ b/app/components/views/SettingsPage/SettingsPage.jsx
@@ -3,7 +3,7 @@ import { CloseWalletModalButton } from "buttons";
 import { TabbedPage, TitleHeader, DescriptionHeader } from "layout";
 import LinksTab from "./LinksTab";
 import LogsTab from "./LogsTab";
-import TutorialsTab from "./TutorialsTab";
+// import TutorialsTab from "./TutorialsTab";
 import ConnectivitySettingsTab from "./ConnectivitySettingsTab";
 import GeneralSettingsTab from "./GeneralSettingsTab";
 import PrivacyandSecuritySettingsTab from "./PrivacyandSecuritySettingsTab";
@@ -81,12 +81,14 @@ const SettingsPage = () => {
       header: SettingsTabHeader,
       label: <T id="settings.tab.sources" m="Sources" />
     },
+    /*
     {
       path: "/settings/tutorials",
       content: TutorialsTab,
       header: SettingsTabHeader,
       label: <T id="settings.tab.tutorials" m="Tutorials" />
     },
+    */
     {
       path: "/settings/logs",
       content: LogsTab,

--- a/app/i18n/docs/en/Tutorials/TicketsPage01.md
+++ b/app/i18n/docs/en/Tutorials/TicketsPage01.md
@@ -1,1 +1,1 @@
-Decred holders can participate in the Staking (Proof-of-Stake) process by time-locking their coins (amounting to the ticket value) in exchange of tickets.
+Decred holders can participate in the Proof-of-Stake (PoS) system by purchasing tickets.

--- a/app/i18n/docs/en/Tutorials/TicketsPage02.md
+++ b/app/i18n/docs/en/Tutorials/TicketsPage02.md
@@ -1,6 +1,1 @@
-These tickets are used to vote on miners’ Proof-of-Work in order to validate changes to the Decred blockchain and on the governance proposals within the Politeia system.
-
-Opt-in governance via time-locking coins. Applies to:
-creating new blocks
-consensus changes
-project management
+These tickets are used to vote on blocks that have been created by the Proof-of-Work (PoW) miners.  These votes allow stakeholders to ensure that blocks are being created properly.  Votes include the ability to vote for or against on-chain consensus changes.  Finally, ticket owndership allows for participation in Decred's off-chain governance system Politeia, where users are able to submit proposals within the Decred eco-system.

--- a/app/i18n/docs/en/Tutorials/TicketsPage03.md
+++ b/app/i18n/docs/en/Tutorials/TicketsPage03.md
@@ -1,1 +1,1 @@
-Staking your funds also generates semi-passive returns with relatively low risk, as each voted ticket receives part of the block reward (link).
+As an incentive for essentially time-locking DCR for tickets, votes also receive a portion of the current block subsidy.

--- a/test/unit/actions/VSPActions.spec.js
+++ b/test/unit/actions/VSPActions.spec.js
@@ -17,7 +17,7 @@ import {
   mockMixedAccountValue,
   mockChangeAccountValue,
   mockMixedAccount
-} from "../components/TicketsPage/PurchaseTab/mocks.js";
+} from "../components/views/TicketsPage/PurchaseTab/mocks.js";
 
 let mockAvailableMainnetVsps = cloneDeep(defaultMockAvailableMainnetVsps);
 const mockAvailableMainnetVspsPubkeys = cloneDeep(

--- a/test/unit/components/views/TransactionPage/TransactionPage.spec.js
+++ b/test/unit/components/views/TransactionPage/TransactionPage.spec.js
@@ -18,7 +18,7 @@ import {
   mockMixedAccountValue,
   mockChangeAccountValue,
   mockMixedAccount
-} from "../../TicketsPage/PurchaseTab/mocks";
+} from "../TicketsPage/PurchaseTab/mocks";
 import { defaultMockAvailableMainnetVsps } from "../../../actions/vspMocks";
 
 const selectors = sel;


### PR DESCRIPTION
With a release coming out soon, and a large number of tutorial's text still in flux, we're going to hide the majority of them.

This also includes the completed text for the Tickets tutorial (that is shown as the staking page warning).