### PR TITLE
Fully sanitize wallet name of invalid chars.

### DIFF
--- a/app/components/views/GetStartedPage/PreCreateWallet/hooks.js
+++ b/app/components/views/GetStartedPage/PreCreateWallet/hooks.js
@@ -64,7 +64,7 @@ export const usePreCreateWallet = ({
       // Filesystem related chars: /\.:
       // Escaped when stored in dcrwallet.conf ini files: ;#[]
       // Specially handled by dcrwallet: $%~
-      const replaceNameChars = /[/\\.:;#[\]$%~]/;
+      const replaceNameChars = /[/\\.:;#[\]$%~]/g;
       newWalletName = newWalletName.replace(replaceNameChars, "");
       // Remove leading spaces.
       if (newWalletName.length > 0 && newWalletName[0] === " ")


### PR DESCRIPTION
When a new wallet name has been provided by the user, every instance of invalid characters should be removed from the name, not just the first.