### PR TITLE
[multi] Fix filterUnlockableAccounts 

### DIFF
--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -1103,6 +1103,7 @@ export const getVSPTicketStatus = (passphrase, tx, decodedTx) => async (
   }
 };
 
-export const SET_ACCOUNT_FOR_TICKET_PURCHASE = "SET_ACCOUNT_FOR_TICKET_PURCHASE";
+export const SET_ACCOUNT_FOR_TICKET_PURCHASE =
+  "SET_ACCOUNT_FOR_TICKET_PURCHASE";
 export const SET_SELECTED_VSP = "SET_SELECTED_VSP";
 export const SET_NUM_TICKETS_TO_BUY = "SET_NUM_TICKETS_TO_BUY";

--- a/app/actions/VSPActions.js
+++ b/app/actions/VSPActions.js
@@ -1102,3 +1102,7 @@ export const getVSPTicketStatus = (passphrase, tx, decodedTx) => async (
     dispatch({ type: GETVSP_TICKET_STATUS_FAILED, error });
   }
 };
+
+export const SET_ACCOUNT_FOR_TICKET_PURCHASE = "SET_ACCOUNT_FOR_TICKET_PURCHASE";
+export const SET_SELECTED_VSP = "SET_SELECTED_VSP";
+export const SET_NUM_TICKETS_TO_BUY = "SET_NUM_TICKETS_TO_BUY";

--- a/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
+++ b/app/components/views/TicketsPage/PurchaseTab/PurchaseTickets/PurchaseTickets.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { PurchasePage } from "./Page";
 import { usePurchaseTab } from "../hooks";
-import { isEqual } from "lodash/fp";
 
 const Tickets = ({ toggleIsLegacy }) => {
   const {
@@ -14,7 +13,6 @@ const Tickets = ({ toggleIsLegacy }) => {
     availableVSPs,
     // TODO treat errors:
     // availableVSPsError,
-    defaultSpendingAccount,
     ticketPrice,
     onPurchaseTicketV3,
     mixedAccount,
@@ -26,36 +24,14 @@ const Tickets = ({ toggleIsLegacy }) => {
     isVSPListingEnabled,
     onEnableVSPListing,
     getRunningIndicator,
-    visibleAccounts
+    account,
+    setAccount,
+    vsp,
+    setVSP,
+    numTicketsToBuy,
+    setNumTicketsToBuy
   } = usePurchaseTab();
 
-  const [account, setAccount] = useState(defaultSpendingAccount);
-  useEffect(() => {
-    const newAccount = visibleAccounts?.find((a) =>
-      isEqual(a.value, account?.value)
-    );
-    newAccount && setAccount(newAccount);
-  }, [visibleAccounts, account]);
-
-  // todo use this vsp to buy solo tickets.
-  const [vsp, setVSP] = useState(() => {
-    if (rememberedVspHost) {
-      // reset rememberedVspHost if it's outdated
-      if (
-        availableVSPs?.find(
-          (availableVSP) => availableVSP.host === rememberedVspHost.host
-        )?.outdated === true
-      ) {
-        setRememberedVspHost(null);
-        return null;
-      } else {
-        return { host: rememberedVspHost.host };
-      }
-    } else {
-      return null;
-    }
-  });
-  const [numTicketsToBuy, setNumTicketsToBuy] = useState(1);
   const [isValid, setIsValid] = useState(false);
 
   const toggleRememberVspHostCheckBox = () => {
@@ -73,9 +49,7 @@ const Tickets = ({ toggleIsLegacy }) => {
   };
 
   const onIncrementNumTickets = () => {
-    setNumTicketsToBuy((numTicketsToBuy) =>
-      numTicketsToBuy == "" ? 1 : numTicketsToBuy + 1
-    );
+    setNumTicketsToBuy(numTicketsToBuy == "" ? 1 : numTicketsToBuy + 1);
   };
 
   const onChangeNumTickets = (numTicketsToBuy) => {
@@ -87,9 +61,7 @@ const Tickets = ({ toggleIsLegacy }) => {
   };
 
   const onDecrementNumTickets = () => {
-    setNumTicketsToBuy((numTicketsToBuy) =>
-      numTicketsToBuy <= 1 ? 1 : numTicketsToBuy - 1
-    );
+    setNumTicketsToBuy(numTicketsToBuy <= 1 ? 1 : numTicketsToBuy - 1);
   };
 
   const onV3PurchaseTicket = (passphrase) => {

--- a/app/components/views/TicketsPage/PurchaseTab/hooks.js
+++ b/app/components/views/TicketsPage/PurchaseTab/hooks.js
@@ -28,11 +28,18 @@ export const usePurchaseTab = () => {
   const rememberedVspHost = useSelector(sel.getRememberedVspHost);
   const visibleAccounts = useSelector(sel.visibleAccounts);
 
-  const selectedAccountForTicketPurchase = useSelector(sel.selectedAccountForTicketPurchase);
+  const selectedAccountForTicketPurchase = useSelector(
+    sel.selectedAccountForTicketPurchase
+  );
   const account = useMemo(() => {
-    const accountName = selectedAccountForTicketPurchase || defaultSpendingAccount.name;
+    const accountName =
+      selectedAccountForTicketPurchase || defaultSpendingAccount.name;
     return visibleAccounts?.find((a) => isEqual(a.name, accountName));
-  }, [visibleAccounts, selectedAccountForTicketPurchase, defaultSpendingAccount]);
+  }, [
+    visibleAccounts,
+    selectedAccountForTicketPurchase,
+    defaultSpendingAccount
+  ]);
 
   const selectedVSP = useSelector(sel.selectedVSP);
 

--- a/app/index.js
+++ b/app/index.js
@@ -101,7 +101,8 @@ const initialState = {
     processManagedTicketsError: null,
     trackedTickets: {},
     needsProcessManagedTickets: true,
-    canDisableProcessManaged: true
+    canDisableProcessManaged: true,
+    numVSPicketsToBuy: 1
   },
   daemon: {
     networkMatch: false,

--- a/app/reducers/vsp.js
+++ b/app/reducers/vsp.js
@@ -30,7 +30,10 @@ import {
   GETUNSPENTUNEXPIREDVSPTICKETS_FAILED,
   GETVSP_TICKET_STATUS_ATTEMPT,
   GETVSP_TICKET_STATUS_SUCCESS,
-  GETVSP_TICKET_STATUS_FAILED
+  GETVSP_TICKET_STATUS_FAILED,
+  SET_ACCOUNT_FOR_TICKET_PURCHASE,
+  SET_SELECTED_VSP,
+  SET_NUM_TICKETS_TO_BUY
 } from "actions/VSPActions";
 import {
   STARTTICKETBUYERV3_ATTEMPT,
@@ -192,7 +195,11 @@ export default function vsp(state = {}, action) {
       return {
         ...state,
         trackedTickets: {},
-        needsProcessManagedTickets: true
+        needsProcessManagedTickets: true,
+        account: null,
+        selectedAccountForTicketPurchase: null,
+        selectedVSP: null,
+        numVSPicketsToBuy: 1
       };
     case GETVSP_ATTEMPT:
       return {
@@ -235,6 +242,21 @@ export default function vsp(state = {}, action) {
         ...state,
         getVSPTicketStatusError: String(action.error),
         getVSPTicketStatusAttempt: false
+      };
+    case SET_ACCOUNT_FOR_TICKET_PURCHASE:
+      return {
+        ...state,
+        selectedAccountForTicketPurchase: action.account.name
+      };
+    case SET_SELECTED_VSP:
+      return {
+        ...state,
+        selectedVSP: action.selectedVSP
+      };
+    case SET_NUM_TICKETS_TO_BUY:
+      return {
+        ...state,
+        numVSPicketsToBuy: action.numVSPicketsToBuy
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -906,7 +906,10 @@ export const getVSPTrackedTicketsCommitAccounts = createSelector(
 );
 export const getVSPTicketBuyerAccount = get(["vsp", "account"]);
 
-export const selectedAccountForTicketPurchase = get(["vsp", "selectedAccountForTicketPurchase"]);
+export const selectedAccountForTicketPurchase = get([
+  "vsp",
+  "selectedAccountForTicketPurchase"
+]);
 export const selectedVSP = get(["vsp", "selectedVSP"]);
 export const numVSPicketsToBuy = get(["vsp", "numVSPicketsToBuy"]);
 
@@ -1768,8 +1771,8 @@ export const isTicketAutoBuyerEnabled = bool(startAutoBuyerResponse);
 export const getRunningIndicator = or(
   getAccountMixerRunning,
   getTicketAutoBuyerRunning,
-  purchaseTicketsRequestAttempt,
-  isTicketAutoBuyerEnabled
+  purchaseTicketsRequestAttempt
+  // isTicketAutoBuyerEnabled  -- legacy autobuery is deprecated
 );
 
 export const restoredFromSeed = get(["dex", "restoredFromSeed"]);

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -906,6 +906,10 @@ export const getVSPTrackedTicketsCommitAccounts = createSelector(
 );
 export const getVSPTicketBuyerAccount = get(["vsp", "account"]);
 
+export const selectedAccountForTicketPurchase = get(["vsp", "selectedAccountForTicketPurchase"]);
+export const selectedVSP = get(["vsp", "selectedVSP"]);
+export const numVSPicketsToBuy = get(["vsp", "numVSPicketsToBuy"]);
+
 // ****************** end of vsp selectors ******************
 
 export const dailyBalancesStats = get(["statistics", "dailyBalances"]);

--- a/test/unit/actions/ControlActions.spec.js
+++ b/test/unit/actions/ControlActions.spec.js
@@ -1,0 +1,171 @@
+import * as ca from "actions/ControlActions";
+import { cloneDeep, isEqual } from "lodash";
+import { createStore } from "test-utils.js";
+
+const controlActions = ca;
+
+const selectedAccountForTicketPurchase = 1;
+const selectedAccountForTicketPurchaseName = "ticket-purchase-account-name";
+
+const ticketBuyerAccount = 2;
+const ticketBuyerAccountName = "ticket-buyer-account-name";
+
+const changeAccount = 3;
+const mixedAccount = 4;
+const dexAccountNumber = 5;
+const dexAccountName = "dex";
+
+const commitmentAccount = 6;
+
+const testBalances = [
+  { accountNumber: 0, accountName: "default" },
+  {
+    accountNumber: selectedAccountForTicketPurchase,
+    accountName: selectedAccountForTicketPurchaseName
+  },
+  { accountNumber: ticketBuyerAccount, accountName: ticketBuyerAccountName },
+  { accountNumber: changeAccount, accountName: "test-account3" },
+  { accountNumber: mixedAccount, accountName: "test-account4" },
+  { accountNumber: dexAccountNumber, accountName: dexAccountName },
+  { accountNumber: commitmentAccount, accountName: "test-account5" }
+];
+
+const initialState = {
+  grpc: { balances: testBalances },
+  walletLoader: {
+    dexAccount: dexAccountName,
+    mixedAccount: mixedAccount,
+    changeAccount: changeAccount
+  },
+  vsp: {
+    account: ticketBuyerAccountName,
+    selectedAccountForTicketPurchase: selectedAccountForTicketPurchaseName,
+    trackedTickets: {
+      "https://teststakepool.decred.org": {
+        host: "https://teststakepool.decred.org",
+        tickets: [
+          {
+            commitmentAccount: commitmentAccount
+          }
+        ]
+      }
+    }
+  }
+};
+
+test("test filterUnlockableAccounts - there is no running progress", () => {
+  const store = createStore(cloneDeep(initialState));
+
+  const accts = [
+    0,
+    selectedAccountForTicketPurchase,
+    ticketBuyerAccount,
+    changeAccount,
+    mixedAccount,
+    dexAccountNumber,
+    commitmentAccount
+  ];
+  const filteredAccounts = controlActions.filterUnlockableAccounts(
+    accts,
+    store.getState
+  );
+
+  // dex account is always filtered out
+  expect(filteredAccounts.includes(dexAccountNumber)).toBeFalsy();
+  // commitment accounts are always filtered out
+  expect(filteredAccounts.includes(commitmentAccount)).toBeFalsy();
+  // all other accounts remained
+  expect(
+    isEqual(filteredAccounts, [
+      0,
+      selectedAccountForTicketPurchase,
+      ticketBuyerAccount,
+      changeAccount,
+      mixedAccount
+    ])
+  ).toBeTruthy();
+});
+
+test("test filterUnlockableAccounts - invalid dex account name", () => {
+  const store = createStore(
+    cloneDeep({ ...initialState, walletLoader: { dexAccount: "invalid" } })
+  );
+
+  const accts = [
+    0,
+    selectedAccountForTicketPurchase,
+    ticketBuyerAccount,
+    changeAccount,
+    mixedAccount,
+    dexAccountNumber
+  ];
+  const filteredAccounts = controlActions.filterUnlockableAccounts(
+    accts,
+    store.getState
+  );
+
+  expect(filteredAccounts.includes(dexAccountNumber)).toBeTruthy();
+  expect(isEqual(filteredAccounts, accts)).toBeTruthy();
+});
+
+const testRunnning = (store) => {
+  const accts = [
+    0,
+    selectedAccountForTicketPurchase,
+    ticketBuyerAccount,
+    changeAccount,
+    mixedAccount,
+    dexAccountNumber
+  ];
+  const filteredAccounts = controlActions.filterUnlockableAccounts(
+    accts,
+    store.getState
+  );
+
+  // dex account is always filtered out
+  expect(filteredAccounts.includes(dexAccountNumber)).toBeFalsy();
+  // commitment accounts are always filtered out
+  expect(filteredAccounts.includes(commitmentAccount)).toBeFalsy();
+  // all other accounts remained
+
+  expect(filteredAccounts.includes(mixedAccount)).toBeFalsy();
+  expect(filteredAccounts.includes(changeAccount)).toBeFalsy();
+  expect(filteredAccounts.includes(ticketBuyerAccount)).toBeFalsy();
+  expect(
+    filteredAccounts.includes(selectedAccountForTicketPurchase)
+  ).toBeFalsy();
+  expect(isEqual(filteredAccounts, [0])).toBeTruthy();
+};
+
+test("test filterUnlockableAccounts - account mixer is running", () => {
+  const store = createStore(
+    cloneDeep({
+      ...initialState,
+      grpc: { ...initialState.grpc, accountMixerRunning: true }
+    })
+  );
+
+  testRunnning(store);
+});
+
+test("test filterUnlockableAccounts - ticket autobuyer is running", () => {
+  const store = createStore(
+    cloneDeep({
+      ...initialState,
+      vsp: { ...initialState.vsp, ticketAutoBuyerRunning: true }
+    })
+  );
+
+  testRunnning(store);
+});
+
+test("test filterUnlockableAccounts - purchase ticket is running", () => {
+  const store = createStore(
+    cloneDeep({
+      ...initialState,
+      control: { purchaseTicketsRequestAttempt: true }
+    })
+  );
+
+  testRunnning(store);
+});


### PR DESCRIPTION
Noticed that `filterUnlockableAccounts` function in `ControlActions` does not filter out the account used for ticket autobuyer, even if the auto buyer has been switched on. This diff probably fixes #3680. Add tests for the function as well.

Also addresses one of the suggestions from #3310:
"[Possible Issue] While manually buying tickets if I change tab and then go back to staking tab sometimes the values given on Purchase Tickets are resetting."
