### PR TITLE
[dex] Bump to dcrdex v0.5.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/decrediton
 go 1.18
 
 require (
-	decred.org/dcrdex v0.5.2
+	decred.org/dcrdex v0.5.3
 	github.com/decred/slog v1.2.0
 	github.com/jrick/logrotate v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 decred.org/cspp/v2 v2.0.0 h1:b4fZrElRufz30rYnBZ2shhC8AjNVTN4i6TMzDi+hk44=
 decred.org/cspp/v2 v2.0.0/go.mod h1:0shJWKTWY3LxZEWGxtbER1Y45+HVjC0WZtj4bctSzCI=
-decred.org/dcrdex v0.5.2 h1:eV4X321cIrL/2yTG5wOVk8iGD2qKfl5RnUv1o6FZ3TI=
-decred.org/dcrdex v0.5.2/go.mod h1:uHhmoe0nL8/OiRw0CvonP8EpDsfGo2TtSo81GPBbXV0=
+decred.org/dcrdex v0.5.3 h1:5IiOYefVnkj/xTFZ4en70TBS+47FWClqmnTUnq09RUo=
+decred.org/dcrdex v0.5.3/go.mod h1:uHhmoe0nL8/OiRw0CvonP8EpDsfGo2TtSo81GPBbXV0=
 decred.org/dcrwallet/v2 v2.0.8 h1:ps0hU8SO2qnCjl4FxQxri8mO8MBWH4NRNW42hSN3E6o=
 decred.org/dcrwallet/v2 v2.0.8/go.mod h1:DEt4isEGSqMiMvo4scTX58oepPIwhTnaMCyTVPxCbzY=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=


### PR DESCRIPTION
No critical updates, but keeping up with the DEX releases.
See https://github.com/decred/dcrdex/releases/tag/v0.5.3