### PR TITLE
[settings] Apply proxy on dcrd/dcrwallet

### DIFF
--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -156,7 +156,9 @@ export function updateStateSettingsChanged(settings, norestart) {
     const networkChange = {
       network: true,
       spvMode: true,
-      daemonStartAdvanced: true
+      daemonStartAdvanced: true,
+      proxyType: true,
+      proxyLocation: true
     };
 
     const newDiffersFromTemp = settingsFields.reduce(

--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -93,8 +93,8 @@ export const saveSettings = (settings) => async (dispatch, getState) => {
     wallet.setupProxy();
   }
 
-  if (needNetworkReset) {
-    dispatch(closeWalletRequest());
+  if (needNetworkReset || updatedProxy) {
+    await dispatch(closeWalletRequest());
     await dispatch(closeDaemonRequest());
     dispatch(backToCredentials());
   }

--- a/app/components/views/SettingsPage/ConnectivitySettingsTab/ProxySettings/ProxySettings.jsx
+++ b/app/components/views/SettingsPage/ConnectivitySettingsTab/ProxySettings/ProxySettings.jsx
@@ -20,12 +20,8 @@ const availableProxyTypes = [
 ];
 
 const ProxySettings = ({ tempSettings, onChangeTempSettings }) => {
-  const {
-    proxyType,
-    proxyLocation,
-    setProxyType,
-    setProxyLocation
-  } = useProxySettings(tempSettings);
+  const { proxyType, proxyLocation, setProxyType, setProxyLocation } =
+    useProxySettings(tempSettings);
 
   const isProxySettingsChanged =
     proxyType !== tempSettings.proxyType ||

--- a/app/components/views/SettingsPage/ConnectivitySettingsTab/ProxySettings/ProxySettings.jsx
+++ b/app/components/views/SettingsPage/ConnectivitySettingsTab/ProxySettings/ProxySettings.jsx
@@ -8,6 +8,8 @@ import {
 } from "constants";
 import styles from "./ProxySettings.module.css";
 import { Label, Box } from "../../helpers";
+import { useProxySettings } from "./hooks";
+import { Button } from "pi-ui";
 
 const availableProxyTypes = [
   { name: <T id="settings.proxy.type.none" m="No Proxy" />, value: null },
@@ -17,41 +19,61 @@ const availableProxyTypes = [
   { name: "SOCKS5", value: PROXYTYPE_SOCKS5 }
 ];
 
-const ProxySettings = ({ tempSettings, onChangeTempSettings }) => (
-  <Box className={styles.box}>
-    <div>
-      <Label id="proxy-type-input">
-        <T id="settings.proxy.type" m="Proxy Type" />
-      </Label>
-      <SettingsInput
-        selectWithBigFont
-        className={styles.input}
-        value={tempSettings.proxyType}
-        onChange={(newProxyType) =>
-          onChangeTempSettings({ proxyType: newProxyType.value })
-        }
-        valueKey="value"
-        labelKey="name"
-        ariaLabelledBy="proxy-type-input"
-        options={availableProxyTypes}
-      />
-    </div>
+const ProxySettings = ({ tempSettings, onChangeTempSettings }) => {
+  const {
+    proxyType,
+    proxyLocation,
+    setProxyType,
+    setProxyLocation
+  } = useProxySettings(tempSettings);
 
-    <div>
-      <Label id="proxy-location">
-        <T id="settings.proxy.location" m="Proxy Location" />
-      </Label>
-      <SettingsTextInput
-        newBiggerFontStyle
-        inputClassNames={styles.settingsTextInput}
-        id="proxyLocationInput"
-        value={tempSettings.proxyLocation}
-        ariaLabelledBy="proxy-location"
-        onChange={(value) => onChangeTempSettings({ proxyLocation: value })}
-      />
-    </div>
-  </Box>
-);
+  const isProxySettingsChanged =
+    proxyType !== tempSettings.proxyType ||
+    proxyLocation !== tempSettings.proxyLocation;
+
+  return (
+    <Box className={styles.box}>
+      <div>
+        <Label id="proxy-type-input">
+          <T id="settings.proxy.type" m="Proxy Type" />
+        </Label>
+        <SettingsInput
+          selectWithBigFont
+          className={styles.input}
+          value={proxyType}
+          onChange={(newProxyType) => setProxyType(newProxyType.value)}
+          valueKey="value"
+          labelKey="name"
+          ariaLabelledBy="proxy-type-input"
+          options={availableProxyTypes}
+        />
+      </div>
+
+      <div>
+        <Label id="proxy-location">
+          <T id="settings.proxy.location" m="Proxy Location" />
+        </Label>
+        <SettingsTextInput
+          newBiggerFontStyle
+          inputClassNames={styles.settingsTextInput}
+          id="proxyLocationInput"
+          value={proxyLocation}
+          ariaLabelledBy="proxy-location"
+          onChange={(value) => setProxyLocation(value)}
+        />
+      </div>
+
+      {isProxySettingsChanged && (
+        <Button
+          className={styles.submitButton}
+          size="sm"
+          onClick={() => onChangeTempSettings({ proxyType, proxyLocation })}>
+          <T id="settings.proxy.save" m="Save proxy settings" />
+        </Button>
+      )}
+    </Box>
+  );
+};
 
 ProxySettings.propTypes = {
   tempSettings: PropTypes.object.isRequired,

--- a/app/components/views/SettingsPage/ConnectivitySettingsTab/ProxySettings/ProxySettings.module.css
+++ b/app/components/views/SettingsPage/ConnectivitySettingsTab/ProxySettings/ProxySettings.module.css
@@ -1,6 +1,6 @@
 .box {
   display: grid;
-  grid-gap: 3rem;
+  grid-gap: 1rem 3rem;
   grid-template-columns: repeat(2, 1fr);
 }
 
@@ -8,8 +8,16 @@
   color: var(--main-dark-blue) !important;
 }
 
+.submitButton {
+  grid-column: 2;
+}
+
 @media (--sm-viewport) {
   .box {
     grid-template-columns: 1fr;
+  }
+
+  .submitButton {
+    grid-column: 1;
   }
 }

--- a/app/components/views/SettingsPage/ConnectivitySettingsTab/ProxySettings/hooks.js
+++ b/app/components/views/SettingsPage/ConnectivitySettingsTab/ProxySettings/hooks.js
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export const useProxySettings = (tempSettings) => {
+  const [proxyType, setProxyType] = useState(tempSettings.proxyType);
+  const [proxyLocation, setProxyLocation] = useState(
+    tempSettings.proxyLocation
+  );
+
+  return {
+    proxyType,
+    proxyLocation,
+    setProxyType,
+    setProxyLocation
+  };
+};

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -28,7 +28,8 @@ import {
   UPGD_ELECTRON8,
   CSPP_URL,
   CSPP_PORT_TESTNET,
-  CSPP_PORT_MAINNET
+  CSPP_PORT_MAINNET,
+  PROXYTYPE_SOCKS5
 } from "constants";
 import * as cfgConstants from "constants/config";
 import os from "os";
@@ -43,6 +44,7 @@ import ini from "ini";
 import { makeRandomString, isPlainString as isString } from "helpers/strings";
 import { makeFileBackup } from "helpers/files";
 import { DEX_LOCALPAGE } from "./externalRequests";
+import { getProxyTypeAndLocation } from "./proxy";
 
 const argv = parseArgs(process.argv.slice(1), OPTIONS);
 const debug = argv.debug || process.env.NODE_ENV === "development";
@@ -390,6 +392,15 @@ export const launchDCRD = (reactIPC, testnet, appdata) =>
       args.push("--testnet");
     }
 
+    const { proxyType, proxyLocation } = getProxyTypeAndLocation();
+    logger.log(
+      "info",
+      `ProxyType: ${proxyType}, ProxyLocation: ${proxyLocation}`
+    );
+    if (proxyType === PROXYTYPE_SOCKS5 && proxyLocation) {
+      args.push(`--proxy=${proxyLocation}`);
+    }
+
     rpcuser = rpc_user;
     rpcpass = rpc_pass;
     rpccert = rpc_cert;
@@ -643,6 +654,15 @@ export const launchDCRWallet = async (
       ? "--csppserver=" + CSPP_URL + ":" + CSPP_PORT_MAINNET
       : "--csppserver=" + CSPP_URL + ":" + CSPP_PORT_TESTNET
   );
+
+  const { proxyType, proxyLocation } = getProxyTypeAndLocation();
+  logger.log(
+    "info",
+    `ProxyType: ${proxyType}, ProxyLocation: ${proxyLocation}`
+  );
+  if (proxyType === PROXYTYPE_SOCKS5 && proxyLocation) {
+    args.push(`--proxy=${proxyLocation}`);
+  }
 
   const dcrwExe = getExecutablePath("dcrwallet", argv.custombinpath);
   if (!fs.existsSync(dcrwExe)) {

--- a/app/main_dev/proxy.js
+++ b/app/main_dev/proxy.js
@@ -11,10 +11,7 @@ import {
 
 export const setupProxy = (logger) =>
   new Promise((resolve, reject) => {
-    const cfg = getGlobalCfg();
-
-    const proxyType = cfg.get(cfgConstants.PROXY_TYPE);
-    const proxyLocation = cfg.get(cfgConstants.PROXY_LOCATION);
+    const { proxyType, proxyLocation } = getProxyTypeAndLocation();
 
     const proxyConfig = {
       pacScript: null,
@@ -58,3 +55,12 @@ export const setupProxy = (logger) =>
       })
       .catch(reject);
   });
+
+export const getProxyTypeAndLocation = () => {
+  const cfg = getGlobalCfg();
+
+  const proxyType = cfg.get(cfgConstants.PROXY_TYPE);
+  const proxyLocation = cfg.get(cfgConstants.PROXY_LOCATION);
+
+  return { proxyType, proxyLocation };
+};


### PR DESCRIPTION
Before this, proxy settings determine only links/API calls.
 This diff applies proxy settings to dcrd and dcrwallet too, when the proxy type is SOCKS 5. With this, users can configure dcrd/dcrwallet as a Tor client.
It changes the proxy settings view a bit too:
- After changing the proxy settings, the daemon and wallet need to restart after confirmation.
- Since the proxy type and location values are firmly related, the submit event does not trigger automatically, but by clicking on a dedicated submit button:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/52497040/188441710-d3a504c3-513f-423a-90e1-66484456afcb.png">

Tests updated also.