### PR TITLE
[Settings] Fix SPV Connect on the Settings Page

### DIFF
--- a/app/components/views/SettingsPage/ConnectivitySettingsTab/NetworkSettings/NetworkSettings.jsx
+++ b/app/components/views/SettingsPage/ConnectivitySettingsTab/NetworkSettings/NetworkSettings.jsx
@@ -135,9 +135,11 @@ const NetworkSettings = ({ tempSettings, onChangeTempSettings }) => (
           value={tempSettings.spvConnect}
           disabled={tempSettings.spvConnectFromCli}
           ariaLabelledBy="spv-connect-input"
-          onChange={(value) =>
-            onChangeTempSettings({ spvConnect: value.split(",") })
-          }
+          onChange={(value) => {
+            onChangeTempSettings({
+              spvConnect: value ? value.split(",") : []
+            });
+          }}
         />
       </SettingsInputWrapper>
     </div>

--- a/test/unit/components/views/SettingsPage/SettingsPage.spec.js
+++ b/test/unit/components/views/SettingsPage/SettingsPage.spec.js
@@ -467,6 +467,14 @@ test.each([
     testSpvConnectValue.join(","),
     { spvConnect: testSpvConnectValue },
     false
+  ],
+  [
+    // clear input field
+    "SPV Connect",
+    testDefaultSpvConnectValue.join(","),
+    "",
+    { spvConnect: [] },
+    false
   ]
 ])("change '%s' TextInput from '%s' to '%s' expeced %s", testTextFieldInput);
 


### PR DESCRIPTION
Save an empty array (which is default value) if the `SPV Connect` field has been cleared instead of:
```    
"spv_connect": [
        ""
 ],
```

Probably solves #3883