### PR TITLE
multi: Remove staking from hw wallet menus.

### DIFF
--- a/app/components/SideBar/MenuLinks/Links.jsx
+++ b/app/components/SideBar/MenuLinks/Links.jsx
@@ -2,6 +2,8 @@ import { FormattedMessage as T } from "react-intl";
 
 export const LN_KEY = "ln";
 export const DEX_KEY = "dex";
+export const TICKETS_KEY = "tickets";
+export const GOV_KEY = "governance";
 
 export const linkList = [
   {
@@ -27,6 +29,7 @@ export const linkList = [
     path: "/governance",
     link: <T id="sidebar.link.governance" m="Governance" />,
     icon: "governance",
+    key: GOV_KEY,
     notifProp: [
       "newProposalsStartedVoting",
       "newNotYetVotedAgendasCount",
@@ -38,6 +41,7 @@ export const linkList = [
     path: "/tickets",
     link: <T id="sidebar.link.staking" m="Staking" />,
     icon: "tickets",
+    key: TICKETS_KEY,
     ariaLabel: "Staking"
   },
   {

--- a/app/components/SideBar/MenuLinks/hooks.js
+++ b/app/components/SideBar/MenuLinks/hooks.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useSelector } from "react-redux";
 import * as sel from "selectors";
-import { linkList, LN_KEY, DEX_KEY } from "./Links";
+import { linkList, LN_KEY, DEX_KEY, TICKETS_KEY, GOV_KEY } from "./Links";
 import { useHistory } from "react-router-dom";
 import { cloneDeep } from "fp";
 
@@ -46,8 +46,11 @@ export function useMenuLinks() {
     if (!lnEnabled) {
       links = links.filter((l) => l.key !== LN_KEY);
     }
+    // TODO: Enable ticket purchacing for Trezor.
     if (isTrezor) {
-      links = links.filter((l) => l.key !== DEX_KEY);
+      links = links.filter(
+        (l) => l.key !== DEX_KEY && l.key !== TICKETS_KEY && l.key !== GOV_KEY
+      );
     }
     return links.map((link) => ({
       ...link,

--- a/app/components/views/HomePage/HomePage.jsx
+++ b/app/components/views/HomePage/HomePage.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { FormattedMessage as T } from "react-intl";
+import { useSelector } from "react-redux";
 import { classNames } from "pi-ui";
 import ErrorScreen from "ErrorScreen";
 import { useService } from "hooks";
@@ -10,6 +11,7 @@ import RecentTransactions from "./RecentTransactions";
 import RecentTickets from "./RecentTickets";
 import { BalanceTab, TicketsTab, TransactionsTab } from "./Tabs";
 import styles from "./HomePage.module.css";
+import * as sel from "selectors";
 
 const ROWS_NUMBER_ON_TABLE = 5;
 
@@ -19,23 +21,23 @@ const tabMessages = {
   transactions: <T id="home.tab.transactions" m="Transactions" />
 };
 
-const tabs = [
-  {
-    label: tabMessages.balance,
-    component: <BalanceTab />,
-    icon: styles.balanceIcon
-  },
-  {
-    label: tabMessages.tickets,
-    component: <TicketsTab />,
-    icon: styles.ticketsIcon
-  },
-  {
-    label: tabMessages.transactions,
-    component: <TransactionsTab />,
-    icon: styles.txIcon
-  }
-];
+const balanceTab = {
+  label: tabMessages.balance,
+  component: <BalanceTab />,
+  icon: styles.balanceIcon
+};
+
+const ticketsTab = {
+  label: tabMessages.tickets,
+  component: <TicketsTab />,
+  icon: styles.ticketsIcon
+};
+
+const transactionsTab = {
+  label: tabMessages.transactions,
+  component: <TransactionsTab />,
+  icon: styles.txIcon
+};
 
 export default () => {
   const { walletService } = useService();
@@ -51,6 +53,27 @@ export default () => {
     goToMyTickets,
     tsDate
   } = useHomePage();
+
+  // TODO: Enable ticket purchacing for Trezor.
+  const isTrezor = useSelector(sel.isTrezor);
+  let recentTickets, tabs;
+  if (isTrezor) {
+    tabs = [balanceTab, transactionsTab];
+  } else {
+    recentTickets = (
+      <RecentTickets
+        {...{
+          tickets,
+          getTransactionsRequestAttempt,
+          getAccountsResponse,
+          rowNumber: ROWS_NUMBER_ON_TABLE,
+          goToMyTickets,
+          tsDate
+        }}
+      />
+    );
+    tabs = [balanceTab, ticketsTab, transactionsTab];
+  }
 
   return walletService ? (
     <StandalonePage>
@@ -86,16 +109,7 @@ export default () => {
             tsDate
           }}
         />
-        <RecentTickets
-          {...{
-            tickets,
-            getTransactionsRequestAttempt,
-            getAccountsResponse,
-            rowNumber: ROWS_NUMBER_ON_TABLE,
-            goToMyTickets,
-            tsDate
-          }}
-        />
+        {recentTickets}
       </div>
     </StandalonePage>
   ) : (

--- a/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.jsx
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import { useSelector } from "react-redux";
 import copy from "clipboard-copy";
 import { FormattedMessage as T, injectIntl, defineMessages } from "react-intl";
 import { ReceiveAccountsSelect, DcrInput } from "inputs";
@@ -14,6 +15,7 @@ import {
   TextHighlighted
 } from "pi-ui";
 import styles from "./ReceivePage.module.css";
+import * as sel from "selectors";
 
 const messages = defineMessages({
   amountPlaceholder: {
@@ -49,6 +51,21 @@ const ReceivePage = ({
   }
   const { theme } = useTheme();
   const iconColor = getThemeProperty(theme, "accent-blue");
+
+  // TODO: Enable ticket purchacing for Trezor.
+  const isTrezor = useSelector(sel.isTrezor);
+  let hardwareWalletWarning;
+  if (isTrezor) {
+    const warningStr =
+      "Caution! Hardware wallets cannot spend from special/staking inputs. " +
+      "Only use this address for receiving funds from normal transacitons. Do not " +
+      "use for staking or treasury related receives.";
+    hardwareWalletWarning = (
+      <label className={styles.hadwareWalletWarning}>
+        <T id="receive.hardwareWalletWarning" m={warningStr} />
+      </label>
+    );
+  }
 
   return (
     <>
@@ -93,6 +110,8 @@ const ReceivePage = ({
             </div>
           </div>
         </div>
+
+        {hardwareWalletWarning}
 
         <div className={styles.line}>
           <TextHighlighted

--- a/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.module.css
+++ b/app/components/views/TransactionsPage/ReceiveTab/ReceivePage/ReceivePage.module.css
@@ -15,6 +15,20 @@
   margin-bottom: 25px;
 }
 
+.hadwareWalletWarning {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  margin-bottom: 12px;
+  font-size: 16px;
+  text-align: center;
+  background-color: rgba(248, 215, 218, 1);
+  border-color: rgba(220, 53, 69, 1);
+  color: rgba(114, 28, 36, 1);
+}
+
 .inputWrapper {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Staking does not currently work for hardware wallets. Remove the screens and options that have to do with staking for now to avoid confusion. Hardware wallets also cannot currently handle stake inputs when signing. Add a warning to receiving screens not to use addresses for staking or treasury receives.

Part of #3865