### PR TITLE
[launcher] Speed up opening the wallet

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -77,7 +77,7 @@ const startWalletServicesTrigger = () => (dispatch, getState) =>
       if (privacyEnabled) {
         dispatch(getAccountMixerServiceAttempt());
       }
-      dispatch(discoverAvailableVSPs());
+      await dispatch(discoverAvailableVSPs());
       await dispatch(getNextAddressAttempt(0));
       await dispatch(getPeerInfo());
       await dispatch(getTicketPriceAttempt());

--- a/app/components/views/GetStartedPage/SetupWallet/ProcessManagedTickets/ProcessManagedTickets.jsx
+++ b/app/components/views/GetStartedPage/SetupWallet/ProcessManagedTickets/ProcessManagedTickets.jsx
@@ -1,26 +1,15 @@
-import { useState, useEffect } from "react";
 import { Subtitle } from "shared";
 import { FormattedMessage as T } from "react-intl";
 import { PassphraseModalButton, InvisibleButton } from "buttons";
 import styles from "./ProcessUnmanagedTickets.module.css";
-import { VSPSelect } from "inputs";
+import { useDaemonStartup } from "hooks";
 
-export default ({
-  cancel,
-  send,
-  onProcessTickets,
-  title,
-  description,
-  noVspSelection,
-  error,
-  isProcessingManaged
-}) => {
-  const [isValid, setIsValid] = useState(false);
-  const [vsp, setVSP] = useState(null);
+export default ({ cancel, send, error }) => {
+  const { onProcessManagedTickets, isProcessingManaged } = useDaemonStartup();
 
   const onSubmitContinue = (passphrase) => {
     // send a continue so we can go to the loading state
-    onProcessTickets(passphrase)
+    onProcessManagedTickets(passphrase)
       .then(() => send({ type: "CONTINUE" }))
       .catch((error) => {
         send({ type: "ERROR", error });
@@ -28,23 +17,28 @@ export default ({
     return;
   };
 
-  useEffect(() => {
-    if (noVspSelection) {
-      setIsValid(true);
-      return;
-    }
-    if (vsp) {
-      setIsValid(true);
-    }
-  }, [vsp, noVspSelection]);
-
   return (
     <div className={styles.content}>
-      <Subtitle className={styles.subtitle} title={title} />
-      <div className={styles.description}>{description}</div>
-      {!noVspSelection && (
-        <VSPSelect className={styles.vspSelect} {...{ onChange: setVSP }} />
-      )}
+      <Subtitle
+        className={styles.subtitle}
+        title={
+          <T
+            id="getstarted.processManagedTickets.title"
+            m="Process Managed Tickets"
+          />
+        }
+      />
+      <div className={styles.description}>
+        {
+          <T
+            id="getstarted.processManagedTickets.description"
+            m={`Your wallet appears to have live tickets. Processing managed
+                 tickets confirms with the VSPs that all of your submitted tickets
+                 are currently known and paid for by the VSPs. If you've already
+                 confirmed your tickets then you may skip this step.`}
+          />
+        }
+      </div>
       {error && <div className="error">{error}</div>}
       <div className={styles.buttonWrapper}>
         <PassphraseModalButton
@@ -52,14 +46,15 @@ export default ({
           modalClassName={styles.passphraseModal}
           onSubmit={onSubmitContinue}
           buttonLabel={<T id="process.mangedTickets.button" m="Continue" />}
-          disabled={!isValid || isProcessingManaged}
+          disabled={isProcessingManaged}
           loading={isProcessingManaged}
         />
-        {!isProcessingManaged && (
-          <InvisibleButton className={styles.skipButton} onClick={cancel}>
-            <T id="process.mangedTickets.button.skip" m="Skip" />
-          </InvisibleButton>
-        )}
+        <InvisibleButton
+          className={styles.skipButton}
+          onClick={cancel}
+          disabled={isProcessingManaged}>
+          <T id="process.mangedTickets.button.skip" m="Skip" />
+        </InvisibleButton>
       </div>
     </div>
   );

--- a/app/components/views/GetStartedPage/SetupWallet/ProcessManagedTickets/index.js
+++ b/app/components/views/GetStartedPage/SetupWallet/ProcessManagedTickets/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ProcessManagedTickets";

--- a/app/components/views/GetStartedPage/SetupWallet/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
+++ b/app/components/views/GetStartedPage/SetupWallet/ProcessUnmanagedTickets/ProcessUnmanagedTickets.jsx
@@ -1,52 +1,44 @@
-import { useState, useEffect } from "react";
 import { Subtitle } from "shared";
 import { FormattedMessage as T } from "react-intl";
 import { PassphraseModalButton, InvisibleButton } from "buttons";
 import styles from "./ProcessUnmanagedTickets.module.css";
 import { VSPSelect } from "inputs";
+import { useProcessUnmanagedTickets } from "./hooks";
 
-export default ({
-  cancel,
-  send,
-  onProcessTickets,
-  title,
-  description,
-  noVspSelection,
-  isProcessingUnmanaged,
-  error,
-  availableVSPs
-}) => {
-  const [isValid, setIsValid] = useState(false);
-  const [vsp, setVSP] = useState(null);
-
-  const onSubmitContinue = (passphrase) => {
-    onProcessTickets(passphrase, vsp.host, vsp.pubkey)
-      .then(() => send({ type: "CONTINUE" }))
-      .catch((error) => {
-        send({ type: "ERROR", error });
-      });
-  };
-
-  useEffect(() => {
-    if (noVspSelection) {
-      setIsValid(true);
-      return;
-    }
-    if (vsp) {
-      setIsValid(true);
-    }
-  }, [vsp, noVspSelection]);
+export default ({ cancel, send, error }) => {
+  const {
+    isProcessingUnmanaged,
+    availableVSPs,
+    vsp,
+    setVSP,
+    onSubmitContinue
+  } = useProcessUnmanagedTickets({ send });
 
   return (
     <div className={styles.content}>
-      <Subtitle className={styles.subtitle} title={title} />
-      <div className={styles.description}>{description}</div>
-      {!noVspSelection && (
-        <VSPSelect
-          className={styles.vspSelect}
-          {...{ onChange: setVSP, options: availableVSPs }}
-        />
-      )}
+      <Subtitle
+        className={styles.subtitle}
+        title={
+          <T
+            id="getstarted.processUnmangedTickets.title"
+            m="Process Unmanaged Tickets"
+          />
+        }
+      />
+      <div className={styles.description}>
+        {
+          <T
+            id="getstarted.processUnmangedTickets.description"
+            m={`Looks like you have vsp ticket with unprocessed fee.
+                If they are picked to vote and they are not linked with a vsp,
+                they may miss, if you are not properly dealing with solo vote.`}
+          />
+        }
+      </div>
+      <VSPSelect
+        className={styles.vspSelect}
+        {...{ onChange: setVSP, options: availableVSPs }}
+      />
       {error && <div className="error">{error}</div>}
       <div className={styles.buttonWrapper}>
         <PassphraseModalButton
@@ -54,14 +46,15 @@ export default ({
           modalClassName={styles.passphraseModal}
           onSubmit={onSubmitContinue}
           buttonLabel={<T id="process.unmangedTickets.button" m="Continue" />}
-          disabled={!isValid || isProcessingUnmanaged}
+          disabled={!vsp || isProcessingUnmanaged}
           loading={isProcessingUnmanaged}
         />
-        {!isProcessingUnmanaged && (
-          <InvisibleButton className={styles.skipButton} onClick={cancel}>
-            <T id="process.unmanagedTickets.button.skip" m="Skip" />
-          </InvisibleButton>
-        )}
+        <InvisibleButton
+          className={styles.skipButton}
+          onClick={cancel}
+          disabled={isProcessingUnmanaged}>
+          <T id="process.unmanagedTickets.button.skip" m="Skip" />
+        </InvisibleButton>
       </div>
     </div>
   );

--- a/app/components/views/GetStartedPage/SetupWallet/ProcessUnmanagedTickets/ProcessUnmanagedTickets.module.css
+++ b/app/components/views/GetStartedPage/SetupWallet/ProcessUnmanagedTickets/ProcessUnmanagedTickets.module.css
@@ -16,5 +16,13 @@
 }
 
 .buttonWrapper {
-  margin-top: 10px;
+  margin-top: 2rem;
+}
+
+.buttonWrapper .skipButton {
+  margin-left: 1rem;
+}
+
+.description {
+  margin-bottom: 1rem;
 }

--- a/app/components/views/GetStartedPage/SetupWallet/ProcessUnmanagedTickets/hooks.js
+++ b/app/components/views/GetStartedPage/SetupWallet/ProcessUnmanagedTickets/hooks.js
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { useSettings } from "hooks";
+import { useSelector } from "react-redux";
+import { useDaemonStartup } from "hooks";
+import { getAvailableVSPs } from "selectors";
+
+export const useProcessUnmanagedTickets = ({ send }) => {
+  const { onProcessUnmanagedTickets, isProcessingUnmanaged } =
+    useDaemonStartup();
+  const { isVSPListingEnabled } = useSettings();
+  const availableVSPs = isVSPListingEnabled
+    ? useSelector(getAvailableVSPs)
+    : [];
+  const [vsp, setVSP] = useState(null);
+
+  const onSubmitContinue = (passphrase) => {
+    onProcessUnmanagedTickets(passphrase, vsp.host, vsp.pubkey)
+      .then(() => send({ type: "CONTINUE" }))
+      .catch((error) => {
+        send({ type: "ERROR", error });
+      });
+  };
+
+  return {
+    isProcessingUnmanaged,
+    availableVSPs,
+    vsp,
+    setVSP,
+    onSubmitContinue
+  };
+};

--- a/app/components/views/GetStartedPage/SetupWallet/ProcessUnmanagedTickets/index.js
+++ b/app/components/views/GetStartedPage/SetupWallet/ProcessUnmanagedTickets/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ProcessUnmanagedTickets";

--- a/app/components/views/GetStartedPage/SetupWallet/hooks.js
+++ b/app/components/views/GetStartedPage/SetupWallet/hooks.js
@@ -3,26 +3,22 @@ import { useService } from "@xstate/react";
 import { IMMATURE, LIVE, UNMINED } from "constants/decrediton";
 import { FormattedMessage as T } from "react-intl";
 import SettingMixedAccount from "./SetMixedAcctPage/SetMixedAcctPage";
-import ProcessUnmanagedTickets from "./ProcessUnmanagedTickets/ProcessUnmanagedTickets";
-import ProcessManagedTickets from "./ProcessManagedTickets/ProcessManagedTickets";
+import ProcessUnmanagedTickets from "./ProcessUnmanagedTickets";
+import ProcessManagedTickets from "./ProcessManagedTickets";
 import SettingAccountsPassphrase from "./SetAccountsPassphrase";
 import ResendVotesToRecentlyUpdatedVSPs from "./ResendVotesToRecentlyUpdatedVSPs";
 import { useDaemonStartup, useAccounts, usePrevious } from "hooks";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import {
   checkAllAccountsEncrypted,
   setAccountsPass
 } from "actions/ControlActions";
 import {
-  getVSPsPubkeys,
   setCanDisableProcessManaged,
   getRecentlyUpdatedUsedVSPs,
   getNotAbstainVotes
 } from "actions/VSPActions";
 import { ExternalLink } from "shared";
-import { DecredLoading } from "indicators";
-import * as sel from "selectors";
-import { useSettings } from "hooks";
 
 export const useWalletSetup = (settingUpWalletRef) => {
   const dispatch = useDispatch();
@@ -32,16 +28,10 @@ export const useWalletSetup = (settingUpWalletRef) => {
   const {
     getCoinjoinOutputspByAcct,
     stakeTransactions,
-    onProcessManagedTickets,
     goToHome,
-    onProcessUnmanagedTickets,
-    isProcessingUnmanaged,
     isProcessingManaged,
     needsProcessManagedTickets
   } = useDaemonStartup();
-
-  const { isVSPListingEnabled } = useSettings();
-  const availableVSPs = useSelector(sel.getAvailableVSPs);
 
   const { mixedAccount } = useAccounts();
 
@@ -55,11 +45,6 @@ export const useWalletSetup = (settingUpWalletRef) => {
     (passphrase) => {
       return dispatch(setAccountsPass(passphrase));
     },
-    [dispatch]
-  );
-
-  const onGetVSPsPubkeys = useCallback(
-    () => dispatch(getVSPsPubkeys()),
     [dispatch]
   );
 
@@ -204,16 +189,6 @@ export const useWalletSetup = (settingUpWalletRef) => {
           }
         }
         break;
-      case "gettingVSPInfo":
-        // if no live tickets, we can skip it.
-        if (!hasLiveVSPdTickets) {
-          sendContinue();
-        } else {
-          component = h(DecredLoading);
-          await onGetVSPsPubkeys();
-          sendContinue();
-        }
-        break;
       case "processingManagedTickets":
         // if no live tickets, we can skip it.
         if (!hasLiveVSPdTickets || !needsProcessManagedTickets) {
@@ -221,28 +196,8 @@ export const useWalletSetup = (settingUpWalletRef) => {
         } else {
           component = h(ProcessManagedTickets, {
             error,
-            onSendContinue: sendContinue,
-            onSendError,
             send,
-            cancel: onSkipProcessManaged,
-            onProcessTickets: onProcessManagedTickets,
-            title: (
-              <T
-                id="getstarted.processManagedTickets.title"
-                m="Process Managed Tickets"
-              />
-            ),
-            isProcessingManaged: isProcessingManaged,
-            noVspSelection: true,
-            description: (
-              <T
-                id="getstarted.processManagedTickets.description"
-                m={`Your wallet appears to have live tickets. Processing managed
-                tickets confirms with the VSPs that all of your submitted tickets
-                are currently known and paid for by the VSPs. If you've already
-                confirmed your tickets then you may skip this step.`}
-              />
-            )
+            cancel: onSkipProcessManaged
           });
         }
         break;
@@ -276,24 +231,7 @@ export const useWalletSetup = (settingUpWalletRef) => {
             send,
             onSendContinue: sendContinue,
             onSendError,
-            onProcessTickets: onProcessUnmanagedTickets,
-            isProcessingUnmanaged: isProcessingUnmanaged,
-            cancel: onSendBack,
-            availableVSPs: isVSPListingEnabled ? availableVSPs : [],
-            title: (
-              <T
-                id="getstarted.processUnmangedTickets.title"
-                m="Process Unmanaged Tickets"
-              />
-            ),
-            description: (
-              <T
-                id="getstarted.processUnmangedTickets.description"
-                m={`Looks like you have vsp ticket with unprocessed fee. If they are picked
-                  to vote and they are not linked with a vsp, they may miss, if you are not
-                  properly dealing with solo vote.`}
-              />
-            )
+            cancel: onSendBack
           });
         }
         break;
@@ -328,24 +266,18 @@ export const useWalletSetup = (settingUpWalletRef) => {
     getCoinjoinOutputspByAcct,
     goToHome,
     mixedAccount,
-    onProcessManagedTickets,
     send,
     stakeTransactions,
     sendContinue,
     isProcessingManaged,
-    isProcessingUnmanaged,
     needsProcessManagedTickets,
-    onProcessUnmanagedTickets,
     onSendBack,
     onSendError,
     previousState,
     current,
-    availableVSPs,
     onCheckAcctsPass,
     onProcessAccounts,
-    onGetVSPsPubkeys,
     onSkipProcessManaged,
-    isVSPListingEnabled,
     onGetRecentlyUpdatedUsedVSPs,
     onGetNotAbstainVotes
   ]);

--- a/app/stateMachines/SetupWalletConfigMachine.js
+++ b/app/stateMachines/SetupWalletConfigMachine.js
@@ -20,12 +20,6 @@ export const SetupWalletConfigMachine = Machine({
     },
     settingMixedAccount: {
       on: {
-        CONTINUE: "gettingVSPInfo"
-      }
-    },
-    gettingVSPInfo: {
-      on: {
-        BACK: "processingManagedTickets",
         CONTINUE: "processingManagedTickets"
       }
     },

--- a/test/unit/actions/VSPActions.spec.js
+++ b/test/unit/actions/VSPActions.spec.js
@@ -348,7 +348,11 @@ test("test getVSPsPubkeys (error)", async () => {
   const testErrorMessage = "test-error-message";
   wallet.getAllVSPs = jest.fn(() => Promise.reject(testErrorMessage));
   const store = createStore({});
-  await store.dispatch(vspActions.getVSPsPubkeys());
+  try {
+    await store.dispatch(vspActions.getVSPsPubkeys());
+  } catch (error) {
+    console.log({ error });
+  }
 
   expect(store.getState().vsp.availableVSPsPubkeys).toEqual(undefined);
   expect(store.getState().vsp.availableVSPsPubkeysError).toEqual(

--- a/test/unit/components/views/GetStaredPage/SetupWallet/ProcessManagedTickets.spec.js
+++ b/test/unit/components/views/GetStaredPage/SetupWallet/ProcessManagedTickets.spec.js
@@ -1,0 +1,374 @@
+import ProcessManagedTickets from "components/views/GetStartedPage/SetupWallet/ProcessManagedTickets";
+import { render } from "test-utils.js";
+import { screen, wait } from "@testing-library/react";
+import user from "@testing-library/user-event";
+import * as sel from "selectors";
+import * as wal from "wallet";
+import * as arrs from "../../../../../../app/helpers/arrays";
+const selectors = sel;
+const wallet = wal;
+const arrays = arrs;
+import {
+  VSP_FEE_PROCESS_ERRORED,
+  VSP_FEE_PROCESS_STARTED,
+  VSP_FEE_PROCESS_PAID,
+  VSP_FEE_PROCESS_CONFIRMED
+} from "constants";
+import {
+  defaultMockAvailableMainnetVsps,
+  defaultMockAvailableTestnetVsps,
+  defaultMockAvailableInvalidVsps,
+  mockPubkeys,
+  fetchTimes
+} from "../../../../actions/vspMocks";
+import {
+  testBalances,
+  changeAccountNumber,
+  mixedAccountNumber,
+  defaultAccountNumber,
+  mockUnlockLockAndGetAccountsAttempt
+} from "../../../../actions/accountMocks";
+import { cloneDeep } from "lodash";
+
+const mockAvailableMainnetVsps = cloneDeep(defaultMockAvailableMainnetVsps);
+const mockAvailableMainnetVspsPubkeys = cloneDeep(
+  defaultMockAvailableMainnetVsps
+).map((v) => ({ ...v, pubkey: `${v.host}-pubkey` }));
+const mockSend = jest.fn(() => {});
+const mockCancel = jest.fn(() => {});
+
+const testPassphrase = "test-passphrase";
+const testWalletService = "test-wallet-service";
+const testError = "test-error";
+
+let mockProcessManagedTickets;
+let mockGetVSPTicketsByFeeStatus;
+let mockGetVSPTrackedTickets;
+let mockGetAllVSPs;
+let mockGetVSPInfo;
+beforeEach(() => {
+  selectors.getAvailableVSPsPubkeys = jest.fn(() => null);
+  selectors.balances = jest.fn(() => cloneDeep(testBalances));
+  selectors.unlockableAccounts = jest.fn(() =>
+    cloneDeep(testBalances).filter(
+      (acct) => acct.accountNumber < Math.pow(2, 31) - 1 && acct.encrypted
+    )
+  );
+  arrays.shuffle = jest.fn((arr) => arr);
+  selectors.getVSPInfoTimeoutTime = jest.fn(() => 100);
+  selectors.isTestNet = jest.fn(() => false);
+  selectors.resendVSPDVoteChoicesAttempt = jest.fn(() => false);
+  selectors.walletService = jest.fn(() => testWalletService);
+  selectors.defaultSpendingAccount = jest.fn(() => ({
+    value: defaultAccountNumber
+  }));
+  selectors.getMixedAccount = jest.fn(() => mixedAccountNumber);
+  selectors.getChangeAccount = jest.fn(() => changeAccountNumber);
+  mockGetAllVSPs = wallet.getAllVSPs = jest.fn(() => [
+    ...cloneDeep(mockAvailableMainnetVsps),
+    ...cloneDeep(defaultMockAvailableTestnetVsps),
+    ...cloneDeep(defaultMockAvailableInvalidVsps)
+  ]);
+  mockGetVSPInfo = wallet.getVSPInfo = jest.fn((host) => {
+    if (!mockPubkeys[host]) {
+      return Promise.reject("invalid host");
+    }
+
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        mockPubkeys[host] !== "invalid"
+          ? resolve({ data: { pubkey: mockPubkeys[host] } })
+          : mockPubkeys[host]
+          ? resolve({ data: {} })
+          : reject("invalid host");
+      }, fetchTimes[host]);
+    });
+  });
+  mockProcessManagedTickets = wallet.processManagedTickets = jest.fn(() => {});
+  mockGetVSPTrackedTickets = wallet.getVSPTrackedTickets = jest.fn(() =>
+    Promise.resolve()
+  );
+  mockGetVSPTicketsByFeeStatus = wallet.getVSPTicketsByFeeStatus = jest.fn(() =>
+    Promise.resolve({
+      ticketHashes: []
+    })
+  );
+});
+
+const getSkipButton = () => screen.getByRole("button", { name: "Skip" });
+const getCancelButton = () => screen.getByRole("button", { name: "Cancel" });
+const getContinueButton = () =>
+  screen.getByRole("button", { name: "Continue" });
+const getModalContinueButton = () =>
+  screen.getAllByRole("button", { name: "Continue" })[1];
+
+const initialState = {
+  grpc: {
+    walletService: testWalletService
+  }
+};
+
+test("skip ProcessManagedTickets and show error", () => {
+  render(
+    <ProcessManagedTickets
+      send={mockSend}
+      cancel={mockCancel}
+      error={testError}
+    />
+  );
+  user.click(getSkipButton());
+  expect(screen.getByText(testError)).toBeInTheDocument();
+  expect(mockCancel).toHaveBeenCalled();
+});
+
+test("do ProcessManagedTickets - in a private wallet", async () => {
+  mockUnlockLockAndGetAccountsAttempt();
+  render(<ProcessManagedTickets send={mockSend} cancel={mockCancel} />, {
+    initialState
+  });
+  const continueButton = getContinueButton();
+  user.click(continueButton);
+
+  expect(screen.getByText("Passphrase")).toBeInTheDocument();
+
+  // cancel first
+  user.click(getCancelButton());
+
+  user.click(continueButton);
+  user.type(screen.getByLabelText("Private Passphrase"), testPassphrase);
+  user.click(getModalContinueButton());
+
+  await wait(() => expect(mockSend).toHaveBeenCalled());
+
+  expect(mockProcessManagedTickets).toHaveBeenNthCalledWith(
+    1,
+    testWalletService,
+    defaultMockAvailableMainnetVsps[0].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[0].host}`],
+    mixedAccountNumber,
+    changeAccountNumber
+  );
+
+  expect(mockProcessManagedTickets).toHaveBeenNthCalledWith(
+    2,
+    testWalletService,
+    defaultMockAvailableMainnetVsps[3].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[3].host}`],
+    mixedAccountNumber,
+    changeAccountNumber
+  );
+
+  expect(mockProcessManagedTickets).toHaveBeenNthCalledWith(
+    3,
+    testWalletService,
+    defaultMockAvailableMainnetVsps[5].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[5].host}`],
+    mixedAccountNumber,
+    changeAccountNumber
+  );
+
+  expect(mockGetVSPTrackedTickets).toHaveBeenCalledTimes(1);
+
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    1,
+    testWalletService,
+    VSP_FEE_PROCESS_ERRORED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    2,
+    testWalletService,
+    VSP_FEE_PROCESS_STARTED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    3,
+    testWalletService,
+    VSP_FEE_PROCESS_PAID
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    4,
+    testWalletService,
+    VSP_FEE_PROCESS_CONFIRMED
+  );
+
+  expect(mockGetAllVSPs).toHaveBeenCalled();
+  expect(mockGetVSPInfo).toHaveBeenCalled();
+});
+
+test("do ProcessManagedTickets - in a default wallet, available vps pubkeys have been already fetched", async () => {
+  selectors.getAvailableVSPsPubkeys = jest.fn(
+    () => mockAvailableMainnetVspsPubkeys
+  );
+  selectors.getMixedAccount = jest.fn(() => null);
+  selectors.getChangeAccount = jest.fn(() => null);
+  mockUnlockLockAndGetAccountsAttempt();
+  render(<ProcessManagedTickets send={mockSend} cancel={mockCancel} />, {
+    initialState
+  });
+  const continueButton = getContinueButton();
+  user.click(continueButton);
+
+  expect(screen.getByText("Passphrase")).toBeInTheDocument();
+
+  // cancel first
+  user.click(getCancelButton());
+
+  user.click(continueButton);
+  user.type(screen.getByLabelText("Private Passphrase"), testPassphrase);
+  user.click(getModalContinueButton());
+
+  await wait(() => expect(mockSend).toHaveBeenCalled());
+
+  expect(mockProcessManagedTickets).toHaveBeenNthCalledWith(
+    1,
+    testWalletService,
+    defaultMockAvailableMainnetVsps[0].host,
+    `${mockAvailableMainnetVsps[0].host}-pubkey`,
+    defaultAccountNumber,
+    defaultAccountNumber
+  );
+
+  expect(mockProcessManagedTickets).toHaveBeenNthCalledWith(
+    2,
+    testWalletService,
+    defaultMockAvailableMainnetVsps[1].host,
+    `${mockAvailableMainnetVsps[1].host}-pubkey`,
+    defaultAccountNumber,
+    defaultAccountNumber
+  );
+
+  expect(mockProcessManagedTickets).toHaveBeenNthCalledWith(
+    3,
+    testWalletService,
+    defaultMockAvailableMainnetVsps[2].host,
+    `${mockAvailableMainnetVsps[2].host}-pubkey`,
+    defaultAccountNumber,
+    defaultAccountNumber
+  );
+
+  expect(mockGetVSPTrackedTickets).toHaveBeenCalledTimes(1);
+
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    1,
+    testWalletService,
+    VSP_FEE_PROCESS_ERRORED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    2,
+    testWalletService,
+    VSP_FEE_PROCESS_STARTED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    3,
+    testWalletService,
+    VSP_FEE_PROCESS_PAID
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    4,
+    testWalletService,
+    VSP_FEE_PROCESS_CONFIRMED
+  );
+
+  expect(mockGetAllVSPs).not.toHaveBeenCalled();
+  expect(mockGetVSPInfo).not.toHaveBeenCalled();
+});
+
+test("do ProcessManagedTickets - in a default wallet, available vps pubkeys have been already fetched", async () => {
+  selectors.getAvailableVSPsPubkeys = jest.fn(
+    () => mockAvailableMainnetVspsPubkeys
+  );
+  selectors.getMixedAccount = jest.fn(() => null);
+  selectors.getChangeAccount = jest.fn(() => null);
+  mockUnlockLockAndGetAccountsAttempt();
+  render(<ProcessManagedTickets send={mockSend} cancel={mockCancel} />, {
+    initialState
+  });
+  const continueButton = getContinueButton();
+  user.click(continueButton);
+
+  expect(screen.getByText("Passphrase")).toBeInTheDocument();
+
+  // cancel first
+  user.click(getCancelButton());
+
+  user.click(continueButton);
+  user.type(screen.getByLabelText("Private Passphrase"), testPassphrase);
+  user.click(getModalContinueButton());
+
+  await wait(() => expect(mockSend).toHaveBeenCalled());
+
+  expect(mockProcessManagedTickets).toHaveBeenNthCalledWith(
+    1,
+    testWalletService,
+    defaultMockAvailableMainnetVsps[0].host,
+    `${mockAvailableMainnetVsps[0].host}-pubkey`,
+    defaultAccountNumber,
+    defaultAccountNumber
+  );
+
+  expect(mockProcessManagedTickets).toHaveBeenNthCalledWith(
+    2,
+    testWalletService,
+    defaultMockAvailableMainnetVsps[1].host,
+    `${mockAvailableMainnetVsps[1].host}-pubkey`,
+    defaultAccountNumber,
+    defaultAccountNumber
+  );
+
+  expect(mockProcessManagedTickets).toHaveBeenNthCalledWith(
+    3,
+    testWalletService,
+    defaultMockAvailableMainnetVsps[2].host,
+    `${mockAvailableMainnetVsps[2].host}-pubkey`,
+    defaultAccountNumber,
+    defaultAccountNumber
+  );
+
+  expect(mockGetVSPTrackedTickets).toHaveBeenCalledTimes(1);
+
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    1,
+    testWalletService,
+    VSP_FEE_PROCESS_ERRORED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    2,
+    testWalletService,
+    VSP_FEE_PROCESS_STARTED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    3,
+    testWalletService,
+    VSP_FEE_PROCESS_PAID
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    4,
+    testWalletService,
+    VSP_FEE_PROCESS_CONFIRMED
+  );
+
+  expect(mockGetAllVSPs).not.toHaveBeenCalled();
+  expect(mockGetVSPInfo).not.toHaveBeenCalled();
+});
+
+test("do ProcessManagedTickets - failed to fetch vsps", async () => {
+  mockUnlockLockAndGetAccountsAttempt();
+  mockGetAllVSPs = wallet.getAllVSPs = jest.fn(() => {
+    throw testError;
+  });
+  render(<ProcessManagedTickets send={mockSend} cancel={mockCancel} />, {
+    initialState
+  });
+  const continueButton = getContinueButton();
+  user.click(continueButton);
+
+  user.type(screen.getByLabelText("Private Passphrase"), testPassphrase);
+  user.click(getModalContinueButton());
+
+  await wait(() => expect(mockSend).toHaveBeenCalled());
+
+  expect(mockGetAllVSPs).toHaveBeenCalled();
+  expect(mockProcessManagedTickets).not.toHaveBeenCalled();
+  expect(mockGetVSPTrackedTickets).not.toHaveBeenCalled();
+  expect(mockGetVSPTicketsByFeeStatus).not.toHaveBeenCalled();
+  expect(mockGetVSPInfo).not.toHaveBeenCalled();
+});

--- a/test/unit/components/views/GetStaredPage/SetupWallet/ProcessUnmanagedTickets.spec.js
+++ b/test/unit/components/views/GetStaredPage/SetupWallet/ProcessUnmanagedTickets.spec.js
@@ -1,0 +1,375 @@
+import ProcessUnmanagedTickets from "components/views/GetStartedPage/SetupWallet/ProcessUnmanagedTickets";
+import { render } from "test-utils.js";
+import { screen, wait } from "@testing-library/react";
+import user from "@testing-library/user-event";
+import * as sel from "selectors";
+import * as wal from "wallet";
+import * as arrs from "../../../../../../app/helpers/arrays";
+const selectors = sel;
+const wallet = wal;
+const arrays = arrs;
+import { DEFAULT_LIGHT_THEME_NAME } from "pi-ui";
+import {
+  VSP_FEE_PROCESS_ERRORED,
+  VSP_FEE_PROCESS_STARTED,
+  VSP_FEE_PROCESS_PAID,
+  VSP_FEE_PROCESS_CONFIRMED,
+  EXTERNALREQUEST_STAKEPOOL_LISTING
+} from "constants";
+import {
+  defaultMockAvailableMainnetVsps,
+  defaultMockAvailableTestnetVsps,
+  defaultMockAvailableInvalidVsps,
+  mockPubkeys,
+  fetchTimes
+} from "../../../../actions/vspMocks";
+import {
+  testBalances,
+  changeAccountNumber,
+  mixedAccountNumber,
+  defaultAccountNumber,
+  mockUnlockLockAndGetAccountsAttempt
+} from "../../../../actions/accountMocks";
+import { cloneDeep } from "lodash";
+
+const mockAvailableMainnetVsps = cloneDeep(defaultMockAvailableMainnetVsps);
+const mockSend = jest.fn(() => {});
+const mockCancel = jest.fn(() => {});
+
+const testPassphrase = "test-passphrase";
+const testWalletService = "test-wallet-service";
+const testError = "test-error";
+const testCustomVspHost = "custom-vsp-host";
+const testCustomVspHostPubkey = "test-custom-vsp-host-pubkey";
+
+let mockProcessUnmanagedTickets;
+let mockGetVSPTicketsByFeeStatus;
+let mockGetAllVSPs;
+let mockGetVSPInfo;
+beforeEach(() => {
+  selectors.getAvailableVSPsPubkeys = jest.fn(() => null);
+  selectors.balances = jest.fn(() => cloneDeep(testBalances));
+  selectors.unlockableAccounts = jest.fn(() =>
+    cloneDeep(testBalances).filter(
+      (acct) => acct.accountNumber < Math.pow(2, 31) - 1 && acct.encrypted
+    )
+  );
+  arrays.shuffle = jest.fn((arr) => arr);
+  selectors.getVSPInfoTimeoutTime = jest.fn(() => 100);
+  selectors.isTestNet = jest.fn(() => false);
+  selectors.resendVSPDVoteChoicesAttempt = jest.fn(() => false);
+  selectors.walletService = jest.fn(() => testWalletService);
+  selectors.defaultSpendingAccount = jest.fn(() => ({
+    value: defaultAccountNumber
+  }));
+  selectors.getMixedAccount = jest.fn(() => mixedAccountNumber);
+  selectors.getChangeAccount = jest.fn(() => changeAccountNumber);
+  mockGetAllVSPs = wallet.getAllVSPs = jest.fn(() => [
+    ...cloneDeep(mockAvailableMainnetVsps),
+    ...cloneDeep(defaultMockAvailableTestnetVsps),
+    ...cloneDeep(defaultMockAvailableInvalidVsps)
+  ]);
+  mockGetVSPInfo = wallet.getVSPInfo = jest.fn((host) => {
+    if (host === `https://${testCustomVspHost}`) {
+      return Promise.resolve({ data: { pubkey: testCustomVspHostPubkey } });
+    }
+    if (!mockPubkeys[host]) {
+      return Promise.reject("invalid host");
+    }
+
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        mockPubkeys[host] !== "invalid"
+          ? resolve({ data: { pubkey: mockPubkeys[host] } })
+          : mockPubkeys[host]
+          ? resolve({ data: {} })
+          : reject("invalid host");
+      }, fetchTimes[host]);
+    });
+  });
+  mockProcessUnmanagedTickets = wallet.processUnmanagedTicketsStartup = jest.fn(
+    () => {}
+  );
+  wallet.getVSPTrackedTickets = jest.fn(() => Promise.resolve());
+  mockGetVSPTicketsByFeeStatus = wallet.getVSPTicketsByFeeStatus = jest.fn(() =>
+    Promise.resolve({
+      ticketHashes: []
+    })
+  );
+
+  selectors.getAvailableVSPs = jest.fn(() => mockAvailableMainnetVsps);
+});
+
+const getSkipButton = () => screen.getByRole("button", { name: "Skip" });
+const getCancelButton = () => screen.getByRole("button", { name: "Cancel" });
+const getContinueButton = () =>
+  screen.getByRole("button", { name: "Continue" });
+const getModalContinueButton = () =>
+  screen.getAllByRole("button", { name: "Continue" })[1];
+
+const initialState = {
+  grpc: {
+    walletService: testWalletService
+  },
+  settings: {
+    currentSettings: {
+      theme: DEFAULT_LIGHT_THEME_NAME,
+      allowedExternalRequests: [EXTERNALREQUEST_STAKEPOOL_LISTING]
+    },
+    tempSettings: {
+      theme: DEFAULT_LIGHT_THEME_NAME,
+      allowedExternalRequests: [EXTERNALREQUEST_STAKEPOOL_LISTING]
+    }
+  }
+};
+
+test("skip ProcessUnmanagedTickets and show error", () => {
+  render(
+    <ProcessUnmanagedTickets
+      send={mockSend}
+      cancel={mockCancel}
+      error={testError}
+    />
+  );
+  expect(screen.getByText(testError)).toBeInTheDocument();
+  user.click(getSkipButton());
+  expect(mockCancel).toHaveBeenCalled();
+});
+
+test("do ProcessUnmanagedTickets - in a private wallet", async () => {
+  mockUnlockLockAndGetAccountsAttempt();
+  render(<ProcessUnmanagedTickets send={mockSend} cancel={mockCancel} />, {
+    initialState
+  });
+  const continueButton = getContinueButton();
+  expect(continueButton.disabled).toBe(true);
+
+  user.click(screen.getByText("Select VSP..."));
+  user.click(screen.getByText(mockAvailableMainnetVsps[0].host));
+  expect(screen.getByText("Loading")).toBeInTheDocument();
+  await wait(() => expect(getContinueButton().disabled).toBeFalsy());
+  expect(screen.queryByText("Loading")).not.toBeInTheDocument();
+  expect(
+    screen.getByText(mockAvailableMainnetVsps[0].host)
+  ).toBeInTheDocument();
+
+  user.click(continueButton);
+  expect(screen.getByText("Passphrase")).toBeInTheDocument();
+
+  // cancel first
+  user.click(getCancelButton());
+
+  user.click(continueButton);
+  user.type(screen.getByLabelText("Private Passphrase"), testPassphrase);
+  user.click(getModalContinueButton());
+
+  await wait(() => expect(mockSend).toHaveBeenCalled());
+
+  expect(mockProcessUnmanagedTickets).toHaveBeenCalledWith(
+    testWalletService,
+    defaultMockAvailableMainnetVsps[0].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[0].host}`],
+    mixedAccountNumber,
+    changeAccountNumber
+  );
+
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    1,
+    testWalletService,
+    VSP_FEE_PROCESS_ERRORED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    2,
+    testWalletService,
+    VSP_FEE_PROCESS_STARTED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    3,
+    testWalletService,
+    VSP_FEE_PROCESS_PAID
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    4,
+    testWalletService,
+    VSP_FEE_PROCESS_CONFIRMED
+  );
+
+  expect(mockGetAllVSPs).not.toHaveBeenCalled();
+  expect(mockGetVSPInfo).toHaveBeenCalled();
+});
+
+test("do ProcessUnmanagedTickets - in a default wallet", async () => {
+  selectors.getMixedAccount = jest.fn(() => null);
+  selectors.getChangeAccount = jest.fn(() => null);
+  mockUnlockLockAndGetAccountsAttempt();
+  render(<ProcessUnmanagedTickets send={mockSend} cancel={mockCancel} />, {
+    initialState
+  });
+  const continueButton = getContinueButton();
+  expect(continueButton.disabled).toBe(true);
+
+  user.click(screen.getByText("Select VSP..."));
+  user.click(screen.getByText(mockAvailableMainnetVsps[0].host));
+  expect(screen.getByText("Loading")).toBeInTheDocument();
+  await wait(() => expect(getContinueButton().disabled).toBeFalsy());
+  expect(screen.queryByText("Loading")).not.toBeInTheDocument();
+  expect(
+    screen.getByText(mockAvailableMainnetVsps[0].host)
+  ).toBeInTheDocument();
+
+  user.click(continueButton);
+  expect(screen.getByText("Passphrase")).toBeInTheDocument();
+
+  // cancel first
+  user.click(getCancelButton());
+
+  user.click(continueButton);
+  user.type(screen.getByLabelText("Private Passphrase"), testPassphrase);
+  user.click(getModalContinueButton());
+
+  await wait(() => expect(mockSend).toHaveBeenCalled());
+
+  expect(mockProcessUnmanagedTickets).toHaveBeenCalledWith(
+    testWalletService,
+    defaultMockAvailableMainnetVsps[0].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[0].host}`],
+    defaultAccountNumber,
+    defaultAccountNumber
+  );
+
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    1,
+    testWalletService,
+    VSP_FEE_PROCESS_ERRORED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    2,
+    testWalletService,
+    VSP_FEE_PROCESS_STARTED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    3,
+    testWalletService,
+    VSP_FEE_PROCESS_PAID
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    4,
+    testWalletService,
+    VSP_FEE_PROCESS_CONFIRMED
+  );
+
+  expect(mockGetAllVSPs).not.toHaveBeenCalled();
+  expect(mockGetVSPInfo).toHaveBeenCalled();
+});
+
+test("do ProcessUnmanagedTickets - vsp listing is not enabled", async () => {
+  mockUnlockLockAndGetAccountsAttempt();
+  render(<ProcessUnmanagedTickets send={mockSend} cancel={mockCancel} />, {
+    initialState: cloneDeep({
+      ...initialState,
+      settings: {
+        ...initialState.settings,
+        tempSettings: {
+          ...initialState.settings.tempSettings,
+          allowedExternalRequests: []
+        }
+      }
+    })
+  });
+
+  const continueButton = getContinueButton();
+  expect(continueButton.disabled).toBe(true);
+
+  user.type(screen.getByRole("combobox"), testCustomVspHost);
+  user.click(screen.getByText(`Create "${testCustomVspHost}"`));
+  expect(screen.getByText("Loading")).toBeInTheDocument();
+  await wait(() =>
+    expect(screen.getByText(testCustomVspHost)).toBeInTheDocument()
+  );
+
+  user.click(continueButton);
+  expect(screen.getByText("Passphrase")).toBeInTheDocument();
+
+  // cancel first
+  user.click(getCancelButton());
+
+  user.click(continueButton);
+  user.type(screen.getByLabelText("Private Passphrase"), testPassphrase);
+  user.click(getModalContinueButton());
+
+  await wait(() => expect(mockSend).toHaveBeenCalled());
+
+  expect(mockProcessUnmanagedTickets).toHaveBeenCalledWith(
+    testWalletService,
+    testCustomVspHost,
+    testCustomVspHostPubkey,
+    mixedAccountNumber,
+    changeAccountNumber
+  );
+
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    1,
+    testWalletService,
+    VSP_FEE_PROCESS_ERRORED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    2,
+    testWalletService,
+    VSP_FEE_PROCESS_STARTED
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    3,
+    testWalletService,
+    VSP_FEE_PROCESS_PAID
+  );
+  expect(mockGetVSPTicketsByFeeStatus).toHaveBeenNthCalledWith(
+    4,
+    testWalletService,
+    VSP_FEE_PROCESS_CONFIRMED
+  );
+
+  expect(mockGetAllVSPs).not.toHaveBeenCalled();
+  expect(mockGetVSPInfo).toHaveBeenCalled();
+});
+
+test("do ProcessUnManagedTickets - failed", async () => {
+  mockProcessUnmanagedTickets = wallet.processUnmanagedTicketsStartup = jest.fn(
+    () => {
+      throw testError;
+    }
+  );
+  mockUnlockLockAndGetAccountsAttempt();
+  render(<ProcessUnmanagedTickets send={mockSend} cancel={mockCancel} />, {
+    initialState
+  });
+  const continueButton = getContinueButton();
+  expect(continueButton.disabled).toBe(true);
+
+  user.click(screen.getByText("Select VSP..."));
+  user.click(screen.getByText(mockAvailableMainnetVsps[0].host));
+  expect(screen.getByText("Loading")).toBeInTheDocument();
+  await wait(() => expect(getContinueButton().disabled).toBeFalsy());
+  expect(screen.queryByText("Loading")).not.toBeInTheDocument();
+  expect(
+    screen.getByText(mockAvailableMainnetVsps[0].host)
+  ).toBeInTheDocument();
+
+  user.click(continueButton);
+  expect(screen.getByText("Passphrase")).toBeInTheDocument();
+
+  user.click(continueButton);
+  user.type(screen.getByLabelText("Private Passphrase"), testPassphrase);
+  user.click(getModalContinueButton());
+
+  await wait(() => expect(mockSend).toHaveBeenCalled());
+
+  expect(mockProcessUnmanagedTickets).toHaveBeenCalledWith(
+    testWalletService,
+    defaultMockAvailableMainnetVsps[0].host,
+    mockPubkeys[`https://${mockAvailableMainnetVsps[0].host}`],
+    mixedAccountNumber,
+    changeAccountNumber
+  );
+
+  expect(mockGetVSPTicketsByFeeStatus).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
Closes #3843

This removes the unnecessary `gettingVSPInfo` step from the setup wallet process. The fetched vsp info is used only in the manage processed tickets part of the flow. Now it's requested only if needed.
Also, this diff cleans up the process managed and unmanaged views and adds tests for them.