### PR TITLE
Bump electron to v17.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "core-decorators": "^0.20.0",
     "cross-env": "^7.0.3",
     "css-loader": "^5.2.0",
-    "electron": "17.0.0",
+    "electron": "17.4.2",
     "electron-builder": "^22.14.5",
     "electron-rebuild": "^3.2.5",
     "enzyme": "^3.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5187,10 +5187,10 @@ electron-to-chromium@^1.3.723:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.737.tgz#196f2e9656f4f3c31930750e1899c091b72d36b5"
   integrity sha512-P/B84AgUSQXaum7a8m11HUsYL8tj9h/Pt5f7Hg7Ty6bm5DxlFq+e5+ouHUoNQMsKDJ7u4yGfI8mOErCmSH9wyg==
 
-electron@17.0.0:
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-17.0.0.tgz#60f00f3e3c657020e807a519700213943468b4d1"
-  integrity sha512-3UXcBQMwbMWdPvGHaSdPMluHrd+/bc+K143MyvE5zVZ+S1XCHt4sau7dj6svJHns5llN0YG/c6h/vRfadIp8Zg==
+electron@17.4.2:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.2.tgz#fb5226100fc3f5d6e319ccad7fa462bf15ee0d94"
+  integrity sha512-SEf0Tsc1GjCccdsmrEtT51DeaF48ZUa711ekVCmVczn40WvKaqQu7M0SB3c/qRLRQyek/Qyi56zpcoOkjJ8L0Q==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
Close #3707 
This fixes an issue that caused dcrwallet/dcrd to not be able to be launch on macOS 10.15 (Catalina).  Users with this issue have confirmed it to be working as expected with the bump.