### PR TITLE
TransactionAction and Txdetails improvements

### DIFF
--- a/app/actions/TransactionActions.js
+++ b/app/actions/TransactionActions.js
@@ -1116,9 +1116,6 @@ export const stakeTransactionNormalizer = (ticket) => (_, getState) => {
   const ticketTx = ticket.ticket || ticket.spender;
   const ticketHash = ticketTx.txHash;
   const spenderTx = hasSpender ? spender : null;
-  const txBlockHash = blockHash
-    ? reverseHash(Buffer.from(blockHash).toString("hex"))
-    : null;
   const txHash = ticket.txHash;
   const txUrl = txURLBuilder(txHash);
   const txBlockHash = blockHash

--- a/app/actions/TransactionActions.js
+++ b/app/actions/TransactionActions.js
@@ -1116,6 +1116,9 @@ export const stakeTransactionNormalizer = (ticket) => (_, getState) => {
   const ticketTx = ticket.ticket || ticket.spender;
   const ticketHash = ticketTx.txHash;
   const spenderTx = hasSpender ? spender : null;
+  const txBlockHash = blockHash
+    ? reverseHash(Buffer.from(blockHash).toString("hex"))
+    : null;
   const txHash = ticket.txHash;
   const txUrl = txURLBuilder(txHash);
   const txBlockHash = blockHash

--- a/app/actions/TransactionActions.js
+++ b/app/actions/TransactionActions.js
@@ -596,6 +596,7 @@ export const getTransactions = (isStake) => async (dispatch, getState) => {
     stakeTransactionsCancel
   } = getState().grpc;
   const chainParams = sel.chainParams(getState());
+  const vspTicketsHashes = sel.getVSPTicketsHashes(getState());
   let {
     getRegularTxsAux,
     getStakeTxsAux,
@@ -703,6 +704,15 @@ export const getTransactions = (isStake) => async (dispatch, getState) => {
   // divide stake transactions and regular transactions map. This way we can
   // have different filter behaviors without one interfering the other.
   const newTxs = divideTransactions(transactions);
+
+  Object.keys(vspTicketsHashes).forEach((feeStatus) => {
+    vspTicketsHashes[feeStatus].forEach((ticketHash) => {
+      if (newTxs.stakeTransactions[ticketHash]) {
+        newTxs.stakeTransactions[ticketHash].feeStatus = feeStatus;
+      }
+    });
+  });
+
   if (isStake) {
     stakeTransactions = {
       ...stakeTransactions,

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -66,12 +66,17 @@ export const getVSPTicketsByFeeStatus = (feeStatus) => (dispatch, getState) =>
         const ticketsHashes = response.ticketHashes;
 
         // add fee status into our stake transactions map.
-        const { stakeTransactions } = getState().grpc;
+        const { stakeTransactions, recentStakeTransactions } = getState().grpc;
         ticketsHashes.forEach((ticketHash) => {
           const tx = stakeTransactions[ticketHash];
           if (tx) {
             tx.feeStatus = feeStatus;
           }
+          recentStakeTransactions.map(
+            (tx) =>
+              (tx.feeStatus =
+                tx.txHash === ticketHash ? feeStatus : tx.feeStatus)
+          );
         });
         // dispatch if we have tickets with error to register.
         if (feeStatus == VSP_FEE_PROCESS_ERRORED && ticketsHashes.length > 0) {
@@ -82,7 +87,8 @@ export const getVSPTicketsByFeeStatus = (feeStatus) => (dispatch, getState) =>
           type: GETVSPTICKETSTATUS_SUCCESS,
           vspTickets: { [feeStatus]: ticketsHashes },
           feeStatus,
-          stakeTransactions
+          stakeTransactions,
+          recentStakeTransactions
         });
 
         resolve(ticketsHashes);

--- a/app/components/shared/TxHistory/RegularTxRow.jsx
+++ b/app/components/shared/TxHistory/RegularTxRow.jsx
@@ -51,7 +51,9 @@ const TxDirection = ({ account, isCred, overview }) => (
         values={{
           acc: (
             <div className={styles.status}>
-              <div className={styles.accountName}>{account}</div>
+              <div className={styles.accountName}>
+                <TruncatedText text={account} max={overview ? 10 : 20} />
+              </div>
             </div>
           )
         }}
@@ -91,7 +93,7 @@ const RegularTxRow = ({
       </span>
       {txDirection === TICKET_FEE ? (
         <div className={classNames("flex-row", styles.txDirection)}>
-          <TxDirection account={txAccountNameDebited} />
+          <TxDirection account={txAccountNameDebited} overview={overview} />
           <TxDirection
             account={txAccountNameCredited}
             isCred

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -72,7 +72,6 @@ const TransactionContent = ({
     isPending,
     voteScript,
     ticketTx,
-    status,
     spenderTx
   } = transactionDetails;
 

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -238,7 +238,14 @@ const TransactionContent = ({
         ) : (
           <div className={styles.topRow}>
             <div className={styles.name}>
-              <T id="txDetails.toAddress" m="To address" />:
+              <T
+                id="txDetails.toAddress"
+                m="{addressCount, plural, one {To address} other {To addresses} }"
+                values={{
+                  addressCount: txOutputs.length + nonWalletOutputs.length
+                }}
+              />
+              :
             </div>
             <div className={classNames(styles.value, styles.nonFlex)}>
               {txOutputs.map(({ address }, i) => (

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -399,12 +399,20 @@ const TransactionContent = ({
               {nonWalletInputs.map(({ address, amount }, idx) => (
                 <div key={idx} className={styles.row}>
                   <div className={styles.address}>
-                    <TruncatedText
-                      text={address}
-                      max={truncateMax}
-                      showTooltip
-                      tooltipClassName={styles.tooltipClassName}
-                    />
+                    {isVote ? (
+                      // Stakebase transactions (votes) have only one (stakebase) non-wallet output
+                      <T
+                        id="txDetails.nonWalletInputs.Stakebase"
+                        m="Stakebase"
+                      />
+                    ) : (
+                      <TruncatedText
+                        text={address}
+                        max={truncateMax}
+                        showTooltip
+                        tooltipClassName={styles.tooltipClassName}
+                      />
+                    )}
                   </div>
                   <div className={styles.amount}>
                     <Balance amount={amount} />

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -71,7 +71,9 @@ const TransactionContent = ({
     rawTx,
     isPending,
     voteScript,
-    ticketTx
+    ticketTx,
+    status,
+    spenderTx
   } = transactionDetails;
 
   const { theme } = useTheme();
@@ -159,6 +161,21 @@ const TransactionContent = ({
                 <NavLink
                   to={location.pathname.replace(txHash, ticketTx.txHash)}>
                   {ticketTx.txHash}
+                </NavLink>
+              </div>
+            </div>
+          </>
+        )}
+        {txType === TICKET && spenderTx && (
+          <>
+            <div className={styles.topRow}>
+              <div className={styles.name}>
+                <T id="txDetails.spendingTx" m="Spending Tx" />:
+              </div>
+              <div className={styles.value}>
+                <NavLink
+                  to={location.pathname.replace(txHash, spenderTx.txHash)}>
+                  {spenderTx.txHash}
                 </NavLink>
               </div>
             </div>

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -1,5 +1,5 @@
 import { useLocation, NavLink } from "react-router-dom";
-import { Balance, ExternalLink } from "shared";
+import { Balance, ExternalLink, TruncatedText } from "shared";
 import {
   KeyBlueButton,
   CopyToClipboardButton,
@@ -107,6 +107,8 @@ const TransactionContent = ({
       .filter((v, i) => walletOutputIndices.indexOf(i) === -1)
       .map(mapNonWalletOutput);
   }
+
+  const truncateMax = 18;
 
   return (
     <>
@@ -364,7 +366,14 @@ const TransactionContent = ({
               </div>
               {txInputs.map(({ accountName, amount }, idx) => (
                 <div key={idx} className={styles.row}>
-                  <div className={styles.address}>{accountName}</div>
+                  <div className={styles.address}>
+                    <TruncatedText
+                      text={accountName}
+                      max={truncateMax}
+                      showTooltip
+                      tooltipClassName={styles.tooltipClassName}
+                    />
+                  </div>
                   <div className={styles.amount}>
                     <Balance amount={amount} />
                   </div>
@@ -383,7 +392,12 @@ const TransactionContent = ({
               {nonWalletInputs.map(({ address, amount }, idx) => (
                 <div key={idx} className={styles.row}>
                   <div className={styles.address}>
-                    {addSpacingAroundText(address)}
+                    <TruncatedText
+                      text={address}
+                      max={truncateMax}
+                      showTooltip
+                      tooltipClassName={styles.tooltipClassName}
+                    />
                   </div>
                   <div className={styles.amount}>
                     <Balance amount={amount} />
@@ -406,11 +420,18 @@ const TransactionContent = ({
               {txOutputs.map(({ accountName, decodedScript, amount }, idx) => (
                 <div key={idx} className={styles.row}>
                   <div className={styles.address}>
-                    {txDirection === TRANSACTION_DIR_SENT
-                      ? "change"
-                      : accountName
-                      ? addSpacingAroundText(accountName)
-                      : addSpacingAroundText(decodedScript.address)}
+                    <TruncatedText
+                      text={
+                        txDirection === TRANSACTION_DIR_SENT
+                          ? "change"
+                          : accountName
+                          ? accountName
+                          : decodedScript.address
+                      }
+                      max={truncateMax}
+                      showTooltip
+                      tooltipClassName={styles.tooltipClassName}
+                    />
                   </div>
                   <div className={styles.amount}>
                     <Balance amount={amount} />
@@ -439,7 +460,12 @@ const TransactionContent = ({
                   <div key={idx} className={styles.row}>
                     <div
                       className={classNames(styles.address, styles.nonWallet)}>
-                      {addSpacingAroundText(address)}
+                      <TruncatedText
+                        text={address}
+                        max={truncateMax}
+                        showTooltip
+                        tooltipClassName={styles.tooltipClassName}
+                      />
                     </div>
                     <div className={styles.amount}>{amount}</div>
                   </div>

--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.module.css
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.module.css
@@ -142,9 +142,6 @@
   border-radius: 3px;
   background-color: var(--blue-highlight-background);
   color: var(--input-color-default);
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
   text-align: center;
   margin-right: 5px;
 }
@@ -153,7 +150,7 @@
   margin-bottom: 5px;
 }
 .address {
-  width: 80px;
+  min-width: 80px;
   margin-bottom: 5px;
 }
 .amount {

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -158,7 +158,8 @@ export default function grpc(state = {}, action) {
     case GETVSPTICKETSTATUS_SUCCESS:
       return {
         ...state,
-        stakeTransactions: action.stakeTransactions
+        stakeTransactions: action.stakeTransactions,
+        recentStakeTransactions: action.recentStakeTransactions
       };
     case CREATEMIXERACCOUNTS_ATTEMPT:
       return {

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -106,8 +106,10 @@ import {
   NEW_TRANSACTIONS_RECEIVED,
   CHANGE_TRANSACTIONS_FILTER
 } from "actions/TransactionActions";
-import { GETVSPTICKETSTATUS_SUCCESS } from "actions/VSPActions";
-import { SETVSPDVOTECHOICE_FAILED } from "../actions/VSPActions";
+import {
+  GETVSPTICKETSTATUS_SUCCESS,
+  SETVSPDVOTECHOICE_FAILED
+} from "actions/VSPActions";
 
 export default function grpc(state = {}, action) {
   let newMaturingBlockHeights;

--- a/test/unit/actions/TransactionActions.spec.js
+++ b/test/unit/actions/TransactionActions.spec.js
@@ -119,6 +119,13 @@ const mockRegularMixedTxHash =
 const mockRegularSelfTxHash =
   "9110b998c418a9007389627bc2ad51e888392f463bc7ccc30dcd927a2f0fa304";
 
+const mockVspTickets = {
+  0: [],
+  1: [mockUnminedTicketHash],
+  2: [],
+  3: [mockVotedTicketHash]
+};
+
 const mockUnminedTransactions = [
   [
     mockRegularTransactions[mockRegularPendingTxHash],
@@ -157,6 +164,7 @@ beforeEach(() => {
   }));
   selectors.isTestNet = jest.fn(() => true);
   selectors.getChangeAccount = jest.fn(() => testChangeAccountId);
+  selectors.getVSPTicketsHashes = jest.fn(() => mockVspTickets);
   mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn((p) => {
     const txHex = rawToHex(p);
     if (mockDecodedTransactions[txHex]) {
@@ -1202,7 +1210,10 @@ test("test getTransactions (fetching regular txs)", async () => {
   expect(
     isEqual(store.getState().grpc.getRegularTxsAux, {
       noMoreTransactions: true,
-      lastTransaction: mockNormalizedStakeTransactions[mockVotedTicketHash]
+      lastTransaction: {
+        ...mockNormalizedStakeTransactions[mockVotedTicketHash],
+        feeStatus: VSP_FEE_PROCESS_CONFIRMED.toString()
+      }
     })
   ).toBeTruthy();
 });
@@ -1273,7 +1284,10 @@ test("test getTransactions (fetching regular txs, listing asc)", async () => {
   expect(
     isEqual(store.getState().grpc.getRegularTxsAux, {
       noMoreTransactions: true,
-      lastTransaction: mockNormalizedStakeTransactions[mockVotedTicketHash]
+      lastTransaction: {
+        ...mockNormalizedStakeTransactions[mockVotedTicketHash],
+        feeStatus: VSP_FEE_PROCESS_CONFIRMED.toString()
+      }
     })
   ).toBeTruthy();
 });
@@ -1318,10 +1332,15 @@ test("test getTransactions (fetching stake txs)", async () => {
 
   const expectedStakeTransactions = {
     ...initialStateCopy.grpc.stakeTransactions,
-    [mockUnminedTicketHash]:
-      mockNormalizedStakeTransactions[mockUnminedTicketHash],
+    [mockUnminedTicketHash]: {
+      ...mockNormalizedStakeTransactions[mockUnminedTicketHash],
+      feeStatus: VSP_FEE_PROCESS_PAID.toString()
+    },
     [mockVoteTx]: mockNormalizedStakeTransactions[mockVoteTx],
-    [mockVotedTicketHash]: mockNormalizedStakeTransactions[mockVotedTicketHash]
+    [mockVotedTicketHash]: {
+      ...mockNormalizedStakeTransactions[mockVotedTicketHash],
+      feeStatus: VSP_FEE_PROCESS_CONFIRMED.toString()
+    }
   };
 
   // regularTransactions and getRegularTxsAux shuld not changed
@@ -1344,7 +1363,10 @@ test("test getTransactions (fetching stake txs)", async () => {
   expect(
     isEqual(store.getState().grpc.getStakeTxsAux, {
       noMoreTransactions: true,
-      lastTransaction: mockNormalizedStakeTransactions[mockVotedTicketHash]
+      lastTransaction: {
+        ...mockNormalizedStakeTransactions[mockVotedTicketHash],
+        feeStatus: VSP_FEE_PROCESS_CONFIRMED.toString()
+      }
     })
   ).toBeTruthy();
 });

--- a/test/unit/actions/TransactionActions.spec.js
+++ b/test/unit/actions/TransactionActions.spec.js
@@ -1,14 +1,49 @@
 import * as cla from "actions/TransactionActions";
+import * as ca from "actions/ControlActions";
+import * as wal from "wallet";
+import * as sel from "selectors";
+import * as cli from "actions/ClientActions";
+import * as am from "actions/AccountMixerActions";
 import { createStore } from "test-utils.js";
 import {
   mockRegularTransactions,
-  mockStakeTransactions,
   mockNormalizedRegularTransactions,
-  mockNormalizedStakeTransactions
+  mockNormalizedStakeTransactions,
+  mockRegularTransactionList
 } from "../components/views/TransactionPage/mocks.js";
+import {
+  mockStakeTransactionList,
+  mockStakeTransactions
+} from "../components/views/TransactionPage/mocks_stakeTransactions.js";
+import { mockTickets } from "../components/views/TransactionPage/mocks_tickets.js";
+import { mockDecodedTransactions } from "../components/views/TransactionPage/mocks_decodedTransactions.js";
+import { mockSpenderTransactions } from "../components/views/TransactionPage/mocks_spenderTransactions.js";
 import { isEqual, cloneDeep } from "lodash/fp";
+import { TestNetParams } from "constants";
+import { walletrpc as api } from "middleware/walletrpc/api_pb";
+const { TransactionDetails } = api;
+import {
+  MaxNonWalletOutputs,
+  TICKET,
+  IMMATURE,
+  VOTE,
+  VOTED,
+  REVOKED,
+  BATCH_TX_COUNT,
+  VSP_FEE_PROCESS_ERRORED,
+  VSP_FEE_PROCESS_STARTED,
+  VSP_FEE_PROCESS_PAID,
+  VSP_FEE_PROCESS_CONFIRMED
+} from "constants";
+import { strHashToRaw, rawToHex, reverseRawHash, hexToBytes } from "helpers";
 
+const controlActions = ca;
 const transactionActions = cla;
+const wallet = wal;
+const selectors = sel;
+const clientActions = cli;
+const accountMixerActions = am;
+const walletService = "walletService";
 const initialState = {
   settings: {
     currentSettings: {
@@ -16,6 +51,7 @@ const initialState = {
     }
   },
   grpc: {
+    walletService,
     getAccountsResponse: {
       accountsList: [
         {
@@ -44,7 +80,7 @@ const initialState = {
         },
         {
           accountNumber: 6,
-          accountName: "mixed"
+          accountName: "account-6"
         },
         {
           accountNumber: 7,
@@ -53,39 +89,1430 @@ const initialState = {
         {
           accountNumber: 15,
           accountName: "account-15"
+        },
+        {
+          accountNumber: 2147483647,
+          accountName: "imported"
         }
       ]
     }
   }
 };
+const testRawTx = [1, 2, 3];
+const testRawTxHex = Buffer.from(testRawTx, "hex");
+const mockVspHost = "mock-vsp-host";
 
-const normalizeTransactions = (txs, store) =>
-  Object.keys(txs).reduce((normalizedMap, txHash) => {
-    const tx = txs[txHash];
-    if (tx.isStake) {
-      normalizedMap[txHash] = store.dispatch(
-        transactionActions.stakeTransactionNormalizer(tx)
-      );
-    } else {
-      normalizedMap[txHash] = store.dispatch(
-        transactionActions.regularTransactionNormalizer(tx)
-      );
+const mockRegularReceivedTxHash =
+  "642e3756be5a38636dfcdc643da9c6f5be8c9a1015b4623ad9cab38ff0ceec8e";
+const mockMissedTicketHash =
+  "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774";
+const mockRegularPendingTxHash =
+  "263f64a32f2f86ffda747242cfc620b0c42689f5c600ef2be22351f53bcd5b0d";
+const mockUnminedTicketHash =
+  "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f";
+const mockVoteTx =
+  "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4";
+const mockVotedTicketHash =
+  "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57";
+const mockRegularMixedTxHash =
+  "ee6dbff0efe2eeb8c803133284462849661709beab258fb57453997afd9f492c";
+const mockRegularSelfTxHash =
+  "9110b998c418a9007389627bc2ad51e888392f463bc7ccc30dcd927a2f0fa304";
+
+const mockUnminedTransactions = [
+  [
+    mockRegularTransactions[mockRegularPendingTxHash],
+    mockStakeTransactions[mockUnminedTicketHash]
+  ],
+  [],
+  []
+];
+const mockMinedTransactions = [
+  [], // unmined call
+  [
+    mockStakeTransactions[mockVoteTx],
+    mockStakeTransactions[mockVotedTicketHash]
+  ],
+  []
+];
+
+const testChangeAccountId = 123;
+
+let mockGetNextAddressAttempt;
+let mockDecodeRawTransaction;
+let mockValidateAddress;
+
+let mockGetVSPTicketsByFeeStatus;
+let mockGetBalanceUpdateAttempt;
+let mockGetStakeInfoAttempt;
+let mockCheckUnmixedAccountBalance;
+let mockGetMixerAcctsSpendableBalances;
+
+beforeEach(() => {
+  mockGetNextAddressAttempt = controlActions.getNextAddressAttempt = jest.fn(
+    () => () => {}
+  );
+  mockValidateAddress = wallet.validateAddress = jest.fn(() => ({
+    isMine: true
+  }));
+  selectors.isTestNet = jest.fn(() => true);
+  selectors.getChangeAccount = jest.fn(() => testChangeAccountId);
+  mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn((p) => {
+    const txHex = rawToHex(p);
+    if (mockDecodedTransactions[txHex]) {
+      const decodedSpender = mockDecodedTransactions[txHex];
+      decodedSpender.inputs = decodedSpender.inputs.map((input) => ({
+        ...input,
+        sigScript: hexToBytes(input.sigScript)
+      }));
+      decodedSpender.outputs = decodedSpender.outputs.map((output) => ({
+        ...output,
+        script: hexToBytes(output.script)
+      }));
+      return cloneDeep(decodedSpender);
     }
-    return normalizedMap;
-  }, {});
+    const tx = mockRegularTransactionList.find((tx) => tx.rawTx === txHex);
+    if (tx) {
+      const res = tx.outputs.map((output) => ({
+        decodedScript: { address: output.address },
+        value: output.value
+      }));
+      return { outputs: res };
+    }
+  });
+  mockValidateAddress = wallet.validateAddress = jest.fn((_, address) => {
+    let isMine = true;
+    Object.keys(mockNormalizedRegularTransactions).forEach((key) => {
+      const tx = mockNormalizedRegularTransactions[key];
+      tx.outputs.forEach((output) => {
+        if (output.address === address) {
+          isMine = output.isChange;
+        }
+      });
+    });
+    return { isMine };
+  });
 
-test("test transactionNormalizer and ticketNormalizer", () => {
+  wallet.getTicket = jest.fn((_, p) => {
+    const txHash = reverseRawHash(p);
+    if (mockTickets[txHash]) {
+      return cloneDeep(mockTickets[txHash]);
+    }
+    let ticket;
+    mockStakeTransactionList.forEach((tx) => {
+      if (tx.ticket?.txHash == txHash) {
+        ticket = tx.ticket;
+      }
+      if (tx.spender?.txHash == txHash) {
+        ticket = tx.spender;
+      }
+    });
+    return cloneDeep(ticket);
+  });
+
+  wallet.getTransaction = jest.fn((_, txHash) => {
+    if (mockSpenderTransactions[txHash]) {
+      return cloneDeep(mockSpenderTransactions[txHash]);
+    }
+  });
+
+  mockGetVSPTicketsByFeeStatus = wallet.getVSPTicketsByFeeStatus = jest.fn(
+    (_, feeStatus) =>
+      Promise.resolve({
+        ticketHashes:
+          feeStatus === VSP_FEE_PROCESS_PAID
+            ? [mockMissedTicketHash]
+            : feeStatus === VSP_FEE_PROCESS_ERRORED
+            ? [mockVotedTicketHash]
+            : feeStatus === VSP_FEE_PROCESS_STARTED
+            ? [mockUnminedTicketHash]
+            : []
+      })
+  );
+  mockGetBalanceUpdateAttempt = clientActions.getBalanceUpdateAttempt = jest.fn(
+    () => () => Promise.resolve()
+  );
+  mockGetStakeInfoAttempt = clientActions.getStakeInfoAttempt = jest.fn(
+    () => () => Promise.resolve()
+  );
+  mockCheckUnmixedAccountBalance = accountMixerActions.checkUnmixedAccountBalance = jest.fn(
+    () => () => Promise.resolve()
+  );
+  mockGetMixerAcctsSpendableBalances = clientActions.getMixerAcctsSpendableBalances = jest.fn(
+    () => () => {}
+  );
+});
+
+test("test transactionNormalizer and ticketNormalizer", async () => {
   const store = createStore(initialState);
 
-  const txs = {
-    ...cloneDeep(mockRegularTransactions),
-    ...cloneDeep(mockStakeTransactions)
-  };
+  const txs = [
+    ...cloneDeep(mockRegularTransactionList),
+    ...cloneDeep(mockStakeTransactionList)
+  ];
   const expectedNormalizedTxs = {
     ...cloneDeep(mockNormalizedRegularTransactions),
     ...cloneDeep(mockNormalizedStakeTransactions)
   };
 
-  const normalizedTransactions = normalizeTransactions(txs, store);
-  expect(isEqual(normalizedTransactions, expectedNormalizedTxs)).toBeTruthy();
+  const normalizedTransactions = await transactionActions.normalizeBatchTx(
+    walletService,
+    TestNetParams,
+    store.dispatch,
+    txs
+  );
+
+  const normalizedTransacitonsList = {};
+  normalizedTransactions.forEach((tx) => {
+    normalizedTransacitonsList[tx.txHash] = tx;
+  });
+  expect(
+    isEqual(normalizedTransacitonsList, expectedNormalizedTxs)
+  ).toBeTruthy();
+});
+
+test("test changeTransactionsFilter", () => {
+  const testTransactionFilter = {
+    search: null,
+    listDirection: "desc",
+    types: [],
+    directions: [],
+    maxAmount: null,
+    minAmount: null
+  };
+  const store = createStore({
+    grpc: {
+      transactionsFilter: testTransactionFilter,
+      regularTransactions: "initial",
+      getRegularTxsAux: "initial"
+    }
+  });
+
+  // not changing list direction, regularTransactions and getRegularTxsAux shouldn't touched
+  store.dispatch(
+    transactionActions.changeTransactionsFilter(testTransactionFilter)
+  );
+  expect(
+    isEqual(store.getState().grpc.transactionsFilter, testTransactionFilter)
+  ).toBeTruthy();
+  expect(
+    isEqual(store.getState().grpc.regularTransactions, "initial")
+  ).toBeTruthy();
+  expect(
+    isEqual(store.getState().grpc.getRegularTxsAux, "initial")
+  ).toBeTruthy();
+
+  // change list direction
+  const newFilter = { listDirection: "new-listDirection" };
+  store.dispatch(transactionActions.changeTransactionsFilter(newFilter));
+
+  expect(
+    isEqual(store.getState().grpc.transactionsFilter, newFilter)
+  ).toBeTruthy();
+
+  expect(isEqual(store.getState().grpc.regularTransactions, {})).toBeTruthy();
+  expect(
+    isEqual(store.getState().grpc.getRegularTxsAux, {
+      noMoreTransactions: false,
+      lastTransaction: null
+    })
+  ).toBeTruthy();
+});
+
+test("test changeTicketsFilter", () => {
+  const testTicketsFilter = {
+    listDirection: "desc",
+    status: null,
+    vspFeeStatus: null
+  };
+  const store = createStore({
+    grpc: {
+      ticketsFilter: testTicketsFilter,
+      stakeTransactions: "initial",
+      getStakeTxsAux: "initial"
+    }
+  });
+
+  // not changing list direction, stakeTransactions and getStakeTxsAux shouldn't touched
+  store.dispatch(transactionActions.changeTicketsFilter(testTicketsFilter));
+  expect(
+    isEqual(store.getState().grpc.ticketsFilter, testTicketsFilter)
+  ).toBeTruthy();
+  expect(
+    isEqual(store.getState().grpc.stakeTransactions, "initial")
+  ).toBeTruthy();
+  expect(isEqual(store.getState().grpc.getStakeTxsAux, "initial")).toBeTruthy();
+
+  // change list direction
+  const newFilter = { listDirection: "new-listDirection" };
+  store.dispatch(transactionActions.changeTicketsFilter(newFilter));
+
+  expect(isEqual(store.getState().grpc.ticketsFilter, newFilter)).toBeTruthy();
+
+  expect(isEqual(store.getState().grpc.stakeTransactions, {})).toBeTruthy();
+  expect(
+    isEqual(store.getState().grpc.getStakeTxsAux, {
+      noMoreTransactions: false,
+      lastTransaction: null
+    })
+  ).toBeTruthy();
+});
+
+test("test checkAccountsToUpdate function", () => {
+  // update accounts related to the transaction balance.
+  const newlyUnminedTransactions = [
+    {
+      credits: [{ account: 0 }, { account: 1 }],
+      debits: [{ previousAccount: 2 }, { previousAccount: 3 }]
+    }
+  ];
+
+  const newlyMinedTransactions = [
+    {
+      credits: [{ account: 4 }, { account: 5 }],
+      debits: [{ previousAccount: 6 }, { previousAccount: 7 }]
+    },
+    // duplicates
+    {
+      credits: [{ account: 1 }, { account: 1 }],
+      debits: [{ previousAccount: 6 }, { previousAccount: 6 }]
+    }
+  ];
+  //
+
+  const accountsToUpdate = transactionActions.checkAccountsToUpdate([
+    ...newlyUnminedTransactions,
+    ...newlyMinedTransactions
+  ]);
+
+  expect(isEqual(accountsToUpdate, [0, 1, 2, 3, 4, 5, 6, 7])).toBeTruthy();
+});
+
+test("test transactionsMaturingHeights function", () => {
+  const txs = [
+    {
+      height: 10,
+      type: TransactionDetails.TransactionType.TICKET_PURCHASE,
+      credits: [{ account: 4 }, { account: 5 }],
+      debits: [{ previousAccount: 6 }, { previousAccount: 7 }]
+    },
+    {
+      height: 10, // same height
+      type: TransactionDetails.TransactionType.TICKET_PURCHASE,
+      credits: [{ account: 4 }, { account: 5 }, { account: 9 }], // additional account
+      debits: [{ previousAccount: 6 }, { previousAccount: 7 }]
+    },
+    {
+      height: 100,
+      type: TransactionDetails.TransactionType.TICKET_PURCHASE,
+      credits: [{ account: 4 }],
+      debits: [{ previousAccount: 7 }]
+    },
+    {
+      height: 200,
+      type: TransactionDetails.TransactionType.VOTE,
+      credits: [{ account: 5 }],
+      debits: [{ previousAccount: 6 }]
+    },
+    {
+      height: 200,
+      type: TransactionDetails.TransactionType.REVOCATION,
+      credits: [{ account: 5 }],
+      debits: [{ previousAccount: 6 }]
+    },
+    {
+      height: 300,
+      type: TransactionDetails.TransactionType.VOTE,
+      credits: [{ account: 9 }],
+      debits: [{ previousAccount: 9 }]
+    }
+  ];
+  const res = transactionActions.transactionsMaturingHeights(
+    txs,
+    TestNetParams
+  );
+  expect(
+    isEqual(res, {
+      11: [4, 5, 6, 7, 9], // height(10) +  SStxChangeMaturity(1)
+      26: [4, 5, 6, 7, 9], // height(10) +  TicketMaturity(16)
+      6154: [4, 5, 6, 7, 9], // height(10) +  TicketExpiry(6144)
+
+      101: [4, 7], // height(100) +  SStxChangeMaturity(1)
+      116: [4, 7], // height(100) +  TicketMaturity(16)
+      6244: [4, 7], // height(100) +  TicketExpiry(6144)
+
+      216: [5, 6], // height(200) +  CoinbaseMaturity(16)
+
+      316: [9] // height(200) +  CoinbaseMaturity(16)
+    })
+  ).toBeTruthy();
+});
+
+test("test getNewAccountAddresses function", () => {
+  const store = createStore({});
+  const txs = [
+    {
+      credits: [{ account: 4 }, { account: 5 }]
+    },
+    {
+      credits: [{ account: 4 }, { account: 5 }, { account: 9 }] // additional account
+    },
+    {
+      credits: [{ account: 4 }]
+    }
+  ];
+  store.dispatch(transactionActions.getNewAccountAddresses(txs));
+
+  expect(mockGetNextAddressAttempt).toHaveBeenNthCalledWith(1, 4);
+  expect(mockGetNextAddressAttempt).toHaveBeenNthCalledWith(2, 5);
+  expect(mockGetNextAddressAttempt).toHaveBeenNthCalledWith(3, 9);
+});
+
+test("test checkForStakeTransactions function", () => {
+  expect(
+    transactionActions.checkForStakeTransactions([
+      {
+        isStake: undefined
+      }
+    ])
+  ).toBeFalsy();
+
+  expect(
+    transactionActions.checkForStakeTransactions([
+      {
+        isStake: false
+      },
+      {
+        isStake: false
+      }
+    ])
+  ).toBeFalsy();
+
+  expect(
+    transactionActions.checkForStakeTransactions([
+      {
+        isStake: true
+      },
+      {
+        isStake: false
+      },
+      {
+        isStake: undefined
+      }
+    ])
+  ).toBeTruthy();
+});
+
+test("test divideTransactions function", () => {
+  const txs = [
+    {
+      txHash: "stakeTxHash",
+      isStake: true
+    },
+    {
+      txHash: "regularTxHash",
+      isStake: false
+    },
+    {
+      txHash: "unknownTxHash",
+      isStake: undefined
+    },
+    {
+      txHash: "stakeTxHash2",
+      isStake: true
+    }
+  ];
+  const res = transactionActions.divideTransactions(txs);
+  expect(
+    isEqual(res, {
+      stakeTransactions: {
+        stakeTxHash: { txHash: "stakeTxHash", isStake: true },
+        stakeTxHash2: { txHash: "stakeTxHash2", isStake: true }
+      },
+      regularTransactions: {
+        regularTxHash: { txHash: "regularTxHash", isStake: false },
+        unknownTxHash: { txHash: "unknownTxHash", isStake: undefined }
+      }
+    })
+  ).toBeTruthy();
+});
+
+test("test getNonWalletOutputs function (called with less than MaxNonWalletOutputs)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3]
+  };
+  const mockDecodedTx = {
+    outputs: [
+      { decodedScript: { address: "test-address-1" }, value: 1 },
+      { decodedScript: { address: "test-address-2" }, value: 2 }
+    ]
+  };
+  mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn(
+    () => mockDecodedTx
+  );
+  mockValidateAddress = wallet.validateAddress = jest.fn((_, address) => ({
+    // first output will be mine, the rest is not
+    isMine: address === mockDecodedTx.outputs[0].decodedScript.address
+  }));
+  const updatedOutputs = await transactionActions.getNonWalletOutputs(
+    walletService,
+    TestNetParams,
+    tx
+  );
+  expect(mockDecodeRawTransaction).toHaveBeenCalledWith(
+    testRawTxHex,
+    TestNetParams
+  );
+  expect(mockValidateAddress).toHaveBeenCalledTimes(
+    mockDecodedTx.outputs.length
+  );
+  expect(mockValidateAddress).toHaveBeenNthCalledWith(
+    1,
+    walletService,
+    "test-address-1"
+  );
+  expect(mockValidateAddress).toHaveBeenNthCalledWith(
+    2,
+    walletService,
+    "test-address-2"
+  );
+  expect(
+    isEqual(updatedOutputs, [
+      { address: "test-address-1", value: 1, isChange: true },
+      { address: "test-address-2", value: 2, isChange: false }
+    ])
+  ).toBeTruthy();
+});
+
+test("test getNonWalletOutputs function (called with more outputs than MaxNonWalletOutputs)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3]
+  };
+  const mockDecodedTx = {
+    outputs: []
+  };
+
+  for (let i = 0; i <= MaxNonWalletOutputs + 1; i++) {
+    mockDecodedTx.outputs.push({
+      decodedScript: { address: `test-address-${i}` },
+      value: i
+    });
+  }
+
+  mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn(
+    () => mockDecodedTx
+  );
+  const updatedOutputs = await transactionActions.getNonWalletOutputs(
+    walletService,
+    TestNetParams,
+    tx
+  );
+  expect(mockDecodeRawTransaction).toHaveBeenCalledWith(
+    testRawTxHex,
+    TestNetParams
+  );
+  expect(mockValidateAddress).not.toHaveBeenCalled();
+  expect(
+    isEqual(
+      updatedOutputs,
+      mockDecodedTx.outputs.map((output) => ({
+        address: output.decodedScript.address,
+        value: output.value
+      }))
+    )
+  ).toBeTruthy();
+});
+
+test("test getNonWalletOutputs function fails", async () => {
+  const tx = {
+    rawTx: [1, 2, 3]
+  };
+
+  mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn(() => {
+    throw "error";
+  });
+  let error;
+  try {
+    await transactionActions.getNonWalletOutputs(
+      walletService,
+      TestNetParams,
+      tx
+    );
+  } catch (e) {
+    error = e;
+  }
+  expect(mockDecodeRawTransaction).toHaveBeenCalledWith(
+    testRawTxHex,
+    TestNetParams
+  );
+  expect(mockValidateAddress).not.toHaveBeenCalled();
+  expect(isEqual(error, "error")).toBeTruthy();
+});
+
+test("test getMissingStakeTxData function (REVOKED)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3]
+  };
+  const mockDecodedTx = {
+    inputs: [{ prevTxId: "test-prev-tx-id-1" }]
+  };
+  const mockTicket = {
+    ticket: "e3bae353b60cb90af66e277ce80fa238e942675e3a2cbe45331b9a010dd006bc"
+  };
+  mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn(
+    () => mockDecodedTx
+  );
+
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => mockTicket));
+  const res = await transactionActions.getMissingStakeTxData(
+    walletService,
+    TestNetParams,
+    tx
+  );
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(mockDecodedTx.inputs[0].prevTxId)
+  );
+  expect(mockDecodeRawTransaction).toHaveBeenCalledWith(
+    testRawTxHex,
+    TestNetParams
+  );
+  expect(
+    isEqual(res, { ticket: mockTicket.ticket, spender: tx, status: REVOKED })
+  ).toBeTruthy();
+});
+
+test("test getMissingStakeTxData function (REVOKED, more than one inputs)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3]
+  };
+  const mockDecodedTx = {
+    inputs: [
+      {
+        prevTxId:
+          "e3bae353b60cb90af66e277ce80fa238e942675e3a2cbe45331b9a010dd006bc"
+      },
+      {
+        prevTxId:
+          "045bd5f19c97b926fe4d090c06a2c25481f5f32d5cefc31ffb36ef86e140b199"
+      },
+      {
+        prevTxId:
+          "51cd137ae3bbe9acebd9dc6b364b6bf8350602db783e78de6a345f264d592068"
+      }
+    ]
+  };
+  const mockTicket = { ticket: "test-ticket-data" };
+  mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn(
+    () => mockDecodedTx
+  );
+
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => mockTicket));
+  const res = await transactionActions.getMissingStakeTxData(
+    walletService,
+    TestNetParams,
+    tx
+  );
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(mockDecodedTx.inputs[1].prevTxId) // use the second input, if it's present
+  );
+  expect(mockDecodeRawTransaction).toHaveBeenCalledWith(
+    testRawTxHex,
+    TestNetParams
+  );
+  expect(
+    isEqual(res, { ticket: mockTicket.ticket, spender: tx, status: REVOKED })
+  ).toBeTruthy();
+});
+
+test("test getMissingStakeTxData function (VOTED)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3],
+    txType: VOTE
+  };
+  const mockDecodedTx = {
+    inputs: [{ prevTxId: "test-prev-tx-id-1" }]
+  };
+  const mockTicket = {
+    ticket: "e3bae353b60cb90af66e277ce80fa238e942675e3a2cbe45331b9a010dd006bc"
+  };
+  mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn(
+    () => mockDecodedTx
+  );
+
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => mockTicket));
+  const res = await transactionActions.getMissingStakeTxData(
+    walletService,
+    TestNetParams,
+    tx
+  );
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(mockDecodedTx.inputs[0].prevTxId)
+  );
+  expect(mockDecodeRawTransaction).toHaveBeenCalledWith(
+    testRawTxHex,
+    TestNetParams
+  );
+  expect(
+    isEqual(res, { ticket: mockTicket.ticket, spender: tx, status: VOTED })
+  ).toBeTruthy();
+});
+
+test("test getMissingStakeTxData function (VOTED, ticket NOT_FOUND)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3],
+    txType: VOTE
+  };
+  const mockDecodedTx = {
+    inputs: [{ prevTxId: "test-prev-tx-id-1" }]
+  };
+  mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn(
+    () => mockDecodedTx
+  );
+
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => {
+    throw "NOT_FOUND";
+  }));
+  const res = await transactionActions.getMissingStakeTxData(
+    walletService,
+    TestNetParams,
+    tx
+  );
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(mockDecodedTx.inputs[0].prevTxId)
+  );
+  expect(mockDecodeRawTransaction).toHaveBeenCalledWith(
+    testRawTxHex,
+    TestNetParams
+  );
+  expect(
+    isEqual(res, { ticket: undefined, spender: tx, status: VOTED })
+  ).toBeTruthy();
+});
+
+test("test getMissingStakeTxData function (VOTED, getting tickket fails with unknown error)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3],
+    txType: VOTE
+  };
+  const mockDecodedTx = {
+    inputs: [{ prevTxId: "test-prev-tx-id-1" }]
+  };
+  mockDecodeRawTransaction = wallet.decodeRawTransaction = jest.fn(
+    () => mockDecodedTx
+  );
+
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => {
+    throw "UNKNOWN_ERROR";
+  }));
+  let error;
+  let res;
+  try {
+    res = await transactionActions.getMissingStakeTxData(
+      walletService,
+      TestNetParams,
+      tx
+    );
+  } catch (e) {
+    error = e;
+  }
+  expect(error).toBe("UNKNOWN_ERROR");
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(mockDecodedTx.inputs[0].prevTxId)
+  );
+  expect(mockDecodeRawTransaction).toHaveBeenCalledWith(
+    testRawTxHex,
+    TestNetParams
+  );
+  expect(res).toBe(undefined);
+});
+
+test("test getMissingStakeTxData function (TICKET)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3],
+    txType: TICKET,
+    txHash: "caa80c92647a4b7cc205de8326a1759138be6a9a884e7984b3cf908aa4a840db"
+  };
+  const mockTicket = {
+    status: IMMATURE,
+    spender: {
+      hash: "045bd5f19c97b926fe4d090c06a2c25481f5f32d5cefc31ffb36ef86e140b199"
+    },
+    ticket: {
+      vspHost: mockVspHost
+    }
+  };
+  const mockTransaction = "mock-transaction";
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => mockTicket));
+  const mockGetTransaction = (wallet.getTransaction = jest.fn(
+    () => mockTransaction
+  ));
+  const res = await transactionActions.getMissingStakeTxData(
+    walletService,
+    TestNetParams,
+    tx
+  );
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(tx.txHash)
+  );
+  expect(mockGetTransaction).toHaveBeenCalledWith(
+    walletService,
+    mockTicket.spender.hash
+  );
+  expect(
+    isEqual(res, {
+      ticket: { ...tx, vspHost: mockVspHost },
+      spender: mockTransaction,
+      status: IMMATURE
+    })
+  ).toBeTruthy();
+});
+
+test("test getMissingStakeTxData function (TICKET, transaction is NOT_FOUND)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3],
+    txType: TICKET,
+    txHash: "caa80c92647a4b7cc205de8326a1759138be6a9a884e7984b3cf908aa4a840db"
+  };
+  const mockTicket = {
+    status: IMMATURE,
+    spender: {
+      hash: "045bd5f19c97b926fe4d090c06a2c25481f5f32d5cefc31ffb36ef86e140b199"
+    },
+    ticket: {
+      vspHost: mockVspHost
+    }
+  };
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => mockTicket));
+  const mockGetTransaction = (wallet.getTransaction = jest.fn(() =>
+    Promise.reject("NOT_FOUND")
+  ));
+  const res = await transactionActions.getMissingStakeTxData(
+    walletService,
+    TestNetParams,
+    tx
+  );
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(tx.txHash)
+  );
+  expect(mockGetTransaction).toHaveBeenCalledWith(
+    walletService,
+    mockTicket.spender.hash
+  );
+  expect(
+    isEqual(res, {
+      ticket: { ...tx, vspHost: mockVspHost },
+      spender: undefined,
+      status: IMMATURE
+    })
+  ).toBeTruthy();
+});
+
+test("test getMissingStakeTxData function (TICKET, getting transaction fails with UNKNOWN_ERROR)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3],
+    txType: TICKET,
+    txHash: "caa80c92647a4b7cc205de8326a1759138be6a9a884e7984b3cf908aa4a840db"
+  };
+  const mockTicket = {
+    status: IMMATURE,
+    spender: {
+      hash: "045bd5f19c97b926fe4d090c06a2c25481f5f32d5cefc31ffb36ef86e140b199"
+    },
+    ticket: {
+      vspHost: mockVspHost
+    }
+  };
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => mockTicket));
+  const mockGetTransaction = (wallet.getTransaction = jest.fn(() =>
+    Promise.reject("UNKNOWN_ERROR")
+  ));
+  let error, res;
+  try {
+    res = await transactionActions.getMissingStakeTxData(
+      walletService,
+      TestNetParams,
+      tx
+    );
+  } catch (e) {
+    error = e;
+  }
+  expect(error).toBe("UNKNOWN_ERROR");
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(tx.txHash)
+  );
+  expect(mockGetTransaction).toHaveBeenCalledWith(
+    walletService,
+    mockTicket.spender.hash
+  );
+  expect(res).toBe(undefined);
+});
+
+test("test getMissingStakeTxData function (TICKET, spender hash is missing)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3],
+    txType: TICKET,
+    txHash: "caa80c92647a4b7cc205de8326a1759138be6a9a884e7984b3cf908aa4a840db"
+  };
+  const mockTicket = {
+    status: IMMATURE,
+    spender: {},
+    ticket: {
+      vspHost: mockVspHost
+    }
+  };
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => mockTicket));
+  const res = await transactionActions.getMissingStakeTxData(
+    walletService,
+    TestNetParams,
+    tx
+  );
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(tx.txHash)
+  );
+  expect(
+    isEqual(res, {
+      ticket: { ...tx, vspHost: mockVspHost },
+      spender: undefined,
+      status: IMMATURE
+    })
+  ).toBeTruthy();
+});
+
+test("test getMissingStakeTxData function (TICKET, getting ticket fails with unknown error)", async () => {
+  const tx = {
+    rawTx: [1, 2, 3],
+    txType: TICKET,
+    txHash: "caa80c92647a4b7cc205de8326a1759138be6a9a884e7984b3cf908aa4a840db"
+  };
+  const mockGetTicket = (wallet.getTicket = jest.fn(() => {
+    throw "UNKNOWN_ERROR";
+  }));
+  let error;
+  let res;
+  try {
+    res = await transactionActions.getMissingStakeTxData(
+      walletService,
+      TestNetParams,
+      tx
+    );
+  } catch (e) {
+    error = e;
+  }
+  expect(error).toBe("UNKNOWN_ERROR");
+  expect(mockGetTicket).toHaveBeenCalledWith(
+    walletService,
+    strHashToRaw(tx.txHash)
+  );
+  expect(res).toBe(undefined);
+});
+
+test("test getStartupTransactions (empty list)", async () => {
+  const initialState = { grpc: { walletService } };
+  const store = createStore(initialState);
+  const mockGetTransactions = (wallet.getTransactions = jest.fn(() => ({
+    unmined: [],
+    mined: []
+  })));
+
+  await store.dispatch(transactionActions.getStartupTransactions());
+
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    1,
+    walletService,
+    -1,
+    -1,
+    50
+  );
+
+  expect(
+    isEqual(store.getState().grpc, {
+      walletService,
+      recentRegularTransactions: [],
+      recentStakeTransactions: [],
+      maturingBlockHeights: {},
+      stakeTransactions: {},
+      regularTransactions: {}
+    })
+  ).toBeTruthy();
+});
+
+test("test getStartupTransactions", async () => {
+  const store = createStore(initialState);
+
+  let callCount = 0;
+  const mockGetTransactions = (wallet.getTransactions = jest.fn(() => {
+    const res = {
+      unmined: cloneDeep(mockUnminedTransactions[callCount]),
+      mined: cloneDeep(mockMinedTransactions[callCount])
+    };
+    callCount += 1;
+    return res;
+  }));
+
+  await store.dispatch(transactionActions.getStartupTransactions());
+
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    1,
+    walletService,
+    -1,
+    -1,
+    50
+  );
+
+  const expectedStoreValues = {
+    walletService,
+    getAccountsResponse: initialState.grpc.getAccountsResponse,
+    maturingBlockHeights: {
+      0: [0],
+      15: [0],
+      6143: [0],
+      919843: [0, 15],
+      919858: [0, 15],
+      925986: [0, 15],
+      932753: [15, 0]
+    },
+    recentRegularTransactions: [
+      mockNormalizedRegularTransactions[mockRegularPendingTxHash]
+    ],
+    recentStakeTransactions: [
+      mockNormalizedStakeTransactions[mockUnminedTicketHash],
+      mockNormalizedStakeTransactions[mockVoteTx],
+      mockNormalizedStakeTransactions[mockVotedTicketHash]
+    ],
+    stakeTransactions: {
+      [mockUnminedTicketHash]:
+        mockNormalizedStakeTransactions[mockUnminedTicketHash],
+      [mockVoteTx]: mockNormalizedStakeTransactions[mockVoteTx],
+      [mockVotedTicketHash]:
+        mockNormalizedStakeTransactions[mockVotedTicketHash]
+    },
+    regularTransactions: {
+      [mockRegularPendingTxHash]:
+        mockNormalizedRegularTransactions[mockRegularPendingTxHash]
+    }
+  };
+
+  expect(isEqual(store.getState().grpc, expectedStoreValues)).toBeTruthy();
+});
+
+const getInitialStateForGetTransactions = (listDirection = "desc") => {
+  const initialStateCopy = cloneDeep(initialState);
+  initialStateCopy.grpc.currentBlockHeight = 964427;
+  initialStateCopy.grpc.regularTransactions = {
+    [mockRegularReceivedTxHash]: cloneDeep(
+      mockNormalizedRegularTransactions[mockRegularReceivedTxHash]
+    )
+  };
+  initialStateCopy.grpc.stakeTransactions = {
+    [mockMissedTicketHash]: cloneDeep(
+      mockNormalizedStakeTransactions[mockMissedTicketHash]
+    )
+  };
+  initialStateCopy.grpc.transactionsFilter = {
+    listDirection,
+    types: [],
+    directions: []
+  };
+  initialStateCopy.grpc.ticketsFilter = {
+    listDirection
+  };
+  initialStateCopy.grpc.getRegularTxsAux = {
+    noMoreTransactions: false,
+    lastTransaction: null
+  };
+  initialStateCopy.grpc.getStakeTxsAux = {
+    noMoreTransactions: false,
+    lastTransaction: null
+  };
+  return initialStateCopy;
+};
+
+test("test getTransactions (fetching regular txs)", async () => {
+  const initialStateCopy = cloneDeep(getInitialStateForGetTransactions());
+  const store = createStore(initialStateCopy);
+
+  let callCount = 0;
+  const mockGetTransactions = (wallet.getTransactions = jest.fn(() => {
+    const res = {
+      unmined: cloneDeep(mockUnminedTransactions[callCount]),
+      mined: cloneDeep(mockMinedTransactions[callCount])
+    };
+    callCount += 1;
+    return res;
+  }));
+
+  await store.dispatch(transactionActions.getTransactions());
+
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    1,
+    walletService,
+    -1,
+    -1,
+    0
+  );
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    2,
+    walletService,
+    initialStateCopy.grpc.currentBlockHeight,
+    1,
+    BATCH_TX_COUNT
+  );
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    3,
+    walletService,
+    mockStakeTransactions[mockVotedTicketHash].height - 1, // last transaction's height -1
+    1,
+    BATCH_TX_COUNT
+  );
+
+  const expectedRegularTransactions = {
+    ...initialStateCopy.grpc.regularTransactions,
+    [mockRegularPendingTxHash]:
+      mockNormalizedRegularTransactions[mockRegularPendingTxHash]
+  };
+  // stakeTransactions and getStakeTxsAux shuld not changed
+  expect(
+    isEqual(
+      store.getState().grpc.stakeTransactions,
+      initialStateCopy.grpc.stakeTransactions
+    )
+  ).toBeTruthy();
+  expect(
+    isEqual(
+      store.getState().grpc.getStakeTxsAux,
+      initialStateCopy.grpc.getStakeTxsAux
+    )
+  ).toBeTruthy();
+  expect(
+    isEqual(
+      store.getState().grpc.regularTransactions,
+      expectedRegularTransactions
+    )
+  ).toBeTruthy();
+
+  expect(
+    isEqual(store.getState().grpc.getRegularTxsAux, {
+      noMoreTransactions: true,
+      lastTransaction: mockNormalizedStakeTransactions[mockVotedTicketHash]
+    })
+  ).toBeTruthy();
+});
+
+test("test getTransactions (fetching regular txs, listing asc)", async () => {
+  const initialStateCopy = getInitialStateForGetTransactions("asc");
+  const store = createStore(initialStateCopy);
+
+  let callCount = 0;
+  const mockGetTransactions = (wallet.getTransactions = jest.fn(() => {
+    const res = {
+      unmined: cloneDeep(mockUnminedTransactions[callCount]),
+      mined: cloneDeep(mockMinedTransactions[callCount])
+    };
+    callCount += 1;
+    return res;
+  }));
+
+  await store.dispatch(transactionActions.getTransactions());
+
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    1,
+    walletService,
+    -1,
+    -1,
+    0
+  );
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    2,
+    walletService,
+    1,
+    initialStateCopy.grpc.currentBlockHeight,
+    BATCH_TX_COUNT
+  );
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    3,
+    walletService,
+    mockStakeTransactions[mockVotedTicketHash].height + 1, // last transaction's height + 1
+    initialStateCopy.grpc.currentBlockHeight,
+    BATCH_TX_COUNT
+  );
+
+  const expectedRegularTransactions = {
+    ...initialStateCopy.grpc.regularTransactions,
+    [mockRegularPendingTxHash]:
+      mockNormalizedRegularTransactions[mockRegularPendingTxHash]
+  };
+  // stakeTransactions and getStakeTxsAux shuld not changed
+  expect(
+    isEqual(
+      store.getState().grpc.stakeTransactions,
+      initialStateCopy.grpc.stakeTransactions
+    )
+  ).toBeTruthy();
+  expect(
+    isEqual(
+      store.getState().grpc.getStakeTxsAux,
+      initialStateCopy.grpc.getStakeTxsAux
+    )
+  ).toBeTruthy();
+  expect(
+    isEqual(
+      store.getState().grpc.regularTransactions,
+      expectedRegularTransactions
+    )
+  ).toBeTruthy();
+
+  expect(
+    isEqual(store.getState().grpc.getRegularTxsAux, {
+      noMoreTransactions: true,
+      lastTransaction: mockNormalizedStakeTransactions[mockVotedTicketHash]
+    })
+  ).toBeTruthy();
+});
+
+test("test getTransactions (fetching stake txs)", async () => {
+  const initialStateCopy = getInitialStateForGetTransactions();
+  const store = createStore(initialStateCopy);
+
+  let callCount = 0;
+  const mockGetTransactions = (wallet.getTransactions = jest.fn(() => {
+    const res = {
+      unmined: cloneDeep(mockUnminedTransactions[callCount]),
+      mined: cloneDeep(mockMinedTransactions[callCount])
+    };
+    callCount += 1;
+    return res;
+  }));
+
+  await store.dispatch(transactionActions.getTransactions(true));
+
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    1,
+    walletService,
+    -1,
+    -1,
+    0
+  );
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    2,
+    walletService,
+    initialStateCopy.grpc.currentBlockHeight,
+    1,
+    BATCH_TX_COUNT
+  );
+  expect(mockGetTransactions).toHaveBeenNthCalledWith(
+    3,
+    walletService,
+    mockStakeTransactions[mockVotedTicketHash].height - 1, // last transaction's height -1
+    1,
+    BATCH_TX_COUNT
+  );
+
+  const expectedStakeTransactions = {
+    ...initialStateCopy.grpc.stakeTransactions,
+    [mockUnminedTicketHash]:
+      mockNormalizedStakeTransactions[mockUnminedTicketHash],
+    [mockVoteTx]: mockNormalizedStakeTransactions[mockVoteTx],
+    [mockVotedTicketHash]: mockNormalizedStakeTransactions[mockVotedTicketHash]
+  };
+
+  // regularTransactions and getRegularTxsAux shuld not changed
+  expect(
+    isEqual(
+      store.getState().grpc.regularTransactions,
+      initialStateCopy.grpc.regularTransactions
+    )
+  ).toBeTruthy();
+  expect(
+    isEqual(
+      store.getState().grpc.getRegularTxsAux,
+      initialStateCopy.grpc.getRegularTxsAux
+    )
+  ).toBeTruthy();
+  expect(
+    isEqual(store.getState().grpc.stakeTransactions, expectedStakeTransactions)
+  ).toBeTruthy();
+
+  expect(
+    isEqual(store.getState().grpc.getStakeTxsAux, {
+      noMoreTransactions: true,
+      lastTransaction: mockNormalizedStakeTransactions[mockVotedTicketHash]
+    })
+  ).toBeTruthy();
+});
+
+const getInitialStateForNewTransactionsReceived = () => {
+  const initialStateCopy = cloneDeep(initialState);
+  initialStateCopy.grpc.unminedTransactions = [];
+  initialStateCopy.grpc.regularTransactions = {
+    [mockRegularReceivedTxHash]: cloneDeep(
+      mockNormalizedRegularTransactions[mockRegularReceivedTxHash]
+    )
+  };
+  initialStateCopy.grpc.stakeTransactions = {
+    [mockMissedTicketHash]: cloneDeep(
+      mockNormalizedStakeTransactions[mockMissedTicketHash]
+    )
+  };
+  initialStateCopy.grpc.recentRegularTransactions = [
+    cloneDeep(mockNormalizedRegularTransactions[mockRegularSelfTxHash])
+  ];
+  initialStateCopy.grpc.recentStakeTransactions = [];
+
+  return initialStateCopy;
+};
+
+test("test newTransactionsReceived (received empty lists)", async () => {
+  const initialStateCopy = getInitialStateForNewTransactionsReceived();
+  const store = createStore(initialStateCopy);
+
+  await store.dispatch(transactionActions.newTransactionsReceived([], []));
+
+  expect(mockGetVSPTicketsByFeeStatus).not.toHaveBeenCalled();
+  expect(mockGetBalanceUpdateAttempt).not.toHaveBeenCalled();
+  expect(mockGetStakeInfoAttempt).not.toHaveBeenCalled();
+  expect(mockCheckUnmixedAccountBalance).not.toHaveBeenCalled();
+  expect(mockGetMixerAcctsSpendableBalances).not.toHaveBeenCalled();
+
+  // console.log(store.getState().grpc);
+
+  expect(
+    isEqual(store.getState().grpc.regularTransactions, {
+      [mockRegularReceivedTxHash]:
+        mockNormalizedRegularTransactions[mockRegularReceivedTxHash]
+    })
+  ).toBeTruthy();
+  expect(
+    isEqual(store.getState().grpc.stakeTransactions, {
+      [mockMissedTicketHash]:
+        mockNormalizedStakeTransactions[mockMissedTicketHash]
+    })
+  ).toBeTruthy();
+
+  expect(
+    isEqual(store.getState().grpc.recentRegularTransactions, [
+      mockNormalizedRegularTransactions[mockRegularSelfTxHash]
+    ])
+  ).toBeTruthy();
+  expect(
+    isEqual(store.getState().grpc.recentStakeTransactions, [])
+  ).toBeTruthy();
+  expect(isEqual(store.getState().grpc.unminedTransactions, [])).toBeTruthy();
+});
+
+test("test newTransactionsReceived", async () => {
+  const initialStateCopy = getInitialStateForNewTransactionsReceived();
+  const store = createStore(initialStateCopy);
+
+  const newlyUnminedTransactions = [
+    cloneDeep(mockRegularTransactions[mockRegularPendingTxHash]),
+    cloneDeep(mockStakeTransactions[mockUnminedTicketHash])
+  ];
+  const newlyMinedTransactions = [
+    cloneDeep(mockStakeTransactions[mockVoteTx]),
+    cloneDeep(mockRegularTransactions[mockRegularMixedTxHash]),
+    cloneDeep(mockStakeTransactions[mockVotedTicketHash])
+  ];
+
+  await store.dispatch(
+    transactionActions.newTransactionsReceived(
+      newlyMinedTransactions,
+      newlyUnminedTransactions
+    )
+  );
+
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    1,
+    walletService,
+    VSP_FEE_PROCESS_ERRORED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    2,
+    walletService,
+    VSP_FEE_PROCESS_STARTED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    3,
+    walletService,
+    VSP_FEE_PROCESS_PAID
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    4,
+    walletService,
+    VSP_FEE_PROCESS_CONFIRMED
+  );
+  expect(mockGetBalanceUpdateAttempt).toHaveBeenCalledWith(0, 0);
+  expect(mockGetStakeInfoAttempt).toHaveBeenCalled();
+  expect(mockCheckUnmixedAccountBalance).toHaveBeenCalledWith(
+    testChangeAccountId
+  );
+  expect(mockGetMixerAcctsSpendableBalances).toHaveBeenCalled();
+
+  expect(
+    isEqual(store.getState().grpc.regularTransactions, {
+      [mockRegularPendingTxHash]:
+        mockNormalizedRegularTransactions[mockRegularPendingTxHash],
+      [mockRegularMixedTxHash]:
+        mockNormalizedRegularTransactions[mockRegularMixedTxHash],
+      [mockRegularReceivedTxHash]:
+        mockNormalizedRegularTransactions[mockRegularReceivedTxHash]
+    })
+  ).toBeTruthy();
+  expect(
+    isEqual(store.getState().grpc.stakeTransactions, {
+      [mockUnminedTicketHash]: {
+        ...mockNormalizedStakeTransactions[mockUnminedTicketHash],
+        feeStatus: VSP_FEE_PROCESS_STARTED.toString()
+      },
+      [mockVoteTx]: mockNormalizedStakeTransactions[mockVoteTx],
+      [mockVotedTicketHash]: {
+        ...mockNormalizedStakeTransactions[mockVotedTicketHash],
+        feeStatus: VSP_FEE_PROCESS_ERRORED
+      },
+      [mockMissedTicketHash]: {
+        ...mockNormalizedStakeTransactions[mockMissedTicketHash],
+        feeStatus: VSP_FEE_PROCESS_PAID
+      }
+    })
+  ).toBeTruthy();
+
+  expect(
+    isEqual(store.getState().grpc.recentRegularTransactions, [
+      mockNormalizedRegularTransactions[mockRegularPendingTxHash],
+      mockNormalizedRegularTransactions[mockRegularMixedTxHash],
+      mockNormalizedRegularTransactions[mockRegularSelfTxHash]
+    ])
+  ).toBeTruthy();
+
+  expect(
+    isEqual(store.getState().grpc.recentStakeTransactions, [
+      {
+        ...mockNormalizedStakeTransactions[mockUnminedTicketHash],
+        feeStatus: VSP_FEE_PROCESS_STARTED.toString()
+      },
+      mockNormalizedStakeTransactions[mockVoteTx],
+      {
+        ...mockNormalizedStakeTransactions[mockVotedTicketHash],
+        feeStatus: VSP_FEE_PROCESS_ERRORED
+      }
+    ])
+  ).toBeTruthy();
+
+  expect(
+    isEqual(store.getState().grpc.unminedTransactions, [
+      mockNormalizedRegularTransactions[mockRegularPendingTxHash],
+      {
+        ...mockNormalizedStakeTransactions[mockUnminedTicketHash],
+        feeStatus: VSP_FEE_PROCESS_STARTED.toString()
+      }
+    ])
+  ).toBeTruthy();
 });

--- a/test/unit/components/views/SettingsPage/SettingsPage.spec.js
+++ b/test/unit/components/views/SettingsPage/SettingsPage.spec.js
@@ -22,7 +22,7 @@ import {
 import { en as enLocale } from "i18n/locales";
 import * as vspa from "actions/VSPActions";
 import { DCR, ATOMS } from "constants";
-import { mockStakeTransactions } from "../TransactionPage/mocks";
+import { mockNormalizedStakeTransactions } from "../TransactionPage/mocks.js";
 
 const ENABLED = "Enabled";
 const DISABLED = "Disabled";
@@ -217,12 +217,12 @@ const testCloseWalletButtonUnpaidTicketFee = async (
   status,
   expectDefaultModal = false
 ) => {
-  selectors.stakeTransactions = jest.fn(() => mockStakeTransactions);
+  selectors.stakeTransactions = jest.fn(() => mockNormalizedStakeTransactions);
   selectors.getVSPTicketsHashes = jest.fn(() => {
     return {
       [VSP_FEE_PROCESS_ERRORED]: [
-        Object.keys(mockStakeTransactions).find(
-          (hash) => mockStakeTransactions[hash].status === status
+        Object.keys(mockNormalizedStakeTransactions).find(
+          (hash) => mockNormalizedStakeTransactions[hash].status === status
         )
       ]
     };

--- a/test/unit/components/views/TicketsPage/MyVSPTickets/MyVSPTicketsTab.spec.js
+++ b/test/unit/components/views/TicketsPage/MyVSPTickets/MyVSPTicketsTab.spec.js
@@ -43,6 +43,7 @@ const initialState = {
       vspFeeStatus: null
     },
     stakeTransactions: {},
+    recentStakeTransactions: [],
     getStakeTxsAux: {
       noMoreTransactions: false
     }

--- a/test/unit/components/views/TransactionPage/TransactionPage.spec.js
+++ b/test/unit/components/views/TransactionPage/TransactionPage.spec.js
@@ -130,8 +130,9 @@ const getPending = () => screen.getByText("Pending");
 const getUnconfirmed = () => screen.getByText("Unconfirmed");
 const queryUnconfirmed = () => screen.queryByText("Unconfirmed");
 const queryPending = () => screen.queryByText("Pending");
-const getToAddressText = () =>
-  screen.getByText("To address:").parentElement.textContent;
+const getToAddressText = (isMulti) =>
+  screen.getByText(isMulti ? "To addresses:" : "To address:").parentElement
+    .textContent;
 const getTransactionFeeText = () =>
   screen.getByText("Transaction fee:").parentElement.textContent;
 const getWalletInputsText = () =>
@@ -173,8 +174,8 @@ test("regular sent pending tx from default account to an external address", asyn
   expect(getSentFromText()).toMatch("Sent FromdefaultUnconfirmed");
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(getPending()).toBeInTheDocument();
-  expect(getToAddressText()).toMatch(
-    "To address: TsacvMFSMWcmxT7dj5UHqgrxB3PP6uwnEtY  TsZJt5A55AcCMp8iBu1rkNCxqJ3Bf1MC8Zk"
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TsacvMFSMWcmxT7dj5UHqgrxB3PP6uwnEtY  TsZJt5A55AcCMp8iBu1rkNCxqJ3Bf1MC8Zk"
   );
   expect(getTransactionFeeText()).toMatch("Transaction fee:0.0000253 DCR");
 
@@ -191,7 +192,7 @@ test("regular sent pending tx from default account to an external address", asyn
   expect(getWalletOutputs()).toMatch("Wallet Outputschange9.9385181 DCR");
   // don't have any non wallet input
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs TsZJt5A55AcCMp8iBu1rkNCxqJ3Bf1MC8Zk 8.00000 DCR"
+    "Non Wallet OutputsTsZJt5A55AcCMp8iBu1rkNCxqJ3Bf1MC8ZkTsZJt5A55...3Bf1MC8Zk8.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
@@ -225,8 +226,8 @@ test("regular received mined tx to the default account", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryPending()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed5,269 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TsVzSRzExt1NRzGwTqu8qyY12t8NH8yiGzV  TsbvHMveM1bTK35aP5Dd2tmFppipvw2faWA"
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TsVzSRzExt1NRzGwTqu8qyY12t8NH8yiGzV  TsbvHMveM1bTK35aP5Dd2tmFppipvw2faWA"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -235,12 +236,12 @@ test("regular received mined tx to the default account", async () => {
   // don't have any wallet input
   expect(getWalletInputsText()).toMatch("Wallet Inputs");
   expect(getNonWalletInputsText()).toMatch(
-    "Non Wallet Inputs 3e68d75f9c2dbdcc3dd3e68fca736835e8d802a732938e17c3dad6b58faa28bf:1 3.00000 DCR aed4058ec3b9849d58b032768b6bd78ffe635b35fe230d7022b6ee7af7f319db:0 1.20000 DCR 19d0afa8310eed1f3112e028c7bed798b7f1b9aff41f1e8eb76d37a86439f96b:1 1.00000 DCR 14b5c15ec10861110b6a45eeb5d392b11b41e389c557ef32568b4718c0152778:0 388.51673938 DCR"
+    "Non Wallet Inputs3e68d75f9c2dbdcc3dd3e68fca736835e8d802a732938e17c3dad6b58faa28bf:13e68d75f9...faa28bf:13.00000 DCRaed4058ec3b9849d58b032768b6bd78ffe635b35fe230d7022b6ee7af7f319db:0aed4058ec...7f319db:01.20000 DCR19d0afa8310eed1f3112e028c7bed798b7f1b9aff41f1e8eb76d37a86439f96b:119d0afa83...439f96b:11.00000 DCR14b5c15ec10861110b6a45eeb5d392b11b41e389c557ef32568b4718c0152778:014b5c15ec...0152778:0388.51673938 DCR"
   );
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 100.00000 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputsdefault100.00000 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs TsbvHMveM1bTK35aP5Dd2tmFppipvw2faWA 293.71666428 DCR"
+    "Non Wallet OutputsTsbvHMveM1bTK35aP5Dd2tmFppipvw2faWATsbvHMveM...ipvw2faWA293.71666428 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
@@ -274,8 +275,8 @@ test("regular self transfer tx to unmixed account", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryPending()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed4 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TsSBV4qZpZHS6QGVi6Zkp8kxBMS8EEF1bCh  TsgdFQemirW9EcAuz94SUCTePPaj5TDEcf8"
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TsSBV4qZpZHS6QGVi6Zkp8kxBMS8EEF1bCh  TsgdFQemirW9EcAuz94SUCTePPaj5TDEcf8"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -286,7 +287,7 @@ test("regular self transfer tx to unmixed account", async () => {
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
   expect(getWalletOutputs()).toMatch(
-    "Wallet Outputs account-4 50.00000 DCR default 13.62441426 DCR"
+    "Wallet Outputsaccount-450.00000 DCRdefault13.62441426 DCR"
   );
   // don't have any non wallet input
   expect(getNonWalletOutputs()).toMatch("Non Wallet Outputs");
@@ -322,8 +323,8 @@ test("self coins from unmixed to mixed account", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryPending()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed11 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TshTsuJmLsbpFCPgFYkeR4nmbRqiAAjGvAR  TsUNW19FJpNjkGrsi1tusvkHYNoZVbvzLTY  TsfhYupZxcqyHMLmJDUZ9qLJxbD6VQkpriC  TsXPm8qFAc1niDd654jaJnRsSSWjBTKGmP5  TsjBaeiu9ZZC2aZ5d4wHRH9H8KeG4szwkEs  TsjwBN1UELsLfV6BZynGfH21qhyBb5PtFaw  TsoPFWy8h8DFKiXXqYxWUaS9uguazs1bzva  TsVV7XBX2B8hj8c76FzWByoZ622DTiQxXUm  TsoQB5qSKdNXJEwr2X5YbUJnBhHaPYv2pA3"
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TshTsuJmLsbpFCPgFYkeR4nmbRqiAAjGvAR  TsUNW19FJpNjkGrsi1tusvkHYNoZVbvzLTY  TsfhYupZxcqyHMLmJDUZ9qLJxbD6VQkpriC  TsXPm8qFAc1niDd654jaJnRsSSWjBTKGmP5  TsjBaeiu9ZZC2aZ5d4wHRH9H8KeG4szwkEs  TsjwBN1UELsLfV6BZynGfH21qhyBb5PtFaw  TsoPFWy8h8DFKiXXqYxWUaS9uguazs1bzva  TsVV7XBX2B8hj8c76FzWByoZ622DTiQxXUm  TsoQB5qSKdNXJEwr2X5YbUJnBhHaPYv2pA3"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -331,14 +332,14 @@ test("self coins from unmixed to mixed account", async () => {
 
   expect(getWalletInputsText()).toMatch("Wallet Inputsaccount-450.00000 DCR");
   expect(getNonWalletInputsText()).toMatch(
-    "Non Wallet Inputs 1fb0d31823836168b59ea0d52d301905aa8c64c694b528e22e901d5b3cac7377:6 14.04694804 DCR 1fb0d31823836168b59ea0d52d301905aa8c64c694b528e22e901d5b3cac7377:13 16.50200823 DCR"
+    "Non Wallet Inputs1fb0d31823836168b59ea0d52d301905aa8c64c694b528e22e901d5b3cac7377:61fb0d3182...cac7377:614.04694804 DCR1fb0d31823836168b59ea0d52d301905aa8c64c694b528e22e901d5b3cac7377:131fb0d3182...ac7377:1316.50200823 DCR"
   );
 
   expect(getWalletOutputs()).toMatch(
     "Wallet Outputschange7.05029094 DCRchange10.73741824 DCRchange10.73741824 DCRchange10.73741824 DCRchange10.73741824 DCR"
   );
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs TsjwBN1UELsLfV6BZynGfH21qhyBb5PtFaw 5.76456469 DCR TsoPFWy8h8DFKiXXqYxWUaS9uguazs1bzva 10.73741824 DCR TsVV7XBX2B8hj8c76FzWByoZ622DTiQxXUm 3.3095045 DCR TsoQB5qSKdNXJEwr2X5YbUJnBhHaPYv2pA3 10.73741824 DCR"
+    "Non Wallet OutputsTsjwBN1UELsLfV6BZynGfH21qhyBb5PtFawTsjwBN1UE...yBb5PtFaw5.76456469 DCRTsoPFWy8h8DFKiXXqYxWUaS9uguazs1bzvaTsoPFWy8h...uazs1bzva10.73741824 DCRTsVV7XBX2B8hj8c76FzWByoZ622DTiQxXUmTsVV7XBX2...2DTiQxXUm3.3095045 DCRTsoQB5qSKdNXJEwr2X5YbUJnBhHaPYv2pA3TsoQB5qSK...HaPYv2pA310.73741824 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
@@ -388,6 +389,9 @@ test("voted ticket", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed4,572 confirmations");
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU  TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 "
+  );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
   expect(queryRebroadcastTransaction()).not.toBeInTheDocument();
@@ -397,9 +401,9 @@ test("voted ticket", async () => {
   );
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 122.71678363 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputsdefault122.71678363 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n 0.00000 DCR TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 0.00000 DCR"
+    "Non Wallet OutputsTsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4nTsYefqPSd...hUUhMfa4n0.00000 DCRTsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2TsR28UZRp...hrNVvbYq20.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
@@ -460,14 +464,12 @@ test("vote tx", async () => {
 
   expect(getWalletInputsText()).toMatch("Wallet Inputsdefault67.85796485 DCR");
   expect(getNonWalletInputsText()).toMatch(
-    "Non Wallet Inputs 0000000000000000000000000000000000000000000000000000000000000000:4294967295 0.04323486 DCR"
+    "Non Wallet InputsStakebase0.04323486 DCR"
   );
 
-  expect(getWalletOutputs()).toMatch(
-    "Wallet Outputs account-15 67.90119971 DCR"
-  );
+  expect(getWalletOutputs()).toMatch("Wallet Outputsaccount-1567.90119971 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs [script] - OP_RETURN OP_DATA_36 e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e00 0.00000 DCR [script] - OP_RETURN OP_DATA_6 01000a000000 0.00000 DCR"
+    "Non Wallet Outputs[script] - OP_RETURN OP_DATA_36 e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e00[script] ...0803b0e000.00000 DCR[script] - OP_RETURN OP_DATA_6 01000a000000[script] ...00a0000000.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
@@ -563,8 +565,8 @@ test("missed ticket", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed372,256 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs  TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 "
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs  TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 "
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -576,9 +578,9 @@ test("missed ticket", async () => {
   // don't have non wallet input
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs imported 95.25589786 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputsimported95.25589786 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp 0.00000 DCR TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 0.00000 DCR"
+    "Non Wallet OutputsTsZRAVD9t8shxck66daNEhaWrWCsYV9e2QpTsZRAVD9t...CsYV9e2Qp0.00000 DCRTsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2TsR28UZRp...hrNVvbYq20.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
@@ -637,7 +639,7 @@ test("revocation", async () => {
   // don't have non wallet input
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 64.75413336 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputsdefault64.75413336 DCR");
   // don't have non wallet output
   expect(getNonWalletOutputs()).toMatch("Non Wallet Outputs");
 
@@ -696,7 +698,7 @@ test("revocation", async () => {
   // don't have non wallet input
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 64.75413336 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputsdefault64.75413336 DCR");
   // don't have non wallet output
   expect(getNonWalletOutputs()).toMatch("Non Wallet Outputs");
 
@@ -744,8 +746,8 @@ test("revoked ticket", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed109,009 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ  Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ  Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -755,7 +757,7 @@ test("revoked ticket", async () => {
   // don't have non wallet input
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 86.00218109 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputsdefault86.00218109 DCR");
   // don't have non wallet output
   expect(getNonWalletOutputs()).toMatch("Non Wallet Outputs");
 
@@ -802,8 +804,8 @@ test("immature ticket", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed1 confirmation");
-  expect(getToAddressText()).toMatch(
-    "To address: TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK  TsTP4a61273kCXL9ZDgRKZsPrV6Emh3nxB7  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK  TsTP4a61273kCXL9ZDgRKZsPrV6Emh3nxB7  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -813,9 +815,9 @@ test("immature ticket", async () => {
   // don't have non wallet input
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 67.85796485 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputsdefault67.85796485 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs TsTP4a61273kCXL9ZDgRKZsPrV6Emh3nxB7 0.00000 DCR TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 0.00000 DCR"
+    "Non Wallet OutputsTsTP4a61273kCXL9ZDgRKZsPrV6Emh3nxB7TsTP4a612...6Emh3nxB70.00000 DCRTsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2TsR28UZRp...hrNVvbYq20.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
@@ -862,8 +864,8 @@ test("live ticket", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed451 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4  TsRBbeBi7cpeoKsMEtzDDi2isLT6ETX8o2p  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4  TsRBbeBi7cpeoKsMEtzDDi2isLT6ETX8o2p  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -873,9 +875,9 @@ test("live ticket", async () => {
   // don't have non wallet input
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 67.85796485 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputsdefault67.85796485 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs TsRBbeBi7cpeoKsMEtzDDi2isLT6ETX8o2p 0.00000 DCR TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 0.00000 DCR"
+    "Non Wallet OutputsTsRBbeBi7cpeoKsMEtzDDi2isLT6ETX8o2pTsRBbeBi7...T6ETX8o2p0.00000 DCRTsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2TsR28UZRp...hrNVvbYq20.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
@@ -941,8 +943,8 @@ test("unmined ticket", async () => {
   expect(getTicketCostText()).toMatch("Ticket Cost0.20000 DCR");
 
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
-  expect(getToAddressText()).toMatch(
-    "To address: TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg  TseGZ7HkiWybyH6LnKdokifkFCn4cJYddm4  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 "
+  expect(getToAddressText(true)).toMatch(
+    "To addresses: TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg  TseGZ7HkiWybyH6LnKdokifkFCn4cJYddm4  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 "
   );
 
   user.click(getAbandonTransactionButton());
@@ -955,9 +957,9 @@ test("unmined ticket", async () => {
   // don't have non wallet input
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 0.20000 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputsdefault0.20000 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs TseGZ7HkiWybyH6LnKdokifkFCn4cJYddm4 0.00000 DCR TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 0.00000 DCR"
+    "Non Wallet OutputsTseGZ7HkiWybyH6LnKdokifkFCn4cJYddm4TseGZ7Hki...n4cJYddm40.00000 DCRTsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2TsR28UZRp...hrNVvbYq20.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
@@ -1026,7 +1028,8 @@ test("show not yet fetched regular tx", async () => {
 });
 
 test("show not yet fetched stake tx", async () => {
-  mockTxHash = "not-yet-fetched-tx-hash";
+  mockTxHash =
+    "05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07";
 
   const mockGetTransactionsResponse = {
     type: transactionActions.GETTRANSACTIONS_COMPLETE,
@@ -1040,12 +1043,8 @@ test("show not yet fetched stake tx", async () => {
   let counter = 0;
   transactionActions.getTransactions = jest.fn(() => (dispatch) => {
     if (counter++ > 3) {
-      mockGetTransactionsResponse.stakeTransactions[mockTxHash] = {
-        ...mockNormalizedStakeTransactions[
-          "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60"
-        ],
-        txHash: mockTxHash
-      };
+      mockGetTransactionsResponse.stakeTransactions[mockTxHash] =
+        mockNormalizedStakeTransactions[mockTxHash];
     }
     return dispatch(mockGetTransactionsResponse);
   });

--- a/test/unit/components/views/TransactionPage/TransactionPage.spec.js
+++ b/test/unit/components/views/TransactionPage/TransactionPage.spec.js
@@ -530,7 +530,7 @@ test("vote tx (votes don't align with what the wallet currently has set)", async
 
 test("missed ticket", async () => {
   mockTxHash =
-    "d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc";
+    "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774";
   const rawTx = mockNormalizedStakeTransactions[mockTxHash].rawTx;
   const mockStakeTransactionMap = {};
   mockStakeTransactionMap[mockTxHash] =
@@ -558,29 +558,31 @@ test("missed ticket", async () => {
 
   expect(getHeaderTitleIconClassName()).toMatch("missed");
   expect(getTitleText()).toMatch("Missed");
-  expect(getTicketCostText()).toMatch("Ticket Cost85.93625324 DCR");
+  expect(getTicketCostText()).toMatch("Ticket Cost95.25589786 DCR");
 
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
-  expect(getConfirmedText()).toMatch("Confirmed16,098 confirmations");
+  expect(getConfirmedText()).toMatch("Confirmed372,256 confirmations");
   expect(getToAddressText()).toMatch(
-    "To address: Tsc5FSv5cAm4sPNzogkq9qYwdx2Gj4XnEoC  TsUpkwUgWxgCumeS9xwHhVbMXcHGBeGfCLG  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+    "To address: TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs  TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 "
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
   expect(queryRebroadcastTransaction()).not.toBeInTheDocument();
 
-  expect(getWalletInputsText()).toMatch("Wallet Inputsdefault85.93628304 DCR");
+  expect(getWalletInputsText()).toMatch(
+    "Wallet Inputsaccount-695.25592746 DCR"
+  );
   // don't have non wallet input
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 85.93625324 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputs imported 95.25589786 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs TsUpkwUgWxgCumeS9xwHhVbMXcHGBeGfCLG 0.00000 DCR TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 0.00000 DCR"
+    "Non Wallet Outputs TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp 0.00000 DCR TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 0.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();
-  expect(getHeightText()).toMatch("Height914582");
+  expect(getHeightText()).toMatch("Height558424");
   expect(getVSPHostText()).toMatch("VSP host:mockVspHost-missed");
 
   user.click(screen.getByText("Back"));
@@ -913,7 +915,7 @@ test("live ticket", async () => {
 
 test("unmined ticket", async () => {
   mockTxHash =
-    "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60";
+    "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f";
   const rawTx = mockNormalizedStakeTransactions[mockTxHash].rawTx;
   const mockStakeTransactionMap = {};
   mockStakeTransactionMap[mockTxHash] =
@@ -936,11 +938,11 @@ test("unmined ticket", async () => {
   expect(getTitleText()).toMatch("Unmined");
   expect(getPending()).toBeInTheDocument();
   expect(getUnconfirmed()).toBeInTheDocument();
-  expect(getTicketCostText()).toMatch("Ticket Cost67.85796485 DCR");
+  expect(getTicketCostText()).toMatch("Ticket Cost0.20000 DCR");
 
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(getToAddressText()).toMatch(
-    "To address: TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7  Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+    "To address: TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg  TseGZ7HkiWybyH6LnKdokifkFCn4cJYddm4  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 "
   );
 
   user.click(getAbandonTransactionButton());
@@ -949,15 +951,13 @@ test("unmined ticket", async () => {
   user.click(getRebroadcastTransaction());
   expect(mockPublishUnminedTransactionsAttempt).toHaveBeenCalled();
 
-  expect(getWalletInputsText()).toMatch(
-    "Wallet Inputsaccount-1567.85799465 DCR"
-  );
+  expect(getWalletInputsText()).toMatch("Wallet Inputsdefault0.2000298 DCR");
   // don't have non wallet input
   expect(getNonWalletInputsText()).toMatch("Non Wallet Inputs");
 
-  expect(getWalletOutputs()).toMatch("Wallet Outputs default 67.85796485 DCR");
+  expect(getWalletOutputs()).toMatch("Wallet Outputs default 0.20000 DCR");
   expect(getNonWalletOutputs()).toMatch(
-    "Non Wallet Outputs Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr 0.00000 DCR TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 0.00000 DCR"
+    "Non Wallet Outputs TseGZ7HkiWybyH6LnKdokifkFCn4cJYddm4 0.00000 DCR TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2 0.00000 DCR"
   );
 
   expect(screen.getByText(rawTx)).toBeInTheDocument();

--- a/test/unit/components/views/TransactionPage/mocks.js
+++ b/test/unit/components/views/TransactionPage/mocks.js
@@ -1,4 +1,4 @@
-const toByteArray = (hex) => {
+export const toByteArray = (hex) => {
   if (!hex || !hex.length) {
     return hex;
   }
@@ -996,7 +996,7 @@ export const mockNormalizedStakeTransactionList = [
       timestamp: 1654202680,
       height: 930685,
       blockHash:
-        "0000000bc17d35756d4383c27e91d83bcb5be0f8bf9943675cba87e8223eeb21",
+        "33383134633937643639643532326435356266653332313833656532306461623735353063653531613232343863333330326538383237313030303030303030",
       hash: "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
       txHash:
         "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
@@ -1029,8 +1029,6 @@ export const mockNormalizedStakeTransactionList = [
       rawTx:
         "010000000154a9b3b3e7a51658a2dcadb7e6cc440acda169c47e785ba6225cab34be43dce50000000000ffffffff03850977940100000000001aba76a91461feb0d2415519047b612320e087729149edb6b388ac00000000000000000000206a1e99bf7a5e99c8c00e09ecef371eabd7865bcf5e112915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6a473044022020cfc5e2bb47ddcd39fdc1a7e82e90a8fb0c2fc01db79c683296b15afb29780c0220216ee46d39c358a18395a035b9cc0af1a0a753eed82deef8694b516b77ee0bdd0121025d5aeb18e8bb8ae1485aed5e2816990ff8b0eee40bb9ab046d738cd6e18b4edd",
       isMix: false,
-      transaction:
-        "dd4e8be1d68c736d04abb90be4eeb0f80f9916285eed5a48e18abbe818eb5a5d022101dd0bee776b514b69f8ee2dd8ee53a7a0f10accb935a09583a158c3396de46e2120020c7829fb5ab19632689cb71dc02f0cfba8902ee8a7c1fd39cddd47bbe2c5cf2020024430476affffffff000000000000000194771529010000000000000000ac88000000000000000000000000000000000000000014a976bd1a000000000000000000004e000000000194771529115ecf5b86d7ab1e37efec090ec0c8995e7abf991e6a2000000000000000000000ac88b3b6ed49917287e02023617b04195541d2b0fe6114a976ba1a0000000000019477098503ffffffff0000000000e5dc43be34ab5c22a65b787ec469a1cd0a44cce6b7addca25816a5e7b3b3a9540100000001",
       vspHost: "mockVspHost",
       txUrl:
         "https://testnet.decred.org/tx/65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60"
@@ -1041,7 +1039,8 @@ export const mockNormalizedStakeTransactionList = [
       blockHash:
         "0000000bc17d35756d4383c27e91d83bcb5be0f8bf9943675cba87e8223eeb21",
       index: 0,
-      hash: "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
+      hash:
+        "1472512351262304275125239808423343934577220111166192222712233111195632030000",
       txHash:
         "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
       txType: "vote",
@@ -1190,9 +1189,9 @@ export const mockNormalizedStakeTransactionList = [
         "0100000001b50f2e03314661b566e3f0f246623c4419d8ec605da401f407a5f67cf148ce920000000000ffffffff039bf372db0200000000001aba76a9145ca8dbd9f8f80baf7605fcf09744410099a12f9b88ac00000000000000000000206a1e53b208495f9fabdfa80b4be10c4d0e488b33f2993fff72db02000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac0000000000000000013fff72db0200000000000000ffffffff6b483045022100d8f4e49c56f3249947a759d7ba766b671579399e758feaa12bc525c822c020f602200266d21d887165183479cf3d06a01470ceadc53b73527f6863ae76bf22a11ea001210355d8fdf5cdec7a8848e6d653d6c379908c256d4b54b7be637ab5018d56d19149",
       isMix: false,
       vspHost: "mockVspHost-votedticket",
+      feeStatus: 1,
       txUrl:
-        "https://testnet.decred.org/tx/6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
-      feeStatus: 1
+        "https://testnet.decred.org/tx/6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57"
     },
     spenderTx: {
       timestamp: 1652874655,
@@ -1282,92 +1281,142 @@ export const mockNormalizedStakeTransactionList = [
     credits: [
       {
         index: 0,
-        account: 0,
-        internal: true,
-        amount: 8593625324,
-        address: "Tsc5FSv5cAm4sPNzogkq9qYwdx2Gj4XnEoC",
-        outputScript: "unapFHlAc365vEeYpW/aMvo2gidAIAgViKw="
+        account: 2147483647,
+        internal: false,
+        amount: 9525589786,
+        address: "TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs",
+        outputScript: "uqkUNP+z1D9bQODb6UJuU4ZfydVT0QOH"
       }
     ],
-    debits: [{ index: 0, previousAccount: 0, previousAmount: 8593628304 }],
-    txHash: "d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc",
+    debits: [
+      {
+        index: 0,
+        previousAccount: 6,
+        previousAmount: 9525592746
+      }
+    ],
+    txHash: "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774",
     blockHash:
       "0000000bc17d35756d4383c27e91d83bcb5be0f8bf9943675cba87e8223eeb21",
-    spenderHash: null,
+    spenderHash:
+      "c44db16d004aa264c3cc8dcf90ecc08caa88964cb6e34477139651b56f46af79",
     ticketHash:
-      "d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc",
+      "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774",
     ticketTx: {
-      timestamp: 1652256415,
-      height: 914582,
+      timestamp: 1605621435,
+      height: 558424,
       blockHash:
         "0000000bc17d35756d4383c27e91d83bcb5be0f8bf9943675cba87e8223eeb21",
       index: 0,
-      hash: "d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc",
+      hash: "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774",
       txHash:
-        "d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc",
+        "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774",
       txType: "ticket",
-      debitsAmount: 8593628304,
-      creditsAmount: 8593625324,
+      debitsAmount: 9525592746,
+      creditsAmount: 9525589786,
       type: 1,
-      amount: -2980,
-      fee: 2980,
-      debitAccounts: [0],
-      creditAddresses: ["Tsc5FSv5cAm4sPNzogkq9qYwdx2Gj4XnEoC"],
+      amount: -2960,
+      fee: 2960,
+      debitAccounts: [6],
+      creditAddresses: ["TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs"],
       isStake: true,
       credits: [
         {
           index: 0,
-          account: 0,
-          internal: true,
-          amount: 8593625324,
-          address: "Tsc5FSv5cAm4sPNzogkq9qYwdx2Gj4XnEoC",
-          outputScript: "unapFHlAc365vEeYpW/aMvo2gidAIAgViKw="
+          account: 2147483647,
+          internal: false,
+          amount: 9525589786,
+          address: "TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs",
+          outputScript: "uqkUNP+z1D9bQODb6UJuU4ZfydVT0QOH"
         }
       ],
       debits: [
         {
           index: 0,
-          previousAccount: 0,
-          previousAmount: 8593628304
+          previousAccount: 6,
+          previousAmount: 9525592746
         }
       ],
       rawTx:
-        "0100000001d5c92daf04dc8a5abfa0d4dd96cc0ce98c78ffa126d299aabe340c7d4baf14360000000000ffffffff03ec5038000200000000001aba76a9147940737eb9bc4798a56fda32fa3682274020081588ac00000000000000000000206a1e29b9f346a3b78f1b4b029429aee2a484fdaaf28b905c380002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001905c38000200000095f40d00010000006b483045022100bdac06f033cd0fe652bd8d5fc21833a3b7064114c8a949c7157f58f5d2dc2e2302206b2bb830c34c75c76ca3df491245c775eeb4eb3e0b73bca6ead94ed34762e439012103033666b327ef4a26ea4f26ce53223f3cd092a063d57f711ea3ec7169cbce4ed9",
+        "0100000001781d53a4f25c754340cf9250f98039c1db2c92bcd58b1e4637c9ca534d9053c00100000000ffffffff031af7c43702000000000018baa91434ffb3d43f5b40e0dbe9426e53865fc9d553d1038700000000000000000000206a1e5c1c4094ac61fc8762be68d7b15cdb4806611cf7aa02c537020000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000006085080001aa02c5370200000057850800010000006a473044022053cad54d349690d3c22b346134ff71da1b527695c6ec1252f11c1e7c5d9da9280220606a81e7d4ea63b448945cfbf1385b85642e0221cf49ca0824e5ec8ff62a61c30121032071d0e49038bcdeee3461296d2c50950b62f08e35caafbd4f2b0d025d1a47e1",
       isMix: false,
       vspHost: "mockVspHost-missed",
       txUrl:
-        "https://testnet.decred.org/tx/d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc"
+        "https://testnet.decred.org/tx/30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774"
     },
-    spenderTx: null,
-    ticketPrice: 8593625324,
-    ticketReward: undefined,
+    spenderTx: {
+      timestamp: 1605714645,
+      height: -1,
+      blockHash: "",
+      index: -1,
+      hash: "c44db16d004aa264c3cc8dcf90ecc08caa88964cb6e34477139651b56f46af79",
+      txHash:
+        "c44db16d004aa264c3cc8dcf90ecc08caa88964cb6e34477139651b56f46af79",
+      txType: "revocation",
+      debitsAmount: 9525589786,
+      creditsAmount: 9525587586,
+      type: 3,
+      amount: -2200,
+      fee: 2200,
+      debitAccounts: [2147483647],
+      creditAddresses: ["TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 6,
+          internal: true,
+          amount: 9525587586,
+          address: "TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp",
+          outputScript: "vHapFFwcQJSsYfyHYr5o17Fc20gGYRz3iKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 2147483647,
+          previousAmount: 9525589786
+        }
+      ],
+      rawTx:
+        "01000000017457e53cda6f04dc671bf2bde52568add0bbe4fb9fc3db74b43a769d0406dd300000000001ffffffff0182eec4370200000000001abc76a9145c1c4094ac61fc8762be68d7b15cdb4806611cf788ac0000000000000000011af7c437020000005885080005000000904730440220163ae79bc0713243f5e627aeafb680fbc2126b153188b4921d954056efc3fa61022040c5ecfdaa83175cef7faf99460b765779c4bcf09cc6e72782d491664bb66dbb01475121038add32307530f18099a9208f32fc04502b40073ea6a6cfebbbd79988270a612e2103f2a96dbe354081542af9571c43662b883d9ae02416cd5080137c0556c7a0976d52ae",
+      isMix: false
+    },
+    ticketPrice: 9525589786,
+    ticketReward: -5160,
     ticketChange: 0,
-    ticketInvestment: 8593628304,
-    ticketTxFee: 2980,
-    ticketStakeRewards: undefined,
-    ticketReturnAmount: undefined,
+    ticketInvestment: 9525592746,
+    ticketTxFee: 2960,
+    ticketStakeRewards: -5.416985732637787e-7,
+    ticketReturnAmount: 9525587586,
     voteScript: undefined,
-    spenderTxFee: 0,
-    enterTimestamp: 1652256415,
-    leaveTimestamp: null,
+    spenderTxFee: 2200,
+    enterTimestamp: 1605621435,
+    leaveTimestamp: 1605714645,
     status: "missed",
     rawTx:
-      "0100000001d5c92daf04dc8a5abfa0d4dd96cc0ce98c78ffa126d299aabe340c7d4baf14360000000000ffffffff03ec5038000200000000001aba76a9147940737eb9bc4798a56fda32fa3682274020081588ac00000000000000000000206a1e29b9f346a3b78f1b4b029429aee2a484fdaaf28b905c380002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001905c38000200000095f40d00010000006b483045022100bdac06f033cd0fe652bd8d5fc21833a3b7064114c8a949c7157f58f5d2dc2e2302206b2bb830c34c75c76ca3df491245c775eeb4eb3e0b73bca6ead94ed34762e439012103033666b327ef4a26ea4f26ce53223f3cd092a063d57f711ea3ec7169cbce4ed9",
+      "0100000001781d53a4f25c754340cf9250f98039c1db2c92bcd58b1e4637c9ca534d9053c00100000000ffffffff031af7c43702000000000018baa91434ffb3d43f5b40e0dbe9426e53865fc9d553d1038700000000000000000000206a1e5c1c4094ac61fc8762be68d7b15cdb4806611cf7aa02c537020000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000006085080001aa02c5370200000057850800010000006a473044022053cad54d349690d3c22b346134ff71da1b527695c6ec1252f11c1e7c5d9da9280220606a81e7d4ea63b448945cfbf1385b85642e0221cf49ca0824e5ec8ff62a61c30121032071d0e49038bcdeee3461296d2c50950b62f08e35caafbd4f2b0d025d1a47e1",
     txType: "ticket",
     isPending: false,
-    accountName: "default",
-    txInputs: [{ accountName: "default", amount: 8593628304, index: 0 }],
-    txOutputs: [
+    accountName: "account-6",
+    txInputs: [
       {
-        accountName: "default",
-        amount: 8593625324,
-        address: "Tsc5FSv5cAm4sPNzogkq9qYwdx2Gj4XnEoC",
+        accountName: "account-6",
+        amount: 9525592746,
         index: 0
       }
     ],
-    height: 914582,
+    txOutputs: [
+      {
+        accountName: "imported",
+        amount: 9525589786,
+        address: "TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs",
+        index: 0
+      }
+    ],
+    height: 558424,
     txUrl:
-      "https://testnet.decred.org/tx/d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc",
+      "https://testnet.decred.org/tx/30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774",
     txBlockUrl:
       "https://testnet.decred.org/block/0000000bc17d35756d4383c27e91d83bcb5be0f8bf9943675cba87e8223eeb21",
     isStake: true,
@@ -1438,9 +1487,10 @@ export const mockNormalizedStakeTransactionList = [
     },
     spenderTx: {
       timestamp: 1643948925,
-      height: -1,
-      blockHash: "",
-      index: -1,
+      height: 868792,
+      blockHash:
+        "30383936626239623038353766316531326239373563366366303133633863343439383530666235616466313033633063343536643165613030303030303030",
+      index: 1,
       hash: "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
       txHash:
         "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
@@ -1532,7 +1582,8 @@ export const mockNormalizedStakeTransactionList = [
     ticketTx: {
       timestamp: 1618322224,
       height: 661573,
-      blockHash: "",
+      blockHash:
+        "37313535336630323163353733646463653136386336623938326131373630343134323163383663386133633832636464306361613433366131303030303030",
       hash: "9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47",
       txHash:
         "9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47",
@@ -1566,7 +1617,9 @@ export const mockNormalizedStakeTransactionList = [
         "010000000120b97bf5eb8969095c3b8fa9590701f910246f464b84db62423b34c37b6747330000000000ffffffff03f0fff6810100000000001aba76a91451d06806b3922a664e9e9cd63fe18caa7081ea6688ac00000000000000000000206a1ec0e4b3a5b5a454e388c6864ae51205223a12dce4940bf781010000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001940bf7810100000044180a00020000006a47304402204be3e7097a452d99c2b56c138f8df33a923f6da1f9f465e56c75b9cdd571864902201bf7a3e9db1cfd3b7f8e55252d5f3c04311275bbc2c4ff2333472840c262b413012102936911a32e4e000e56f82207ec5d39a66b9971021869905087b23a10399cb1b0",
       isMix: false,
       txUrl:
-        "https://testnet.decred.org/tx/9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47"
+        "https://testnet.decred.org/tx/9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47",
+      vspHost:
+        "mock-vspHost-c1092ece233a5f25ab5c9510a5c0fc16cfd036d9f4c9f32ee5c7ea8ca3886e8c"
     },
     spenderTx: {
       timestamp: 1622730448,
@@ -1655,97 +1708,103 @@ export const mockNormalizedStakeTransactionList = [
         index: 0,
         account: 0,
         internal: true,
-        amount: 6785796485,
-        address: "TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7",
-        outputScript: "unapFGH+sNJBVRkEe2EjIOCHcpFJ7baziKw="
+        amount: 20000000,
+        address: "TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg",
+        outputScript: "unapFAVpSQ3nfoA2C1xW+RhdcLMvdGCoiKw="
       }
     ],
-    debits: [{ index: 0, previousAccount: 15, previousAmount: 6785799465 }],
-    txHash: "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
+    debits: [
+      {
+        index: 0,
+        previousAccount: 0,
+        previousAmount: 20002980
+      }
+    ],
+    txHash: "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f",
     blockHash: null,
     spenderHash: null,
     ticketHash:
-      "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
+      "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f",
     ticketTx: {
-      timestamp: 1654202499,
+      timestamp: 1658937788,
       height: -1,
       blockHash: null,
-      index: 0,
-      hash: "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
+      index: 1,
+      hash: "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f",
       txHash:
-        "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
+        "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f",
       txType: "ticket",
-      debitsAmount: 6785799465,
-      creditsAmount: 6785796485,
+      debitsAmount: 20002980,
+      creditsAmount: 20000000,
       type: 1,
       amount: -2980,
       fee: 2980,
-      debitAccounts: [15],
-      creditAddresses: ["TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7"],
+      debitAccounts: [0],
+      creditAddresses: ["TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg"],
       isStake: true,
       credits: [
         {
           index: 0,
           account: 0,
           internal: true,
-          amount: 6785796485,
-          address: "TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7",
-          outputScript: "unapFGH+sNJBVRkEe2EjIOCHcpFJ7baziKw="
+          amount: 20000000,
+          address: "TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg",
+          outputScript: "unapFAVpSQ3nfoA2C1xW+RhdcLMvdGCoiKw="
         }
       ],
       debits: [
         {
           index: 0,
-          previousAccount: 15,
-          previousAmount: 6785799465
+          previousAccount: 0,
+          previousAmount: 20002980
         }
       ],
       rawTx:
-        "010000000154a9b3b3e7a51658a2dcadb7e6cc440acda169c47e785ba6225cab34be43dce50000000000ffffffff03850977940100000000001aba76a91461feb0d2415519047b612320e087729149edb6b388ac00000000000000000000206a1e99bf7a5e99c8c00e09ecef371eabd7865bcf5e112915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6a473044022020cfc5e2bb47ddcd39fdc1a7e82e90a8fb0c2fc01db79c683296b15afb29780c0220216ee46d39c358a18395a035b9cc0af1a0a753eed82deef8694b516b77ee0bdd0121025d5aeb18e8bb8ae1485aed5e2816990ff8b0eee40bb9ab046d738cd6e18b4edd",
+        "01000000011babed986d25d5c3c27a1626e6caa344899949974a83bf63a49c2b1fa5f0514a0000000000ffffffff03002d31010000000000001aba76a9140569490de77e80360b5c56f9185d70b32f7460a888ac00000000000000000000206a1e9154057f4df98e818b05779aea2a20f6b624012ea438310100000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a43831010000000000000000ffffffff6a4730440220290c05e17b48e8c6ed6ee42326565a91416835b75c5f481b10a16e5b0dfa9f67022001d99b93ae971419db6e411dab042828e34ed2b0c7fcd30bd50ccae3d333a393012102af8273525052a10d5c8906ea288968d6f8c7e68caeaab58554b429e8f535e269",
       isMix: false,
       vspHost: "mockVspHost-unmined",
       txUrl:
-        "https://testnet.decred.org/tx/65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60"
+        "https://testnet.decred.org/tx/d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f"
     },
     spenderTx: null,
-    ticketPrice: 6785796485,
+    ticketPrice: 20000000,
     ticketReward: undefined,
     ticketChange: 0,
-    ticketInvestment: 6785799465,
+    ticketInvestment: 20002980,
     ticketTxFee: 2980,
+    spenderTxFee: 0,
     ticketStakeRewards: undefined,
     ticketReturnAmount: undefined,
     voteScript: undefined,
-    spenderTxFee: 0,
-    enterTimestamp: 1654202499,
+    enterTimestamp: 1658937788,
     leaveTimestamp: null,
     status: "unmined",
     rawTx:
-      "010000000154a9b3b3e7a51658a2dcadb7e6cc440acda169c47e785ba6225cab34be43dce50000000000ffffffff03850977940100000000001aba76a91461feb0d2415519047b612320e087729149edb6b388ac00000000000000000000206a1e99bf7a5e99c8c00e09ecef371eabd7865bcf5e112915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6a473044022020cfc5e2bb47ddcd39fdc1a7e82e90a8fb0c2fc01db79c683296b15afb29780c0220216ee46d39c358a18395a035b9cc0af1a0a753eed82deef8694b516b77ee0bdd0121025d5aeb18e8bb8ae1485aed5e2816990ff8b0eee40bb9ab046d738cd6e18b4edd",
+      "01000000011babed986d25d5c3c27a1626e6caa344899949974a83bf63a49c2b1fa5f0514a0000000000ffffffff03002d31010000000000001aba76a9140569490de77e80360b5c56f9185d70b32f7460a888ac00000000000000000000206a1e9154057f4df98e818b05779aea2a20f6b624012ea438310100000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a43831010000000000000000ffffffff6a4730440220290c05e17b48e8c6ed6ee42326565a91416835b75c5f481b10a16e5b0dfa9f67022001d99b93ae971419db6e411dab042828e34ed2b0c7fcd30bd50ccae3d333a393012102af8273525052a10d5c8906ea288968d6f8c7e68caeaab58554b429e8f535e269",
     txType: "ticket",
     isPending: true,
-    accountName: "account-15",
+    accountName: "default",
     txInputs: [
       {
-        accountName: "account-15",
-        amount: 6785799465,
+        accountName: "default",
+        amount: 20002980,
         index: 0
       }
     ],
     txOutputs: [
       {
         accountName: "default",
-        amount: 6785796485,
-        address: "TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7",
+        amount: 20000000,
+        address: "TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg",
         index: 0
       }
     ],
     height: -1,
     txUrl:
-      "https://testnet.decred.org/tx/65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
+      "https://testnet.decred.org/tx/d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f",
     txBlockUrl: "https://testnet.decred.org/block/null",
     isStake: true,
-    feeStatus: 1
+    feeStatus: undefined
   },
   // immature
   {
@@ -1848,7 +1907,7 @@ export const mockNormalizedStakeTransactionList = [
     txBlockUrl:
       "https://testnet.decred.org/block/0000000bc17d35756d4383c27e91d83bcb5be0f8bf9943675cba87e8223eeb21",
     isStake: true,
-    feeStatus: 1
+    feeStatus: undefined
   },
   // live
   {
@@ -1955,818 +2014,6 @@ export const mockNormalizedStakeTransactionList = [
   }
 ];
 
-export const mockStakeTransactionList = [
-  // vote tx
-  {
-    timestamp: 1654485406,
-    height: 932737,
-    blockHash:
-      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-    index: 0,
-    hash:
-      "1472512351262304275125239808423343934577220111166192222712233111195632030000",
-    txHash: "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
-    txType: "vote",
-    debitsAmount: 6785796485,
-    creditsAmount: 6790119971,
-    type: 2,
-    amount: 4323486,
-    fee: 0,
-    debitAccounts: [0],
-    creditAddresses: ["Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr"],
-    isStake: true,
-    credits: [
-      {
-        index: 2,
-        account: 15,
-        internal: true,
-        amount: 6790119971,
-        address: "Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr",
-        outputScript: "u3apFJm/el6ZyMAOCezvNx6r14Zbz14RiKw="
-      }
-    ],
-    debits: [
-      {
-        index: 1,
-        previousAccount: 0,
-        previousAmount: 6785796485
-      }
-    ],
-    rawTx:
-      "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff60ed215decf9ec50b50ff4477db42b1603178dab67e35d59f22b0de16cf4c1650000000001ffffffff0300000000000000000000266a24e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e0000000000000000000000086a0601000a0000002302b9940100000000001abb76a91499bf7a5e99c8c00e09ecef371eabd7865bcf5e1188ac0000000000000000029ef841000000000000000000ffffffff02000085097794010000007d330e00060000006a473044022038c9d8cafe8d98a904c72760e29a7f1e3942c9ef398a7384ca7b946517a3f598022016768855eae1edb7297ee52717bb4c1a247e836fce316a1d681026f4bcf9e5240121027bf4538b926d5668452965c44dbf8724b571ee6b3bae2eab59fd6969e6e87f13",
-    isMix: false,
-    ticket: {
-      timestamp: 1654202680,
-      height: 930685,
-      blockHash:
-        "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-      hash: "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
-      txHash:
-        "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
-      txType: "ticket",
-      debitsAmount: 6785799465,
-      creditsAmount: 6785796485,
-      type: 1,
-      amount: -2980,
-      fee: 2980,
-      debitAccounts: [15],
-      creditAddresses: ["TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 6785796485,
-          address: "TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7",
-          outputScript: "unapFGH+sNJBVRkEe2EjIOCHcpFJ7baziKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 15,
-          previousAmount: 6785799465
-        }
-      ],
-      rawTx:
-        "010000000154a9b3b3e7a51658a2dcadb7e6cc440acda169c47e785ba6225cab34be43dce50000000000ffffffff03850977940100000000001aba76a91461feb0d2415519047b612320e087729149edb6b388ac00000000000000000000206a1e99bf7a5e99c8c00e09ecef371eabd7865bcf5e112915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6a473044022020cfc5e2bb47ddcd39fdc1a7e82e90a8fb0c2fc01db79c683296b15afb29780c0220216ee46d39c358a18395a035b9cc0af1a0a753eed82deef8694b516b77ee0bdd0121025d5aeb18e8bb8ae1485aed5e2816990ff8b0eee40bb9ab046d738cd6e18b4edd",
-      isMix: false,
-      transaction:
-        "dd4e8be1d68c736d04abb90be4eeb0f80f9916285eed5a48e18abbe818eb5a5d022101dd0bee776b514b69f8ee2dd8ee53a7a0f10accb935a09583a158c3396de46e2120020c7829fb5ab19632689cb71dc02f0cfba8902ee8a7c1fd39cddd47bbe2c5cf2020024430476affffffff000000000000000194771529010000000000000000ac88000000000000000000000000000000000000000014a976bd1a000000000000000000004e000000000194771529115ecf5b86d7ab1e37efec090ec0c8995e7abf991e6a2000000000000000000000ac88b3b6ed49917287e02023617b04195541d2b0fe6114a976ba1a0000000000019477098503ffffffff0000000000e5dc43be34ab5c22a65b787ec469a1cd0a44cce6b7addca25816a5e7b3b3a9540100000001",
-      vspHost: "mockVspHost",
-      txUrl:
-        "https://testnet.decred.org/tx/65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60"
-    },
-    spender: {
-      timestamp: 1654485406,
-      height: 932737,
-      blockHash:
-        "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-      index: 0,
-      hash: "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
-      txHash:
-        "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
-      txType: "vote",
-      debitsAmount: 6785796485,
-      creditsAmount: 6790119971,
-      type: 2,
-      amount: 4323486,
-      fee: 0,
-      debitAccounts: [0],
-      creditAddresses: ["Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr"],
-      isStake: true,
-      credits: [
-        {
-          index: 2,
-          account: 15,
-          internal: true,
-          amount: 6790119971,
-          address: "Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr",
-          outputScript: "u3apFJm/el6ZyMAOCezvNx6r14Zbz14RiKw="
-        }
-      ],
-      debits: [
-        {
-          index: 1,
-          previousAccount: 0,
-          previousAmount: 6785796485
-        }
-      ],
-      rawTx:
-        "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff60ed215decf9ec50b50ff4477db42b1603178dab67e35d59f22b0de16cf4c1650000000001ffffffff0300000000000000000000266a24e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e0000000000000000000000086a0601000a0000002302b9940100000000001abb76a91499bf7a5e99c8c00e09ecef371eabd7865bcf5e1188ac0000000000000000029ef841000000000000000000ffffffff02000085097794010000007d330e00060000006a473044022038c9d8cafe8d98a904c72760e29a7f1e3942c9ef398a7384ca7b946517a3f598022016768855eae1edb7297ee52717bb4c1a247e836fce316a1d681026f4bcf9e5240121027bf4538b926d5668452965c44dbf8724b571ee6b3bae2eab59fd6969e6e87f13",
-      isMix: false
-    },
-    status: "voted"
-  },
-  // voted ticket
-  {
-    timestamp: 1652858637,
-    height: 919842,
-    blockHash:
-      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-    index: 0,
-    hash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
-    txHash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
-    txType: "ticket",
-    debitsAmount: 12271681343,
-    creditsAmount: 12271678363,
-    type: 1,
-    amount: -2980,
-    fee: 2980,
-    debitAccounts: [15],
-    creditAddresses: ["TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU"],
-    isStake: true,
-    credits: [
-      {
-        index: 0,
-        account: 0,
-        internal: true,
-        amount: 12271678363,
-        address: "TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU",
-        outputScript: "unapFFyo29n4+AuvdgX88JdEQQCZoS+biKw="
-      }
-    ],
-    debits: [
-      {
-        index: 0,
-        previousAccount: 15,
-        previousAmount: 12271681343
-      }
-    ],
-    rawTx:
-      "0100000001b50f2e03314661b566e3f0f246623c4419d8ec605da401f407a5f67cf148ce920000000000ffffffff039bf372db0200000000001aba76a9145ca8dbd9f8f80baf7605fcf09744410099a12f9b88ac00000000000000000000206a1e53b208495f9fabdfa80b4be10c4d0e488b33f2993fff72db02000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac0000000000000000013fff72db0200000000000000ffffffff6b483045022100d8f4e49c56f3249947a759d7ba766b671579399e758feaa12bc525c822c020f602200266d21d887165183479cf3d06a01470ceadc53b73527f6863ae76bf22a11ea001210355d8fdf5cdec7a8848e6d653d6c379908c256d4b54b7be637ab5018d56d19149",
-    isMix: false,
-    vspHost: "mockVspHost-votedticket",
-    ticket: {
-      timestamp: 1652858637,
-      height: 919842,
-      blockHash:
-        "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-      index: 0,
-      hash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
-      txHash:
-        "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
-      txType: "ticket",
-      debitsAmount: 12271681343,
-      creditsAmount: 12271678363,
-      type: 1,
-      amount: -2980,
-      fee: 2980,
-      debitAccounts: [15],
-      creditAddresses: ["TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 12271678363,
-          address: "TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU",
-          outputScript: "unapFFyo29n4+AuvdgX88JdEQQCZoS+biKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 15,
-          previousAmount: 12271681343
-        }
-      ],
-      rawTx:
-        "0100000001b50f2e03314661b566e3f0f246623c4419d8ec605da401f407a5f67cf148ce920000000000ffffffff039bf372db0200000000001aba76a9145ca8dbd9f8f80baf7605fcf09744410099a12f9b88ac00000000000000000000206a1e53b208495f9fabdfa80b4be10c4d0e488b33f2993fff72db02000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac0000000000000000013fff72db0200000000000000ffffffff6b483045022100d8f4e49c56f3249947a759d7ba766b671579399e758feaa12bc525c822c020f602200266d21d887165183479cf3d06a01470ceadc53b73527f6863ae76bf22a11ea001210355d8fdf5cdec7a8848e6d653d6c379908c256d4b54b7be637ab5018d56d19149",
-      isMix: false,
-      vspHost: "mockVspHost-votedticket",
-      txUrl:
-        "https://testnet.decred.org/tx/6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
-      feeStatus: 1
-    },
-    spender: {
-      timestamp: 1652874655,
-      height: -1,
-      blockHash: "",
-      index: -1,
-      hash: "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
-      txHash:
-        "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
-      txType: "vote",
-      debitsAmount: 12271678363,
-      creditsAmount: 12276267831,
-      type: 2,
-      amount: 4589468,
-      fee: 0,
-      debitAccounts: [0],
-      creditAddresses: ["TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n"],
-      isStake: true,
-      credits: [
-        {
-          index: 2,
-          account: 15,
-          internal: true,
-          amount: 12276267831,
-          address: "TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n",
-          outputScript: "u3apFFOyCElfn6vfqAtL4QxNDkiLM/KZiKw="
-        }
-      ],
-      debits: [
-        {
-          index: 1,
-          previousAccount: 0,
-          previousAmount: 12271678363
-        }
-      ],
-      rawTx:
-        "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff574f7189057261e0e816b09306c3dd4ae55146be8d1ce52a4d5c2475fdcf85600000000001ffffffff0300000000000000000000266a2432c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e0000000000000000000000086a0601000a00000037fbb8db0200000000001abb76a91453b208495f9fabdfa80b4be10c4d0e488b33f29988ac0000000000000000029c0746000000000000000000ffffffff0200009bf372db0200000022090e00110000006a4730440220481a66bdf843d6fe2f41b0b5ba129cfec694f82bac72602d08998a2a8b792fb2022003b0a2c8ddfcc317fdb5fac33cc0fbff280ce4bc250caef3e94840c79ef60ee301210355174775888e14ed49e50dd0b904e6dca3f6b4595afd9248a020a4aa87ae469e",
-      isMix: false
-    },
-    status: "voted",
-    feeStatus: 1
-  },
-  // missed
-  {
-    timestamp: 1652256415,
-    height: 914582,
-    blockHash:
-      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-    index: 0,
-    hash: "7d6d36b1ee3edc40941aadfab51a8b179d166a0612300742c0e39e60fac16873",
-    txHash: "d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc",
-    txType: "ticket",
-    debitsAmount: 8593628304,
-    creditsAmount: 8593625324,
-    type: 1,
-    amount: -2980,
-    fee: 2980,
-    debitAccounts: [0],
-    creditAddresses: ["Tsc5FSv5cAm4sPNzogkq9qYwdx2Gj4XnEoC"],
-    isStake: true,
-    credits: [
-      {
-        index: 0,
-        account: 0,
-        internal: true,
-        amount: 8593625324,
-        address: "Tsc5FSv5cAm4sPNzogkq9qYwdx2Gj4XnEoC",
-        outputScript: "unapFHlAc365vEeYpW/aMvo2gidAIAgViKw="
-      }
-    ],
-    debits: [
-      {
-        index: 0,
-        previousAccount: 0,
-        previousAmount: 8593628304
-      }
-    ],
-    rawTx:
-      "0100000001d5c92daf04dc8a5abfa0d4dd96cc0ce98c78ffa126d299aabe340c7d4baf14360000000000ffffffff03ec5038000200000000001aba76a9147940737eb9bc4798a56fda32fa3682274020081588ac00000000000000000000206a1e29b9f346a3b78f1b4b029429aee2a484fdaaf28b905c380002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001905c38000200000095f40d00010000006b483045022100bdac06f033cd0fe652bd8d5fc21833a3b7064114c8a949c7157f58f5d2dc2e2302206b2bb830c34c75c76ca3df491245c775eeb4eb3e0b73bca6ead94ed34762e439012103033666b327ef4a26ea4f26ce53223f3cd092a063d57f711ea3ec7169cbce4ed9",
-    isMix: false,
-    ticket: {
-      timestamp: 1652256415,
-      height: 914582,
-      blockHash:
-        "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-      index: 0,
-      hash: "d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc",
-      txHash:
-        "d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc",
-      txType: "ticket",
-      debitsAmount: 8593628304,
-      creditsAmount: 8593625324,
-      type: 1,
-      amount: -2980,
-      fee: 2980,
-      debitAccounts: [0],
-      creditAddresses: ["Tsc5FSv5cAm4sPNzogkq9qYwdx2Gj4XnEoC"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 8593625324,
-          address: "Tsc5FSv5cAm4sPNzogkq9qYwdx2Gj4XnEoC",
-          outputScript: "unapFHlAc365vEeYpW/aMvo2gidAIAgViKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 0,
-          previousAmount: 8593628304
-        }
-      ],
-      rawTx:
-        "0100000001d5c92daf04dc8a5abfa0d4dd96cc0ce98c78ffa126d299aabe340c7d4baf14360000000000ffffffff03ec5038000200000000001aba76a9147940737eb9bc4798a56fda32fa3682274020081588ac00000000000000000000206a1e29b9f346a3b78f1b4b029429aee2a484fdaaf28b905c380002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001905c38000200000095f40d00010000006b483045022100bdac06f033cd0fe652bd8d5fc21833a3b7064114c8a949c7157f58f5d2dc2e2302206b2bb830c34c75c76ca3df491245c775eeb4eb3e0b73bca6ead94ed34762e439012103033666b327ef4a26ea4f26ce53223f3cd092a063d57f711ea3ec7169cbce4ed9",
-      isMix: false,
-      vspHost: "mockVspHost-missed",
-      txUrl:
-        "https://testnet.decred.org/tx/d05c30941362f0bf74b8ccbadea892b68de11ba8aa74fe13a170bb289d7426cc"
-    },
-    status: "missed"
-  },
-  // revoked ticket
-  {
-    timestamp: 1637487987,
-    height: 815405,
-    blockHash:
-      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-    index: 0,
-    hash: "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
-    txHash: "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
-    txType: "ticket",
-    debitsAmount: 8600221089,
-    creditsAmount: 8600218109,
-    type: 1,
-    amount: -2980,
-    fee: 2980,
-    debitAccounts: [0],
-    creditAddresses: ["TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ"],
-    isStake: true,
-    credits: [
-      {
-        index: 0,
-        account: 0,
-        internal: true,
-        amount: 8600218109,
-        address: "TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ",
-        outputScript: "unapFOlPYM9gpJSRDMD+KPZi22h5RnROiKw="
-      }
-    ],
-    debits: [
-      {
-        index: 0,
-        previousAccount: 0,
-        previousAmount: 8600221089
-      }
-    ],
-    rawTx:
-      "010000000145dff3de5ec042630f66a9ba4ea2ed6d70f3fa306af01858a83efa676d3779000000000000ffffffff03fde99c000200000000001aba76a914e94f60cf60a494910cc0fe28f662db687946744e88ac00000000000000000000206a1e8ef37a84dc2bc7c924877e1ab3026b3b5a102e5fa1f59c0002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a1f59c00020000002c710c00030000006a47304402206888557060684807b6e78f47ea8c186debe45f2316a584abe60c5495f36f77f80220249421832ab9ea9e6bbb70d50376e7f48258b3108a345dc299d1de8186e046060121036343175c705537c636732c42fa699ba96f6296bc66b915216cbc833d00e18e10",
-    isMix: false,
-    spender: {
-      timestamp: 1643948925,
-      height: -1,
-      blockHash: "",
-      index: -1,
-      hash: "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
-      txHash:
-        "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
-      txType: "revocation",
-      debitsAmount: 8600218109,
-      creditsAmount: 8600218109,
-      type: 3,
-      amount: 0,
-      fee: 0,
-      debitAccounts: [0],
-      creditAddresses: ["Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 8600218109,
-          address: "Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy",
-          outputScript: "vHapFI7zeoTcK8fJJId+GrMCaztaEC5fiKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 0,
-          previousAmount: 8600218109
-        }
-      ],
-      rawTx:
-        "0200000001997fa9df69903ad5d40fce86f0da366f3d9c13b842e947d1d0859a30e3e24eb00000000001ffffffff01fde99c000200000000001abc76a9148ef37a84dc2bc7c924877e1ab3026b3b5a102e5f88ac000000000000000001fde99c00020000002d710c000800000000",
-      isMix: false
-    },
-    status: "revoked",
-    ticket: {
-      timestamp: 1637487987,
-      height: 815405,
-      blockHash:
-        "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-      index: 0,
-      hash: "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
-      txHash:
-        "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
-      txType: "ticket",
-      debitsAmount: 8600221089,
-      creditsAmount: 8600218109,
-      type: 1,
-      amount: -2980,
-      fee: 2980,
-      debitAccounts: [0],
-      creditAddresses: ["TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 8600218109,
-          address: "TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ",
-          outputScript: "unapFOlPYM9gpJSRDMD+KPZi22h5RnROiKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 0,
-          previousAmount: 8600221089
-        }
-      ],
-      rawTx:
-        "010000000145dff3de5ec042630f66a9ba4ea2ed6d70f3fa306af01858a83efa676d3779000000000000ffffffff03fde99c000200000000001aba76a914e94f60cf60a494910cc0fe28f662db687946744e88ac00000000000000000000206a1e8ef37a84dc2bc7c924877e1ab3026b3b5a102e5fa1f59c0002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a1f59c00020000002c710c00030000006a47304402206888557060684807b6e78f47ea8c186debe45f2316a584abe60c5495f36f77f80220249421832ab9ea9e6bbb70d50376e7f48258b3108a345dc299d1de8186e046060121036343175c705537c636732c42fa699ba96f6296bc66b915216cbc833d00e18e10",
-      isMix: false,
-      vspHost: "",
-      txUrl:
-        "https://testnet.decred.org/tx/b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99"
-    }
-  },
-  // revocation
-  {
-    timestamp: 1622730448,
-    height: 697812,
-    blockHash:
-      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-    index: 0,
-    hash: "8c6e88a38ceac7e52ef3c9f4d936d0cf16fcc0a510955cab255f3a23ce2e09c1",
-    txHash: "c1092ece233a5f25ab5c9510a5c0fc16cfd036d9f4c9f32ee5c7ea8ca3886e8c",
-    txType: "revocation",
-    debitsAmount: 6475415536,
-    creditsAmount: 6475413336,
-    type: 3,
-    amount: -2200,
-    fee: 2200,
-    debitAccounts: [0],
-    creditAddresses: ["Tsic4BsFzDL1jhR4LTbWS8LvGFgxjqFG3pU"],
-    isStake: true,
-    credits: [
-      {
-        index: 0,
-        account: 0,
-        internal: true,
-        amount: 6475413336,
-        address: "Tsic4BsFzDL1jhR4LTbWS8LvGFgxjqFG3pU",
-        outputScript: "vHapFMDks6W1pFTjiMaGSuUSBSI6EtzkiKw="
-      }
-    ],
-    debits: [
-      {
-        index: 0,
-        previousAccount: 0,
-        previousAmount: 6475415536
-      }
-    ],
-    rawTx:
-      "010000000147ecbf246e47f6e9e2616baece2a0d70c63184d09904a22eb2ca438211fc1b9a0000000001ffffffff0158f7f6810100000000001abc76a914c0e4b3a5b5a454e388c6864ae51205223a12dce488ac000000000000000001f0fff6810100000045180a00060000006b483045022100ab8406a6b9bf915b48dd251519d64a7c8cf8019adc370bdd82b8d914e128280a02204ed8d9726d3a0b8186cba70e1dfd28be1ef3d9eb4e94dd412c85bc979b49a878012102ce47d2933e9b7a2fdd867dd95716ffa7674ea15083349c9dfc2f3a29ddb28052",
-    ticket: {
-      timestamp: 1618322224,
-      height: 661573,
-      blockHash: "",
-      hash: "9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47",
-      txHash:
-        "9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47",
-      txType: "ticket",
-      debitsAmount: 6475418516,
-      creditsAmount: 6475415536,
-      type: 1,
-      amount: -2980,
-      fee: 2980,
-      debitAccounts: [0],
-      creditAddresses: ["TsYUisRdHbZ7p4y2w2Hfnu9zp9bUn6BzxPu"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 6475415536,
-          address: "TsYUisRdHbZ7p4y2w2Hfnu9zp9bUn6BzxPu",
-          outputScript: "unapFFHQaAazkipmTp6c1j/hjKpwgepmiKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 0,
-          previousAmount: 6475418516
-        }
-      ],
-      rawTx:
-        "010000000120b97bf5eb8969095c3b8fa9590701f910246f464b84db62423b34c37b6747330000000000ffffffff03f0fff6810100000000001aba76a91451d06806b3922a664e9e9cd63fe18caa7081ea6688ac00000000000000000000206a1ec0e4b3a5b5a454e388c6864ae51205223a12dce4940bf781010000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001940bf7810100000044180a00020000006a47304402204be3e7097a452d99c2b56c138f8df33a923f6da1f9f465e56c75b9cdd571864902201bf7a3e9db1cfd3b7f8e55252d5f3c04311275bbc2c4ff2333472840c262b413012102936911a32e4e000e56f82207ec5d39a66b9971021869905087b23a10399cb1b0",
-      isMix: false
-    },
-    spender: {
-      timestamp: 1622730448,
-      height: 697812,
-      blockHash:
-        "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-      index: 0,
-      hash: "8c6e88a38ceac7e52ef3c9f4d936d0cf16fcc0a510955cab255f3a23ce2e09c1",
-      txHash:
-        "c1092ece233a5f25ab5c9510a5c0fc16cfd036d9f4c9f32ee5c7ea8ca3886e8c",
-      txType: "revocation",
-      debitsAmount: 6475415536,
-      creditsAmount: 6475413336,
-      type: 3,
-      amount: -2200,
-      fee: 2200,
-      debitAccounts: [0],
-      creditAddresses: ["Tsic4BsFzDL1jhR4LTbWS8LvGFgxjqFG3pU"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 6475413336,
-          address: "Tsic4BsFzDL1jhR4LTbWS8LvGFgxjqFG3pU",
-          outputScript: "vHapFMDks6W1pFTjiMaGSuUSBSI6EtzkiKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 0,
-          previousAmount: 6475415536
-        }
-      ],
-      rawTx:
-        "010000000147ecbf246e47f6e9e2616baece2a0d70c63184d09904a22eb2ca438211fc1b9a0000000001ffffffff0158f7f6810100000000001abc76a914c0e4b3a5b5a454e388c6864ae51205223a12dce488ac000000000000000001f0fff6810100000045180a00060000006b483045022100ab8406a6b9bf915b48dd251519d64a7c8cf8019adc370bdd82b8d914e128280a02204ed8d9726d3a0b8186cba70e1dfd28be1ef3d9eb4e94dd412c85bc979b49a878012102ce47d2933e9b7a2fdd867dd95716ffa7674ea15083349c9dfc2f3a29ddb28052",
-      isMix: false
-    },
-    status: "revoked"
-  },
-  // unmined
-  {
-    timestamp: 1654202499,
-    height: -1,
-    blockHash: null,
-    index: 0,
-    hash: "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
-    txHash: "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
-    txType: "ticket",
-    debitsAmount: 6785799465,
-    creditsAmount: 6785796485,
-    type: 1,
-    amount: -2980,
-    fee: 2980,
-    debitAccounts: [15],
-    creditAddresses: ["TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7"],
-    isStake: true,
-    credits: [
-      {
-        index: 0,
-        account: 0,
-        internal: true,
-        amount: 6785796485,
-        address: "TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7",
-        outputScript: "unapFGH+sNJBVRkEe2EjIOCHcpFJ7baziKw="
-      }
-    ],
-    debits: [
-      {
-        index: 0,
-        previousAccount: 15,
-        previousAmount: 6785799465
-      }
-    ],
-    rawTx:
-      "010000000154a9b3b3e7a51658a2dcadb7e6cc440acda169c47e785ba6225cab34be43dce50000000000ffffffff03850977940100000000001aba76a91461feb0d2415519047b612320e087729149edb6b388ac00000000000000000000206a1e99bf7a5e99c8c00e09ecef371eabd7865bcf5e112915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6a473044022020cfc5e2bb47ddcd39fdc1a7e82e90a8fb0c2fc01db79c683296b15afb29780c0220216ee46d39c358a18395a035b9cc0af1a0a753eed82deef8694b516b77ee0bdd0121025d5aeb18e8bb8ae1485aed5e2816990ff8b0eee40bb9ab046d738cd6e18b4edd",
-    isMix: false,
-    ticket: {
-      timestamp: 1654202499,
-      height: -1,
-      blockHash: null,
-      index: 0,
-      hash: "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
-      txHash:
-        "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
-      txType: "ticket",
-      debitsAmount: 6785799465,
-      creditsAmount: 6785796485,
-      type: 1,
-      amount: -2980,
-      fee: 2980,
-      debitAccounts: [15],
-      creditAddresses: ["TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 6785796485,
-          address: "TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7",
-          outputScript: "unapFGH+sNJBVRkEe2EjIOCHcpFJ7baziKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 15,
-          previousAmount: 6785799465
-        }
-      ],
-      rawTx:
-        "010000000154a9b3b3e7a51658a2dcadb7e6cc440acda169c47e785ba6225cab34be43dce50000000000ffffffff03850977940100000000001aba76a91461feb0d2415519047b612320e087729149edb6b388ac00000000000000000000206a1e99bf7a5e99c8c00e09ecef371eabd7865bcf5e112915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6a473044022020cfc5e2bb47ddcd39fdc1a7e82e90a8fb0c2fc01db79c683296b15afb29780c0220216ee46d39c358a18395a035b9cc0af1a0a753eed82deef8694b516b77ee0bdd0121025d5aeb18e8bb8ae1485aed5e2816990ff8b0eee40bb9ab046d738cd6e18b4edd",
-      isMix: false,
-      vspHost: "mockVspHost-unmined",
-      txUrl:
-        "https://testnet.decred.org/tx/65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60"
-    },
-    status: "unmined",
-    feeStatus: 1
-  },
-  // immature
-  {
-    timestamp: 1654203366,
-    height: 930690,
-    blockHash:
-      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-    index: 0,
-    hash: "f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530",
-    txHash: "f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530",
-    txType: "ticket",
-    debitsAmount: 6785799465,
-    creditsAmount: 6785796485,
-    type: 1,
-    amount: -2980,
-    fee: 2980,
-    debitAccounts: [0],
-    creditAddresses: ["TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK"],
-    isStake: true,
-    credits: [
-      {
-        index: 0,
-        account: 0,
-        internal: true,
-        amount: 6785796485,
-        address: "TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK",
-        outputScript: "unapFA+UU96/HfOSYqbq+B/LmP95fIlciKw="
-      }
-    ],
-    debits: [
-      {
-        index: 0,
-        previousAccount: 0,
-        previousAmount: 6785799465
-      }
-    ],
-    rawTx:
-      "01000000011a1b3fc2661245ba6b8cab9e315cf76b16c565f1c1277512608d51906f1636c10000000000ffffffff03850977940100000000001aba76a9140f9453debf1df39262a6eaf81fcb98ff797c895c88ac00000000000000000000206a1e19e5ba2f1f3b99efe1090707638af39998a1b7582915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6b483045022100a510695025634a249cda2c85fe63a43312cb0ee5c02db2f1256fe4f835702f8002202b0f4c7e093500b75626a4829c9705a370cb2f2f834702abe8b9ac268d5ac57b012102dfa5deeeee8b65f2738483d412f2bb5627fa7f761b132f3b4eef2e154151902c",
-    isMix: false,
-    ticket: {
-      timestamp: 1654203366,
-      height: 930690,
-      blockHash:
-        "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-      index: 0,
-      hash: "f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530",
-      txHash:
-        "f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530",
-      txType: "ticket",
-      debitsAmount: 6785799465,
-      creditsAmount: 6785796485,
-      type: 1,
-      amount: -2980,
-      fee: 2980,
-      debitAccounts: [0],
-      creditAddresses: ["TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 6785796485,
-          address: "TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK",
-          outputScript: "unapFA+UU96/HfOSYqbq+B/LmP95fIlciKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 0,
-          previousAmount: 6785799465
-        }
-      ],
-      rawTx:
-        "01000000011a1b3fc2661245ba6b8cab9e315cf76b16c565f1c1277512608d51906f1636c10000000000ffffffff03850977940100000000001aba76a9140f9453debf1df39262a6eaf81fcb98ff797c895c88ac00000000000000000000206a1e19e5ba2f1f3b99efe1090707638af39998a1b7582915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6b483045022100a510695025634a249cda2c85fe63a43312cb0ee5c02db2f1256fe4f835702f8002202b0f4c7e093500b75626a4829c9705a370cb2f2f834702abe8b9ac268d5ac57b012102dfa5deeeee8b65f2738483d412f2bb5627fa7f761b132f3b4eef2e154151902c",
-      isMix: false,
-      vspHost: "mockVspHost-immature",
-      txUrl:
-        "https://testnet.decred.org/tx/f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530"
-    },
-    status: "immature",
-    feeStatus: 1
-  },
-  // live
-  {
-    timestamp: 1654204193,
-    height: 930696,
-    blockHash:
-      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-    index: 0,
-    hash: "05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e079",
-    txHash: "05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07",
-    txType: "ticket",
-    debitsAmount: 6785799465,
-    creditsAmount: 6785796485,
-    type: 1,
-    amount: -2980,
-    fee: 2980,
-    debitAccounts: [0],
-    creditAddresses: ["TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4"],
-    isStake: true,
-    credits: [
-      {
-        index: 0,
-        account: 0,
-        internal: true,
-        amount: 6785796485,
-        address: "TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4",
-        outputScript: "unapFIMhyeEfBENiiiK/SodiN02IfAYyiKw="
-      }
-    ],
-    debits: [
-      {
-        index: 0,
-        previousAccount: 0,
-        previousAmount: 6785799465
-      }
-    ],
-    rawTx:
-      "010000000164f0acf752429210f469c6536c857d092aac8bc84fa661f013b535aa6394c4710000000000ffffffff03850977940100000000001aba76a9148321c9e11f0443628a22bf4a8762374d887c063288ac00000000000000000000206a1e01ca6bb0120ca64e750a9cbaa66597f010c1c03d2915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6b483045022100a58c8e7b6f33b3c3fdc43dfa7472d19e39cc8c22c5990f94ca45a9458c860bfe02202227864c234f9a2c328418cabf6a5934e99d16806a8492805ad4243155d77e63012102029965f740c2b87c21dca96fb4195f71dae34b779ef4daed5902f98a0c09a437",
-    isMix: false,
-    ticket: {
-      timestamp: 1654204193,
-      height: 930696,
-      blockHash:
-        "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
-      index: 0,
-      hash: "05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07",
-      txHash:
-        "05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07",
-      txType: "ticket",
-      debitsAmount: 6785799465,
-      creditsAmount: 6785796485,
-      type: 1,
-      amount: -2980,
-      fee: 2980,
-      debitAccounts: [0],
-      creditAddresses: ["TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4"],
-      isStake: true,
-      credits: [
-        {
-          index: 0,
-          account: 0,
-          internal: true,
-          amount: 6785796485,
-          address: "TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4",
-          outputScript: "unapFIMhyeEfBENiiiK/SodiN02IfAYyiKw="
-        }
-      ],
-      debits: [
-        {
-          index: 0,
-          previousAccount: 0,
-          previousAmount: 6785799465
-        }
-      ],
-      rawTx:
-        "010000000164f0acf752429210f469c6536c857d092aac8bc84fa661f013b535aa6394c4710000000000ffffffff03850977940100000000001aba76a9148321c9e11f0443628a22bf4a8762374d887c063288ac00000000000000000000206a1e01ca6bb0120ca64e750a9cbaa66597f010c1c03d2915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6b483045022100a58c8e7b6f33b3c3fdc43dfa7472d19e39cc8c22c5990f94ca45a9458c860bfe02202227864c234f9a2c328418cabf6a5934e99d16806a8492805ad4243155d77e63012102029965f740c2b87c21dca96fb4195f71dae34b779ef4daed5902f98a0c09a437",
-      isMix: false,
-      vspHost: "mockVspHost-live",
-      txUrl:
-        "https://testnet.decred.org/tx/05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07"
-    },
-    status: "live"
-  }
-];
-
 export const mockRegularTransactions = {};
 mockRegularTransactionList.forEach((tx) => {
   tx.blockHash = toByteArray(tx.blockHash);
@@ -2776,18 +2023,6 @@ mockRegularTransactionList.forEach((tx) => {
 export const mockNormalizedRegularTransactions = {};
 mockNormalizedRegularTransactionList.forEach((tx) => {
   mockNormalizedRegularTransactions[tx.txHash] = tx;
-});
-
-export const mockStakeTransactions = {};
-mockStakeTransactionList.forEach((tx) => {
-  tx.blockHash = toByteArray(tx.blockHash);
-  if (tx.ticket) {
-    tx.ticket.blockHash = toByteArray(tx.ticket.blockHash);
-  }
-  if (tx.spender) {
-    tx.spender.blockHash = toByteArray(tx.spender.blockHash);
-  }
-  mockStakeTransactions[tx.txHash] = tx;
 });
 
 export const mockNormalizedStakeTransactions = {};

--- a/test/unit/components/views/TransactionPage/mocks_decodedTransactions.js
+++ b/test/unit/components/views/TransactionPage/mocks_decodedTransactions.js
@@ -1,0 +1,192 @@
+export const mockDecodedTransactions = {
+  "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff60ed215decf9ec50b50ff4477db42b1603178dab67e35d59f22b0de16cf4c1650000000001ffffffff0300000000000000000000266a24e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e0000000000000000000000086a0601000a0000002302b9940100000000001abb76a91499bf7a5e99c8c00e09ecef371eabd7865bcf5e1188ac0000000000000000029ef841000000000000000000ffffffff02000085097794010000007d330e00060000006a473044022038c9d8cafe8d98a904c72760e29a7f1e3942c9ef398a7384ca7b946517a3f598022016768855eae1edb7297ee52717bb4c1a247e836fce316a1d681026f4bcf9e5240121027bf4538b926d5668452965c44dbf8724b571ee6b3bae2eab59fd6969e6e87f13": {
+    version: 1,
+    serType: 0,
+    numInputs: 2,
+    inputs: [
+      {
+        prevTxId:
+          "0000000000000000000000000000000000000000000000000000000000000000",
+        outputIndex: 4294967295,
+        outputTree: 0,
+        sequence: 4294967295,
+        index: 0,
+        valueIn: 4323486,
+        blockHeight: 0,
+        blockIndex: 4294967295,
+        sigScript: "0000"
+      },
+      {
+        prevTxId:
+          "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
+        outputIndex: 0,
+        outputTree: 1,
+        sequence: 4294967295,
+        index: 1,
+        valueIn: 6785796485,
+        blockHeight: 930685,
+        blockIndex: 6,
+        sigScript:
+          "473044022038c9d8cafe8d98a904c72760e29a7f1e3942c9ef398a7384ca7b946517a3f598022016768855eae1edb7297ee52717bb4c1a247e836fce316a1d681026f4bcf9e5240121027bf4538b926d5668452965c44dbf8724b571ee6b3bae2eab59fd6969e6e87f13"
+      }
+    ],
+    numOutputs: 3,
+    outputs: [
+      {
+        value: 0,
+        version: 0,
+        script:
+          "6a24e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e00",
+        index: 0,
+        decodedScript: {
+          scriptClass: 0,
+          address: null,
+          requiredSig: 0,
+          asm:
+            "OP_RETURN OP_DATA_36 e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e00"
+        }
+      },
+      {
+        value: 0,
+        version: 0,
+        script: "6a0601000a000000",
+        index: 1,
+        decodedScript: {
+          scriptClass: 0,
+          address: null,
+          requiredSig: 0,
+          asm: "OP_RETURN OP_DATA_6 01000a000000"
+        }
+      },
+      {
+        value: 6790119971,
+        version: 0,
+        script: "bb76a91499bf7a5e99c8c00e09ecef371eabd7865bcf5e1188ac",
+        index: 2,
+        decodedScript: {
+          scriptClass: 7,
+          address: "Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr",
+          requiredSig: 1,
+          asm:
+            "OP_SSGEN OP_DUP OP_HASH160 OP_DATA_20 99bf7a5e99c8c00e09ecef371eabd7865bcf5e11 OP_EQUALVERIFY OP_CHECKSIG"
+        }
+      }
+    ],
+    lockTime: 0,
+    expiry: 0
+  },
+  "010000000147ecbf246e47f6e9e2616baece2a0d70c63184d09904a22eb2ca438211fc1b9a0000000001ffffffff0158f7f6810100000000001abc76a914c0e4b3a5b5a454e388c6864ae51205223a12dce488ac000000000000000001f0fff6810100000045180a00060000006b483045022100ab8406a6b9bf915b48dd251519d64a7c8cf8019adc370bdd82b8d914e128280a02204ed8d9726d3a0b8186cba70e1dfd28be1ef3d9eb4e94dd412c85bc979b49a878012102ce47d2933e9b7a2fdd867dd95716ffa7674ea15083349c9dfc2f3a29ddb28052": {
+    version: 1,
+    serType: 0,
+    numInputs: 1,
+    inputs: [
+      {
+        prevTxId:
+          "9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47",
+        outputIndex: 0,
+        outputTree: 1,
+        sequence: 4294967295,
+        index: 0,
+        valueIn: 6475415536,
+        blockHeight: 661573,
+        blockIndex: 6,
+        sigScript:
+          "483045022100ab8406a6b9bf915b48dd251519d64a7c8cf8019adc370bdd82b8d914e128280a02204ed8d9726d3a0b8186cba70e1dfd28be1ef3d9eb4e94dd412c85bc979b49a878012102ce47d2933e9b7a2fdd867dd95716ffa7674ea15083349c9dfc2f3a29ddb28052"
+      }
+    ],
+    numOutputs: 1,
+    outputs: [
+      {
+        value: 6475413336,
+        version: 0,
+        script: "bc76a914c0e4b3a5b5a454e388c6864ae51205223a12dce488ac",
+        index: 0,
+        decodedScript: {
+          scriptClass: 8,
+          address: "Tsic4BsFzDL1jhR4LTbWS8LvGFgxjqFG3pU",
+          requiredSig: 1,
+          asm:
+            "OP_SSRTX OP_DUP OP_HASH160 OP_DATA_20 c0e4b3a5b5a454e388c6864ae51205223a12dce4 OP_EQUALVERIFY OP_CHECKSIG"
+        }
+      }
+    ],
+    lockTime: 0,
+    expiry: 0
+  },
+  "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff574f7189057261e0e816b09306c3dd4ae55146be8d1ce52a4d5c2475fdcf85600000000001ffffffff0300000000000000000000266a2432c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e0000000000000000000000086a0601000a00000037fbb8db0200000000001abb76a91453b208495f9fabdfa80b4be10c4d0e488b33f29988ac0000000000000000029c0746000000000000000000ffffffff0200009bf372db0200000022090e00110000006a4730440220481a66bdf843d6fe2f41b0b5ba129cfec694f82bac72602d08998a2a8b792fb2022003b0a2c8ddfcc317fdb5fac33cc0fbff280ce4bc250caef3e94840c79ef60ee301210355174775888e14ed49e50dd0b904e6dca3f6b4595afd9248a020a4aa87ae469e": {
+    version: 1,
+    serType: 0,
+    numInputs: 2,
+    inputs: [
+      {
+        prevTxId:
+          "0000000000000000000000000000000000000000000000000000000000000000",
+        outputIndex: 4294967295,
+        outputTree: 0,
+        sequence: 4294967295,
+        index: 0,
+        valueIn: 4589468,
+        blockHeight: 0,
+        blockIndex: 4294967295,
+        sigScript: "0000"
+      },
+      {
+        prevTxId:
+          "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
+        outputIndex: 0,
+        outputTree: 1,
+        sequence: 4294967295,
+        index: 1,
+        valueIn: 12271678363,
+        blockHeight: 919842,
+        blockIndex: 17,
+        sigScript:
+          "4730440220481a66bdf843d6fe2f41b0b5ba129cfec694f82bac72602d08998a2a8b792fb2022003b0a2c8ddfcc317fdb5fac33cc0fbff280ce4bc250caef3e94840c79ef60ee301210355174775888e14ed49e50dd0b904e6dca3f6b4595afd9248a020a4aa87ae469e"
+      }
+    ],
+    numOutputs: 3,
+    outputs: [
+      {
+        value: 0,
+        version: 0,
+        script:
+          "6a2432c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e00",
+        index: 0,
+        decodedScript: {
+          scriptClass: 0,
+          address: null,
+          requiredSig: 0,
+          asm:
+            "OP_RETURN OP_DATA_36 32c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e00"
+        }
+      },
+      {
+        value: 0,
+        version: 0,
+        script: "6a0601000a000000",
+        index: 1,
+        decodedScript: {
+          scriptClass: 0,
+          address: null,
+          requiredSig: 0,
+          asm: "OP_RETURN OP_DATA_6 01000a000000"
+        }
+      },
+      {
+        value: 12276267831,
+        version: 0,
+        script: "bb76a91453b208495f9fabdfa80b4be10c4d0e488b33f29988ac",
+        index: 2,
+        decodedScript: {
+          scriptClass: 7,
+          address: "TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n",
+          requiredSig: 1,
+          asm:
+            "OP_SSGEN OP_DUP OP_HASH160 OP_DATA_20 53b208495f9fabdfa80b4be10c4d0e488b33f299 OP_EQUALVERIFY OP_CHECKSIG"
+        }
+      }
+    ],
+    lockTime: 0,
+    expiry: 0
+  }
+};

--- a/test/unit/components/views/TransactionPage/mocks_spenderTransactions.js
+++ b/test/unit/components/views/TransactionPage/mocks_spenderTransactions.js
@@ -1,0 +1,151 @@
+export const mockSpenderTransactions = {
+  c44db16d004aa264c3cc8dcf90ecc08caa88964cb6e34477139651b56f46af79: {
+    timestamp: 1605714645,
+    height: -1,
+    blockHash: "",
+    index: -1,
+    hash: "c44db16d004aa264c3cc8dcf90ecc08caa88964cb6e34477139651b56f46af79",
+    txHash: "c44db16d004aa264c3cc8dcf90ecc08caa88964cb6e34477139651b56f46af79",
+    txType: "revocation",
+    debitsAmount: 9525589786,
+    creditsAmount: 9525587586,
+    type: 3,
+    amount: -2200,
+    fee: 2200,
+    debitAccounts: [2147483647],
+    creditAddresses: ["TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 6,
+        internal: true,
+        amount: 9525587586,
+        address: "TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp",
+        outputScript: "vHapFFwcQJSsYfyHYr5o17Fc20gGYRz3iKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 2147483647,
+        previousAmount: 9525589786
+      }
+    ],
+    rawTx:
+      "01000000017457e53cda6f04dc671bf2bde52568add0bbe4fb9fc3db74b43a769d0406dd300000000001ffffffff0182eec4370200000000001abc76a9145c1c4094ac61fc8762be68d7b15cdb4806611cf788ac0000000000000000011af7c437020000005885080005000000904730440220163ae79bc0713243f5e627aeafb680fbc2126b153188b4921d954056efc3fa61022040c5ecfdaa83175cef7faf99460b765779c4bcf09cc6e72782d491664bb66dbb01475121038add32307530f18099a9208f32fc04502b40073ea6a6cfebbbd79988270a612e2103f2a96dbe354081542af9571c43662b883d9ae02416cd5080137c0556c7a0976d52ae",
+    isMix: false
+  },
+  c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d: {
+    timestamp: 1643948925,
+    height: 868792,
+    blockHash:
+      "00000000ae1d654c0c301fda5bf058944c8c310fc6c579b21e1f7580b9bb6980",
+    index: 1,
+    hash: "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
+    txHash: "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
+    txType: "revocation",
+    debitsAmount: 8600218109,
+    creditsAmount: 8600218109,
+    type: 3,
+    amount: 0,
+    fee: 0,
+    debitAccounts: [0],
+    creditAddresses: ["Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 0,
+        internal: true,
+        amount: 8600218109,
+        address: "Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy",
+        outputScript: "vHapFI7zeoTcK8fJJId+GrMCaztaEC5fiKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 0,
+        previousAmount: 8600218109
+      }
+    ],
+    rawTx:
+      "0200000001997fa9df69903ad5d40fce86f0da366f3d9c13b842e947d1d0859a30e3e24eb00000000001ffffffff01fde99c000200000000001abc76a9148ef37a84dc2bc7c924877e1ab3026b3b5a102e5f88ac000000000000000001fde99c00020000002d710c000800000000",
+    isMix: false
+  },
+  "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4": {
+    timestamp: 1654485406,
+    height: -1,
+    blockHash: "",
+    index: -1,
+    hash: "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
+    txHash: "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
+    txType: "vote",
+    debitsAmount: 6785796485,
+    creditsAmount: 6790119971,
+    type: 2,
+    amount: 4323486,
+    fee: 0,
+    debitAccounts: [0],
+    creditAddresses: ["Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr"],
+    isStake: true,
+    credits: [
+      {
+        index: 2,
+        account: 15,
+        internal: true,
+        amount: 6790119971,
+        address: "Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr",
+        outputScript: "u3apFJm/el6ZyMAOCezvNx6r14Zbz14RiKw="
+      }
+    ],
+    debits: [
+      {
+        index: 1,
+        previousAccount: 0,
+        previousAmount: 6785796485
+      }
+    ],
+    rawTx:
+      "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff60ed215decf9ec50b50ff4477db42b1603178dab67e35d59f22b0de16cf4c1650000000001ffffffff0300000000000000000000266a24e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e0000000000000000000000086a0601000a0000002302b9940100000000001abb76a91499bf7a5e99c8c00e09ecef371eabd7865bcf5e1188ac0000000000000000029ef841000000000000000000ffffffff02000085097794010000007d330e00060000006a473044022038c9d8cafe8d98a904c72760e29a7f1e3942c9ef398a7384ca7b946517a3f598022016768855eae1edb7297ee52717bb4c1a247e836fce316a1d681026f4bcf9e5240121027bf4538b926d5668452965c44dbf8724b571ee6b3bae2eab59fd6969e6e87f13",
+    isMix: false
+  },
+  fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da: {
+    timestamp: 1652874655,
+    height: -1,
+    blockHash: "",
+    index: -1,
+    hash: "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
+    txHash: "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
+    txType: "vote",
+    debitsAmount: 12271678363,
+    creditsAmount: 12276267831,
+    type: 2,
+    amount: 4589468,
+    fee: 0,
+    debitAccounts: [0],
+    creditAddresses: ["TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n"],
+    isStake: true,
+    credits: [
+      {
+        index: 2,
+        account: 15,
+        internal: true,
+        amount: 12276267831,
+        address: "TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n",
+        outputScript: "u3apFFOyCElfn6vfqAtL4QxNDkiLM/KZiKw="
+      }
+    ],
+    debits: [
+      {
+        index: 1,
+        previousAccount: 0,
+        previousAmount: 12271678363
+      }
+    ],
+    rawTx:
+      "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff574f7189057261e0e816b09306c3dd4ae55146be8d1ce52a4d5c2475fdcf85600000000001ffffffff0300000000000000000000266a2432c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e0000000000000000000000086a0601000a00000037fbb8db0200000000001abb76a91453b208495f9fabdfa80b4be10c4d0e488b33f29988ac0000000000000000029c0746000000000000000000ffffffff0200009bf372db0200000022090e00110000006a4730440220481a66bdf843d6fe2f41b0b5ba129cfec694f82bac72602d08998a2a8b792fb2022003b0a2c8ddfcc317fdb5fac33cc0fbff280ce4bc250caef3e94840c79ef60ee301210355174775888e14ed49e50dd0b904e6dca3f6b4595afd9248a020a4aa87ae469e",
+    isMix: false
+  }
+};

--- a/test/unit/components/views/TransactionPage/mocks_stakeTransactions.js
+++ b/test/unit/components/views/TransactionPage/mocks_stakeTransactions.js
@@ -1,0 +1,336 @@
+import { toByteArray } from "./mocks.js";
+
+export const mockStakeTransactionList = [
+  // vote tx
+  {
+    timestamp: 1654485406,
+    height: 932737,
+    blockHash:
+      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
+    index: 0,
+    hash:
+      "1472512351262304275125239808423343934577220111166192222712233111195632030000",
+    txHash: "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
+    txType: "vote",
+    debitsAmount: 6785796485,
+    creditsAmount: 6790119971,
+    type: 2,
+    amount: 4323486,
+    fee: 0,
+    debitAccounts: [0],
+    creditAddresses: ["Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr"],
+    isStake: true,
+    credits: [
+      {
+        index: 2,
+        account: 15,
+        internal: true,
+        amount: 6790119971,
+        address: "Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr",
+        outputScript: "u3apFJm/el6ZyMAOCezvNx6r14Zbz14RiKw="
+      }
+    ],
+    debits: [
+      {
+        index: 1,
+        previousAccount: 0,
+        previousAmount: 6785796485
+      }
+    ],
+    rawTx:
+      "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff60ed215decf9ec50b50ff4477db42b1603178dab67e35d59f22b0de16cf4c1650000000001ffffffff0300000000000000000000266a24e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e0000000000000000000000086a0601000a0000002302b9940100000000001abb76a91499bf7a5e99c8c00e09ecef371eabd7865bcf5e1188ac0000000000000000029ef841000000000000000000ffffffff02000085097794010000007d330e00060000006a473044022038c9d8cafe8d98a904c72760e29a7f1e3942c9ef398a7384ca7b946517a3f598022016768855eae1edb7297ee52717bb4c1a247e836fce316a1d681026f4bcf9e5240121027bf4538b926d5668452965c44dbf8724b571ee6b3bae2eab59fd6969e6e87f13",
+    isMix: false
+  },
+  // voted ticket
+  {
+    timestamp: 1652858637,
+    height: 919842,
+    blockHash:
+      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
+    index: 0,
+    hash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
+    txHash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
+    txType: "ticket",
+    debitsAmount: 12271681343,
+    creditsAmount: 12271678363,
+    type: 1,
+    amount: -2980,
+    fee: 2980,
+    debitAccounts: [15],
+    creditAddresses: ["TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 0,
+        internal: true,
+        amount: 12271678363,
+        address: "TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU",
+        outputScript: "unapFFyo29n4+AuvdgX88JdEQQCZoS+biKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 15,
+        previousAmount: 12271681343
+      }
+    ],
+    rawTx:
+      "0100000001b50f2e03314661b566e3f0f246623c4419d8ec605da401f407a5f67cf148ce920000000000ffffffff039bf372db0200000000001aba76a9145ca8dbd9f8f80baf7605fcf09744410099a12f9b88ac00000000000000000000206a1e53b208495f9fabdfa80b4be10c4d0e488b33f2993fff72db02000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac0000000000000000013fff72db0200000000000000ffffffff6b483045022100d8f4e49c56f3249947a759d7ba766b671579399e758feaa12bc525c822c020f602200266d21d887165183479cf3d06a01470ceadc53b73527f6863ae76bf22a11ea001210355d8fdf5cdec7a8848e6d653d6c379908c256d4b54b7be637ab5018d56d19149",
+    isMix: false,
+    vspHost: "mockVspHost-votedticket",
+    feeStatus: 1
+  },
+  // missed
+  {
+    timestamp: 1605621435,
+    height: 558424,
+    blockHash:
+      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
+    index: 0,
+    hash: "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774",
+    txHash: "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774",
+    txType: "ticket",
+    debitsAmount: 9525592746,
+    creditsAmount: 9525589786,
+    type: 1,
+    amount: -2960,
+    fee: 2960,
+    debitAccounts: [6],
+    creditAddresses: ["TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 2147483647,
+        internal: false,
+        amount: 9525589786,
+        address: "TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs",
+        outputScript: "uqkUNP+z1D9bQODb6UJuU4ZfydVT0QOH"
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 6,
+        previousAmount: 9525592746
+      }
+    ],
+    rawTx:
+      "0100000001781d53a4f25c754340cf9250f98039c1db2c92bcd58b1e4637c9ca534d9053c00100000000ffffffff031af7c43702000000000018baa91434ffb3d43f5b40e0dbe9426e53865fc9d553d1038700000000000000000000206a1e5c1c4094ac61fc8762be68d7b15cdb4806611cf7aa02c537020000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000006085080001aa02c5370200000057850800010000006a473044022053cad54d349690d3c22b346134ff71da1b527695c6ec1252f11c1e7c5d9da9280220606a81e7d4ea63b448945cfbf1385b85642e0221cf49ca0824e5ec8ff62a61c30121032071d0e49038bcdeee3461296d2c50950b62f08e35caafbd4f2b0d025d1a47e1",
+    isMix: false,
+    vspHost: "mockVspHost-missed",
+    txUrl:
+      "https://testnet.decred.org/tx/30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774"
+  },
+  // revoked ticket
+  {
+    timestamp: 1637487987,
+    height: 815405,
+    blockHash:
+      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
+    index: 0,
+    hash: "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
+    txHash: "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
+    txType: "ticket",
+    debitsAmount: 8600221089,
+    creditsAmount: 8600218109,
+    type: 1,
+    amount: -2980,
+    fee: 2980,
+    debitAccounts: [0],
+    creditAddresses: ["TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 0,
+        internal: true,
+        amount: 8600218109,
+        address: "TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ",
+        outputScript: "unapFOlPYM9gpJSRDMD+KPZi22h5RnROiKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 0,
+        previousAmount: 8600221089
+      }
+    ],
+    rawTx:
+      "010000000145dff3de5ec042630f66a9ba4ea2ed6d70f3fa306af01858a83efa676d3779000000000000ffffffff03fde99c000200000000001aba76a914e94f60cf60a494910cc0fe28f662db687946744e88ac00000000000000000000206a1e8ef37a84dc2bc7c924877e1ab3026b3b5a102e5fa1f59c0002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a1f59c00020000002c710c00030000006a47304402206888557060684807b6e78f47ea8c186debe45f2316a584abe60c5495f36f77f80220249421832ab9ea9e6bbb70d50376e7f48258b3108a345dc299d1de8186e046060121036343175c705537c636732c42fa699ba96f6296bc66b915216cbc833d00e18e10",
+    isMix: false
+  },
+  // revocation
+  {
+    timestamp: 1622730448,
+    height: 697812,
+    blockHash:
+      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
+    index: 0,
+    hash: "8c6e88a38ceac7e52ef3c9f4d936d0cf16fcc0a510955cab255f3a23ce2e09c1",
+    txHash: "c1092ece233a5f25ab5c9510a5c0fc16cfd036d9f4c9f32ee5c7ea8ca3886e8c",
+    txType: "revocation",
+    debitsAmount: 6475415536,
+    creditsAmount: 6475413336,
+    type: 3,
+    amount: -2200,
+    fee: 2200,
+    debitAccounts: [0],
+    creditAddresses: ["Tsic4BsFzDL1jhR4LTbWS8LvGFgxjqFG3pU"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 0,
+        internal: true,
+        amount: 6475413336,
+        address: "Tsic4BsFzDL1jhR4LTbWS8LvGFgxjqFG3pU",
+        outputScript: "vHapFMDks6W1pFTjiMaGSuUSBSI6EtzkiKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 0,
+        previousAmount: 6475415536
+      }
+    ],
+    rawTx:
+      "010000000147ecbf246e47f6e9e2616baece2a0d70c63184d09904a22eb2ca438211fc1b9a0000000001ffffffff0158f7f6810100000000001abc76a914c0e4b3a5b5a454e388c6864ae51205223a12dce488ac000000000000000001f0fff6810100000045180a00060000006b483045022100ab8406a6b9bf915b48dd251519d64a7c8cf8019adc370bdd82b8d914e128280a02204ed8d9726d3a0b8186cba70e1dfd28be1ef3d9eb4e94dd412c85bc979b49a878012102ce47d2933e9b7a2fdd867dd95716ffa7674ea15083349c9dfc2f3a29ddb28052",
+    isMix: false
+  },
+  // unmined
+  {
+    timestamp: 1658937788,
+    height: -1,
+    blockHash: null,
+    index: 1,
+    hash: "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f",
+    txHash: "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f",
+    txType: "ticket",
+    debitsAmount: 20002980,
+    creditsAmount: 20000000,
+    type: 1,
+    amount: -2980,
+    fee: 2980,
+    debitAccounts: [0],
+    creditAddresses: ["TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 0,
+        internal: true,
+        amount: 20000000,
+        address: "TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg",
+        outputScript: "unapFAVpSQ3nfoA2C1xW+RhdcLMvdGCoiKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 0,
+        previousAmount: 20002980
+      }
+    ],
+    rawTx:
+      "01000000011babed986d25d5c3c27a1626e6caa344899949974a83bf63a49c2b1fa5f0514a0000000000ffffffff03002d31010000000000001aba76a9140569490de77e80360b5c56f9185d70b32f7460a888ac00000000000000000000206a1e9154057f4df98e818b05779aea2a20f6b624012ea438310100000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a43831010000000000000000ffffffff6a4730440220290c05e17b48e8c6ed6ee42326565a91416835b75c5f481b10a16e5b0dfa9f67022001d99b93ae971419db6e411dab042828e34ed2b0c7fcd30bd50ccae3d333a393012102af8273525052a10d5c8906ea288968d6f8c7e68caeaab58554b429e8f535e269",
+    isMix: false,
+    vspHost: "mockVspHost-unmined",
+    txUrl:
+      "https://testnet.decred.org/tx/d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f"
+  },
+  // immature
+  {
+    timestamp: 1654203366,
+    height: 930690,
+    blockHash:
+      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
+    index: 0,
+    hash: "f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530",
+    txHash: "f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530",
+    txType: "ticket",
+    debitsAmount: 6785799465,
+    creditsAmount: 6785796485,
+    type: 1,
+    amount: -2980,
+    fee: 2980,
+    debitAccounts: [0],
+    creditAddresses: ["TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 0,
+        internal: true,
+        amount: 6785796485,
+        address: "TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK",
+        outputScript: "unapFA+UU96/HfOSYqbq+B/LmP95fIlciKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 0,
+        previousAmount: 6785799465
+      }
+    ],
+    rawTx:
+      "01000000011a1b3fc2661245ba6b8cab9e315cf76b16c565f1c1277512608d51906f1636c10000000000ffffffff03850977940100000000001aba76a9140f9453debf1df39262a6eaf81fcb98ff797c895c88ac00000000000000000000206a1e19e5ba2f1f3b99efe1090707638af39998a1b7582915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6b483045022100a510695025634a249cda2c85fe63a43312cb0ee5c02db2f1256fe4f835702f8002202b0f4c7e093500b75626a4829c9705a370cb2f2f834702abe8b9ac268d5ac57b012102dfa5deeeee8b65f2738483d412f2bb5627fa7f761b132f3b4eef2e154151902c",
+    isMix: false
+  },
+  // live
+  {
+    timestamp: 1654204193,
+    height: 930696,
+    blockHash:
+      "21eb3e22e887ba5c674399bff8e05bcb3bd8917ec283436d75357dc10b000000",
+    index: 0,
+    hash: "05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07",
+    txHash: "05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07",
+    txType: "ticket",
+    debitsAmount: 6785799465,
+    creditsAmount: 6785796485,
+    type: 1,
+    amount: -2980,
+    fee: 2980,
+    debitAccounts: [0],
+    creditAddresses: ["TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4"],
+    isStake: true,
+    credits: [
+      {
+        index: 0,
+        account: 0,
+        internal: true,
+        amount: 6785796485,
+        address: "TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4",
+        outputScript: "unapFIMhyeEfBENiiiK/SodiN02IfAYyiKw="
+      }
+    ],
+    debits: [
+      {
+        index: 0,
+        previousAccount: 0,
+        previousAmount: 6785799465
+      }
+    ],
+    rawTx:
+      "010000000164f0acf752429210f469c6536c857d092aac8bc84fa661f013b535aa6394c4710000000000ffffffff03850977940100000000001aba76a9148321c9e11f0443628a22bf4a8762374d887c063288ac00000000000000000000206a1e01ca6bb0120ca64e750a9cbaa66597f010c1c03d2915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6b483045022100a58c8e7b6f33b3c3fdc43dfa7472d19e39cc8c22c5990f94ca45a9458c860bfe02202227864c234f9a2c328418cabf6a5934e99d16806a8492805ad4243155d77e63012102029965f740c2b87c21dca96fb4195f71dae34b779ef4daed5902f98a0c09a437",
+    isMix: false
+  }
+];
+
+export const mockStakeTransactions = {};
+mockStakeTransactionList.forEach((tx) => {
+  tx.blockHash = toByteArray(tx.blockHash);
+  if (tx.ticket) {
+    tx.ticket.blockHash = toByteArray(tx.ticket.blockHash);
+  }
+  if (tx.spender) {
+    tx.spender.blockHash = toByteArray(tx.spender.blockHash);
+  }
+  mockStakeTransactions[tx.txHash] = tx;
+});

--- a/test/unit/components/views/TransactionPage/mocks_tickets.js
+++ b/test/unit/components/views/TransactionPage/mocks_tickets.js
@@ -1,0 +1,663 @@
+export const mockTickets = {
+  "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60": {
+    status: "voted",
+    block: {
+      hash: "0000000017288e2033c8422a15ec0557bad02ee38123efb55d225d96d79c4183",
+      height: 930685,
+      timestamp: 1654202680
+    },
+    ticket: {
+      timestamp: 1654202680,
+      height: 930685,
+      blockHash:
+        "0000000017288e2033c8422a15ec0557bad02ee38123efb55d225d96d79c4183",
+      hash: "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
+      txHash:
+        "65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60",
+      txType: "ticket",
+      debitsAmount: 6785799465,
+      creditsAmount: 6785796485,
+      type: 1,
+      amount: -2980,
+      fee: 2980,
+      debitAccounts: [15],
+      creditAddresses: ["TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 6785796485,
+          address: "TsZxH8PTsbnWHg7ty2xFhUH9uzizLrNSAy7",
+          outputScript: "unapFGH+sNJBVRkEe2EjIOCHcpFJ7baziKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 15,
+          previousAmount: 6785799465
+        }
+      ],
+      rawTx:
+        "010000000154a9b3b3e7a51658a2dcadb7e6cc440acda169c47e785ba6225cab34be43dce50000000000ffffffff03850977940100000000001aba76a91461feb0d2415519047b612320e087729149edb6b388ac00000000000000000000206a1e99bf7a5e99c8c00e09ecef371eabd7865bcf5e112915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6a473044022020cfc5e2bb47ddcd39fdc1a7e82e90a8fb0c2fc01db79c683296b15afb29780c0220216ee46d39c358a18395a035b9cc0af1a0a753eed82deef8694b516b77ee0bdd0121025d5aeb18e8bb8ae1485aed5e2816990ff8b0eee40bb9ab046d738cd6e18b4edd",
+      isMix: false,
+      vspHost: "mockVspHost",
+      txUrl:
+        "https://testnet.decred.org/tx/65c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60"
+    },
+    spender: {
+      timestamp: 1654485406,
+      height: -1,
+      blockHash: null,
+      index: 0,
+      hash: "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
+      txHash:
+        "843128b4209be24400f5c7452aad43c2a7592979fcce6de22695e501c6a4d3b4",
+      txType: "vote",
+      debitsAmount: 6785796485,
+      creditsAmount: 6790119971,
+      type: 2,
+      amount: 4323486,
+      fee: 0,
+      debitAccounts: [0],
+      creditAddresses: ["Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr"],
+      isStake: true,
+      credits: [
+        {
+          index: 2,
+          account: 15,
+          internal: true,
+          amount: 6790119971,
+          address: "Tsf35F2zDqv9EmDC1pTqixwNe5ytxyseRGr",
+          outputScript: "u3apFJm/el6ZyMAOCezvNx6r14Zbz14RiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 1,
+          previousAccount: 0,
+          previousAmount: 6785796485
+        }
+      ],
+      rawTx:
+        "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff60ed215decf9ec50b50ff4477db42b1603178dab67e35d59f22b0de16cf4c1650000000001ffffffff0300000000000000000000266a24e4d5021f882b7926497679f68b14dbf77fdd2a901b24560ab297789e00000000803b0e0000000000000000000000086a0601000a0000002302b9940100000000001abb76a91499bf7a5e99c8c00e09ecef371eabd7865bcf5e1188ac0000000000000000029ef841000000000000000000ffffffff02000085097794010000007d330e00060000006a473044022038c9d8cafe8d98a904c72760e29a7f1e3942c9ef398a7384ca7b946517a3f598022016768855eae1edb7297ee52717bb4c1a247e836fce316a1d681026f4bcf9e5240121027bf4538b926d5668452965c44dbf8724b571ee6b3bae2eab59fd6969e6e87f13",
+      isMix: false,
+      transaction:
+        "137fe8e66969fd59ab2eae3b6bee71b52487bf4dc465294568566d928b53f47b02210124e5f9bcf42610681d6a31ce6f837e241a4cbb1727e57e29b7ede1ea55887616200298f5a31765947bca84738a39efc942391e7f9ae26027c704a9988dfecad8c93820024430476a00000006000e337d0000000194770985000002ffffffff00000000000000000041f89e020000000000000000ac88115ecf5b86d7ab1e37efec090ec0c8995e7abf9914a976bb1a00000000000194b902230000000a0001066a0800000000000000000000000e3b80000000009e7897b20a56241b902add7ff7db148bf679764926792b881f02d5e4246a260000000000000000000003ffffffff010000000065c1f46ce10d2bf2595de367ab8d1703162bb47d47f40fb550ecf9ec5d21ed60ffffffff00ffffffff00000000000000000000000000000000000000000000000000000000000000000200000001"
+    }
+  },
+  "9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47": {
+    status: "expired",
+    block: {
+      hash: "0000001a634aac0ddc28c3a8c68c124140671a289b6c861ecdd375c120f35517",
+      height: 661573,
+      timestamp: 1618322224
+    },
+    ticket: {
+      timestamp: 1618322224,
+      height: 661573,
+      blockHash:
+        "0000001a634aac0ddc28c3a8c68c124140671a289b6c861ecdd375c120f35517",
+      hash: "9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47",
+      txHash:
+        "9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47",
+      txType: "ticket",
+      debitsAmount: 6475418516,
+      creditsAmount: 6475415536,
+      type: 1,
+      amount: -2980,
+      fee: 2980,
+      debitAccounts: [0],
+      creditAddresses: ["TsYUisRdHbZ7p4y2w2Hfnu9zp9bUn6BzxPu"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 6475415536,
+          address: "TsYUisRdHbZ7p4y2w2Hfnu9zp9bUn6BzxPu",
+          outputScript: "unapFFHQaAazkipmTp6c1j/hjKpwgepmiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 0,
+          previousAmount: 6475418516
+        }
+      ],
+      rawTx:
+        "010000000120b97bf5eb8969095c3b8fa9590701f910246f464b84db62423b34c37b6747330000000000ffffffff03f0fff6810100000000001aba76a91451d06806b3922a664e9e9cd63fe18caa7081ea6688ac00000000000000000000206a1ec0e4b3a5b5a454e388c6864ae51205223a12dce4940bf781010000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001940bf7810100000044180a00020000006a47304402204be3e7097a452d99c2b56c138f8df33a923f6da1f9f465e56c75b9cdd571864902201bf7a3e9db1cfd3b7f8e55252d5f3c04311275bbc2c4ff2333472840c262b413012102936911a32e4e000e56f82207ec5d39a66b9971021869905087b23a10399cb1b0",
+      isMix: false,
+      txUrl:
+        "https://testnet.decred.org/tx/9a1bfc118243cab22ea20499d08431c6700d2aceae6b61e2e9f6476e24bfec47",
+      vspHost:
+        "mock-vspHost-c1092ece233a5f25ab5c9510a5c0fc16cfd036d9f4c9f32ee5c7ea8ca3886e8c"
+    },
+    spender: {
+      timestamp: 1622730448,
+      height: -1,
+      blockHash: null,
+      index: 0,
+      hash: "c1092ece233a5f25ab5c9510a5c0fc16cfd036d9f4c9f32ee5c7ea8ca3886e8c",
+      txHash:
+        "c1092ece233a5f25ab5c9510a5c0fc16cfd036d9f4c9f32ee5c7ea8ca3886e8c",
+      txType: "revocation",
+      debitsAmount: 6475415536,
+      creditsAmount: 6475413336,
+      type: 3,
+      amount: -2200,
+      fee: 2200,
+      debitAccounts: [0],
+      creditAddresses: ["Tsic4BsFzDL1jhR4LTbWS8LvGFgxjqFG3pU"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 6475413336,
+          address: "Tsic4BsFzDL1jhR4LTbWS8LvGFgxjqFG3pU",
+          outputScript: "vHapFMDks6W1pFTjiMaGSuUSBSI6EtzkiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 0,
+          previousAmount: 6475415536
+        }
+      ],
+      rawTx:
+        "010000000147ecbf246e47f6e9e2616baece2a0d70c63184d09904a22eb2ca438211fc1b9a0000000001ffffffff0158f7f6810100000000001abc76a914c0e4b3a5b5a454e388c6864ae51205223a12dce488ac000000000000000001f0fff6810100000045180a00060000006b483045022100ab8406a6b9bf915b48dd251519d64a7c8cf8019adc370bdd82b8d914e128280a02204ed8d9726d3a0b8186cba70e1dfd28be1ef3d9eb4e94dd412c85bc979b49a878012102ce47d2933e9b7a2fdd867dd95716ffa7674ea15083349c9dfc2f3a29ddb28052",
+      isMix: false
+    }
+  },
+  "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774": {
+    status: "missed",
+    block: {
+      hash: "0000005d1fb9e2c9b514f849f20c40d51085e0176e277d5c19ba7f4fd491a825",
+      height: 558424,
+      timestamp: 1605621435
+    },
+    ticket: {
+      timestamp: 1605621435,
+      height: 558424,
+      blockHash:
+        "0000005d1fb9e2c9b514f849f20c40d51085e0176e277d5c19ba7f4fd491a825",
+      hash: "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774",
+      txHash:
+        "30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774",
+      txType: "ticket",
+      debitsAmount: 9525592746,
+      creditsAmount: 9525589786,
+      type: 1,
+      amount: -2960,
+      fee: 2960,
+      debitAccounts: [6],
+      creditAddresses: ["TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 2147483647,
+          internal: false,
+          amount: 9525589786,
+          address: "TccM3W31vkNXUCosK4Y5vYrmtiWWjuecHFs",
+          outputScript: "uqkUNP+z1D9bQODb6UJuU4ZfydVT0QOH"
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 6,
+          previousAmount: 9525592746
+        }
+      ],
+      rawTx:
+        "0100000001781d53a4f25c754340cf9250f98039c1db2c92bcd58b1e4637c9ca534d9053c00100000000ffffffff031af7c43702000000000018baa91434ffb3d43f5b40e0dbe9426e53865fc9d553d1038700000000000000000000206a1e5c1c4094ac61fc8762be68d7b15cdb4806611cf7aa02c537020000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000006085080001aa02c5370200000057850800010000006a473044022053cad54d349690d3c22b346134ff71da1b527695c6ec1252f11c1e7c5d9da9280220606a81e7d4ea63b448945cfbf1385b85642e0221cf49ca0824e5ec8ff62a61c30121032071d0e49038bcdeee3461296d2c50950b62f08e35caafbd4f2b0d025d1a47e1",
+      isMix: false,
+      transaction:
+        "e1471a5d020d2b4fbdafca358ef0620b95502c6d296134eedebc3890e4d07120032101c3612af68fece52408ca49cf21022e64855b38f1fb5c9448b463ead4e7816a60200228a99d5d7c1e1cf15212ecc69576521bda71ff3461342bc2d39096344dd5ca5320024430476a00000001000885570000000237c502aa010008856000000000ac88000000000000000000000000000000000000000014a976bd1a0000000000000000000058000000000237c502aaf71c610648db5cb1d768be6287fc61ac94401c5c1e6a20000000000000000000008703d153d5c95f86536e42e9dbe0405b3fd4b3ff3414a9ba1800000000000237c4f71a03ffffffff0000000001c053904d53cac937461e8bd5bc922cdbc13980f95092cf4043755cf2a4531d780100000001",
+      vspHost: "mockVspHost-missed",
+      txUrl:
+        "https://testnet.decred.org/tx/30dd06049d763ab474dbc39ffbe4bbd0ad6825e5bdf21b67dc046fda3ce55774"
+    },
+    spender: {
+      timestamp: 1605714645,
+      height: -1,
+      blockHash: null,
+      index: 0,
+      hash: "c44db16d004aa264c3cc8dcf90ecc08caa88964cb6e34477139651b56f46af79",
+      txHash:
+        "c44db16d004aa264c3cc8dcf90ecc08caa88964cb6e34477139651b56f46af79",
+      txType: "revocation",
+      debitsAmount: 9525589786,
+      creditsAmount: 9525587586,
+      type: 3,
+      amount: -2200,
+      fee: 2200,
+      debitAccounts: [2147483647],
+      creditAddresses: ["TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 6,
+          internal: true,
+          amount: 9525587586,
+          address: "TsZRAVD9t8shxck66daNEhaWrWCsYV9e2Qp",
+          outputScript: "vHapFFwcQJSsYfyHYr5o17Fc20gGYRz3iKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 2147483647,
+          previousAmount: 9525589786
+        }
+      ],
+      rawTx:
+        "01000000017457e53cda6f04dc671bf2bde52568add0bbe4fb9fc3db74b43a769d0406dd300000000001ffffffff0182eec4370200000000001abc76a9145c1c4094ac61fc8762be68d7b15cdb4806611cf788ac0000000000000000011af7c437020000005885080005000000904730440220163ae79bc0713243f5e627aeafb680fbc2126b153188b4921d954056efc3fa61022040c5ecfdaa83175cef7faf99460b765779c4bcf09cc6e72782d491664bb66dbb01475121038add32307530f18099a9208f32fc04502b40073ea6a6cfebbbd79988270a612e2103f2a96dbe354081542af9571c43662b883d9ae02416cd5080137c0556c7a0976d52ae",
+      isMix: false
+    }
+  },
+  b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99: {
+    status: "revoked",
+    block: {
+      hash: "000000080433728b66a9dcd5471205adde4df9619af27f45613f60c4d3dc8a02",
+      height: 815405,
+      timestamp: 1637487987
+    },
+    ticket: {
+      timestamp: 1637487987,
+      height: 815405,
+      blockHash:
+        "000000080433728b66a9dcd5471205adde4df9619af27f45613f60c4d3dc8a02",
+      hash: "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
+      txHash:
+        "b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99",
+      txType: "ticket",
+      debitsAmount: 8600221089,
+      creditsAmount: 8600218109,
+      type: 1,
+      amount: -2980,
+      fee: 2980,
+      debitAccounts: [0],
+      creditAddresses: ["TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 8600218109,
+          address: "TsnHm1YjaLMmnFsyGwt54D4P53aFaNqeESJ",
+          outputScript: "unapFOlPYM9gpJSRDMD+KPZi22h5RnROiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 0,
+          previousAmount: 8600221089
+        }
+      ],
+      rawTx:
+        "010000000145dff3de5ec042630f66a9ba4ea2ed6d70f3fa306af01858a83efa676d3779000000000000ffffffff03fde99c000200000000001aba76a914e94f60cf60a494910cc0fe28f662db687946744e88ac00000000000000000000206a1e8ef37a84dc2bc7c924877e1ab3026b3b5a102e5fa1f59c0002000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a1f59c00020000002c710c00030000006a47304402206888557060684807b6e78f47ea8c186debe45f2316a584abe60c5495f36f77f80220249421832ab9ea9e6bbb70d50376e7f48258b3108a345dc299d1de8186e046060121036343175c705537c636732c42fa699ba96f6296bc66b915216cbc833d00e18e10",
+      isMix: false,
+      transaction:
+        "108ee1003d83bc6c2115b966bc96626fa99b69fa422c7336c63755705c1743630321010646e08681ded199c25d348a10b35882f4e77603d570bb6b9eeab92a832194242002f8776ff395540ce6ab84a516235fe4eb6d188cea478fe7b6074868607055886820024430476a00000003000c712c00000002009cf5a1010000000000000000ac88000000000000000000000000000000000000000014a976bd1a000000000000000000004e0000000002009cf5a15f2e105a3b6b02b31a7e8724c9c72bdc847af38e1e6a2000000000000000000000ac884e74467968db62f628fec00c9194a460cf604fe914a976ba1a000000000002009ce9fd03ffffffff00000000000079376d67fa3ea85818f06a30faf3706deda24ebaa9660f6342c05edef3df450100000001",
+      vspHost: "",
+      txUrl:
+        "https://testnet.decred.org/tx/b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f99"
+    },
+    spender: {
+      timestamp: 1643948925,
+      height: -1,
+      blockHash: null,
+      index: 0,
+      hash: "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
+      txHash:
+        "c63ff33bf5955e8636d57be2762d60e1fedaf65c92548e08784db9a4e433de1d",
+      txType: "revocation",
+      debitsAmount: 8600218109,
+      creditsAmount: 8600218109,
+      type: 3,
+      amount: 0,
+      fee: 0,
+      debitAccounts: [0],
+      creditAddresses: ["Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 8600218109,
+          address: "Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy",
+          outputScript: "vHapFI7zeoTcK8fJJId+GrMCaztaEC5fiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 0,
+          previousAmount: 8600218109
+        }
+      ],
+      rawTx:
+        "0200000001997fa9df69903ad5d40fce86f0da366f3d9c13b842e947d1d0859a30e3e24eb00000000001ffffffff01fde99c000200000000001abc76a9148ef37a84dc2bc7c924877e1ab3026b3b5a102e5f88ac000000000000000001fde99c00020000002d710c000800000000",
+      isMix: false,
+      transaction:
+        "0000000008000c712d00000002009ce9fd010000000000000000ac885f2e105a3b6b02b31a7e8724c9c72bdc847af38e14a976bc1a000000000002009ce9fd01ffffffff0100000000b04ee2e3309a85d0d147e942b8139c3d6f36daf086ce0fd4d53a9069dfa97f990100000002"
+    }
+  },
+  d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f: {
+    status: "unmined",
+    block: null,
+    ticket: {
+      timestamp: 1658937788,
+      height: -1,
+      blockHash: null,
+      index: 0,
+      hash: "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f",
+      txHash:
+        "d6b457b87edf02391e9adb4021d830259178bc4c906129b55445f2918ad5fb6f",
+      txType: "ticket",
+      debitsAmount: 20002980,
+      creditsAmount: 20000000,
+      type: 1,
+      amount: -2980,
+      fee: 2980,
+      debitAccounts: [0],
+      creditAddresses: ["TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 20000000,
+          address: "TsRWjysgoNXTS7JAQXfsaAzts8UM3Dq3WUg",
+          outputScript: "unapFAVpSQ3nfoA2C1xW+RhdcLMvdGCoiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 0,
+          previousAmount: 20002980
+        }
+      ],
+      rawTx:
+        "01000000011babed986d25d5c3c27a1626e6caa344899949974a83bf63a49c2b1fa5f0514a0000000000ffffffff03002d31010000000000001aba76a9140569490de77e80360b5c56f9185d70b32f7460a888ac00000000000000000000206a1e9154057f4df98e818b05779aea2a20f6b624012ea438310100000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001a43831010000000000000000ffffffff6a4730440220290c05e17b48e8c6ed6ee42326565a91416835b75c5f481b10a16e5b0dfa9f67022001d99b93ae971419db6e411dab042828e34ed2b0c7fcd30bd50ccae3d333a393012102af8273525052a10d5c8906ea288968d6f8c7e68caeaab58554b429e8f535e269",
+      isMix: false,
+      transaction:
+        "69e235f5e829b45485b5aaae8ce6c7f8d6688928ea06895c0da15250527382af02210193a333d3e3ca0cd50bd3fcc7b0d24ee3282804ab1d416edb191497ae939bd9012002679ffa0d5b6ea1101b485f5cb7356841915a562623e46eedc6e8487be1050c2920024430476affffffff0000000000000000013138a4010000000000000000ac88000000000000000000000000000000000000000014a976bd1a000000000000000000004e0000000000013138a42e0124b6f6202aea9a77058b818ef94d7f0554911e6a2000000000000000000000ac88a860742fb3705d18f9565c0b36807ee70d49690514a976ba1a00000000000001312d0003ffffffff00000000004a51f0a51f2b9ca463bf834a9749998944a3cae626167ac2c3d5256d98edab1b0100000001",
+      vspHost: "mockVspHost-unmined"
+    },
+    spender: {
+      timestamp: 0,
+      height: -1,
+      blockHash: null,
+      index: 0,
+      hash: "",
+      txHash: null,
+      txType: "regular",
+      debitsAmount: 0,
+      creditsAmount: 0,
+      type: 0,
+      amount: 0,
+      fee: 0,
+      debitAccounts: [],
+      creditAddresses: [],
+      isStake: false,
+      credits: [],
+      debits: [],
+      rawTx: null,
+      direction: "sent",
+      isMix: false
+    }
+  },
+  f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530: {
+    status: "immature",
+    block: {
+      hash: "00000000c6bc60d4227652382007799a066f94f3086f6ff56d6c0e726908c4c9",
+      height: 930690,
+      timestamp: 1654203366
+    },
+    ticket: {
+      timestamp: 1654203366,
+      height: 930690,
+      blockHash:
+        "00000000c6bc60d4227652382007799a066f94f3086f6ff56d6c0e726908c4c9",
+      hash: "f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530",
+      txHash:
+        "f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530",
+      txType: "ticket",
+      debitsAmount: 6785799465,
+      creditsAmount: 6785796485,
+      type: 1,
+      amount: -2980,
+      fee: 2980,
+      debitAccounts: [0],
+      creditAddresses: ["TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 6785796485,
+          address: "TsSSWJRNEor8X6R33GSoo68p3yq3zFuGoVK",
+          outputScript: "unapFA+UU96/HfOSYqbq+B/LmP95fIlciKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 0,
+          previousAmount: 6785799465
+        }
+      ],
+      rawTx:
+        "01000000011a1b3fc2661245ba6b8cab9e315cf76b16c565f1c1277512608d51906f1636c10000000000ffffffff03850977940100000000001aba76a9140f9453debf1df39262a6eaf81fcb98ff797c895c88ac00000000000000000000206a1e19e5ba2f1f3b99efe1090707638af39998a1b7582915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6b483045022100a510695025634a249cda2c85fe63a43312cb0ee5c02db2f1256fe4f835702f8002202b0f4c7e093500b75626a4829c9705a370cb2f2f834702abe8b9ac268d5ac57b012102dfa5deeeee8b65f2738483d412f2bb5627fa7f761b132f3b4eef2e154151902c",
+      isMix: false,
+      transaction:
+        "2c905141152eef4e3b2f131b767ffa2756bbf212d4838473f2658beeeedea5df0221017bc55a8d26acb9e8ab0247832f2fcb70a305979c82a42656b70035097e4c0f2b2002802f7035f8e46f25f1b22dc0e50ecb1233a463fe852cda9c244a6325506910a50021024530486bffffffff000000000000000194771529010000000000000000ac88000000000000000000000000000000000000000014a976bd1a000000000000000000004e00000000019477152958b7a19899f38a63070709e1ef993b1f2fbae5191e6a2000000000000000000000ac885c897c79ff98cb1ff8eaa66292f31dbfde53940f14a976ba1a0000000000019477098503ffffffff0000000000c136166f90518d60127527c1f165c5166bf75c319eab8c6bba451266c23f1b1a0100000001",
+      vspHost: "mockVspHost-immature",
+      txUrl:
+        "https://testnet.decred.org/tx/f0085fbc5f7476dc4907618262ae6e8a967ab1ac21c55465ed1dc31369dec530"
+    },
+    spender: {
+      timestamp: 0,
+      height: -1,
+      blockHash: null,
+      index: 0,
+      hash: "",
+      txHash: null,
+      txType: "regular",
+      debitsAmount: 0,
+      creditsAmount: 0,
+      type: 0,
+      amount: 0,
+      fee: 0,
+      debitAccounts: [],
+      creditAddresses: [],
+      isStake: false,
+      credits: [],
+      debits: [],
+      rawTx: null,
+      direction: "sent",
+      isMix: false
+    }
+  },
+  "05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07": {
+    status: "live",
+    block: {
+      hash: "00000000d0ac2c2cf4065c823f3a71033edc0afe2b9be90482e0c10ff57c80f6",
+      height: 930696,
+      timestamp: 1654204193
+    },
+    ticket: {
+      timestamp: 1654204193,
+      height: 930696,
+      blockHash:
+        "00000000d0ac2c2cf4065c823f3a71033edc0afe2b9be90482e0c10ff57c80f6",
+      hash: "05fba7101e0d038bad81777f221189eebce9461d1181djjhj284f32ed3664e07",
+      txHash:
+        "05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07",
+      txType: "ticket",
+      debitsAmount: 6785799465,
+      creditsAmount: 6785796485,
+      type: 1,
+      amount: -2980,
+      fee: 2980,
+      debitAccounts: [0],
+      creditAddresses: ["TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 6785796485,
+          address: "TscyVUMxevtGhTuTvM6LkLnvQGU97kEyUg4",
+          outputScript: "unapFIMhyeEfBENiiiK/SodiN02IfAYyiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 0,
+          previousAmount: 6785799465
+        }
+      ],
+      rawTx:
+        "010000000164f0acf752429210f469c6536c857d092aac8bc84fa661f013b535aa6394c4710000000000ffffffff03850977940100000000001aba76a9148321c9e11f0443628a22bf4a8762374d887c063288ac00000000000000000000206a1e01ca6bb0120ca64e750a9cbaa66597f010c1c03d2915779401000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000001291577940100000000000000ffffffff6b483045022100a58c8e7b6f33b3c3fdc43dfa7472d19e39cc8c22c5990f94ca45a9458c860bfe02202227864c234f9a2c328418cabf6a5934e99d16806a8492805ad4243155d77e63012102029965f740c2b87c21dca96fb4195f71dae34b779ef4daed5902f98a0c09a437",
+      isMix: false,
+      transaction:
+        "37a4090c8af90259eddaf49e774be3da715f19b46fa9dc217cb8c240f7659902022101637ed7553124d45a8092846a80169de934596abfca1884322c9a4f234c8627222002fe0b868c45a945ca940f99c5228ccc399ed17274fa3dc4fdc3b3336f7b8e8ca50021024530486bffffffff000000000000000194771529010000000000000000ac88000000000000000000000000000000000000000014a976bd1a000000000000000000004e0000000001947715293dc0c110f09765a6ba9c0a754ea60c12b06bca011e6a2000000000000000000000ac8832067c884d3762874abf228a6243041fe1c9218314a976ba1a0000000000019477098503ffffffff000000000071c49463aa35b513f061a64fc88bac2a097d856c53c669f410924252f7acf0640100000001",
+      vspHost: "mockVspHost-live",
+      txUrl:
+        "https://testnet.decred.org/tx/05fba7101e0d038bad81777f221189eebce9461d1181d961a284f32ed3664e07"
+    },
+    spender: {
+      timestamp: 0,
+      height: -1,
+      blockHash: null,
+      index: 0,
+      hash: "",
+      txHash: null,
+      txType: "regular",
+      debitsAmount: 0,
+      creditsAmount: 0,
+      type: 0,
+      amount: 0,
+      fee: 0,
+      debitAccounts: [],
+      creditAddresses: [],
+      isStake: false,
+      credits: [],
+      debits: [],
+      rawTx: null,
+      direction: "sent",
+      isMix: false
+    }
+  },
+  "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57": {
+    status: "voted",
+    block: {
+      hash: "00000000bbf1f33870cec5e4da9a7eb7a80c17b07cd3ba4865f4086fa6f8cd3e",
+      height: 919842,
+      timestamp: 1652858637
+    },
+    ticket: {
+      timestamp: 1652858637,
+      height: 919842,
+      blockHash:
+        "00000000bbf1f33870cec5e4da9a7eb7a80c17b07cd3ba4865f4086fa6f8cd3e",
+      hash: "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
+      txHash:
+        "6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57",
+      txType: "ticket",
+      debitsAmount: 12271681343,
+      creditsAmount: 12271678363,
+      type: 1,
+      amount: -2980,
+      fee: 2980,
+      debitAccounts: [15],
+      creditAddresses: ["TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU"],
+      isStake: true,
+      credits: [
+        {
+          index: 0,
+          account: 0,
+          internal: true,
+          amount: 12271678363,
+          address: "TsZU4vitduHQ4JWY5hjXFpqWa4DmUsaLenU",
+          outputScript: "unapFFyo29n4+AuvdgX88JdEQQCZoS+biKw="
+        }
+      ],
+      debits: [
+        {
+          index: 0,
+          previousAccount: 15,
+          previousAmount: 12271681343
+        }
+      ],
+      rawTx:
+        "0100000001b50f2e03314661b566e3f0f246623c4419d8ec605da401f407a5f67cf148ce920000000000ffffffff039bf372db0200000000001aba76a9145ca8dbd9f8f80baf7605fcf09744410099a12f9b88ac00000000000000000000206a1e53b208495f9fabdfa80b4be10c4d0e488b33f2993fff72db02000000004e000000000000000000001abd76a914000000000000000000000000000000000000000088ac0000000000000000013fff72db0200000000000000ffffffff6b483045022100d8f4e49c56f3249947a759d7ba766b671579399e758feaa12bc525c822c020f602200266d21d887165183479cf3d06a01470ceadc53b73527f6863ae76bf22a11ea001210355d8fdf5cdec7a8848e6d653d6c379908c256d4b54b7be637ab5018d56d19149",
+      isMix: false,
+      transaction:
+        "4991d1568d01b57a63beb7544b6d258c9079c3d653d6e648887aeccdf5fdd855032101a01ea122bf76ae63687f52733bc5adce7014a0063dcf7934186571881dd266022002f620c022c825c52ba1ea8f759e397915676b76bad759a7479924f3569ce4f4d80021024530486bffffffff0000000000000002db72ff3f010000000000000000ac88000000000000000000000000000000000000000014a976bd1a000000000000000000004e0000000002db72ff3f99f2338b480e4d0ce14b0ba8dfab9f5f4908b2531e6a2000000000000000000000ac889b2fa19900414497f0fc0576af0bf8f8d9dba85c14a976ba1a000000000002db72f39b03ffffffff000000000092ce48f17cf6a507f401a45d60ecd819443c6246f2f0e366b5614631032e0fb50100000001",
+      vspHost: "mockVspHost-votedticket",
+      txUrl:
+        "https://testnet.decred.org/tx/6085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57"
+    },
+    spender: {
+      timestamp: 1652874655,
+      height: -1,
+      blockHash: null,
+      index: 0,
+      hash: "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
+      txHash:
+        "fbde49cea3a4f27110aed317dff2e8c2f00d44550bce68f5ef182b1d356d79da",
+      txType: "vote",
+      debitsAmount: 12271678363,
+      creditsAmount: 12276267831,
+      type: 2,
+      amount: 4589468,
+      fee: 0,
+      debitAccounts: [0],
+      creditAddresses: ["TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n"],
+      isStake: true,
+      credits: [
+        {
+          index: 2,
+          account: 15,
+          internal: true,
+          amount: 12276267831,
+          address: "TsYefqPSd4tBj2MFBaFirMhPK8hUUhMfa4n",
+          outputScript: "u3apFFOyCElfn6vfqAtL4QxNDkiLM/KZiKw="
+        }
+      ],
+      debits: [
+        {
+          index: 1,
+          previousAccount: 0,
+          previousAmount: 12271678363
+        }
+      ],
+      rawTx:
+        "01000000020000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff574f7189057261e0e816b09306c3dd4ae55146be8d1ce52a4d5c2475fdcf85600000000001ffffffff0300000000000000000000266a2432c8b01145a24d62ff8db613ca24a3b92e2472bac893ad0e864f1c8b00000000a8090e0000000000000000000000086a0601000a00000037fbb8db0200000000001abb76a91453b208495f9fabdfa80b4be10c4d0e488b33f29988ac0000000000000000029c0746000000000000000000ffffffff0200009bf372db0200000022090e00110000006a4730440220481a66bdf843d6fe2f41b0b5ba129cfec694f82bac72602d08998a2a8b792fb2022003b0a2c8ddfcc317fdb5fac33cc0fbff280ce4bc250caef3e94840c79ef60ee301210355174775888e14ed49e50dd0b904e6dca3f6b4595afd9248a020a4aa87ae469e",
+      isMix: false,
+      transaction:
+        "9e46ae87aaa420a04892fd5a59b4f6a3dce604b9d00de549ed148e8875471755032101e30ef69ec74048e9f3ae0c25bce40c28fffbc03cc3fab5fd17c3fcddc8a2b0032002b22f798b2a8a99082d6072ac2bf894c6fe9c12bab5b0412ffed643f8bd661a4820024430476a00000011000e092200000002db72f39b000002ffffffff00000000000000000046079c020000000000000000ac8899f2338b480e4d0ce14b0ba8dfab9f5f4908b25314a976bb1a000000000002dbb8fb370000000a0001066a0800000000000000000000000e09a8000000008b1c4f860ead93c8ba72242eb9a324ca13b68dff624da24511b0c832246a260000000000000000000003ffffffff01000000006085cffd75245c4d2ae51c8dbe4651e54addc30693b016e8e061720589714f57ffffffff00ffffffff00000000000000000000000000000000000000000000000000000000000000000200000001"
+    }
+  }
+};


### PR DESCRIPTION
This diff cleans and adds detailed tests for TransactionActions, and TransactionPage.
Builds on top of https://github.com/decred/decrediton/pull/3778

Closes #3689

Also, it improves the Transaction details view:
- truncates the addresses and account names, if necessary. Before/after:
![trunk](https://user-images.githubusercontent.com/52497040/182832432-47f40096-a8fd-4cf8-9ac9-94e8e98b7dcc.png)
- truncates the long account names on the overview view. Before/after: 
<img width="303" alt="image" src="https://user-images.githubusercontent.com/52497040/182833526-9c455bbe-f150-4ba4-bfff-fa20a2ef6b8a.png">
<img width="305" alt="image" src="https://user-images.githubusercontent.com/52497040/182833660-acbc96db-bb4e-41ae-ad02-6c270e9465c7.png">

- show the correct plural address label on the tx details view. (To address: vs. To addresses: )

- Stakebase transactions (votes) have only one (`stakebase`) non-wallet output.

- fix block display and URL on tx details view. before/after:
<img width="527" alt="image" src="https://user-images.githubusercontent.com/52497040/182836230-8b91e257-f771-4775-868f-a99e9d71783e.png">
<img width="530" alt="image" src="https://user-images.githubusercontent.com/52497040/182836504-27eddcf1-ee1c-4f3d-ba9e-17c2e0ad62ca.png">

- show `Spending Tx` on the tx details view: 
<img width="414" alt="image" src="https://user-images.githubusercontent.com/52497040/182836965-a8813bbb-fc72-45db-bae0-fdc7dc0149bd.png">

- sometimes on the Ticket History view, the app showed the ticket as `Solo` though it is paid (or in another fee status). This diff fixes it: before/after
<img width="729" alt="image" src="https://user-images.githubusercontent.com/52497040/185649804-479ea375-1515-4820-9f85-4d7baa8d50ca.png">
<img width="729" alt="image" src="https://user-images.githubusercontent.com/52497040/185649985-02f15a0e-114f-4dae-a6e6-b483f298dfe0.png">







