### PR TITLE
[staking] Add Ticket spent entry to the revocation tx details page

### DIFF
--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -9,6 +9,7 @@ import { FormattedMessage as T } from "react-intl";
 import { walletrpc as api } from "middleware/walletrpc/api_pb";
 import {
   VOTE,
+  REVOCATION,
   TRANSACTION_DIR_RECEIVED,
   TRANSACTION_DIR_SENT,
   TICKET
@@ -76,6 +77,7 @@ const TransactionContent = ({
   const iconBgColor = getThemeProperty(theme, "alert-icon-bg-color");
 
   const isVote = txType === VOTE;
+  const isRevocation = txType === REVOCATION;
   const agendaChoicesData =
     isVote &&
     Object.keys(voteScript.voteChoices).map((issueId) => {
@@ -144,7 +146,7 @@ const TransactionContent = ({
             )}
           </div>
         </div>
-        {isVote ? (
+        {(isVote || isRevocation) && (
           <>
             <div className={styles.topRow}>
               <div className={styles.name}>
@@ -156,6 +158,10 @@ const TransactionContent = ({
                 </ExternalLink>
               </div>
             </div>
+          </>
+        )}
+        {isVote ? (
+          <>
             <div className={styles.topRow}>
               <div className={styles.name}>
                 <T id="txDetails.lastBlockValid" m="Last Block Valid" />:

--- a/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.jsx
+++ b/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.jsx
@@ -8,7 +8,10 @@ import {
   TICKET,
   LIVE,
   VOTE,
+  VOTED,
   MISSED,
+  REVOKED,
+  EXPIRED,
   UNMINED,
   IMMATURE,
   REVOCATION,
@@ -37,12 +40,18 @@ import styles from "./TransactionHeader.module.css";
 const messages = defineMessages({
   [TICKET]: { id: "txDetails.type.ticket", defaultMessage: "Ticket" },
   [VOTE]: { id: "txDetails.type.vote", defaultMessage: "Vote" },
-  [REVOCATION]: { id: "txDetails.type.revoke", defaultMessage: "Revoke" },
+  [REVOCATION]: {
+    id: "txDetails.type.revocation",
+    defaultMessage: "Revocation"
+  },
   [COINBASE]: { id: "txDetails.type.coinbase", defaultMessage: "Coinbase" },
   [MISSED]: { id: "txDetails.type.missed", defaultMessage: "Missed" },
   [UNMINED]: { id: "txDetails.type.unmined", defaultMessage: "Unmined" },
   [IMMATURE]: { id: "txDetails.type.immature", defaultMessage: "Immature" },
-  [LIVE]: { id: "txDetails.type.live", defaultMessage: "Live" }
+  [LIVE]: { id: "txDetails.type.live", defaultMessage: "Live" },
+  [VOTED]: { id: "txDetails.type.voted", defaultMessage: "Voted" },
+  [REVOKED]: { id: "txDetails.type.revoked", defaultMessage: "Revoked" },
+  [EXPIRED]: { id: "txDetails.type.expired", defaultMessage: "Expired" }
 });
 
 const headerIcons = {
@@ -68,32 +77,27 @@ const icon = ({ txType, txDirection, status }) =>
         [MISSED, UNMINED, IMMATURE].includes(status) ? status : txType
       ];
 
-const title = ({
-  txType,
-  txAmount,
-  txDirection,
-  ticketReward,
-  intl,
-  status
-}) => {
-  let titleComp;
-  txType !== REGULAR
-    ? (titleComp = [MISSED, UNMINED, IMMATURE, LIVE].includes(status)
-        ? intl.formatMessage(messages[status])
-        : intl.formatMessage(messages[txType]))
-    : (titleComp = (
-        <Balance
-          title
-          bold
-          amount={
-            txDirection !== TRANSACTION_DIR_RECEIVED ? -txAmount : txAmount
-          }
-        />
-      ));
-  if (txType === TICKET && ticketReward) {
-    titleComp = `${titleComp}, Voted`;
+const title = ({ txType, txAmount, txDirection, intl, status }) => {
+  if (txType === REGULAR) {
+    return (
+      <Balance
+        title
+        bold
+        amount={txDirection !== TRANSACTION_DIR_RECEIVED ? -txAmount : txAmount}
+      />
+    );
+  } else if (txType === TICKET) {
+    return `${intl.formatMessage(messages[txType])}, ${intl.formatMessage(
+      messages[status]
+    )}`;
+  } else if (messages[txType]) {
+    return intl.formatMessage(messages[txType]);
+  } else if (messages[status]) {
+    return intl.formatMessage(messages[status]);
+  } else {
+    console.error("unknown transaction");
+    return "";
   }
-  return titleComp;
 };
 
 const backBtn = ({ goBack }) => (
@@ -238,7 +242,6 @@ const TransactionHeader = ({
         txType,
         txAmount,
         txDirection,
-        ticketReward,
         intl,
         status
       })}

--- a/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.jsx
+++ b/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.jsx
@@ -154,7 +154,11 @@ const subtitle = ({
           {leaveTimestamp && (
             <div className={styles.subtitlePair}>
               <div className={styles.subtitleSentfrom}>
-                <T id="txDetails.votedOn" m="Voted On" />
+                {txType === REVOCATION ? (
+                  <T id="txDetails.missedOn" m="Missed On" />
+                ) : (
+                  <T id="txDetails.votedOn" m="Voted On" />
+                )}
               </div>
               <div className={styles.subtitleDate}>
                 <T

--- a/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.jsx
+++ b/app/components/views/TransactionPage/TransactionHeader/TransactionHeader.jsx
@@ -95,7 +95,7 @@ const title = ({ txType, txAmount, txDirection, intl, status }) => {
   } else if (messages[status]) {
     return intl.formatMessage(messages[status]);
   } else {
-    console.error("unknown transaction");
+    console.error("unknown transaction type");
     return "";
   }
 };

--- a/test/unit/components/views/TicketsPage/MyVSPTickets/MyVSPTicketsTab.spec.js
+++ b/test/unit/components/views/TicketsPage/MyVSPTickets/MyVSPTicketsTab.spec.js
@@ -15,7 +15,8 @@ import {
   VSP_FEE_PROCESS_PAID,
   VSP_FEE_PROCESS_ERRORED,
   VSP_FEE_PROCESS_CONFIRMED,
-  EXTERNALREQUEST_STAKEPOOL_LISTING
+  EXTERNALREQUEST_STAKEPOOL_LISTING,
+  TICKET
 } from "constants";
 import { mockAvailableVsps, mockVspInfo } from "../PurchaseTab/mocks";
 import { en as enLocale } from "i18n/locales";
@@ -55,13 +56,20 @@ const initialState = {
   }
 };
 
+const mockStakeTickets = {};
+Object.keys(mockStakeTransactions).forEach((txHash) => {
+  if (mockStakeTransactions[txHash].txType === TICKET) {
+    mockStakeTickets[txHash] = mockStakeTransactions[txHash];
+  }
+});
+
 const getTestTxs = (startTs) => {
   const txList = {};
   const startDate = new Date(startTs * 1000);
   let lastTransaction;
 
-  Object.keys(mockStakeTransactions).forEach((txHash) => {
-    lastTransaction = { ...mockStakeTransactions[txHash] };
+  Object.keys(mockStakeTickets).forEach((txHash) => {
+    lastTransaction = { ...mockStakeTickets[txHash] };
     startDate.setHours(startDate.getHours() - 1);
     const ts = Math.floor(startDate.getTime() / 1000);
     lastTransaction.txHash = `test-txHash-${ts}`;
@@ -191,7 +199,7 @@ const viewAllTxs = (mockGetTransactionsResponse, chunkCount) => {
   return mockGetTransactionsResponse;
 };
 
-test("test vps ticket status list", async () => {
+test("test vsp ticket status list", async () => {
   jest.useFakeTimers();
   let allTestTxs = {};
   let mockGetTransactionsResponse = {
@@ -294,7 +302,7 @@ test("test vps ticket status list", async () => {
 
   await wait(() => expect(getHistoryPageContent().childElementCount).toBe(17));
   expect(mockGetTransactions).toHaveBeenCalledTimes(
-    Object.keys(allTestTxs).length / Object.keys(mockStakeTransactions).length
+    Object.keys(allTestTxs).length / Object.keys(mockStakeTickets).length
   );
   expect(queryLoadingMoreLabel()).not.toBeInTheDocument();
   expect(getNoMoreTicketsLabel()).toBeInTheDocument();

--- a/test/unit/components/views/TransactionPage/TransactionPage.spec.js
+++ b/test/unit/components/views/TransactionPage/TransactionPage.spec.js
@@ -552,7 +552,7 @@ test("missed ticket", async () => {
   expect(mockGoBackHistory).toHaveBeenCalled();
 });
 
-test("revoked ticket", async () => {
+test("revocation", async () => {
   mockTxHash =
     "c1092ece233a5f25ab5c9510a5c0fc16cfd036d9f4c9f32ee5c7ea8ca3886e8c";
   const rawTx = mockStakeTransactions[mockTxHash].rawTx;
@@ -581,7 +581,7 @@ test("revoked ticket", async () => {
   await wait(() => getIODetails());
 
   expect(getHeaderTitleIconClassName()).toMatch("revocation");
-  expect(getTitleText()).toMatch("Revoke");
+  expect(getTitleText()).toMatch("Revocation");
   expect(getTicketCostText()).toMatch("Ticket Cost64.75415536 DCR");
   expect(getRewardText()).toMatch("Reward-0.0000518 DCR");
 
@@ -605,6 +605,64 @@ test("revoked ticket", async () => {
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
   expect(getHeightText()).toMatch("Height697812");
+
+  user.click(screen.getByText("Back"));
+  expect(mockGoBackHistory).toHaveBeenCalled();
+});
+
+test("revoked ticket", async () => {
+  mockTxHash =
+    "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99";
+  const rawTx = mockStakeTransactions[mockTxHash].rawTx;
+  const mockStakeTransactionMap = {};
+  mockStakeTransactionMap[mockTxHash] = mockStakeTransactions[mockTxHash];
+  selectors.currentBlockHeight = jest.fn(() => 924414);
+
+  render(<TransactionPage />, {
+    initialState: {
+      grpc: {
+        regularTransactions: {},
+        stakeTransactions: mockStakeTransactionMap,
+        decodedTransactions: {},
+        getAccountsResponse: {
+          accountsList: [
+            {
+              accountNumber: 0,
+              accountName: "default"
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  await wait(() => getIODetails());
+
+  expect(getHeaderTitleIconClassName()).toMatch("ticket");
+  expect(getTitleText()).toMatch("Ticket, Revoked");
+  expect(getTicketCostText()).toMatch("Ticket Cost86.00218109 DCR");
+  expect(getRewardText()).toMatch("Reward-0.0000298 DCR");
+
+  expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
+  expect(queryUnconfirmed()).not.toBeInTheDocument();
+  expect(getConfirmedText()).toMatch("Confirmed109,009 confirmations");
+  expect(getToAddressText()).toMatch(
+    "To address: Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy  Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+  );
+
+  expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
+  expect(queryRebroadcastTransaction()).not.toBeInTheDocument();
+
+  expect(getWalletInputsText()).toMatch("Wallet Inputsdefault86.00218109 DCR");
+  // don't have non wallet input
+  expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
+
+  expect(getWalletOutputs()).toMatch("Wallet Outputs default 86.00218109 DCR");
+  // don't have non wallet output
+  expect(getNonWalletOutputs()).toMatch("Non Wallet Outputs");
+
+  expect(screen.getByText(rawTx)).toBeInTheDocument();
+  expect(getHeightText()).toMatch("Height815405");
 
   user.click(screen.getByText("Back"));
   expect(mockGoBackHistory).toHaveBeenCalled();

--- a/test/unit/components/views/TransactionPage/TransactionPage.spec.js
+++ b/test/unit/components/views/TransactionPage/TransactionPage.spec.js
@@ -383,11 +383,73 @@ test("self coins from unmixed to mixed account", async () => {
 
 test("voted ticket", async () => {
   mockTxHash =
-    "f5c4259f1ae264a6bc7e52d5f602967e947fdebdb8bc7a551a18d36ab1933e17";
+    "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57";
   const rawTx = mockStakeTransactions[mockTxHash].rawTx;
   const mockStakeTransactionMap = {};
   mockStakeTransactionMap[mockTxHash] = mockStakeTransactions[mockTxHash];
-  selectors.currentBlockHeight = jest.fn(() => 712217);
+  selectors.currentBlockHeight = jest.fn(() => 924414);
+
+  render(<TransactionPage />, {
+    initialState: {
+      grpc: {
+        regularTransactions: {},
+        stakeTransactions: mockStakeTransactionMap,
+        decodedTransactions: {},
+        getAccountsResponse: {
+          accountsList: [
+            {
+              accountNumber: 0,
+              accountName: "default"
+            }
+          ]
+        }
+      }
+    },
+    currentSettings: {
+      network: "testnet"
+    }
+  });
+
+  await wait(() => getIODetails());
+
+  expect(getHeaderTitleIconClassName()).toMatch("ticket");
+  expect(getTitleText()).toMatch("Ticket, Voted");
+  expect(getTicketCostText()).toMatch("Ticket Cost122.71678363 DCR");
+  expect(getRewardText()).toMatch("Reward0.04586488 DCR");
+
+  expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
+  expect(queryUnconfirmed()).not.toBeInTheDocument();
+  expect(getConfirmedText()).toMatch("Confirmed4,572 confirmations");
+
+  expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
+  expect(queryRebroadcastTransaction()).not.toBeInTheDocument();
+
+  expect(getWalletInputsText()).toMatch("Wallet Inputsdefault122.71678363 DCR");
+  expect(getNonWalletInputsText()).toMatch(
+    "Non Wallet Inputs 92ce48f17cf6a507f401a45d60ecd819443c6246f2f0e366b5614631032e0fb5:0 122.71681343 DCR"
+  );
+
+  expect(getWalletOutputs()).toMatch("Wallet Outputs default 122.76267831 DCR");
+  expect(getNonWalletOutputs()).toMatch(
+    "Non Wallet Outputs TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU 122.71678363 DCR TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n 0.00000 DCR"
+  );
+
+  expect(screen.getByText(rawTx)).toBeInTheDocument();
+  expect(getHeightText()).toMatch("Height919842");
+
+  user.click(screen.getByText("Back"));
+  expect(mockGoBackHistory).toHaveBeenCalled();
+
+  expect(getVSPHostText()).toMatch("VSP host:mockVspHost");
+});
+
+test("vote tx", async () => {
+  mockTxHash =
+    "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da";
+  const rawTx = mockStakeTransactions[mockTxHash].rawTx;
+  const mockStakeTransactionMap = {};
+  mockStakeTransactionMap[mockTxHash] = mockStakeTransactions[mockTxHash];
+  selectors.currentBlockHeight = jest.fn(() => 924414);
 
   render(<TransactionPage />, {
     initialState: {
@@ -414,54 +476,54 @@ test("voted ticket", async () => {
 
   expect(getHeaderTitleIconClassName()).toMatch("vote");
   expect(getTitleText()).toMatch("Vote");
-  expect(getTicketCostText()).toMatch("Ticket Cost100.88957415 DCR");
-  expect(getRewardText()).toMatch("Reward0.04841163 DCR");
+  expect(getTicketCostText()).toMatch("Ticket Cost122.71678363 DCR");
+  expect(getRewardText()).toMatch("Reward0.04586488 DCR");
 
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
-  expect(getConfirmedText()).toMatch("Confirmed4,989 confirmations");
+  expect(getConfirmedText()).toMatch("Confirmed4,437 confirmations");
   expect(getTicketSpentText()).toMatch(
-    "Ticket Spent:65b2b6f8195d1aece698c9d6058ccd97e60e18484d619e6b0b8317bb660cb27f"
+    "Ticket Spent:6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
   expect(queryRebroadcastTransaction()).not.toBeInTheDocument();
 
-  expect(getWalletInputsText()).toMatch("Wallet Inputsdefault100.88957415 DCR");
+  expect(getWalletInputsText()).toMatch("Wallet Inputsdefault122.71678363 DCR");
   expect(getNonWalletInputsText()).toMatch(
-    "Non Wallet Inputs 0000000000000000000000000000000000000000000000000000000000000000:4294967295 0.04844143 DCR"
+    "Non Wallet Inputs 0000000000000000000000000000000000000000000000000000000000000000:4294967295 0.04589468 DCR"
   );
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 100.93801558 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputs default 122.76267831 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs [script] - OP_RETURN OP_DATA_36 d77be628eb5a04f845a27ddf86ddf721e2a6e68e130334c36e87c7ee000000009bca0a00 0.00000 DCR [script] - OP_RETURN OP_DATA_6 010009000000 0.00000 DCR"
+    "Non Wallet Outputs [script] - OP_RETURN OP_DATA_36 32c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e00 0.00000 DCR [script] - OP_RETURN OP_DATA_6 01000a000000 0.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
-  expect(getHeightText()).toMatch("Height707228");
+  expect(getHeightText()).toMatch("Height919977");
 
   user.click(screen.getByText("Back"));
   expect(mockGoBackHistory).toHaveBeenCalled();
 
   expect(screen.getByText("Agenda Choices:").parentNode.textContent).toMatch(
-    "Enable decentralized Treasury opcodes as defined in DCP0006treasuryabstain"
+    "Agenda Choices:Change maximum treasury expenditure policy as defined in DCP0007reverttreasurypolicyabstainEnable explicit version upgrades as defined in DCP0008explicitverupgradesabstainEnable automatic ticket revocations as defined in DCP0009autorevocationsabstainChange block reward subsidy split to 10/80/10 as defined in DCP0010changesubsidysplitabstain"
   );
 
   expect(getVSPHostText()).toMatch("VSP host:mockVspHost");
   expect(getLastBlockValidText()).toMatch("Last Block Valid:true");
-  expect(getVoteVersionText()).toMatch("Vote Version:9");
+  expect(getVoteVersionText()).toMatch("Vote Version:10");
   expect(getVoteBitsText()).toMatch("Vote Bits:0x0001");
 });
 
-test("voted ticket (votes don't align with what the wallet currently has set)", async () => {
+test("vote tx (votes don't align with what the wallet currently has set)", async () => {
   mockTxHash =
-    "f5c4259f1ae264a6bc7e52d5f602967e947fdebdb8bc7a551a18d36ab1933e17";
+    "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da";
   const mockStakeTransactionMap = {};
   mockStakeTransactionMap[mockTxHash] = mockStakeTransactions[mockTxHash];
   selectors.currentBlockHeight = jest.fn(() => 712217);
   selectors.voteChoices = jest.fn(() => [
     {
-      agendaId: "treasury",
+      agendaId: "changesubsidysplit",
       choiceId: "yes"
     }
   ]);
@@ -490,7 +552,7 @@ test("voted ticket (votes don't align with what the wallet currently has set)", 
   await wait(() => getIODetails());
 
   expect(screen.getByText("Agenda Choices:").parentNode.textContent).toMatch(
-    "Enable decentralized Treasury opcodes as defined in DCP0006treasuryabstainThis doesn't align with what the wallet currently has set (yes)"
+    "Agenda Choices:Change maximum treasury expenditure policy as defined in DCP0007reverttreasurypolicyabstainEnable explicit version upgrades as defined in DCP0008explicitverupgradesabstainEnable automatic ticket revocations as defined in DCP0009autorevocationsabstainChange block reward subsidy split to 10/80/10 as defined in DCP0010changesubsidysplitabstainThis doesn't align with what the wallet currently has set (yes)"
   );
 });
 

--- a/test/unit/components/views/TransactionPage/mocks.js
+++ b/test/unit/components/views/TransactionPage/mocks.js
@@ -608,119 +608,248 @@ export const mockOldTxs = [
 ];
 
 const mockStakeTransactionList = [
-  // voted tx
+  // vote tx
   {
-    timestamp: 1623957771,
-    height: 707228,
+    timestamp: 1652874655,
+    height: 919977,
     blockHash:
-      "22ed8c58e324add4fc81ed7dd6c207b44e9b475a4f097f473ac829bc00000000",
+      "000000005af1c046f26b1a4336280e37a84a8d8e20898a1a27af18a4f23c2e56",
     index: 0,
-    txHash: "f5c4259f1ae264a6bc7e52d5f602967e947fdebdb8bc7a551a18d36ab1933e17",
-    txType: "ticket",
-    debitsAmount: 10088957415,
-    creditsAmount: 10093801558,
+    hash: "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
+    txHash: "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
+    txType: "vote",
+    debitsAmount: 12271678363,
+    creditsAmount: 12276267831,
     type: 2,
-    amount: 4844143,
+    amount: 4589468,
     fee: 0,
     debitAccounts: [0],
-    creditAddresses: ["Tsiu5Fie3crHKsxSjqs2vHDe18UE3Hfk4UZ"],
+    creditAddresses: ["TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n"],
     isStake: true,
     credits: [
       {
         index: 2,
-        account: 0,
+        account: 15,
         internal: true,
-        amount: 10093801558,
-        address: "Tsiu5Fie3crHKsxSjqs2vHDe18UE3Hfk4UZ",
-        outputScript: "u3apFMQcqc0gnZ+tUTJCUUwU/Z56q57QiKw="
+        amount: 12276267831,
+        address: "TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n",
+        outputScript: "u3apFFOyCElfn6vfqAtL4QxNDkiLM/KZiKw="
       }
     ],
     debits: [
       {
         index: 1,
         previousAccount: 0,
-        previousAmount: 10088957415
+        previousAmount: 12271678363
       }
     ],
     rawTx:
-      "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff7fb20c66bb17830b6b9e614d48180ee697cd8c05d6c998e6ec1a5d19f8b6b2650000000001ffffffff0300000000000000000000266a24d77be628eb5a04f845a27ddf86ddf721e2a6e68e130334c36e87c7ee000000009bca0a0000000000000000000000086a060100090000005630a3590200000000001abb76a914c41ca9cd209d9fad513242514c14fd9e7aab9ed088ac0000000000000000026fea49000000000000000000ffffffff020000e745595902000000fcc70a00070000006a47304402203fa6bddd0a24f662488f803d6b9d2b2c182f64570fe2c0c81f1217524267084502205ac7adcf0a795e8aee17c72725a3cc246caa0ae4424ee44e5f3008eddf15384501210275d5ca22c7dbbd8300cd7f399100c2fd10596ea6b9eae19897204bdf9ca13d5b",
+      "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff574f7189057261e0e816b09306c3dd4ae55146be8d1ce52a4d5c2475fdcf85600000000001ffffffff0300000000000000000000266a2432c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e0000000000000000000000086a0601000a00000037fbb8db0200000000001abb76a91453b208495f9fabdfa80b4be10c4d0e488b33f29988ac0000000000000000029c0746000000000000000000ffffffff0200009bf372db0200000022090e00110000006a4730440220481a66bdf843d6fe2f41b0b5ba129cfec694f82bac72602d08998a2a8b792fb2022003b0a2c8ddfcc317fdb5fac33cc0fbff280ce4bc250caef3e94840c79ef60ee301210355174775888e14ed49e50dd0b904e6dca3f6b4595afd9248a020a4aa87ae469e",
+    isMix: false,
     ticket: {
-      timestamp: 1623877720,
-      height: -1,
-      blockHash: "",
-      index: -1,
-      hash: "7fb20c66bb17830b6b9e614d48180ee697cd8c05d6c998e6ec1a5d19f8b6b265",
+      timestamp: 1652858637,
+      height: 919842,
+      blockHash:
+        "000000005af1c046f26b1a4336280e37a84a8d8e20898a1a27af18a4f23c2e56",
+      hash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
       txHash:
-        "65b2b6f8195d1aece698c9d6058ccd97e60e18484d619e6b0b8317bb660cb27f",
+        "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
       txType: "ticket",
-      debitsAmount: 10088960395,
-      creditsAmount: 10088957415,
+      debitsAmount: 12271681343,
+      creditsAmount: 12271678363,
       type: 1,
       amount: -2980,
       fee: 2980,
-      debitAccounts: [0],
-      creditAddresses: ["TsbwpAG7ZDEoLmdPKKDMjYXEDMUPvGUVmmQ"],
+      debitAccounts: [15],
+      creditAddresses: ["TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU"],
       isStake: true,
       credits: [
         {
           index: 0,
           account: 0,
           internal: true,
-          amount: 10088957415,
-          address: "TsbwpAG7ZDEoLmdPKKDMjYXEDMUPvGUVmmQ",
-          outputScript: "unapFHfYbkcM9vvFsoYJ+mdCILoWClnFiKw="
+          amount: 12271678363,
+          address: "TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU",
+          outputScript: "unapFFyo29n4+AuvdgX88JdEQQCZoS+biKw="
         }
       ],
       debits: [
         {
           index: 0,
-          previousAccount: 0,
-          previousAmount: 10088960395
+          previousAccount: 15,
+          previousAmount: 12271681343
         }
       ],
       rawTx:
-        "01000000016a44272cf3e3471a4e8ac5fb3218103d70199baf16defe23dec165b63b3bb1390000000000ffffffff03e74559590200000000001aba76a91477d86e470cf6fbc5b28609fa674220ba160a59c588ac00000000000000000000206a1ec41ca9cd209d9fad513242514c14fd9e7aab9ed08b515959020000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac0000000000000000018b51595902000000fbc70a001c0000006a473044022011e6efdea3f868a6c385cdad482474584d618ffca8c3ab1a86ff5262c0ad0e3b022077431b0b15c319f35b030ac93e8f22857cf75c30fa58a331b64df951e083933c0121038f084993a5787eca01865ebf5711cbd278348c39c14029d3a60205d5e2302a02",
-      vspHost: "mockVspHost"
+        "0100000001b50f2e03314661b566e3f0f246623c4419d8ec605da401f407a5f67cf148ce920000000000ffffffff039bf372db0200000000001aba76a9145ca8dbd9f8f80baf7605fcf09744410099a12f9b88ac00000000000000000000206a1e53b208495f9fabdfa80b4be10c4d0e488b33f2993fff72db02000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac0000000000000000013fff72db0200000000000000ffffffff6b483045022100d8f4e49c56f3249947a759d7ba766b671579399e758feaa12bc525c822c020f602200266d21d887165183479cf3d06a01470ceadc53b73527f6863ae76bf22a11ea001210355d8fdf5cdec7a8848e6d653d6c379908c256d4b54b7be637ab5018d56d19149",
+      isMix: false,
+      transaction:
+        "4991d1568d01b57a63beb7544b6d258c9079c3d653d6e648887aeccdf5fdd855032101a01ea122bf76ae63687f52733bc5adce7014a0063dcf7934186571881dd266022002f620c022c825c52ba1ea8f759e397915676b76bad759a7479924f3569ce4f4d80021024530486bffffffff0000000000000002db72ff3f010000000000000000ac88000000000000000000000000000000000000000014a976bd1a000000000000000000004e0000000002db72ff3f99f2338b480e4d0ce14b0ba8dfab9f5f4908b2531e6a2000000000000000000000ac889b2fa19900414497f0fc0576af0bf8f8d9dba85c14a976ba1a000000000002db72f39b03ffffffff000000000092ce48f17cf6a507f401a45d60ecd819443c6246f2f0e366b5614631032e0fb50100000001",
+      vspHost: "mockVspHost",
+      txUrl:
+        "https://testnet.decred.org/tx/6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57"
     },
     spender: {
-      timestamp: 1623957771,
-      height: 707228,
+      timestamp: 1652874655,
+      height: 919977,
       blockHash:
-        "22ed8c58e324add4fc81ed7dd6c207b44e9b475a4f097f473ac829bc00000000",
+        "000000005af1c046f26b1a4336280e37a84a8d8e20898a1a27af18a4f23c2e56",
       index: 0,
-      hash: "173e93b16ad3181a557abcb8bdde7f947e9602f6d5527ebca664e21a9f25c4f5",
+      hash: "000000005af1c046f26b1a4336280e37a84a8d8e20898a1a27af18a4f23c2e56",
       txHash:
-        "f5c4259f1ae264a6bc7e52d5f602967e947fdebdb8bc7a551a18d36ab1933e17",
+        "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
       txType: "vote",
-      debitsAmount: 10088957415,
-      creditsAmount: 10093801558,
+      debitsAmount: 12271678363,
+      creditsAmount: 12276267831,
       type: 2,
-      amount: 4844143,
+      amount: 4589468,
       fee: 0,
       debitAccounts: [0],
-      creditAddresses: ["Tsiu5Fie3crHKsxSjqs2vHDe18UE3Hfk4UZ"],
+      creditAddresses: ["TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n"],
       isStake: true,
       credits: [
         {
           index: 2,
           account: 0,
           internal: true,
-          amount: 10093801558,
-          address: "Tsiu5Fie3crHKsxSjqs2vHDe18UE3Hfk4UZ",
-          outputScript: "u3apFMQcqc0gnZ+tUTJCUUwU/Z56q57QiKw="
+          amount: 12276267831,
+          address: "TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n",
+          outputScript: "u3apFFOyCElfn6vfqAtL4QxNDkiLM/KZiKw="
         }
       ],
       debits: [
         {
           index: 1,
           previousAccount: 0,
-          previousAmount: 10088957415
+          previousAmount: 12271678363
         }
       ],
       rawTx:
-        "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff7fb20c66bb17830b6b9e614d48180ee697cd8c05d6c998e6ec1a5d19f8b6b2650000000001ffffffff0300000000000000000000266a24d77be628eb5a04f845a27ddf86ddf721e2a6e68e130334c36e87c7ee000000009bca0a0000000000000000000000086a060100090000005630a3590200000000001abb76a914c41ca9cd209d9fad513242514c14fd9e7aab9ed088ac0000000000000000026fea49000000000000000000ffffffff020000e745595902000000fcc70a00070000006a47304402203fa6bddd0a24f662488f803d6b9d2b2c182f64570fe2c0c81f1217524267084502205ac7adcf0a795e8aee17c72725a3cc246caa0ae4424ee44e5f3008eddf15384501210275d5ca22c7dbbd8300cd7f399100c2fd10596ea6b9eae19897204bdf9ca13d5b"
+        "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff574f7189057261e0e816b09306c3dd4ae55146be8d1ce52a4d5c2475fdcf85600000000001ffffffff0300000000000000000000266a2432c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e0000000000000000000000086a0601000a00000037fbb8db0200000000001abb76a91453b208495f9fabdfa80b4be10c4d0e488b33f29988ac0000000000000000029c0746000000000000000000ffffffff0200009bf372db0200000022090e00110000006a4730440220481a66bdf843d6fe2f41b0b5ba129cfec694f82bac72602d08998a2a8b792fb2022003b0a2c8ddfcc317fdb5fac33cc0fbff280ce4bc250caef3e94840c79ef60ee301210355174775888e14ed49e50dd0b904e6dca3f6b4595afd9248a020a4aa87ae469e",
+      isMix: false
     },
     status: "voted"
+  },
+  // voted ticket
+  {
+    timestamp: 1652858637,
+    height: 919842,
+    blockHash:
+      "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
+    index: 0,
+    hash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
+    txHash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
+    txType: "ticket",
+    debitsAmount: 12271681343,
+    creditsAmount: 12271678363,
+    type: 1,
+    amount: -2980,
+    fee: 2980,
+    debitAccounts: [15],
+    creditAddresses: ["TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 0,
+        internal: true,
+        amount: 12271678363,
+        address: "TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU",
+        outputScript: "unapFFyo29n4+AuvdgX88JdEQQCZoS+biKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 15,
+        previousAmount: 12271681343
+      }
+    ],
+    rawTx:
+      "0100000001b50f2e03314661b566e3f0f246623c4419d8ec605da401f407a5f67cf148ce920000000000ffffffff039bf372db0200000000001aba76a9145ca8dbd9f8f80baf7605fcf09744410099a12f9b88ac00000000000000000000206a1e53b208495f9fabdfa80b4be10c4d0e488b33f2993fff72db02000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac0000000000000000013fff72db0200000000000000ffffffff6b483045022100d8f4e49c56f3249947a759d7ba766b671579399e758feaa12bc525c822c020f602200266d21d887165183479cf3d06a01470ceadc53b73527f6863ae76bf22a11ea001210355d8fdf5cdec7a8848e6d653d6c379908c256d4b54b7be637ab5018d56d19149",
+    isMix: false,
+    ticket: {
+      timestamp: 1652858637,
+      height: 919842,
+      blockHash:
+        "00000000bbf1f33870cec5e4da9a7eb7a80c17b07cd3ba4865f4086fa6f8cd3e",
+      index: 0,
+      hash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
+      txHash:
+        "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
+      txType: "ticket",
+      debitsAmount: 12271681343,
+      creditsAmount: 12271678363,
+      type: 1,
+      amount: -2980,
+      fee: 2980,
+      debitAccounts: [15],
+      creditAddresses: ["TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 12271678363,
+          address: "TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU",
+          outputScript: "unapFFyo29n4+AuvdgX88JdEQQCZoS+biKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 15,
+          previousAmount: 12271681343
+        }
+      ],
+      rawTx:
+        "0100000001b50f2e03314661b566e3f0f246623c4419d8ec605da401f407a5f67cf148ce920000000000ffffffff039bf372db0200000000001aba76a9145ca8dbd9f8f80baf7605fcf09744410099a12f9b88ac00000000000000000000206a1e53b208495f9fabdfa80b4be10c4d0e488b33f2993fff72db02000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac0000000000000000013fff72db0200000000000000ffffffff6b483045022100d8f4e49c56f3249947a759d7ba766b671579399e758feaa12bc525c822c020f602200266d21d887165183479cf3d06a01470ceadc53b73527f6863ae76bf22a11ea001210355d8fdf5cdec7a8848e6d653d6c379908c256d4b54b7be637ab5018d56d19149",
+      isMix: false,
+      vspHost: "mockVspHost",
+      txUrl:
+        "https://testnet.decred.org/tx/6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57"
+    },
+    spender: {
+      timestamp: 1652874655,
+      height: -1,
+      blockHash: "",
+      index: -1,
+      hash: "000000005af1c046f26b1a4336280e37a84a8d8e20898a1a27af18a4f23c2e56",
+      txHash:
+        "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
+      txType: "vote",
+      debitsAmount: 12271678363,
+      creditsAmount: 12276267831,
+      type: 2,
+      amount: 4589468,
+      fee: 0,
+      debitAccounts: [0],
+      creditAddresses: ["TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n"],
+      isStake: true,
+      credits: [
+        {
+          index: 2,
+          account: 0,
+          internal: true,
+          amount: 12276267831,
+          address: "TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n",
+          outputScript: "u3apFFOyCElfn6vfqAtL4QxNDkiLM/KZiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 1,
+          previousAccount: 0,
+          previousAmount: 12271678363
+        }
+      ],
+      rawTx:
+        "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff574f7189057261e0e816b09306c3dd4ae55146be8d1ce52a4d5c2475fdcf85600000000001ffffffff0300000000000000000000266a2432c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e0000000000000000000000086a0601000a00000037fbb8db0200000000001abb76a91453b208495f9fabdfa80b4be10c4d0e488b33f29988ac0000000000000000029c0746000000000000000000ffffffff0200009bf372db0200000022090e00110000006a4730440220481a66bdf843d6fe2f41b0b5ba129cfec694f82bac72602d08998a2a8b792fb2022003b0a2c8ddfcc317fdb5fac33cc0fbff280ce4bc250caef3e94840c79ef60ee301210355174775888e14ed49e50dd0b904e6dca3f6b4595afd9248a020a4aa87ae469e",
+      isMix: false
+    },
+    status: "voted",
+    feeStatus: 1
   },
   // missed
   {

--- a/test/unit/components/views/TransactionPage/mocks.js
+++ b/test/unit/components/views/TransactionPage/mocks.js
@@ -616,7 +616,7 @@ const mockStakeTransactionList = [
       "22ed8c58e324add4fc81ed7dd6c207b44e9b475a4f097f473ac829bc00000000",
     index: 0,
     txHash: "f5c4259f1ae264a6bc7e52d5f602967e947fdebdb8bc7a551a18d36ab1933e17",
-    txType: "vote",
+    txType: "ticket",
     debitsAmount: 10088957415,
     creditsAmount: 10093801558,
     type: 2,
@@ -800,7 +800,127 @@ const mockStakeTransactionList = [
     },
     status: "missed"
   },
-  // revoked
+  // revoked ticket
+  {
+    timestamp: 1637487987,
+    height: 815405,
+    blockHash:
+      "000000080433728b66a9dcd5471205adde4df9619af27f45613f60c4d3dc8a02",
+    index: 0,
+    hash: "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
+    txHash: "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
+    txType: "ticket",
+    debitsAmount: 8600221089,
+    creditsAmount: 8600218109,
+    type: 1,
+    amount: -2980,
+    fee: 2980,
+    debitAccounts: [0],
+    creditAddresses: ["TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 0,
+        internal: true,
+        amount: 8600218109,
+        address: "TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ",
+        outputScript: "unapFOlPYM9gpJSRDMD+KPZi22h5RnROiKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 0,
+        previousAmount: 8600221089
+      }
+    ],
+    rawTx:
+      "010000000145dff3de5ec042630f66a9ba4ea2ed6d70f3fa306af01858a83efa676d3779000000000000ffffffff03fde99c000200000000001aba76a914e94f60cf60a494910cc0fe28f662db687946744e88ac00000000000000000000206a1e8ef37a84dc2bc7c924877e1ab3026b3b5a102e5fa1f59c0002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a1f59c00020000002c710c00030000006a47304402206888557060684807b6e78f47ea8c186debe45f2316a584abe60c5495f36f77f80220249421832ab9ea9e6bbb70d50376e7f48258b3108a345dc299d1de8186e046060121036343175c705537c636732c42fa699ba96f6296bc66b915216cbc833d00e18e10",
+    isMix: false,
+    spender: {
+      timestamp: 1643948925,
+      height: -1,
+      blockHash: "",
+      index: -1,
+      hash: "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
+      txHash:
+        "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
+      txType: "revocation",
+      debitsAmount: 8600218109,
+      creditsAmount: 8600218109,
+      type: 3,
+      amount: 0,
+      fee: 0,
+      debitAccounts: [0],
+      creditAddresses: ["Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 8600218109,
+          address: "Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy",
+          outputScript: "vHapFI7zeoTcK8fJJId+GrMCaztaEC5fiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 0,
+          previousAmount: 8600218109
+        }
+      ],
+      rawTx:
+        "0200000001997fa9df69903ad5d40fce86f0da366f3d9c13b842e947d1d0859a30e3e24eb00000000001ffffffff01fde99c000200000000001abc76a9148ef37a84dc2bc7c924877e1ab3026b3b5a102e5f88ac000000000000000001fde99c00020000002d710c000800000000",
+      isMix: false
+    },
+    status: "revoked",
+    ticket: {
+      timestamp: 1637487987,
+      height: 815405,
+      blockHash:
+        "000000080433728b66a9dcd5471205adde4df9619af27f45613f60c4d3dc8a02",
+      index: 0,
+      hash: "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
+      txHash:
+        "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
+      txType: "ticket",
+      debitsAmount: 8600221089,
+      creditsAmount: 8600218109,
+      type: 1,
+      amount: -2980,
+      fee: 2980,
+      debitAccounts: [0],
+      creditAddresses: ["TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 8600218109,
+          address: "TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ",
+          outputScript: "unapFOlPYM9gpJSRDMD+KPZi22h5RnROiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 0,
+          previousAmount: 8600221089
+        }
+      ],
+      rawTx:
+        "010000000145dff3de5ec042630f66a9ba4ea2ed6d70f3fa306af01858a83efa676d3779000000000000ffffffff03fde99c000200000000001aba76a914e94f60cf60a494910cc0fe28f662db687946744e88ac00000000000000000000206a1e8ef37a84dc2bc7c924877e1ab3026b3b5a102e5fa1f59c0002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a1f59c00020000002c710c00030000006a47304402206888557060684807b6e78f47ea8c186debe45f2316a584abe60c5495f36f77f80220249421832ab9ea9e6bbb70d50376e7f48258b3108a345dc299d1de8186e046060121036343175c705537c636732c42fa699ba96f6296bc66b915216cbc833d00e18e10",
+      isMix: false,
+      vspHost: "",
+      txUrl:
+        "https://testnet.decred.org/tx/b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99"
+    }
+  },
+  // revocation
   {
     timestamp: 1622730448,
     height: 697812,


### PR DESCRIPTION
This diff adds the Ticket spent entry to the revocation tx details page and renamed "Voted On" to "Missed On", as @davecgh suggested on the matrix.

Also, I noticed that the titles of the details page are often not correct (e.g. revocation was `revoke`, the revoked tickets were `ticket, voted`).  I tried to find and fix all such cases. Tests were updated and extended.

<img width="721" alt="image" src="https://user-images.githubusercontent.com/52497040/170100575-51921094-ec8b-4fe4-9f42-d09b3c370e44.png">
