### PR TITLE
Register F5 shortcut on browser-window-focus and unregister all shortcuts on blur

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -876,13 +876,23 @@ app.on("ready", async () => {
       contextIsolation: true
     }
   });
-  globalShortcut.register("F5", () =>
-    BrowserWindow.getFocusedWindow().reload()
-  );
+});
+
+app.on("browser-window-focus", () => {
+  globalShortcut.register("F5", () => {
+    if (BrowserWindow.getFocusedWindow()) {
+      BrowserWindow.getFocusedWindow().reload();
+    }
+  });
+});
+
+app.on("browser-window-blur", () => {
+  globalShortcut.unregisterAll();
 });
 
 app.on("before-quit", async (event) => {
   logger.log("info", "Caught before-quit. Set decrediton as was closed");
+  globalShortcut.unregisterAll();
   event.preventDefault();
   cleanShutdown(mainWindow, app, GetDcrdPID(), GetDcrwPID());
   try {


### PR DESCRIPTION
This is a fix for a bug introduced in #3785: pressing F5 on another window, the decrediton crashed.