### PR TITLE
[governance] Fix never ending loading button on Treasury Spending tab

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -732,17 +732,23 @@ export const setTreasuryPolicy = (key, policy, passphrase) => async (
   getState
 ) => {
   dispatch({ payload: { key, policy }, type: SETTREASURY_POLICY_ATTEMPT });
-  await dispatch(
-    unlockAllAcctAndExecFn(passphrase, () =>
-      wallet
-        .setTreasuryPolicy(sel.votingService(getState()), key, policy)
-        .then(() => {
-          dispatch({ type: SETTREASURY_POLICY_SUCCESS });
-          dispatch(getTreasuryPolicies());
-        })
-        .catch((error) => dispatch({ error, type: SETTREASURY_POLICY_FAILED }))
-    )
-  );
+  try {
+    await dispatch(
+      unlockAllAcctAndExecFn(passphrase, () =>
+        wallet
+          .setTreasuryPolicy(sel.votingService(getState()), key, policy)
+          .then(() => {
+            dispatch({ type: SETTREASURY_POLICY_SUCCESS });
+            dispatch(getTreasuryPolicies());
+          })
+          .catch((error) =>
+            dispatch({ error, type: SETTREASURY_POLICY_FAILED })
+          )
+      )
+    );
+  } catch (error) {
+    dispatch({ error, type: SETTREASURY_POLICY_FAILED });
+  }
 };
 
 export const GETMESSAGEVERIFICATIONSERVICE_ATTEMPT =


### PR DESCRIPTION
This diff fixes an issue reported on the matrix: https://matrix.to/#/!xUNvyzkFgiMjhvPbIi:decred.org/$RaiT6lI5j06bTU4MBGVpshfVDdrMQ2ozZd7FRF_12SQ?via=decred.org&via=matrix.org&via=planetdecred.org 
(button never ending loading when a wrong password is used to set the preference)

Also, update tests.