### PR TITLE
[privacy] renaming StakeShuffle

### DIFF
--- a/app/components/views/PrivacyPage/PrivacyTab/PrivacyContent.jsx
+++ b/app/components/views/PrivacyPage/PrivacyTab/PrivacyContent.jsx
@@ -43,7 +43,7 @@ const PrivacyContent = ({
   return (
     <div className={styles.privacyContent}>
       <Subtitle
-        title={<T id="privacy.coinMixer" m="Stakeshuffle++" />}
+        title={<T id="privacy.coinMixer" m="StakeShuffle" />}
         className={classNames(styles.isRow)}
         children={
           <div className={classNames(styles.contentTitleButtonsArea)}>

--- a/app/i18n/docs/en/Warnings/MixerIntroduction.md
+++ b/app/i18n/docs/en/Warnings/MixerIntroduction.md
@@ -1,4 +1,4 @@
-Stakeshuffle++ requires two dedicated wallet accounts - a "mixed" account and an
+StakeShuffle requires two dedicated wallet accounts - a "mixed" account and an
 "unmixed" account.
 
 When the account mixer is activated, Decred will be transferred from the unmixed


### PR DESCRIPTION
This renames `Stakeshuffle++` to `StakeShuffle` as @xaur suggested: https://github.com/decred/decrediton/pull/3767#issuecomment-1156804362