### PR TITLE
Fix js warning in ToggleSwitch component

### DIFF
--- a/app/components/buttons/ToggleSwitch/ToggleSwitch.jsx
+++ b/app/components/buttons/ToggleSwitch/ToggleSwitch.jsx
@@ -29,8 +29,8 @@ const ToggleSwitch = ({
         <Toggle
           {...{
             onToggle: onClick,
-            toggled: enabled,
-            disabled,
+            toggled: !!enabled,
+            disabled: !!disabled,
             className
           }}
         />


### PR DESCRIPTION
This fixes js warning:
```
react_devtools_backend.js:6 Warning: Failed prop type: The prop `toggled` is marked as required in `Toggle`, but its value is undefined`.
```
reported in https://github.com/decred/decrediton/pull/2869#issuecomment-1165400364

