### PR TITLE
staking: display wrong passphrase error.

### DIFF
--- a/app/actions/ControlActions.js
+++ b/app/actions/ControlActions.js
@@ -417,7 +417,7 @@ export const purchaseTicketsAttempt =
         })
       );
     } catch (error) {
-      console.log({ error });
+      dispatch({ error, type: PURCHASETICKETS_FAILED });
     } finally {
       if (needToRestartMixer) {
         const mixedAccount = sel.getMixedAccount(getState());


### PR DESCRIPTION
This commit fixes a bug in the ticket purchase flow, where wrong passphrase 
error wasnt displayed in the toast.

Fixes #3897.