### PR TITLE
dex: do not set password on native dex wallet

### DIFF
--- a/modules/dex/libdexc/adapter.go
+++ b/modules/dex/libdexc/adapter.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -280,6 +281,15 @@ func (c *CoreAdapter) setWalletPassword(raw json.RawMessage) (string, error) {
 	})
 	if err := json.Unmarshal(raw, form); err != nil {
 		return "", err
+	}
+	ws := c.core.WalletState(form.AssetID)
+	if ws == nil {
+		return "", errors.New("no wallet")
+	}
+	if ws.WalletType != "dcrwalletRPC" { // client/asset/dcr.walletTypeDcrwRPC
+		// Only change the wallet password if it's Decrediton's dcrwallet (as
+		// opposed to a native SPV wallet built into DEX).
+		return "", nil
 	}
 	return "", c.core.SetWalletPassword([]byte(form.AppPW), form.AssetID, []byte(form.Pass))
 }


### PR DESCRIPTION
Some Decrediton users have changed their DEX Decred wallet to be of type "SPV" (native) in the DEX Wallets page.  This means DEX on longer uses Decrediton's dcrwallet.  While there is no point in doing this, people still do it and they will get an error similar to the following:

![image](https://user-images.githubusercontent.com/9373513/235705192-dc60ede3-6839-45d5-99ed-c100e1ab1d71.png)

That above error came from `UpdateWallet` (`createWalletDexCall`), not the private password change form.  I still do not understand how to reproduce that particular error or even the circumstances when `createWalletDexCall` is used, but it lead me to the related issue with changing the wallet password.