### PR TITLE
[governance] Update voting preference async

### DIFF
--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -480,7 +480,9 @@ export const setVSPDVoteChoices = (passphrase, vsps) => async (
   try {
     dispatch({ type: SETVSPDVOTECHOICE_ATTEMPT });
 
-    const vsps = await dispatch(discoverAvailableVSPs());
+    if (!vsps) {
+      vsps = await dispatch(discoverAvailableVSPs());
+    }
     if (!isArray(vsps)) {
       throw new Error("INVALID_VSPS");
     }
@@ -510,6 +512,12 @@ export const setVSPDVoteChoices = (passphrase, vsps) => async (
                         pubkey,
                         feeAccount,
                         changeAccount
+                      );
+                      await dispatch(
+                        updateUsedVSPs({
+                          host: vsp.host,
+                          vspdversion: vsp.vspData?.vspdversion
+                        })
                       );
                     } catch (error) {
                       reject({
@@ -560,7 +568,6 @@ export const setVSPDVoteChoices = (passphrase, vsps) => async (
     return true;
   } catch (error) {
     dispatch({ type: SETVSPDVOTECHOICE_FAILED, error });
-    throw error;
   }
 };
 

--- a/app/components/views/AgendaDetailsPage/hooks.js
+++ b/app/components/views/AgendaDetailsPage/hooks.js
@@ -27,9 +27,8 @@ export const useAgendaDetails = () => {
   const selectedChoice = getAgendaSelectedChoice(agenda, voteChoices);
 
   const [newSelectedChoice, setNewSelectedChoice] = useState(selectedChoice);
-  const settingVoteChoices = useSelector(sel.setVoteChoicesAttempt);
   const settingVspdVoteChoices = useSelector(sel.setVspdVoteChoicesAttempt);
-  const isLoading = settingVoteChoices || settingVspdVoteChoices;
+  const isLoading = settingVspdVoteChoices;
 
   const dispatch = useDispatch();
   const goBackHistory = useCallback(() => dispatch(cli.goBackHistory()), [

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -46,6 +46,8 @@ import {
   SYNCVSPTICKETS_FAILED,
   PROCESSMANAGEDTICKETS_FAILED,
   SETVSPDVOTECHOICE_FAILED,
+  SETVSPDVOTECHOICE_SINGLE_FAILED,
+  SETVSPDVOTECHOICE_PARTIAL_SUCCESS,
   GETVSP_TICKET_STATUS_FAILED
 } from "actions/VSPActions";
 import {
@@ -550,11 +552,24 @@ const messages = defineMessages({
   SETVOTECHOICES_SUCCESS: {
     id: "set.vote.success",
     defaultMessage:
-      "You have successfully updated your wallet vote choices on any VSPs you may have had set up."
+      "You have successfully updated your wallet vote choices on any VSP you may have had set up."
+  },
+  SETVSPDVOTECHOICE_PARTIAL_SUCCESS: {
+    id: "set.vote.partial.success",
+    defaultMessage:
+      "You have partially updated your wallet vote choices on any VSP you may have had set up."
   },
   SETVSPDVOTECHOICE_FAILED: {
     id: "set.vspdvote.failed",
     defaultMessage: "Set vspd vote choices failed: {originalError}"
+  },
+  SETVSPDVOTECHOICE_SINGLE_FAILED: {
+    id: "set.vspdvote.single.failed",
+    defaultMessage: "Set vspd vote choice failed on {host}. {originalError}"
+  },
+  SETVSPDVOTECHOICE_TIMEOUT_FAILED: {
+    id: "set.vspdvote.timeout.failed",
+    defaultMessage: "Set vspd vote choice timeout exceded on {host}"
   },
   GETVSP_TICKET_STATUS_FAILED: {
     id: "set.getvspticketstatus.failed",
@@ -712,6 +727,7 @@ export default function snackbar(state = {}, action) {
     case SYNCVSPTICKETS_SUCCESS:
     case SETVOTECHOICES_SUCCESS:
     case SETTREASURY_POLICY_SUCCESS:
+    case SETVSPDVOTECHOICE_PARTIAL_SUCCESS:
     case DISCOVERUSAGE_SUCCESS:
     case SETTINGS_SAVE:
       type = "Success";
@@ -837,6 +853,7 @@ export default function snackbar(state = {}, action) {
     case PROCESSMANAGEDTICKETS_FAILED:
     case SETVOTECHOICES_FAILED:
     case SETVSPDVOTECHOICE_FAILED:
+    case SETVSPDVOTECHOICE_SINGLE_FAILED:
     case GETVSP_TICKET_STATUS_FAILED:
     case DEX_STARTUP_FAILED:
     case DEX_LOGIN_FAILED:
@@ -872,6 +889,13 @@ export default function snackbar(state = {}, action) {
       }
 
       values = { originalError: String(action.error) };
+
+      // custom values for some error messages
+      switch (action.type) {
+        case REFRESHSTAKEPOOLPURCHASEINFORMATION_FAILED:
+        case SETVSPDVOTECHOICE_SINGLE_FAILED:
+          values = { ...values, host: action.host };
+      }
 
       if (process.env.NODE_ENV === "development" && action.error) {
         // in development mode, log failures as errors in the console which helps

--- a/app/reducers/snackbar.js
+++ b/app/reducers/snackbar.js
@@ -892,7 +892,6 @@ export default function snackbar(state = {}, action) {
 
       // custom values for some error messages
       switch (action.type) {
-        case REFRESHSTAKEPOOLPURCHASEINFORMATION_FAILED:
         case SETVSPDVOTECHOICE_SINGLE_FAILED:
           values = { ...values, host: action.host };
       }

--- a/test/unit/actions/VSPActions.spec.js
+++ b/test/unit/actions/VSPActions.spec.js
@@ -10,8 +10,19 @@ import {
   defaultMockAvailableMainnetVsps,
   defaultMockAvailableTestnetVsps,
   defaultMockAvailableInvalidVsps,
-  mockTickets
+  mockTickets,
+  mockPubkeys,
+  fetchTimes,
+  mockVSPTicketInfoResponse
 } from "./vspMocks.js";
+import { mockStakeTransactions } from "../components/views/TransactionPage/mocks.js";
+import {
+  mockMixedAccountValue,
+  mockChangeAccountValue,
+  mockMixedAccount,
+  mockDefaultAccount,
+  mockDefaultAccountValue
+} from "../components/views/TicketsPage/PurchaseTab/mocks";
 import { USED_VSPS } from "constants/config";
 import { MIN_VSP_VERSION } from "constants";
 import { LIVE } from "constants";
@@ -34,25 +45,10 @@ let mockSetVspdAgendaChoices;
 let mockSignMessageAttempt;
 let mockGetVSPTicketStatus;
 let mockProcessManagedTickets;
+let mockSetVspdAgendaChoices;
 
 const testPassphrase = "test-passphrase";
 const testError = "test-error-message";
-
-const mockPubkeys = {
-  [`https://${mockAvailableMainnetVsps[0].host}`]: "test-pubkey1",
-  [`https://${mockAvailableMainnetVsps[1].host}`]: null, // will be rejected
-  [`https://${mockAvailableMainnetVsps[2].host}`]: "invalid", // invalid host
-  [`https://${mockAvailableMainnetVsps[3].host}`]: "test-pubkey3",
-  [`https://${mockAvailableMainnetVsps[4].host}`]: "test-pubkey4"
-};
-
-const fetchTimes = {
-  [`https://${mockAvailableMainnetVsps[0].host}`]: 20,
-  [`https://${mockAvailableMainnetVsps[1].host}`]: 10,
-  [`https://${mockAvailableMainnetVsps[2].host}`]: 5,
-  [`https://${mockAvailableMainnetVsps[3].host}`]: 0,
-  [`https://${mockAvailableMainnetVsps[4].host}`]: 1000 // will timeout
-};
 
 const testDefaultSpendingAccount = 0;
 const testMixedAccount = 2;
@@ -72,6 +68,8 @@ const mockDefaultUsedVSPs = {
     }
   ]
 };
+const mockSig = "test-sig";
+const testPassphrase = "test-passphrase";
 
 const mockVoteChoices = [
   {
@@ -114,24 +112,6 @@ const mockAllAgendasAllFinished = mockAllAgendas.map((v) => ({
 }));
 
 const mockSig = "test-sig";
-const mockVSPTicketInfoResponse = {
-  data: {
-    timestamp: 1651855899,
-    ticketconfirmed: true,
-    feetxstatus: "confirmed",
-    feetxhash: "test-feetxhash",
-    altsignaddress: "",
-    votechoices: {
-      autorevocations: "abstain",
-      changesubsidysplit: "abstain",
-      explicitverupgrades: "abstain",
-      reverttreasurypolicy: "abstain"
-    },
-    tspendpolicy: {},
-    treasurypolicy: {},
-    request: "test-request"
-  }
-};
 
 beforeEach(() => {
   selectors.getVSPInfoTimeoutTime = jest.fn(() => 100);
@@ -146,7 +126,6 @@ beforeEach(() => {
     () => mockAvailableMainnetVspsPubkeys
   );
   arrays.shuffle = jest.fn((arr) => arr);
-  wallet.getVSPInfo = jest.fn(() => {});
   wallet.getAllVSPs = jest.fn(() => [
     ...mockAvailableMainnetVsps,
     ...cloneDeep(defaultMockAvailableTestnetVsps),
@@ -159,6 +138,20 @@ beforeEach(() => {
     get: mockWalletCfgGet,
     set: mockWalletCfgSet
   });
+  mockSignMessageAttempt = controlActions.signMessageAttempt = jest.fn(
+    () => () => mockSig
+  );
+  mockGetVSPTicketStatus = wallet.getVSPTicketStatus = jest.fn(() =>
+    Promise.resolve(mockVSPTicketInfoResponse)
+  );
+
+  mockProcessManagedTickets = wallet.processManagedTickets = jest.fn(
+    () => () => {}
+  );
+  wallet.getVSPTicketsByFeeStatus = jest.fn(() =>
+    Promise.resolve({ ticketHashes: [] })
+  );
+  wallet.getVSPTrackedTickets = jest.fn(() => Promise.resolve());
   mockSetVspdAgendaChoices = wallet.setVspdAgendaChoices = jest.fn(() => {});
   wallet.getVSPInfo = jest.fn((host) => {
     if (!mockPubkeys[host]) {
@@ -175,20 +168,6 @@ beforeEach(() => {
       }, fetchTimes[host]);
     });
   });
-  mockSignMessageAttempt = controlActions.signMessageAttempt = jest.fn(
-    () => () => mockSig
-  );
-  mockGetVSPTicketStatus = wallet.getVSPTicketStatus = jest.fn(() =>
-    Promise.resolve(mockVSPTicketInfoResponse)
-  );
-
-  mockProcessManagedTickets = wallet.processManagedTickets = jest.fn(
-    () => () => {}
-  );
-  wallet.getVSPTicketsByFeeStatus = jest.fn(() =>
-    Promise.resolve({ ticketHashes: [] })
-  );
-  wallet.getVSPTrackedTickets = jest.fn(() => Promise.resolve());
 });
 
 const testRandomVSP = async (
@@ -218,7 +197,6 @@ test("test getRandomVSP", async () => {
   await testRandomVSP(5, undefined, "The available VSPs list is empty.");
 
   // high maxFee
-  wallet.getVSPInfo = jest.fn(() => Promise.resolve(mockVspInfo));
   await testRandomVSP(
     5,
     {
@@ -327,40 +305,6 @@ test("test discoverAvailableVSPs (error)", async () => {
 });
 
 test("test getVSPsPubkeys", async () => {
-  const mockPubkeys = {
-    [`https://${mockAvailableMainnetVsps[0].host}`]: "test-pubkey1",
-    [`https://${mockAvailableMainnetVsps[1].host}`]: null, // will be rejected
-    [`https://${mockAvailableMainnetVsps[2].host}`]: "invalid",
-    [`https://${mockAvailableMainnetVsps[3].host}`]: "test-pubkey3",
-    [`https://${mockAvailableMainnetVsps[4].host}`]: "test-pubkey4",
-    [`https://${mockAvailableMainnetVsps[5].host}`]: "test-pubkey5"
-  };
-
-  const fetchTimes = {
-    [`https://${mockAvailableMainnetVsps[0].host}`]: 20,
-    [`https://${mockAvailableMainnetVsps[1].host}`]: 10,
-    [`https://${mockAvailableMainnetVsps[2].host}`]: 5,
-    [`https://${mockAvailableMainnetVsps[3].host}`]: 0,
-    [`https://${mockAvailableMainnetVsps[4].host}`]: 1000, // will timeout
-    [`https://${mockAvailableMainnetVsps[5].host}`]: 0
-  };
-
-  wallet.getVSPInfo = jest.fn((host) => {
-    if (!mockPubkeys[host]) {
-      return Promise.reject();
-    }
-
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        mockPubkeys[host] !== "invalid"
-          ? resolve({ data: { pubkey: mockPubkeys[host] } })
-          : mockPubkeys[host]
-          ? resolve({ data: {} })
-          : reject();
-      }, fetchTimes[host]);
-    });
-  });
-
   const store = createStore({});
   await store.dispatch(vspActions.getVSPsPubkeys());
 
@@ -1358,4 +1302,228 @@ test("test getVSPTicketStatus (signMessage error)", async () => {
   expect(mockSignMessageAttempt).toHaveBeenCalled();
   expect(mockGetVSPTicketStatus).not.toHaveBeenCalled();
   expect(store.getState().vsp.getVSPTicketStatusError).toEqual(undefined);
+});
+
+test("test setVSPDVoteChoices", async () => {
+  selectors.getMixedAccount = jest.fn(() => null);
+  selectors.getChangeAccount = jest.fn(() => null);
+  selectors.defaultSpendingAccount = jest.fn(() => mockDefaultAccount);
+
+  const store = createStore({});
+  await store.dispatch(vspActions.setVSPDVoteChoices(testPassphrase));
+  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
+    1, // fist call
+    undefined, // walletService
+    defaultMockAvailableMainnetVsps[3].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[3].host}`],
+    mockDefaultAccountValue,
+    mockDefaultAccountValue
+  );
+
+  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
+    2, // second call
+    undefined, // walletService
+    defaultMockAvailableMainnetVsps[0].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[0].host}`],
+    mockDefaultAccountValue,
+    mockDefaultAccountValue
+  );
+
+  expect(store.getState().snackbar.messages[0].type).toBe("Error");
+  expect(store.getState().snackbar.messages[0].message.id).toBe(
+    "set.vspdvote.single.failed"
+  );
+  expect(store.getState().snackbar.messages[0].values.originalError).toBe(
+    "invalid host"
+  );
+  expect(store.getState().snackbar.messages[0].values.host).toBe(
+    mockAvailableMainnetVsps[1].host
+  );
+
+  expect(store.getState().snackbar.messages[1].type).toBe("Error");
+  expect(store.getState().snackbar.messages[1].message.id).toBe(
+    "set.vspdvote.single.failed"
+  );
+  expect(store.getState().snackbar.messages[1].values.originalError).toMatch(
+    "missing pubkey"
+  );
+  expect(store.getState().snackbar.messages[1].values.host).toBe(
+    mockAvailableMainnetVsps[2].host
+  );
+
+  expect(store.getState().snackbar.messages[2].type).toBe("Error");
+  expect(store.getState().snackbar.messages[2].message.id).toBe(
+    "set.vspdvote.single.failed"
+  );
+  expect(store.getState().snackbar.messages[2].values.originalError).toMatch(
+    "timeout"
+  );
+  expect(store.getState().snackbar.messages[2].values.host).toBe(
+    mockAvailableMainnetVsps[4].host
+  );
+
+  expect(store.getState().snackbar.messages[3].type).toBe("Success");
+  expect(store.getState().snackbar.messages[3].message.id).toBe(
+    "set.vote.partial.success"
+  );
+});
+
+test("test setVSPDVoteChoices in a private wallet, all request finish successfully", async () => {
+  selectors.getMixedAccount = jest.fn(() => mockMixedAccountValue);
+  selectors.getChangeAccount = jest.fn(() => mockChangeAccountValue);
+  wallet.getVSPInfo = jest.fn(() => Promise.resolve(mockVspInfo));
+  const store = createStore({});
+  await store.dispatch(vspActions.setVSPDVoteChoices(testPassphrase));
+
+  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
+    1, // fist call
+    undefined, // walletService
+    defaultMockAvailableMainnetVsps[0].host,
+    mockVspInfo.data.pubkey,
+    mockMixedAccountValue,
+    mockChangeAccountValue
+  );
+
+  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
+    2,
+    undefined, // walletService
+    defaultMockAvailableMainnetVsps[1].host,
+    mockVspInfo.data.pubkey,
+    mockMixedAccountValue,
+    mockChangeAccountValue
+  );
+
+  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
+    3,
+    undefined, // walletService
+    defaultMockAvailableMainnetVsps[2].host,
+    mockVspInfo.data.pubkey,
+    mockMixedAccountValue,
+    mockChangeAccountValue
+  );
+
+  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
+    4,
+    undefined, // walletService
+    defaultMockAvailableMainnetVsps[3].host,
+    mockVspInfo.data.pubkey,
+    mockMixedAccountValue,
+    mockChangeAccountValue
+  );
+
+  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
+    5,
+    undefined, // walletService
+    defaultMockAvailableMainnetVsps[4].host,
+    mockVspInfo.data.pubkey,
+    mockMixedAccountValue,
+    mockChangeAccountValue
+  );
+
+  // only one success snackbar is visible
+  expect(store.getState().snackbar.messages[0].type).toBe("Success");
+  expect(store.getState().snackbar.messages[0].message.id).toBe(
+    "set.vote.success"
+  );
+});
+
+test("test setVSPDVoteChoices (received error)", async () => {
+  selectors.getMixedAccount = jest.fn(() => null);
+  selectors.getChangeAccount = jest.fn(() => null);
+  selectors.defaultSpendingAccount = jest.fn(() => mockDefaultAccount);
+
+  const testErrorMessage = "test-error-msg";
+  mockSetVspdAgendaChoices = wallet.setVspdAgendaChoices = jest.fn(() =>
+    Promise.reject(testErrorMessage)
+  );
+  const store = createStore({});
+  await store.dispatch(vspActions.setVSPDVoteChoices(testPassphrase));
+  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
+    1, // fist call
+    undefined, // walletService
+    defaultMockAvailableMainnetVsps[3].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[3].host}`],
+    mockDefaultAccountValue,
+    mockDefaultAccountValue
+  );
+
+  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
+    2, // second call
+    undefined, // walletService
+    defaultMockAvailableMainnetVsps[0].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[0].host}`],
+    mockDefaultAccountValue,
+    mockDefaultAccountValue
+  );
+
+  expect(store.getState().snackbar.messages[0].type).toBe("Error");
+  expect(store.getState().snackbar.messages[0].message.id).toBe(
+    "set.vspdvote.single.failed"
+  );
+  expect(store.getState().snackbar.messages[0].values.originalError).toBe(
+    testErrorMessage
+  );
+  expect(store.getState().snackbar.messages[0].values.host).toBe(
+    mockAvailableMainnetVsps[0].host
+  );
+
+  expect(store.getState().snackbar.messages[1].type).toBe("Error");
+  expect(store.getState().snackbar.messages[1].message.id).toBe(
+    "set.vspdvote.single.failed"
+  );
+  expect(store.getState().snackbar.messages[1].values.originalError).toMatch(
+    "invalid host"
+  );
+  expect(store.getState().snackbar.messages[1].values.host).toBe(
+    mockAvailableMainnetVsps[1].host
+  );
+
+  expect(store.getState().snackbar.messages[2].type).toBe("Error");
+  expect(store.getState().snackbar.messages[2].message.id).toBe(
+    "set.vspdvote.single.failed"
+  );
+  expect(store.getState().snackbar.messages[2].values.originalError).toMatch(
+    "missing pubkey"
+  );
+  expect(store.getState().snackbar.messages[2].values.host).toBe(
+    mockAvailableMainnetVsps[2].host
+  );
+
+  expect(store.getState().snackbar.messages[3].type).toBe("Error");
+  expect(store.getState().snackbar.messages[3].message.id).toBe(
+    "set.vspdvote.single.failed"
+  );
+  expect(store.getState().snackbar.messages[3].values.originalError).toBe(
+    testErrorMessage
+  );
+  expect(store.getState().snackbar.messages[3].values.host).toBe(
+    mockAvailableMainnetVsps[3].host
+  );
+
+  expect(store.getState().snackbar.messages[4].type).toBe("Error");
+  expect(store.getState().snackbar.messages[4].message.id).toBe(
+    "set.vspdvote.single.failed"
+  );
+  expect(store.getState().snackbar.messages[4].values.originalError).toMatch(
+    "timeout"
+  );
+  expect(store.getState().snackbar.messages[4].values.host).toBe(
+    mockAvailableMainnetVsps[4].host
+  );
+});
+
+test("test setVSPDVoteChoices (no available VSP)", async () => {
+  selectors.getAvailableVSPs = jest.fn(() => null);
+  wallet.getAllVSPs = jest.fn(() => null);
+  const store = createStore({});
+  await store.dispatch(vspActions.setVSPDVoteChoices(testPassphrase));
+
+  // only one error snackbar is visible
+  expect(store.getState().snackbar.messages[0].type).toBe("Error");
+  expect(store.getState().snackbar.messages[0].message.id).toBe(
+    "set.vspdvote.failed"
+  );
+  expect(store.getState().snackbar.messages[0].values.originalError).toMatch(
+    "INVALID_VSPS"
+  );
 });

--- a/test/unit/actions/VSPActions.spec.js
+++ b/test/unit/actions/VSPActions.spec.js
@@ -15,11 +15,9 @@ import {
   fetchTimes,
   mockVSPTicketInfoResponse
 } from "./vspMocks.js";
-import { mockStakeTransactions } from "../components/views/TransactionPage/mocks.js";
 import {
   mockMixedAccountValue,
   mockChangeAccountValue,
-  mockMixedAccount,
   mockDefaultAccount,
   mockDefaultAccountValue
 } from "../components/views/TicketsPage/PurchaseTab/mocks";
@@ -45,9 +43,7 @@ let mockSetVspdAgendaChoices;
 let mockSignMessageAttempt;
 let mockGetVSPTicketStatus;
 let mockProcessManagedTickets;
-let mockSetVspdAgendaChoices;
 
-const testPassphrase = "test-passphrase";
 const testError = "test-error-message";
 
 const testDefaultSpendingAccount = 0;
@@ -110,8 +106,6 @@ const mockAllAgendasAllFinished = mockAllAgendas.map((v) => ({
   ...v,
   finished: true
 }));
-
-const mockSig = "test-sig";
 
 beforeEach(() => {
   selectors.getVSPInfoTimeoutTime = jest.fn(() => 100);
@@ -461,7 +455,7 @@ test("test updateUsedVSPs - update existing vsp", async () => {
 });
 
 test("test setVSPDVoteChoices", async () => {
-  const mockUsedVSPs = {
+  const mockUsedVSPsOrig = {
     [USED_VSPS]: [
       {
         host: defaultMockAvailableMainnetVsps[0].host,
@@ -470,6 +464,7 @@ test("test setVSPDVoteChoices", async () => {
       }
     ]
   };
+  const mockUsedVSPs = cloneDeep(mockUsedVSPsOrig);
   mockWalletCfgSet = jest.fn((key, usedVSP) => {
     mockUsedVSPs[key] = usedVSP;
   });
@@ -493,8 +488,8 @@ test("test setVSPDVoteChoices", async () => {
   expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
     1, // first call
     undefined, // walletService
-    defaultMockAvailableMainnetVsps[0].host,
-    mockPubkeys[`https://${mockAvailableMainnetVsps[0].host}`],
+    defaultMockAvailableMainnetVsps[3].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[3].host}`],
     testDefaultSpendingAccount,
     testDefaultSpendingAccount
   );
@@ -502,14 +497,15 @@ test("test setVSPDVoteChoices", async () => {
   expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
     2, // second call
     undefined, // walletService
-    defaultMockAvailableMainnetVsps[3].host,
-    mockPubkeys[`https://${mockAvailableMainnetVsps[3].host}`],
+    defaultMockAvailableMainnetVsps[0].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[0].host}`],
     testDefaultSpendingAccount,
     testDefaultSpendingAccount
   );
 
   expect(mockWalletCfgSet).toHaveBeenNthCalledWith(1, USED_VSPS, [
-    expectedUpdatedVSPs[0]
+    mockUsedVSPsOrig[USED_VSPS][0],
+    expectedUpdatedVSPs[1]
   ]);
   expect(mockWalletCfgSet).toHaveBeenNthCalledWith(
     2,
@@ -663,43 +659,6 @@ test("test setVSPDVoteChoices in a private wallet, all request finish successful
   expect(store.getState().vsp.usedVSPs[3]).toEqual(expectedUpdatedVSPs[3]);
   expect(store.getState().vsp.usedVSPs[4]).toEqual(expectedUpdatedVSPs[4]);
   expect(store.getState().vsp.usedVSPs[5]).toEqual(expectedUpdatedVSPs[5]);
-});
-
-test("test setVSPDVoteChoices (received error)", async () => {
-  selectors.getMixedAccount = jest.fn(() => null);
-  selectors.getChangeAccount = jest.fn(() => null);
-  const testErrorMessage = "test-error-msg";
-  mockSetVspdAgendaChoices = wallet.setVspdAgendaChoices = jest.fn(() =>
-    Promise.reject(testErrorMessage)
-  );
-  const store = createStore({});
-  let receivedErrorMsg;
-  try {
-    await store.dispatch(vspActions.setVSPDVoteChoices(testPassphrase));
-  } catch (error) {
-    receivedErrorMsg = error;
-  }
-
-  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
-    1, // first call
-    undefined, // walletService
-    defaultMockAvailableMainnetVsps[0].host,
-    mockPubkeys[`https://${mockAvailableMainnetVsps[0].host}`],
-    testDefaultSpendingAccount,
-    testDefaultSpendingAccount
-  );
-
-  expect(mockSetVspdAgendaChoices).toHaveBeenNthCalledWith(
-    2, // second call
-    undefined, // walletService
-    defaultMockAvailableMainnetVsps[3].host,
-    mockPubkeys[`https://${mockAvailableMainnetVsps[3].host}`],
-    testDefaultSpendingAccount,
-    testDefaultSpendingAccount
-  );
-
-  expect(store.getState().snackbar.messages[0].type).toBe("Error");
-  expect(receivedErrorMsg).toEqual(testErrorMessage);
 });
 
 test("test getRecentlyUpdatedUsedVSPs - success", async () => {

--- a/test/unit/actions/vspMocks.js
+++ b/test/unit/actions/vspMocks.js
@@ -181,3 +181,40 @@ export const mockTickets = [
     }
   }
 ];
+
+export const mockPubkeys = {
+  [`https://${defaultMockAvailableMainnetVsps[0].host}`]: "test-pubkey1",
+  [`https://${defaultMockAvailableMainnetVsps[1].host}`]: null, // will be rejected
+  [`https://${defaultMockAvailableMainnetVsps[2].host}`]: "invalid", // invalid host
+  [`https://${defaultMockAvailableMainnetVsps[3].host}`]: "test-pubkey3",
+  [`https://${defaultMockAvailableMainnetVsps[4].host}`]: "test-pubkey4",
+  [`https://${defaultMockAvailableMainnetVsps[5].host}`]: "test-pubkey5"
+};
+
+export const fetchTimes = {
+  [`https://${defaultMockAvailableMainnetVsps[0].host}`]: 20,
+  [`https://${defaultMockAvailableMainnetVsps[1].host}`]: 10,
+  [`https://${defaultMockAvailableMainnetVsps[2].host}`]: 5,
+  [`https://${defaultMockAvailableMainnetVsps[3].host}`]: 0,
+  [`https://${defaultMockAvailableMainnetVsps[4].host}`]: 1000, // will timeout
+  [`https://${defaultMockAvailableMainnetVsps[5].host}`]: 30
+};
+
+export const mockVSPTicketInfoResponse = {
+  data: {
+    timestamp: 1651855899,
+    ticketconfirmed: true,
+    feetxstatus: "confirmed",
+    feetxhash: "test-feetxhash",
+    altsignaddress: "",
+    votechoices: {
+      autorevocations: "abstain",
+      changesubsidysplit: "abstain",
+      explicitverupgrades: "abstain",
+      reverttreasurypolicy: "abstain"
+    },
+    tspendpolicy: {},
+    treasurypolicy: {},
+    request: "test-request"
+  }
+};

--- a/test/unit/components/views/TicketsPage/PurchaseTab/mocks.js
+++ b/test/unit/components/views/TicketsPage/PurchaseTab/mocks.js
@@ -31,6 +31,7 @@ export const mockAvailableVsps = [
     }
   }
 ];
+export const mockDefaultAccountValue = 0;
 export const mockMixedAccountValue = 6;
 export const mockChangeAccountValue = 6;
 export const mockNumTicketsToBuy = 1;
@@ -42,4 +43,13 @@ export const mockMixedAccount = {
   spendableAndUnit: "249.79547928 DCR",
   total: 24979547928,
   value: mockMixedAccountValue
+};
+export const mockDefaultAccount = {
+  hidden: false,
+  label: "default: 3.79547928 DCR",
+  name: "default",
+  spendable: 379547928,
+  spendableAndUnit: "3.79547928 DCR",
+  total: 379547928,
+  value: mockDefaultAccountValue
 };


### PR DESCRIPTION
Closes #3717 

By updating voting preference asynchronous, the process takes 3 times faster on mainnet (3s vs 11s) in my environment.

The error handling improved too. For example: 
<img width="302" alt="2022-09-02_13-11" src="https://user-images.githubusercontent.com/52497040/188128551-0cb27907-5174-40c4-bba3-db995ca1c098.png">

Tests are also added.

