### PR TITLE
[DEX] Auto update wallet passphrase on update private passphrase

### DIFF
--- a/app/actions/DexActions.js
+++ b/app/actions/DexActions.js
@@ -260,6 +260,32 @@ export const createWalletDex = (
   }
 };
 
+export const DEX_SETWALLET_PASSWORD_ATTEMPT = "DEX_SETWALLET_PASSWORD_ATTEMPT";
+export const DEX_SETWALLET_PASSWORD_SUCCESS = "DEX_SETWALLET_PASSWORD_SUCCESS";
+export const DEX_SETWALLET_PASSWORD_FAILED = "DEX_SETWALLET_PASSWORD_FAILED";
+
+export const setWalletPasswordDex = (passphrase, appPassphrase) => async (
+  dispatch,
+  getState
+) => {
+  dispatch({ type: DEX_SETWALLET_PASSWORD_ATTEMPT });
+  if (!sel.dexActive(getState())) {
+    dispatch({
+      type: DEX_SETWALLET_PASSWORD_FAILED,
+      error: "Dex isn't active"
+    });
+    return;
+  }
+  try {
+    const assetID = 42;
+    await dex.setWalletPassword(assetID, passphrase, appPassphrase);
+    dispatch({ type: DEX_SETWALLET_PASSWORD_SUCCESS });
+  } catch (error) {
+    dispatch({ type: DEX_SETWALLET_PASSWORD_FAILED, error });
+    return;
+  }
+};
+
 export const DEX_USER_ATTEMPT = "DEX_USER_ATTEMPT";
 export const DEX_USER_SUCCESS = "DEX_USER_SUCCESS";
 export const DEX_USER_FAILED = "DEX_USER_FAILED";

--- a/app/components/modals/ChangePassphraseModal/ChangePassphraseModal.jsx
+++ b/app/components/modals/ChangePassphraseModal/ChangePassphraseModal.jsx
@@ -13,6 +13,7 @@ const ChangePassphraseModal = ({ onCancelModal, onSubmit, ...props }) => {
   const [error, setIsError] = useState("");
   const intl = useIntl();
   const dexActive = useSelector(sel.dexActive);
+  const dexAccountName = useSelector(sel.dexAccount());
 
   const resetState = useCallback(() => {
     setNewPassphrase(null);
@@ -73,6 +74,7 @@ const ChangePassphraseModal = ({ onCancelModal, onSubmit, ...props }) => {
         dexAppPassword,
         setDexAppPassword,
         dexActive,
+        dexAccountName,
         error,
         intl
       }}

--- a/app/components/modals/ChangePassphraseModal/ChangePassphraseModal.jsx
+++ b/app/components/modals/ChangePassphraseModal/ChangePassphraseModal.jsx
@@ -2,17 +2,22 @@ import Modal from "./ChangePassphraseModalContent";
 import { useEffect, useState, useCallback } from "react";
 import { FormattedMessage as T } from "react-intl";
 import { useIntl } from "react-intl";
+import { useSelector } from "react-redux";
+import * as sel from "selectors";
 
 const ChangePassphraseModal = ({ onCancelModal, onSubmit, ...props }) => {
   const [newPassphrase, setNewPassphrase] = useState(null);
   const [confirmPrivPass, setConfirmPrivPass] = useState(null);
+  const [dexAppPassword, setDexAppPassword] = useState(null);
   const [isValid, setIsValid] = useState(false);
   const [error, setIsError] = useState("");
   const intl = useIntl();
+  const dexActive = useSelector(sel.dexActive);
 
   const resetState = useCallback(() => {
     setNewPassphrase(null);
     setConfirmPrivPass(null);
+    setDexAppPassword(null);
   }, []);
 
   const onCancelModalCallback = useCallback(() => {
@@ -22,10 +27,10 @@ const ChangePassphraseModal = ({ onCancelModal, onSubmit, ...props }) => {
 
   const onSubmitCallback = useCallback(
     (passPhrase) => {
-      onSubmit(passPhrase, { newPassphrase, priv: true });
+      onSubmit(passPhrase, { newPassphrase, priv: true, dexAppPassword });
       resetState();
     },
-    [newPassphrase, onSubmit, resetState]
+    [newPassphrase, onSubmit, resetState, dexAppPassword]
   );
 
   useEffect(() => {
@@ -65,6 +70,9 @@ const ChangePassphraseModal = ({ onCancelModal, onSubmit, ...props }) => {
         onSubmit: onSubmitCallback,
         setNewPassphrase,
         setConfirmPrivPass,
+        dexAppPassword,
+        setDexAppPassword,
+        dexActive,
         error,
         intl
       }}

--- a/app/components/modals/ChangePassphraseModal/ChangePassphraseModal.module.css
+++ b/app/components/modals/ChangePassphraseModal/ChangePassphraseModal.module.css
@@ -1,0 +1,6 @@
+.dexAppPasswordDesc {
+  margin: -1rem 0 0.5rem 0;
+  color: var(--text-secondary-color);
+  font-size: var(--font-size-small);
+  font-style: italic;
+}

--- a/app/components/modals/ChangePassphraseModal/ChangePassphraseModalContent.jsx
+++ b/app/components/modals/ChangePassphraseModal/ChangePassphraseModalContent.jsx
@@ -1,6 +1,7 @@
 import { PasswordInput } from "inputs";
 import { PassphraseModal } from "modals";
 import { defineMessages } from "react-intl";
+import styles from "./ChangePassphraseModal.module.css";
 
 const messages = defineMessages({
   newPassphraseLabelText: {
@@ -18,6 +19,19 @@ const messages = defineMessages({
   confirmPassphraseplaceholderText: {
     id: "changePassModal.confirmPassphrasePlaceholder",
     defaultMessage: "Confirm your Private Passphrase"
+  },
+  dexAppPasswordLabelText: {
+    id: "dexPassModal.confirm",
+    defaultMessage: "DEX App Passsword"
+  },
+  dexAppPasswordPlaceholderText: {
+    id: "dexPassModal.dexPasswordPlaceholder",
+    defaultMessage: "Write your DEX App Passsword"
+  },
+  dexAppPasswordDesc: {
+    id: "dexPassModal.dexAppPasswordDesc",
+    defaultMessage:
+      "Providing DEX app password automatically propagates the changes to dexc too"
   }
 });
 
@@ -31,6 +45,9 @@ const Modal = ({
   onTriggerPassphraseModalSubmit,
   error,
   intl,
+  dexAppPassword,
+  setDexAppPassword,
+  dexActive,
   ...props
 }) => (
   <PassphraseModal
@@ -61,8 +78,27 @@ const Modal = ({
       )}
       value={confirmPrivPass}
       onChange={(e) => setConfirmPrivPass(e.target.value)}
-      onKeyDownSubmit={onTriggerPassphraseModalSubmit}
+      onKeyDownSubmit={!dexActive && onTriggerPassphraseModalSubmit}
     />
+    {dexActive && (
+      <>
+        <PasswordInput
+          newBiggerFontStyle
+          id="dexAppPasswordInput"
+          required
+          label={intl.formatMessage(messages.dexAppPasswordLabelText)}
+          placeholder={intl.formatMessage(
+            messages.dexAppPasswordPlaceholderText
+          )}
+          value={dexAppPassword}
+          onChange={(e) => setDexAppPassword(e.target.value)}
+          onKeyDownSubmit={onTriggerPassphraseModalSubmit}
+        />
+        <div className={styles.dexAppPasswordDesc}>
+          {intl.formatMessage(messages.dexAppPasswordDesc)}
+        </div>
+      </>
+    )}
     {error && <div className="error">{error}</div>}
   </PassphraseModal>
 );

--- a/app/components/modals/ChangePassphraseModal/ChangePassphraseModalContent.jsx
+++ b/app/components/modals/ChangePassphraseModal/ChangePassphraseModalContent.jsx
@@ -48,6 +48,7 @@ const Modal = ({
   dexAppPassword,
   setDexAppPassword,
   dexActive,
+  dexAccountName,
   ...props
 }) => (
   <PassphraseModal
@@ -80,7 +81,7 @@ const Modal = ({
       onChange={(e) => setConfirmPrivPass(e.target.value)}
       onKeyDownSubmit={!dexActive && onTriggerPassphraseModalSubmit}
     />
-    {dexActive && (
+    {dexActive && dexAccountName && (
       <>
         <PasswordInput
           newBiggerFontStyle

--- a/app/components/modals/ChangePassphraseModal/ChangePassphraseModalContent.jsx
+++ b/app/components/modals/ChangePassphraseModal/ChangePassphraseModalContent.jsx
@@ -81,7 +81,7 @@ const Modal = ({
       onChange={(e) => setConfirmPrivPass(e.target.value)}
       onKeyDownSubmit={!dexActive && onTriggerPassphraseModalSubmit}
     />
-    {dexActive && dexAccountName && (
+    {dexActive && dexAccountName && dexAccountName !== "" && (
       <>
         <PasswordInput
           newBiggerFontStyle

--- a/app/hooks/useSettings.js
+++ b/app/hooks/useSettings.js
@@ -26,8 +26,10 @@ const useSettings = () => {
 
   const onAttemptChangePassphrase = useCallback(
     (oldPass, args) => {
-      const { newPassphrase, priv } = args;
-      dispatch(ca.changePassphraseAttempt(oldPass, newPassphrase, priv));
+      const { newPassphrase, priv, dexAppPassword } = args;
+      dispatch(
+        ca.changePassphraseAttempt(oldPass, newPassphrase, priv, dexAppPassword)
+      );
     },
     [dispatch]
   );

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -69,6 +69,7 @@ import {
   checkInitDex,
   initDex,
   createWalletDex,
+  setWalletPasswordDex,
   userDex,
   loginDex,
   logoutDex,
@@ -417,6 +418,8 @@ handle("start-dex", startDex);
 handle("stop-dex", stopDex);
 
 handle("launch-dex-window", createDexWindow);
+
+handle("set-wallet-password-dex", setWalletPasswordDex);
 
 function createDexWindow(serverAddress) {
   dexWindow.loadURL("http://" + serverAddress);

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -22,6 +22,7 @@ import {
   initCheckDex,
   initDexCall,
   createWalletDexCall,
+  setWalletPasswordDexCall,
   userDexCall,
   loginDexCall,
   logoutDexCall,
@@ -370,6 +371,32 @@ export const createWalletDex = async (
     return createWallet;
   } catch (e) {
     logger.log("error", `error create wallet dex: ${e}`);
+    return e;
+  }
+};
+
+export const setWalletPasswordDex = async (
+  assetID,
+  passphrase,
+  appPassphrase
+) => {
+  if (!GetDexPID()) {
+    logger.log(
+      "info",
+      "Skipping setting wallet password since dex is not runnning"
+    );
+    return false;
+  }
+
+  try {
+    const setWalletPassword = await setWalletPasswordDexCall(
+      assetID,
+      passphrase,
+      appPassphrase
+    );
+    return setWalletPassword;
+  } catch (e) {
+    logger.log("error", `error set wallet password dex: ${e}`);
     return e;
   }
 };

--- a/app/main_dev/launch.js
+++ b/app/main_dev/launch.js
@@ -1017,6 +1017,21 @@ export const createWalletDexCall = (
   }
 };
 
+export const setWalletPasswordDexCall = (
+  assetID,
+  passphrase,
+  appPassphrase
+) => {
+  if (!dex) {
+    return;
+  }
+  return callDEX("SetWalletPassword", {
+    pass: passphrase,
+    appPass: appPassphrase,
+    assetID
+  });
+};
+
 export const userDexCall = () => (!dex ? null : callDEX("User", {}));
 
 export const GetDcrwPort = () => dcrwPort;

--- a/app/reducers/dex.js
+++ b/app/reducers/dex.js
@@ -38,7 +38,10 @@ import {
   DEX_CONFIRM_SEED_ATTEMPT,
   DEX_CONFIRM_SEED_SUCCESS,
   DEX_CONFIRM_SEED_FAILED,
-  RESET_DEXACCOUNT
+  RESET_DEXACCOUNT,
+  DEX_SETWALLET_PASSWORD_ATTEMPT,
+  DEX_SETWALLET_PASSWORD_FAILED,
+  DEX_SETWALLET_PASSWORD_SUCCESS
 } from "../actions/DexActions";
 import { CLOSEWALLET_SUCCESS } from "actions/WalletLoaderActions";
 
@@ -123,6 +126,24 @@ export default function ln(state = {}, action) {
         ...state,
         createWalletAttempt: false,
         createWalletError: null
+      };
+    case DEX_SETWALLET_PASSWORD_ATTEMPT:
+      return {
+        ...state,
+        setWalletPasswordAttempt: true,
+        setWalletPasswordError: null
+      };
+    case DEX_SETWALLET_PASSWORD_FAILED:
+      return {
+        ...state,
+        setWalletPasswordAttempt: false,
+        setWalletPasswordError: action.error
+      };
+    case DEX_SETWALLET_PASSWORD_SUCCESS:
+      return {
+        ...state,
+        setWalletPasswordAttempt: false,
+        setWalletPasswordError: null
       };
     case DEX_USER_ATTEMPT:
       return {

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -105,7 +105,10 @@ export default function walletLoader(state = {}, action) {
         synced: false,
         syncLastFetchedHeaderTime: null,
         needsPassPhrase: false,
-        syncRescanAttempt: false
+        syncRescanAttempt: false,
+        dexAccount: null,
+        dexEnabled: null,
+        dexReady: null
       };
     case UPDATEDISCOVERACCOUNTS:
       return { ...state, discoverAccountsComplete: action.complete };

--- a/app/wallet/dex/index.js
+++ b/app/wallet/dex/index.js
@@ -10,3 +10,4 @@ export const exportSeed = invocable("export-seed-dex");
 export const createWallet = invocable("create-wallet-dex");
 export const user = invocable("user-dex");
 export const launchWindow = invocable("launch-dex-window");
+export const setWalletPassword = invocable("set-wallet-password-dex");

--- a/modules/dex/libdexc/adapter.go
+++ b/modules/dex/libdexc/adapter.go
@@ -73,16 +73,17 @@ func NewCoreAdapter() *CoreAdapter {
 		"startServer": c.startServer,
 		"shutdown":    c.shutdown,
 		// Pass-throughs to Core
-		"Init":         c.init,
-		"ExportSeed":   c.exportSeed,
-		"CreateWallet": c.createWallet,
-		"UpdateWallet": c.updateWallet,
-		"User":         c.user,
-		"PreRegister":  c.discoverAcct,
-		"Register":     c.register,
-		"Login":        c.login,
-		"Logout":       c.logout,
-		"DexConfig":    c.getDexConfig,
+		"Init":              c.init,
+		"ExportSeed":        c.exportSeed,
+		"CreateWallet":      c.createWallet,
+		"UpdateWallet":      c.updateWallet,
+		"SetWalletPassword": c.setWalletPassword,
+		"User":              c.user,
+		"PreRegister":       c.discoverAcct,
+		"Register":          c.register,
+		"Login":             c.login,
+		"Logout":            c.logout,
+		"DexConfig":         c.getDexConfig,
 	}
 	c.wg = new(sync.WaitGroup)
 
@@ -268,6 +269,18 @@ func (c *CoreAdapter) updateWallet(raw json.RawMessage) (string, error) {
 			Type:    form.Type,
 		},
 	)
+}
+
+func (c *CoreAdapter) setWalletPassword(raw json.RawMessage) (string, error) {
+	form := new(struct {
+		AppPW   string `json:"appPass"`
+		AssetID uint32 `json:"assetID"`
+		Pass    string `json:"pass"`
+	})
+	if err := json.Unmarshal(raw, form); err != nil {
+		return "", err
+	}
+	return "", c.core.SetWalletPassword([]byte(form.AppPW), form.AssetID, []byte(form.Pass))
 }
 
 func (c *CoreAdapter) createWallet(raw json.RawMessage) (string, error) {

--- a/test/unit/actions/ControlActions.spec.js
+++ b/test/unit/actions/ControlActions.spec.js
@@ -1,8 +1,19 @@
+import * as d from "actions/DexActions";
 import * as ca from "actions/ControlActions";
+import * as wal from "wallet";
 import { cloneDeep, isEqual } from "lodash";
 import { createStore } from "test-utils.js";
+import { testBalances, dexAccountName } from "./accountMocks.js";
 
 const controlActions = ca;
+const wallet = wal;
+const dexActions = d;
+
+const testWalletService = "test-wallet-service";
+const testError = "test-error";
+const testPassphrase = "test-passphrase";
+const testNewPassphrase = "test-new-passphrase";
+const testDEXAppPassword = "test-new-password";
 
 const selectedAccountForTicketPurchase = 1;
 const selectedAccountForTicketPurchaseName = "ticket-purchase-account-name";
@@ -13,25 +24,13 @@ const ticketBuyerAccountName = "ticket-buyer-account-name";
 const changeAccount = 3;
 const mixedAccount = 4;
 const dexAccountNumber = 5;
-const dexAccountName = "dex";
-
 const commitmentAccount = 6;
 
-const testBalances = [
-  { accountNumber: 0, accountName: "default" },
-  {
-    accountNumber: selectedAccountForTicketPurchase,
-    accountName: selectedAccountForTicketPurchaseName
-  },
-  { accountNumber: ticketBuyerAccount, accountName: ticketBuyerAccountName },
-  { accountNumber: changeAccount, accountName: "test-account3" },
-  { accountNumber: mixedAccount, accountName: "test-account4" },
-  { accountNumber: dexAccountNumber, accountName: dexAccountName },
-  { accountNumber: commitmentAccount, accountName: "test-account5" }
-];
-
 const initialState = {
-  grpc: { balances: testBalances },
+  grpc: {
+    balances: testBalances,
+    walletService: testWalletService
+  },
   walletLoader: {
     dexAccount: dexAccountName,
     mixedAccount: mixedAccount,
@@ -52,6 +51,20 @@ const initialState = {
     }
   }
 };
+
+let mockSetAccountPassphrase;
+let mockSetWalletPasswordDex;
+let mockChangePassphrase;
+
+beforeEach(() => {
+  mockSetAccountPassphrase = wallet.setAccountPassphrase = jest.fn(() => {});
+  mockChangePassphrase = wallet.changePassphrase = jest.fn(() =>
+    Promise.resolve({})
+  );
+  mockSetWalletPasswordDex = dexActions.setWalletPasswordDex = jest.fn(
+    () => () => {}
+  );
+});
 
 test("test filterUnlockableAccounts - there is no running progress", () => {
   const store = createStore(cloneDeep(initialState));
@@ -168,47 +181,6 @@ test("test filterUnlockableAccounts - purchase ticket is running", () => {
   );
 
   testRunnning(store);
-});
-
-import * as d from "actions/DexActions";
-import * as ca from "actions/ControlActions";
-import { cloneDeep } from "lodash";
-import { createStore } from "test-utils.js";
-import * as wal from "wallet";
-import { testBalances, dexAccountName } from "./accountMocks.js";
-
-const controlActions = ca;
-const wallet = wal;
-const dexActions = d;
-
-const testWalletService = "test-wallet-service";
-const testError = "test-error";
-const testPassphrase = "test-passphrase";
-const testNewPassphrase = "test-new-passphrase";
-const testDEXAppPassword = "test-new-password";
-
-const initialState = {
-  grpc: {
-    balances: testBalances,
-    walletService: testWalletService
-  },
-  walletLoader: {
-    dexAccount: dexAccountName
-  }
-};
-
-let mockSetAccountPassphrase;
-let mockSetWalletPasswordDex;
-let mockChangePassphrase;
-
-beforeEach(() => {
-  mockSetAccountPassphrase = wallet.setAccountPassphrase = jest.fn(() => {});
-  mockChangePassphrase = wallet.changePassphrase = jest.fn(() =>
-    Promise.resolve({})
-  );
-  mockSetWalletPasswordDex = dexActions.setWalletPasswordDex = jest.fn(
-    () => () => {}
-  );
 });
 
 test("test changePassphraseAttempt", async () => {

--- a/test/unit/actions/ControlActions.spec.js
+++ b/test/unit/actions/ControlActions.spec.js
@@ -169,3 +169,163 @@ test("test filterUnlockableAccounts - purchase ticket is running", () => {
 
   testRunnning(store);
 });
+
+import * as d from "actions/DexActions";
+import * as ca from "actions/ControlActions";
+import { cloneDeep } from "lodash";
+import { createStore } from "test-utils.js";
+import * as wal from "wallet";
+import { testBalances, dexAccountName } from "./accountMocks.js";
+
+const controlActions = ca;
+const wallet = wal;
+const dexActions = d;
+
+const testWalletService = "test-wallet-service";
+const testError = "test-error";
+const testPassphrase = "test-passphrase";
+const testNewPassphrase = "test-new-passphrase";
+const testDEXAppPassword = "test-new-password";
+
+const initialState = {
+  grpc: {
+    balances: testBalances,
+    walletService: testWalletService
+  },
+  walletLoader: {
+    dexAccount: dexAccountName
+  }
+};
+
+let mockSetAccountPassphrase;
+let mockSetWalletPasswordDex;
+let mockChangePassphrase;
+
+beforeEach(() => {
+  mockSetAccountPassphrase = wallet.setAccountPassphrase = jest.fn(() => {});
+  mockChangePassphrase = wallet.changePassphrase = jest.fn(() =>
+    Promise.resolve({})
+  );
+  mockSetWalletPasswordDex = dexActions.setWalletPasswordDex = jest.fn(
+    () => () => {}
+  );
+});
+
+test("test changePassphraseAttempt", async () => {
+  const testPriv = true;
+  const store = createStore(cloneDeep(initialState));
+  await store.dispatch(
+    controlActions.changePassphraseAttempt(
+      testPassphrase,
+      testNewPassphrase,
+      testPriv
+    )
+  );
+
+  expect(mockChangePassphrase).toHaveBeenCalledWith(
+    testWalletService,
+    testPassphrase,
+    testNewPassphrase,
+    testPriv
+  );
+
+  testBalances.forEach(({ accountNumber, accountName }, index) => {
+    if (accountName !== "imported") {
+      expect(mockSetAccountPassphrase).toHaveBeenNthCalledWith(
+        index + 1,
+        testWalletService,
+        accountNumber,
+        testPassphrase,
+        testNewPassphrase,
+        null
+      );
+    }
+  });
+
+  expect(mockSetWalletPasswordDex).not.toHaveBeenCalled();
+  expect(store.getState().control.changePassphraseError).toBeNull();
+  expect(store.getState().control.changePassphraseRequestAttempt).toBeFalsy();
+  expect(store.getState().control.changePassphraseResponse).toStrictEqual({});
+  expect(store.getState().control.changePassphraseSuccess).toBe(
+    "Your private passphrase was successfully updated."
+  );
+});
+
+test("test changePassphraseAttempt - failed", async () => {
+  mockChangePassphrase = wallet.changePassphrase = jest.fn(() =>
+    Promise.reject(testError)
+  );
+  const testPriv = true;
+  const store = createStore(cloneDeep(initialState));
+  await store.dispatch(
+    controlActions.changePassphraseAttempt(
+      testPassphrase,
+      testNewPassphrase,
+      testPriv
+    )
+  );
+
+  expect(mockChangePassphrase).toHaveBeenCalledWith(
+    testWalletService,
+    testPassphrase,
+    testNewPassphrase,
+    testPriv
+  );
+
+  expect(mockSetAccountPassphrase).not.toHaveBeenCalled();
+  expect(mockSetWalletPasswordDex).not.toHaveBeenCalled();
+
+  expect(store.getState().control.changePassphraseError).toBe(testError);
+  expect(store.getState().control.changePassphraseRequestAttempt).toBeFalsy();
+  expect(store.getState().control.changePassphraseResponse).toBe(undefined);
+  expect(store.getState().control.changePassphraseSuccess).toBe(undefined);
+});
+
+test("test changePassphraseAttempt - dex is active", async () => {
+  const testPriv = true;
+  const store = createStore(
+    cloneDeep({
+      ...initialState,
+      dex: { ...initialState.dex, active: true }
+    })
+  );
+  await store.dispatch(
+    controlActions.changePassphraseAttempt(
+      testPassphrase,
+      testNewPassphrase,
+      testPriv,
+      testDEXAppPassword
+    )
+  );
+
+  expect(mockChangePassphrase).toHaveBeenCalledWith(
+    testWalletService,
+    testPassphrase,
+    testNewPassphrase,
+    testPriv
+  );
+
+  testBalances.forEach(({ accountNumber, accountName }, index) => {
+    if (accountName !== "imported") {
+      expect(mockSetAccountPassphrase).toHaveBeenNthCalledWith(
+        index + 1,
+        testWalletService,
+        accountNumber,
+        testPassphrase,
+        testNewPassphrase,
+        null
+      );
+    }
+  });
+  expect(mockSetWalletPasswordDex).toHaveBeenCalledWith(
+    testNewPassphrase,
+    testDEXAppPassword
+  );
+
+  expect(store.getState().control.changePassphraseError).toBeNull();
+  expect(store.getState().control.changePassphraseRequestAttempt).toBeFalsy();
+  expect(store.getState().control.changePassphraseResponse).toStrictEqual({});
+  expect(store.getState().control.changePassphraseSuccess).toBe(
+    "Your private passphrase was successfully updated."
+  );
+});

--- a/test/unit/actions/accountMocks.js
+++ b/test/unit/actions/accountMocks.js
@@ -1,0 +1,62 @@
+export const selectedAccountNumberForTicketPurchase = 1;
+export const selectedAccountForTicketPurchaseName =
+  "ticket-purchase-account-name";
+
+export const ticketBuyerAccountNumber = 2;
+export const ticketBuyerAccountName = "ticket-buyer-account-name";
+
+export const changeAccountNumber = 3;
+export const mixedAccountNumber = 4;
+export const mixedAccountName = "mixed";
+export const mixedAccount = {
+  value: mixedAccountNumber,
+  encrypted: true,
+  name: mixedAccountName
+};
+export const defaultAccountNumber = 0;
+export const defaultAccount = { value: defaultAccountNumber, encrypted: true };
+export const dexAccountNumber = 5;
+export const dexAccountName = "dex";
+
+export const commitmentAccountNumber = 6;
+export const unencryptedAccount = 7;
+
+export const testBalances = [
+  { accountNumber: 0, accountName: "default", encrypted: true },
+  {
+    accountNumber: selectedAccountNumberForTicketPurchase,
+    accountName: selectedAccountForTicketPurchaseName,
+    encrypted: true
+  },
+  {
+    accountNumber: ticketBuyerAccountNumber,
+    accountName: ticketBuyerAccountName,
+    encrypted: true
+  },
+  {
+    accountNumber: changeAccountNumber,
+    accountName: "test-account3",
+    encrypted: true
+  },
+  {
+    accountNumber: mixedAccountNumber,
+    accountName: mixedAccountName,
+    encrypted: true
+  },
+  {
+    accountNumber: dexAccountNumber,
+    accountName: dexAccountName,
+    encrypted: true
+  },
+  {
+    accountNumber: commitmentAccountNumber,
+    accountName: "test-account5",
+    encrypted: true
+  },
+  {
+    accountNumber: unencryptedAccount,
+    accountName: "test-account6",
+    encrypted: false
+  },
+  { accountNumber: 2147483647, accountName: "imported", encrypted: false }
+];

--- a/test/unit/components/views/SettingsPage/SettingsPage.spec.js
+++ b/test/unit/components/views/SettingsPage/SettingsPage.spec.js
@@ -712,11 +712,93 @@ test("test update private passphrase", () => {
   expect(screen.queryByText("Fill all fields.")).not.toBeInTheDocument();
   expect(continueButton.disabled).toBe(false);
 
+  expect(
+    screen.queryByLabelText(/^DEX App Passsword/i)
+  ).not.toBeInTheDocument();
   user.click(screen.getByText("Continue"));
   expect(mockChangePassphrase).toHaveBeenCalledWith(
     testPassphrase,
     testNewPassphrase,
-    true
+    true,
+    null
+  );
+});
+
+test("test update private passphrase, DEX is active", () => {
+  render(<SettingsPage />, {
+    initialState: {
+      settings: testSettings,
+      dex: {
+        active: true
+      }
+    }
+  });
+  user.click(screen.getByText("Privacy and Security"));
+  const updateButton = screen.getByRole("button", {
+    name: "Update Private Passphrase"
+  });
+  const modalHeaderText = "Change your passphrase";
+  // click and cancel
+  user.click(updateButton);
+  expect(screen.getByText(modalHeaderText)).toBeInTheDocument();
+  user.click(screen.getByText("Cancel"));
+  expect(screen.queryByText(modalHeaderText)).not.toBeInTheDocument();
+
+  user.click(updateButton);
+  expect(screen.getByText(modalHeaderText)).toBeInTheDocument();
+
+  const continueButton = screen.getByText("Continue");
+  expect(continueButton.disabled).toBe(true);
+  // test 'This Field is required' error message
+  testPassphraseInputRequiedErrorMsg("Private Passphrase");
+  testPassphraseInputRequiedErrorMsg("New Private Passphrase");
+  testPassphraseInputRequiedErrorMsg("Confirm");
+  expect(continueButton.disabled).toBe(true);
+
+  // fill input fields
+  const testPassphrase = "test-passphrase";
+  const testNewPassphrase = "test-new-passphrase";
+  const testDEXAppPasspword = "test-dex-app-password";
+  const testConfirmPassphrase = "test-confirm-passphrase";
+  user.type(screen.getByLabelText(/^private passphrase/i), testPassphrase);
+  user.type(
+    screen.getByLabelText(/^new private passphrase/i),
+    testNewPassphrase
+  );
+  expect(continueButton.disabled).toBe(true);
+  user.type(screen.getByLabelText(/^confirm/i), testConfirmPassphrase);
+  expect(screen.getByText("Passwords does not match.")).toBeInTheDocument();
+
+  // fix confirm passphrase
+  user.clear(screen.getByLabelText(/^confirm/i));
+  user.type(screen.getByLabelText(/^confirm/i), testNewPassphrase);
+  expect(
+    screen.queryByText("Passwords does not match.")
+  ).not.toBeInTheDocument();
+  expect(continueButton.disabled).toBe(false);
+
+  // clear confirm and new passphrases. should get an error message
+  user.clear(screen.getByLabelText(/^confirm/i));
+  user.clear(screen.getByLabelText(/^new private passphrase/i));
+  expect(screen.getByText("Fill all fields.")).toBeInTheDocument();
+  expect(continueButton.disabled).toBe(true);
+
+  //refill inputs
+  user.type(
+    screen.getByLabelText(/^new private passphrase/i),
+    testNewPassphrase
+  );
+  user.type(screen.getByLabelText(/^confirm/i), testNewPassphrase);
+  expect(screen.queryByText("Fill all fields.")).not.toBeInTheDocument();
+  expect(continueButton.disabled).toBe(false);
+
+  user.type(screen.getByLabelText(/^DEX App Passsword/i), testDEXAppPasspword);
+  user.click(screen.getByText("Continue"));
+  expect(mockChangePassphrase).toHaveBeenCalledWith(
+    testPassphrase,
+    testNewPassphrase,
+    true,
+    testDEXAppPasspword
   );
 });
 

--- a/test/unit/components/views/SettingsPage/SettingsPage.spec.js
+++ b/test/unit/components/views/SettingsPage/SettingsPage.spec.js
@@ -730,6 +730,9 @@ test("test update private passphrase, DEX is active", () => {
       settings: testSettings,
       dex: {
         active: true
+      },
+      walletLoader: {
+        dexAccount: "test-dex-account-name"
       }
     }
   });
@@ -800,6 +803,47 @@ test("test update private passphrase, DEX is active", () => {
     true,
     testDEXAppPasspword
   );
+});
+
+test("test update private passphrase, DEX is active, but dex account is null", () => {
+  render(<SettingsPage />, {
+    initialState: {
+      settings: testSettings,
+      dex: {
+        active: true
+      }
+    }
+  });
+  user.click(screen.getByText("Privacy and Security"));
+  const updateButton = screen.getByRole("button", {
+    name: "Update Private Passphrase"
+  });
+  user.click(updateButton);
+  expect(
+    screen.queryByLabelText(/^DEX App Passsword/i)
+  ).not.toBeInTheDocument();
+});
+
+test("test update private passphrase, DEX is active, but dex account is empty string", () => {
+  render(<SettingsPage />, {
+    initialState: {
+      settings: testSettings,
+      dex: {
+        active: true
+      },
+      walletLoader: {
+        dexAccount: ""
+      }
+    }
+  });
+  user.click(screen.getByText("Privacy and Security"));
+  const updateButton = screen.getByRole("button", {
+    name: "Update Private Passphrase"
+  });
+  user.click(updateButton);
+  expect(
+    screen.queryByLabelText(/^DEX App Passsword/i)
+  ).not.toBeInTheDocument();
 });
 
 test("update private passphrase is disabled", () => {


### PR DESCRIPTION
Closes  #3820
Builds on top of  #3800

This diff introduces an additional DEX app password input on the private passphrase modal if DEX is active.
If the user provides the DEX app password, the app automatically propagates the changes to `dexc` too

<img width="343" alt="image" src="https://user-images.githubusercontent.com/52497040/197763598-f593fe25-cf32-4cd2-bfa9-ab1e7b475a05.png">
