### PR TITLE
[launcher] Fix time estimation during block syncing

### DIFF
--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -661,7 +661,7 @@ export const syncDaemon = () => (dispatch, getState) =>
               return;
             }
 
-            if (blockStart === 0) {
+            if (!blockStart || !timeStart) {
               dispatch({
                 syncHeight,
                 currentBlockCount: blockCount,


### PR DESCRIPTION
Closes #2431

Way to reproduce: 
1. start syncing blocks (SPV disabled)
2. enable SPV from settings. 
3. open a wallet
4. disable SPV from settings. It resets the app, and when the syncing restarts, the time estimation breaks:
<img width="252" alt="2022-10-03_13-56" src="https://user-images.githubusercontent.com/52497040/193604762-34651a7d-4bb5-4471-a76d-6dfa390d2810.png">
The estimated time should look something like this:
<img width="241" alt="2022-10-03_14-00" src="https://user-images.githubusercontent.com/52497040/193604936-e5f79ffe-47a5-4372-83da-384e81b581e0.png">


