### PR TITLE
[governance] use testnet PiKeys on testnet

### DIFF
--- a/app/components/views/GovernancePage/TreasurySpendingTab/TreasurySpendingTab.jsx
+++ b/app/components/views/GovernancePage/TreasurySpendingTab/TreasurySpendingTab.jsx
@@ -10,6 +10,7 @@ const TreasurySpendingTab = () => {
     setTreasuryPolicy,
     policyOptions,
     treasuryPolicies,
+    dcrdSourceLink,
     PiKeys,
     isLoading
   } = useTreasurySpending();
@@ -27,7 +28,7 @@ const TreasurySpendingTab = () => {
                 link: (
                   <ExternalLink
                     className={styles.proposalsLink}
-                    href="https://github.com/decred/dcrd/blob/master/chaincfg/mainnetparams.go#L485">
+                    href={dcrdSourceLink}>
                     dcrd source code
                   </ExternalLink>
                 )

--- a/app/components/views/GovernancePage/TreasurySpendingTab/TreasurySpendingTab.jsx
+++ b/app/components/views/GovernancePage/TreasurySpendingTab/TreasurySpendingTab.jsx
@@ -3,7 +3,6 @@ import PageHeader from "../PageHeader";
 import styles from "./TreasurySpendingTab.module.css";
 import { useTreasurySpending } from "./hooks";
 import { TreasuryPolicyCard } from "./helpers";
-import { PiKeys } from "constants";
 import { ExternalLink } from "shared";
 
 const TreasurySpendingTab = () => {
@@ -11,6 +10,7 @@ const TreasurySpendingTab = () => {
     setTreasuryPolicy,
     policyOptions,
     treasuryPolicies,
+    PiKeys,
     isLoading
   } = useTreasurySpending();
 

--- a/app/components/views/GovernancePage/TreasurySpendingTab/hooks.js
+++ b/app/components/views/GovernancePage/TreasurySpendingTab/hooks.js
@@ -5,6 +5,8 @@ import { FormattedMessage as T } from "react-intl";
 
 export function useTreasurySpending() {
   const treasuryPolicies = useSelector(sel.treasuryPolicies);
+  const chainParams = useSelector(sel.chainParams);
+  const PiKeys = chainParams.PiKeys;
   const setTreasuryPolicyRequestAttempt = useSelector(
     sel.setTreasuryPolicyRequestAttempt
   );
@@ -32,6 +34,7 @@ export function useTreasurySpending() {
     treasuryPolicies,
     setTreasuryPolicy,
     policyOptions,
+    PiKeys,
     isLoading: !!setTreasuryPolicyRequestAttempt
   };
 }

--- a/app/components/views/GovernancePage/TreasurySpendingTab/hooks.js
+++ b/app/components/views/GovernancePage/TreasurySpendingTab/hooks.js
@@ -10,6 +10,10 @@ export function useTreasurySpending() {
   const setTreasuryPolicyRequestAttempt = useSelector(
     sel.setTreasuryPolicyRequestAttempt
   );
+  const isTestNet = useSelector(sel.isTestNet);
+  const dcrdSourceLink = isTestNet
+    ? "https://github.com/decred/dcrd/blob/master/chaincfg/testnetparams.go#L391"
+    : "https://github.com/decred/dcrd/blob/master/chaincfg/mainnetparams.go#L479";
   const dispatch = useDispatch();
 
   const setTreasuryPolicy = (key, policy, passphrase) =>
@@ -34,6 +38,7 @@ export function useTreasurySpending() {
     treasuryPolicies,
     setTreasuryPolicy,
     policyOptions,
+    dcrdSourceLink,
     PiKeys,
     isLoading: !!setTreasuryPolicyRequestAttempt
   };

--- a/app/constants/decred.js
+++ b/app/constants/decred.js
@@ -35,7 +35,13 @@ export const TestNetParams = {
 
   // DefaultWalletRPCListener is the default host and port that will be used
   // if the rpc server is started (currently only used when DEX is enabled).
-  DefaultWalletRPCListener: "127.0.0.1:19110"
+  DefaultWalletRPCListener: "127.0.0.1:19110",
+  // Sanctioned Politeia keys.
+  // Only showing the first Pi trusted key for now.
+  PiKeys: [
+    "03beca9bbd227ca6bb5a58e03a36ba2b52fff09093bd7a50aee1193bccd257fb8a"
+    // "03e647c014f55265da506781f0b2d67674c35cb59b873d9926d483c4ced9a7bbd3",
+  ]
 };
 
 export const MainNetParams = {
@@ -65,7 +71,13 @@ export const MainNetParams = {
 
   // DefaultWalletRPCListener is the default host and port that will be used
   // if the rpc server is started (currently only used when DEX is enabled).
-  DefaultWalletRPCListener: "127.0.0.1:9110"
+  DefaultWalletRPCListener: "127.0.0.1:9110",
+  // Sanctioned Politeia keys.
+  // Only showing the first Pi trusted key for now.
+  PiKeys: [
+    "03f6e7041f1cf51ee10e0a01cd2b0385ce3cd9debaabb2296f7e9dee9329da946c"
+    // "0319a37405cb4d1691971847d7719cfce70857c0f6e97d7c9174a3998cf0ab86dd",
+  ]
 };
 
 // MAX_DCR_AMOUNT represents the maximum decred amount in atoms.
@@ -137,12 +149,5 @@ export const SStxPKHMinOutSize = 32;
 // less than 10 non wallet outputs.  We also limit listing addresses on
 // the transaction details when over this amount.
 export const MaxNonWalletOutputs = 10;
-
-// Sanctioned Politeia keys.
-// Only showing the first Pi trusted key for now.
-export const PiKeys = [
-  "03f6e7041f1cf51ee10e0a01cd2b0385ce3cd9debaabb2296f7e9dee9329da946c"
-  // "0319a37405cb4d1691971847d7719cfce70857c0f6e97d7c9174a3998cf0ab86dd",
-];
 
 export const MIN_VSP_VERSION = "1.1.0";


### PR DESCRIPTION
Now treasury spending page use testnet governance keys on testnet and it links to the testnet dcrd source code.
Thanks to @dreacot and @davecgh for reporting this issue on the matrix.