### PR TITLE
[UX] To addresses instead of to address for txn with multiple outs

### DIFF
--- a/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
+++ b/app/components/views/TransactionPage/TransactionContent/TransactionContent.jsx
@@ -234,7 +234,17 @@ const TransactionContent = ({
         ) : (
           <div className={styles.topRow}>
             <div className={styles.name}>
-              <T id="txDetails.toAddress" m="To address" />:
+              {txOutputs.length + nonWalletOutputs.length >= 2 ? (
+                <T
+                  id="txDetails.toAddresses"
+                  m="To addresses:"
+                />
+              ) : (
+                <T
+                  id="txDetails.toAddress"
+                  m="To address:"
+                />
+              )}
             </div>
             <div className={classNames(styles.value, styles.nonFlex)}>
               {txOutputs.map(({ address }, i) => (

--- a/app/i18n/translations/original.json
+++ b/app/i18n/translations/original.json
@@ -1636,6 +1636,7 @@
   "txDetails.ticketSpent": "Ticket Spent",
   "txDetails.timestamp": "{timestamp, date, medium} {timestamp, time, medium}",
   "txDetails.toAddress": "To address",
+  "txDetails.toAddresses": "To addresses",
   "txDetails.tooManyNonWalletOutputs": "Please use the txid link above to see all non-wallet outputs on dcrdata.",
   "txDetails.tooManyNonWalletOutputsAddresses": "Please use the txid link above to see all non-wallet addresses on dcrdata.",
   "txDetails.transactionFeeLabel": "Transaction fee",

--- a/app/i18n/translations/previous_original.json
+++ b/app/i18n/translations/previous_original.json
@@ -1539,6 +1539,7 @@
   "txDetails.ticketCost": "Ticket Cost",
   "txDetails.timestamp": "{timestamp, date, medium} {timestamp, time, medium}",
   "txDetails.toAddress": "To address",
+  "txDetails.toAddresses": "To addresses",
   "txDetails.tooManyNonWalletOutputs": "Please use the txid link above to see all non-wallet outputs on dcrdata.",
   "txDetails.tooManyNonWalletOutputsAddresses": "Please use the txid link above to see all non-wallet addresses on dcrdata.",
   "txDetails.transactionFeeLabel": "Transaction fee",

--- a/test/unit/components/views/TransactionPage/TransactionPage.spec.js
+++ b/test/unit/components/views/TransactionPage/TransactionPage.spec.js
@@ -130,7 +130,6 @@ const queryPending = () => screen.queryByText("Pending");
 const getToAddressText = () =>
   screen.getByText("To address:").parentElement.textContent;
 const getToAddressesText = () =>
-  // TODO
   screen.getByText("To addresses:").parentElement.textContent;
 const getTransactionFeeText = () =>
   screen.getByText("Transaction fee:").parentElement.textContent;

--- a/test/unit/components/views/TransactionPage/TransactionPage.spec.js
+++ b/test/unit/components/views/TransactionPage/TransactionPage.spec.js
@@ -129,6 +129,9 @@ const queryUnconfirmed = () => screen.queryByText("Unconfirmed");
 const queryPending = () => screen.queryByText("Pending");
 const getToAddressText = () =>
   screen.getByText("To address:").parentElement.textContent;
+const getToAddressesText = () =>
+  // TODO
+  screen.getByText("To addresses:").parentElement.textContent;
 const getTransactionFeeText = () =>
   screen.getByText("Transaction fee:").parentElement.textContent;
 const getWalletInputsText = () =>
@@ -178,8 +181,8 @@ test("regular sent pending tx from default account to an external address", asyn
   expect(getSentFromText()).toMatch("Sent FromdefaultUnconfirmed");
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(getPending()).toBeInTheDocument();
-  expect(getToAddressText()).toMatch(
-    "To address: TsacvMFSMWcmxT7dj5UHqgrxB3PP6uwnEtY  TsZJt5A55AcCMp8iBu1rkNCxqJ3Bf1MC8Zk"
+  expect(getToAddressesText()).toMatch(
+    "To addresses: TsacvMFSMWcmxT7dj5UHqgrxB3PP6uwnEtY  TsZJt5A55AcCMp8iBu1rkNCxqJ3Bf1MC8Zk"
   );
   expect(getTransactionFeeText()).toMatch("Transaction fee:0.0000253 DCR");
 
@@ -238,8 +241,8 @@ test("regular received mined tx to the default account", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryPending()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed5,269 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TsVzSRzExt1NRzGwTqu8qyY12t8NH8yiGzV  TsbvHMveM1bTK35aP5Dd2tmFppipvw2faWA"
+  expect(getToAddressesText()).toMatch(
+    "To addresses: TsVzSRzExt1NRzGwTqu8qyY12t8NH8yiGzV  TsbvHMveM1bTK35aP5Dd2tmFppipvw2faWA"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -299,8 +302,8 @@ test("regular self transfer tx to unmixed account", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryPending()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed4 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TsSBV4qZpZHS6QGVi6Zkp8kxBMS8EEF1bCh  TsgdFQemirW9EcAuz94SUCTePPaj5TDEcf8"
+  expect(getToAddressesText()).toMatch(
+    "To addresses: TsSBV4qZpZHS6QGVi6Zkp8kxBMS8EEF1bCh  TsgdFQemirW9EcAuz94SUCTePPaj5TDEcf8"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -355,8 +358,8 @@ test("self coins from unmixed to mixed account", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryPending()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed11 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TshTsuJmLsbpFCPgFYkeR4nmbRqiAAjGvAR  TsUNW19FJpNjkGrsi1tusvkHYNoZVbvzLTY  TsfhYupZxcqyHMLmJDUZ9qLJxbD6VQkpriC  TsXPm8qFAc1niDd654jaJnRsSSWjBTKGmP5  TsjBaeiu9ZZC2aZ5d4wHRH9H8KeG4szwkEs  TsjwBN1UELsLfV6BZynGfH21qhyBb5PtFaw  TsoPFWy8h8DFKiXXqYxWUaS9uguazs1bzva  TsVV7XBX2B8hj8c76FzWByoZ622DTiQxXUm  TsoQB5qSKdNXJEwr2X5YbUJnBhHaPYv2pA3"
+  expect(getToAddressesText()).toMatch(
+    "To addresses: TshTsuJmLsbpFCPgFYkeR4nmbRqiAAjGvAR  TsUNW19FJpNjkGrsi1tusvkHYNoZVbvzLTY  TsfhYupZxcqyHMLmJDUZ9qLJxbD6VQkpriC  TsXPm8qFAc1niDd654jaJnRsSSWjBTKGmP5  TsjBaeiu9ZZC2aZ5d4wHRH9H8KeG4szwkEs  TsjwBN1UELsLfV6BZynGfH21qhyBb5PtFaw  TsoPFWy8h8DFKiXXqYxWUaS9uguazs1bzva  TsVV7XBX2B8hj8c76FzWByoZ622DTiQxXUm  TsoQB5qSKdNXJEwr2X5YbUJnBhHaPYv2pA3"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -590,8 +593,8 @@ test("missed ticket", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed5,271 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TsZu7GLduXJKyD69vpuBrTj6Ja2sREAY1M1  TsTRP3GpMrtvRZ2XK5CopdZ9HhxsRJ75Cwn  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+  expect(getToAddressesText()).toMatch(
+    "To addresses: TsZu7GLduXJKyD69vpuBrTj6Ja2sREAY1M1  TsTRP3GpMrtvRZ2XK5CopdZ9HhxsRJ75Cwn  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -708,8 +711,8 @@ test("revoked ticket", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed109,009 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy  Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+  expect(getToAddressesText()).toMatch(
+    "To addresses: Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy  Tse3z6zJhWhb5Eir4s7KjZRv4koC9fEkAYy  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -765,8 +768,8 @@ test("immature ticket", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed12 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TscNc4DXrcuFgFJ6WyohhKaqvyDyJ8pksUU  TsVa9jpZGjAg1oqHBsUbrEtFbQjv9rUjVfj  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+  expect(getToAddressesText()).toMatch(
+    "To addresses: TscNc4DXrcuFgFJ6WyohhKaqvyDyJ8pksUU  TsVa9jpZGjAg1oqHBsUbrEtFbQjv9rUjVfj  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -824,8 +827,8 @@ test("live ticket", async () => {
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
   expect(queryUnconfirmed()).not.toBeInTheDocument();
   expect(getConfirmedText()).toMatch("Confirmed12 confirmations");
-  expect(getToAddressText()).toMatch(
-    "To address: TscNc4DXrcuFgFJ6WyohhKaqvyDyJ8pksUU  TsVa9jpZGjAg1oqHBsUbrEtFbQjv9rUjVfj  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+  expect(getToAddressesText()).toMatch(
+    "To addresses: TscNc4DXrcuFgFJ6WyohhKaqvyDyJ8pksUU  TsVa9jpZGjAg1oqHBsUbrEtFbQjv9rUjVfj  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
   );
 
   expect(queryAbandonTransactionButton()).not.toBeInTheDocument();
@@ -910,8 +913,8 @@ test("unmined ticket", async () => {
   expect(getTicketCostText()).toMatch("Ticket Cost37.31114774 DCR");
 
   expect(getTransactionText()).toMatch(`Transaction:${mockTxHash}`);
-  expect(getToAddressText()).toMatch(
-    "To address: TscNc4DXrcuFgFJ6WyohhKaqvyDyJ8pksUU  TsVa9jpZGjAg1oqHBsUbrEtFbQjv9rUjVfj  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
+  expect(getToAddressesText()).toMatch(
+    "To addresses: TscNc4DXrcuFgFJ6WyohhKaqvyDyJ8pksUU  TsVa9jpZGjAg1oqHBsUbrEtFbQjv9rUjVfj  TsR28UZRprhgQQhzWns2M6cAwchrNVvbYq2"
   );
 
   user.click(getAbandonTransactionButton());

--- a/test/unit/components/views/TransactionPage/mocks.js
+++ b/test/unit/components/views/TransactionPage/mocks.js
@@ -103,7 +103,7 @@ const mockRegularTransactionList = [
       }
     ]
   },
-  // regular self transfer transactio
+  // regular self transfer transaction
   {
     timestamp: 1624605208,
     height: 712832,


### PR DESCRIPTION
I've poked at the code a bit, here is how I think a fix might look like (it works for me, screenshots below are based on testnet txns).

Closes https://github.com/decred/decrediton/issues/3817.

Single output: 

<img width="400" alt="image" src="https://user-images.githubusercontent.com/112318969/196057465-d61f5458-3365-4324-9c43-45af6ac4c354.png">

Multiple outputs: 

<img width="400" alt="image" src="https://user-images.githubusercontent.com/112318969/196057518-71720da1-c0eb-4519-8d4d-c24903052556.png">

