### PR TITLE
Add the missing `Load Custom Translation` menu item on macOS

### DIFF
--- a/app/main_dev/templates.js
+++ b/app/main_dev/templates.js
@@ -95,6 +95,13 @@ const darwinTemplate = (mainWindow, loadCustomTranslation, locale) => [
         click() {
           mainWindow.setFullScreen(!mainWindow.isFullScreen());
         }
+      },
+      {
+        label: locale.messages["appMenu.loadCustomTranslation"],
+        accelerator: "",
+        click() {
+          loadCustomTranslation();
+        }
       }
     ]
   },


### PR DESCRIPTION
Add the missing `View -> Load Custom Translation` menu item on macOS.
Closes #3896 