### PR TITLE
trezor: Add trezord-go to bin.

### DIFF
--- a/app/actions/TrezorActions.js
+++ b/app/actions/TrezorActions.js
@@ -1,4 +1,5 @@
 import { wallet, fs } from "wallet-preload-shim";
+import { trezord } from "wallet-preload-shim";
 import * as selectors from "selectors";
 import { hexToBytes, str2utf8hex, rawToHex } from "helpers";
 import {
@@ -47,13 +48,14 @@ export const TRZ_TREZOR_ENABLED = "TRZ_TREZOR_ENABLED";
 
 // enableTrezor attepts to start a connection with connect if none exist and
 // connect to a trezor device.
-export const enableTrezor = () => (dispatch, getState) => {
+export const enableTrezor = () => async (dispatch, getState) => {
   dispatch({ type: TRZ_TREZOR_ENABLED });
 
   if (!setListeners) {
     setDeviceListeners(dispatch, getState);
     setListeners = true;
   }
+  await trezord.start();
   connect()(dispatch, getState);
 };
 
@@ -104,7 +106,8 @@ export const TRZ_TREZOR_DISABLED = "TRZ_TREZOR_DISABLED";
 // disableTrezor disables trezor integration for the current wallet. Note
 // that it does **not** disable in the config, so the wallet will restart as a
 // trezor wallet next time it's opened.
-export const disableTrezor = () => (dispatch) => {
+export const disableTrezor = () => async (dispatch) => {
+  await trezord.stop();
   dispatch({ type: TRZ_TREZOR_DISABLED });
 };
 

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -62,6 +62,8 @@ import {
   startDcrlnd,
   stopDcrlnd,
   removeDcrlnd,
+  startTrezord,
+  stopTrezord,
   lnScbInfo,
   startDex,
   stopDex,
@@ -409,6 +411,10 @@ handle("user-dex", userDex);
 handle("start-dex", startDex);
 
 handle("stop-dex", stopDex);
+
+handle("start-trezord", startTrezord);
+
+handle("stop-trezord", stopTrezord);
 
 handle("launch-dex-window", createDexWindow);
 

--- a/app/main_dev/constants.js
+++ b/app/main_dev/constants.js
@@ -18,7 +18,7 @@ Options
   --rpccert          Specify RPC Certificate
   --rpcconnect       Specify RPC connection in 'host:port' or 'host' format (latter uses the default RPC port). Note that different ports are used for RPC and SPV connections.
   --extrawalletargs  Pass extra arguments to dcrwallet.
-  --custombinpath    Custom path for dcrd/dcrwallet/dcrctl binaries.
+  --custombinpath    Custom path for dcrd/dcrwallet/dcrctl/trezord-go binaries.
 `;
 
 export const VERSION_MESSAGE = `${app.name} version ${app.getVersion()}`;

--- a/app/main_dev/ipc.js
+++ b/app/main_dev/ipc.js
@@ -18,6 +18,9 @@ import {
   launchDCRLnd,
   GetDcrlndPID,
   GetDcrlndCreds,
+  launchTrezord,
+  GetTrezordPID,
+  closeTrezord,
   launchDex,
   initCheckDex,
   initDexCall,
@@ -247,6 +250,26 @@ export const startDcrlnd = async (
     return e;
   }
 };
+
+export const startTrezord = async () => {
+  if (GetTrezordPID() && GetTrezordPID() !== -1) {
+    logger.log(
+      "info",
+      `Skipping restart of trezord-go as it is already running ${GetTrezordPID()}`
+    );
+    return { wasRunning: true };
+  }
+
+  try {
+    const started = await launchTrezord();
+    return started;
+  } catch (e) {
+    logger.log("error", `error launching trezord-go: ${e}`);
+    return e;
+  }
+};
+
+export const stopTrezord = () => closeTrezord();
 
 export const startDex = async (walletPath, testnet, locale) => {
   if (GetDexPID()) {

--- a/app/main_dev/logging.js
+++ b/app/main_dev/logging.js
@@ -8,6 +8,7 @@ let dcrdLogs = Buffer.from("");
 let dcrwalletLogs = Buffer.from("");
 let dcrlndLogs = Buffer.from("");
 let dexcLogs = Buffer.from("");
+let trezordLogs = Buffer.from("");
 let privacyLogs = Buffer.from("");
 
 let logger;
@@ -163,6 +164,10 @@ export const AddToDexcLog = (destIO, data, debug) => {
   dexcLogs = AddToLog(destIO, dexcLogs, data, debug);
 };
 
+export const AddToTrezordLog = (destIO, data, debug) => {
+  trezordLogs = AddToLog(destIO, trezordLogs, data, debug);
+};
+
 export const AddToPrivacyLog = (destIO, data, debug) => {
   // if log contains any of those messages we consider it a privacy log.
   const privacyLogsArray = [
@@ -186,6 +191,8 @@ export const GetDcrdLogs = () => dcrdLogs;
 export const GetDcrwalletLogs = () => dcrwalletLogs;
 
 export const GetDcrlndLogs = () => dcrlndLogs;
+
+export const GetTrezordLogs = () => trezordLogs;
 
 export const GetDexcLogs = () => dexcLogs;
 
@@ -221,6 +228,7 @@ export function ClearDcrwalletLogs() {
   dcrwalletLogs = Buffer.from("");
   dcrlndLogs = Buffer.from("");
   dexcLogs = Buffer.from("");
+  trezordLogs = Buffer.from("");
 }
 
 // dcrd upgrades warning.

--- a/app/wallet-preload-shim.js
+++ b/app/wallet-preload-shim.js
@@ -4,3 +4,4 @@ export const walletCrypto = window.walletCrypto;
 export const dex = window.dex;
 export const ln = window.ln;
 export const politeia = window.politeia;
+export const trezord = window.trezord;

--- a/app/wallet-preload.js
+++ b/app/wallet-preload.js
@@ -3,6 +3,7 @@ import * as wallet from "wallet";
 import * as walletCrypto from "wallet/crypto";
 import * as dex from "wallet/dex";
 import * as ln from "wallet/ln";
+import * as trezord from "wallet/trezord";
 import * as politeia from "wallet/politeia";
 import { contextBridge } from "electron";
 
@@ -13,7 +14,8 @@ const api = {
   walletCrypto: walletCrypto,
   dex: dex,
   ln: ln,
-  politeia: politeia
+  politeia: politeia,
+  trezord: trezord
 };
 
 try {

--- a/app/wallet/trezord/index.js
+++ b/app/wallet/trezord/index.js
@@ -1,0 +1,4 @@
+import { invocable } from "helpers/electronRenderer";
+
+export const start = invocable("start-trezord");
+export const stop = invocable("stop-trezord");

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - go get -u -v github.com/decred/dcrd
   - go get -u -v github.com/decred/dcrwallet
   - go get -u -v github.com/Masterminds/glide
+  - go get -u -v github.com/trezor/trezord-go
   - go get -u github.com/golang/dep/cmd/dep
   - cd %GOPATH%\\src\\github.com\\decred\\dcrd
   - glide i
@@ -29,11 +30,15 @@ install:
   - cd ../dcrwallet
   - dep ensure
   - go install
+  - cd ../trezord-go
+  - dep ensure
+  - go install
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir bin
   - cp %GOPATH%\\bin\\dcrd.exe bin/
   - cp %GOPATH%\\bin\\dcrctl.exe bin/
   - cp %GOPATH%\\bin\\dcrwallet.exe bin/
+  - cp %GOPATH%\\bin\\trezord-go.exe bin/
   - npm install
 
 build_script:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
       "^electron-store$": "<rootDir>/test/mocks/electronStore.js",
       "wallet$": "<rootDir>/test/mocks/walletMock.js",
       "^dex$": "<rootDir>/test/mocks/dexMock.js",
+      "^trezord$": "<rootDir>/test/mocks/trezordMock.js",
       "^walletCrypto$": "<rootDir>/app/wallet/crypto.js",
       "^fetchModule$": "<rootDir>/app/helpers/fetchModule.js",
       "wallet-preload-shim$": "<rootDir>/test/mocks/walletPreloadShimMock.js"

--- a/test/mocks/trezordMock.js
+++ b/test/mocks/trezordMock.js
@@ -1,0 +1,4 @@
+export default {};
+
+export const start = () => {};
+export const stop = () => {};

--- a/test/mocks/walletPreloadShimMock.js
+++ b/test/mocks/walletPreloadShimMock.js
@@ -1,4 +1,5 @@
 export * as dex from "./dexMock.js";
 export * as wallet from "./walletMock.js";
 export * as fs from "./fsMock.js";
+export * as trezord from "./trezordMock.js";
 export const politeia = {};


### PR DESCRIPTION
If a user opens a trezor wallet, also start the trezor bridge that is
needed for communications.

part of #3901