### PR TITLE
[css] Fix governance notification icon

### DIFF
--- a/app/components/views/HomePage/GovernanceNotification/GovernanceNotification.module.css
+++ b/app/components/views/HomePage/GovernanceNotification/GovernanceNotification.module.css
@@ -21,7 +21,6 @@
   margin-top: 0.3rem;
   position: absolute;
   display: inline-block;
-  z-index: 10;
   border-radius: 50%;
   background-color: var(--stroke-color-focused);
 }


### PR DESCRIPTION
The governance notification icon stays visible when the user clicks one of the transactions on the home view. This diff fixes it by removing the unnecessary z-index property.

<img width="279" alt="2022-07-05_11-24" src="https://user-images.githubusercontent.com/52497040/177296257-58d8b979-48a7-4761-b211-c94981d1d1c8.png">
