### PR TITLE
[actions] Make GetWalletService syncable

### DIFF
--- a/app/actions/ClientActions.js
+++ b/app/actions/ClientActions.js
@@ -184,7 +184,7 @@ export const getWalletServiceAttempt = () => (dispatch, getState) => {
   } = getState();
   dispatch({ type: GETWALLETSERVICE_ATTEMPT });
   const grpcCertAndKey = wallet.getDcrwalletGrpcKeyCert();
-  wallet
+  return wallet
     .getWalletService(
       sel.isTestNet(getState()),
       walletName,


### PR DESCRIPTION
This fixes a bug when wallet operations (for example GetBestBlock) are attempted before the GetWalletServiceAttempt fully completes, causing the wallet not to load.